### PR TITLE
Container utilities and deps

### DIFF
--- a/packages/bridge_utils.rb
+++ b/packages/bridge_utils.rb
@@ -1,0 +1,40 @@
+# Adapted from Arch Linux bridge-utils PKGBUILD at:
+# https://github.com/archlinux/svntogit-packages/raw/packages/bridge-utils/trunk/PKGBUILD
+
+require 'package'
+
+class Bridge_utils < Package
+  description 'Utilities for configuring the Linux ethernet bridge'
+  homepage 'https://wiki.linuxfoundation.org/networking/bridge'
+  version '1.7.1'
+  license 'GPL'
+  compatibility 'all'
+  source_url 'https://mirrors.edge.kernel.org/pub/linux/utils/net/bridge-utils/bridge-utils-1.7.1.tar.xz'
+  source_sha256 'a61d8be4f1a1405c60c8ef38d544f0c18c05b33b9b07e5b4b31033536165e60e'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bridge_utils/1.7.1_armv7l/bridge_utils-1.7.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bridge_utils/1.7.1_armv7l/bridge_utils-1.7.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bridge_utils/1.7.1_i686/bridge_utils-1.7.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bridge_utils/1.7.1_x86_64/bridge_utils-1.7.1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '41f566515eee8a83ce368c61e912cb11fcb023da3dca2573ab45ca99c85a3b58',
+     armv7l: '41f566515eee8a83ce368c61e912cb11fcb023da3dca2573ab45ca99c85a3b58',
+       i686: '3a0367f328261023cd4c9b5d3e464822197b2fdce828e170ca654fb2e497cbe7',
+     x86_64: 'bf7b7e4461e09843909ce3585e4b11a3187f38b09471170f35fdc75e4dc72929'
+  })
+
+  def self.build
+    system 'autoreconf -fvi'
+    system "./configure \
+      #{CREW_OPTIONS} \
+      --sbindir=#{CREW_PREFIX}/bin \
+      --sysconfdir=#{CREW_PREFIX}/etc"
+    system 'make'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end

--- a/packages/bst.rb
+++ b/packages/bst.rb
@@ -1,0 +1,36 @@
+require 'package'
+
+class Bst < Package
+  description 'bst (pronounced "bestie") is a one-stop shop for running programs in isolated Linux environments.'
+  homepage 'https://github.com/aristanetworks/bst'
+  version '1.0.0-rc1'
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://github.com/aristanetworks/bst.git'
+  git_hashtag "v#{version}"
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bst/1.0.0-rc1_armv7l/bst-1.0.0-rc1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bst/1.0.0-rc1_armv7l/bst-1.0.0-rc1-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bst/1.0.0-rc1_x86_64/bst-1.0.0-rc1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '867f159bc4b7a6951bbc2cac8358bf313a4cccd0f62c7f56cbf2f96b69764964',
+     armv7l: '867f159bc4b7a6951bbc2cac8358bf313a4cccd0f62c7f56cbf2f96b69764964',
+     x86_64: 'df1255b0bc150e8a323396cdba09acfb16137495b2d1aa07860577ae2c7df842'
+  })
+
+  depends_on 'scdoc' => :build
+
+  def self.build
+    system "meson #{CREW_MESON_OPTIONS} \
+      -Dno-setcap-or-suid=true \
+      builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/containerd.rb
+++ b/packages/containerd.rb
@@ -27,7 +27,6 @@ class Containerd < Package
   depends_on 'runc'
   depends_on 'go' => ':build'
   depends_on 'btrfsprogs' => ':build'
-  # depends_on 'elogind' => ':build'
   depends_on 'libseccomp' => ':build'
   depends_on 'containers_common' => ':build'
   depends_on 'go_md2man' => ':build'

--- a/packages/containerd.rb
+++ b/packages/containerd.rb
@@ -10,6 +10,7 @@ class Containerd < Package
   license 'Apache'
   compatibility 'all'
   source_url 'https://github.com/containerd/containerd.git'
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/containerd/1.6.1_armv7l/containerd-1.6.1-chromeos-armv7l.tar.zst',
@@ -22,8 +23,7 @@ class Containerd < Package
      x86_64: '6924a4ebf2d3f50a2e9d7f18e3c23a1733d9ad1441a5115e0810a070bc5a16e6'
   })
 
-  git_hashtag "v#{version}"
-
+  depends_on 'docker_systemctl_replacement'
   depends_on 'runc'
   depends_on 'go' => ':build'
   depends_on 'btrfsprogs' => ':build'
@@ -33,23 +33,25 @@ class Containerd < Package
 
   def self.patch
     system "sed -i 's,/sbin,#{CREW_PREFIX}/bin,g' containerd.service"
+    system "sed -i 's,/run,/var/run/chrome,g' defaults/defaults_unix.go"
+    system "sed -i 's,/var,#{CREW_PREFIX}/var,g' defaults/defaults_unix.go"
+    system "sed -i 's,/etc,#{CREW_PREFIX}/etc,g' defaults/defaults_unix.go"
   end
 
   def self.build
-    system 'export '
     system "GOFLAGS='-trimpath -mod=readonly -modcacherw' make VERSION=v1.6.1 GO_BUILD_FLAGS='-trimpath -mod=readonly -modcacherw' GO_GCFLAGS= EXTRA_LDFLAGS='-buildid='"
     system "GOFLAGS='-trimpath -mod=readonly -modcacherw' make VERSION=v1.6.1 man"
   end
 
   def self.install
     FileUtils.mkdir_p %W[
-      #{CREW_DEST_PREFIX}/etc/elogind
+      #{CREW_DEST_PREFIX}/.config/systemd/user
       #{CREW_DEST_MAN_PREFIX}/man5
       #{CREW_DEST_MAN_PREFIX}/man8
     ]
     system "make PREFIX=#{CREW_PREFIX} DESTDIR=#{CREW_DEST_DIR} install"
-    system "install -Dm644 containerd.service #{CREW_DEST_PREFIX}/etc/elogind/containerd.service"
-    system "install -Dm644 man/*.8 -t #{CREW_DEST_MAN_PREFIX}/man8"
-    system "install -Dm644 man/*.5 -t #{CREW_DEST_MAN_PREFIX}/man5"
+    FileUtils.install 'containerd.service', "#{CREW_DEST_PREFIX}/.config/systemd/user/containerd.service", mode: 0o644
+    FileUtils.install Dir['man/*.5'], "#{CREW_DEST_MAN_PREFIX}/man5", mode: 0o644
+    FileUtils.install Dir['man/*.8'], "#{CREW_DEST_MAN_PREFIX}/man8", mode: 0o644
   end
 end

--- a/packages/containerd.rb
+++ b/packages/containerd.rb
@@ -18,9 +18,9 @@ class Containerd < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/containerd/1.6.1_x86_64/containerd-1.6.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '7b6e3f286221f1fea542f6ab6d3e8d0a53f64c5209a350825bb9c19c5209bb0e',
-     armv7l: '7b6e3f286221f1fea542f6ab6d3e8d0a53f64c5209a350825bb9c19c5209bb0e',
-     x86_64: '3806d0395d8c649334eaf10da8d594a29a38cc89d3afdbf1ad7bc64cfac6ae9f'
+    aarch64: '3dba84f318f5cf7afc5ae8e2180a1f0cc932c2f5be9421ae02b284068141fe49',
+     armv7l: '3dba84f318f5cf7afc5ae8e2180a1f0cc932c2f5be9421ae02b284068141fe49',
+     x86_64: '9c54047cf84e44409c7d15d301a3fd260863b9e6ac3295303eb0ece54e010c8f'
   })
 
   depends_on 'docker_systemctl_replacement'
@@ -43,374 +43,33 @@ class Containerd < Package
   end
 
   def self.build
-    system "GOFLAGS='-trimpath -mod=readonly -modcacherw' make VERSION=v1.6.1 GO_BUILD_FLAGS='-trimpath -mod=readonly -modcacherw' GO_GCFLAGS= EXTRA_LDFLAGS='-buildid='"
-    system "GOFLAGS='-trimpath -mod=readonly -modcacherw' make VERSION=v1.6.1 man"
-    @config_toml = <<~'CONFIG_TOML_EOF'
-          root = "/var/lib/containerd"
-          state = "/run/containerd"
-          oom_score = 0
-          imports = ["/etc/containerd/runtime_*.toml", "./debug.toml"]
+    system "GOFLAGS='-trimpath -mod=readonly -modcacherw' make VERSION=v#{version} GO_BUILD_FLAGS='-trimpath -mod=readonly -modcacherw' GO_GCFLAGS= EXTRA_LDFLAGS='-buildid='"
+    system "GOFLAGS='-trimpath -mod=readonly -modcacherw' make VERSION=v#{version} man"
+    @config_toml = <<~CONFIG_TOML_EOF
+      version = 2
+      root = "#{CREW_PREFIX}/.local/share/containerd"
+      state = "/var/run/chrome/containerd"
 
-          [grpc]
-            address = "/run/containerd/containerd.sock"
-            uid = 0
-            gid = 0
+      [grpc]
+        address = "/var/run/chrome/containerd/containerd.sock"
 
-          [debug]
-            address = "/run/containerd/debug.sock"
-            uid = 0
-            gid = 0
-            level = "info"
-
-          [metrics]
-            address = ""
-            grpc_histogram = false
-
-          [cgroup]
-            path = ""
-
-          [plugins]
-            [plugins.cgroups]
-              no_prometheus = false
-            [plugins.diff]
-              default = ["walking"]
-            [plugins.linux]
-              shim = "containerd-shim"
-              runtime = "runc"
-              runtime_root = ""
-              no_shim = false
-              shim_debug = false
-            [plugins.scheduler]
-              pause_threshold = 0.02
-              deletion_threshold = 0
-              mutation_threshold = 100
-              schedule_delay = 0
-              startup_delay = "100ms"
-            [plugins."io.containerd.runtime-shim.v2.shim"]
-              platforms = ["linux/amd64"]
-              sched_core = true
-            [plugins."io.containerd.service.v1.tasks-service"]
-              rdt_config_file = "/etc/rdt-config.yaml"
-          # Use config version 2 to enable new configuration fields.
-          # Config file is parsed as version 1 by default.
-          # Version 2 uses long plugin names, i.e. "io.containerd.grpc.v1.cri" vs "cri".
-          version = 2
-      compatibility 'all'
-
-          # The 'plugins."io.containerd.grpc.v1.cri"' table contains all of the server options.
-          [plugins."io.containerd.grpc.v1.cri"]
-
-            # disable_tcp_service disables serving CRI on the TCP server.
-            # Note that a TCP server is enabled for containerd if TCPAddress is set in section [grpc].
-            disable_tcp_service = true
-
-            # stream_server_address is the ip address streaming server is listening on.
-            stream_server_address = "127.0.0.1"
-
-            # stream_server_port is the port streaming server is listening on.
-            stream_server_port = "0"
-
-            # stream_idle_timeout is the maximum time a streaming connection can be
-            # idle before the connection is automatically closed.
-            # The string is in the golang duration format, see:
-            #   https://golang.org/pkg/time/#ParseDuration
-            stream_idle_timeout = "4h"
-
-            # enable_selinux indicates to enable the selinux support.
-            enable_selinux = false
-
-            # selinux_category_range allows the upper bound on the category range to be set.
-            # if not specified or set to 0, defaults to 1024 from the selinux package.
-            selinux_category_range = 1024
-
-            # sandbox_image is the image used by sandbox container.
-            sandbox_image = "k8s.gcr.io/pause:3.6"
-
-            # stats_collect_period is the period (in seconds) of snapshots stats collection.
-            stats_collect_period = 10
-
-            # enable_tls_streaming enables the TLS streaming support.
-            # It generates a self-sign certificate unless the following x509_key_pair_streaming are both set.
-            enable_tls_streaming = false
-
-            # tolerate_missing_hugetlb_controller if set to false will error out on create/update
-            # container requests with huge page limits if the cgroup controller for hugepages is not present.
-            # This helps with supporting Kubernetes <=1.18 out of the box. (default is `true`)
-            tolerate_missing_hugetlb_controller = true
-
-            # ignore_image_defined_volumes ignores volumes defined by the image. Useful for better resource
-          	# isolation, security and early detection of issues in the mount configuration when using
-          	# ReadOnlyRootFilesystem since containers won't silently mount a temporary volume.
-            ignore_image_defined_volumes = false
-
-            # netns_mounts_under_state_dir places all mounts for network namespaces under StateDir/netns
-            # instead of being placed under the hardcoded directory /var/run/netns. Changing this setting
-            # requires that all containers are deleted.
-            netns_mounts_under_state_dir = false
-
-            # 'plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming' contains a x509 valid key pair to stream with tls.
-            [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
-              # tls_cert_file is the filepath to the certificate paired with the "tls_key_file"
-              tls_cert_file = ""
-
-              # tls_key_file is the filepath to the private key paired with the "tls_cert_file"
-              tls_key_file = ""
-
-            # max_container_log_line_size is the maximum log line size in bytes for a container.
-            # Log line longer than the limit will be split into multiple lines. -1 means no
-            # limit.
-            max_container_log_line_size = 16384
-
-            # disable_cgroup indicates to disable the cgroup support.
-            # This is useful when the daemon does not have permission to access cgroup.
-            disable_cgroup = false
-
-            # disable_apparmor indicates to disable the apparmor support.
-            # This is useful when the daemon does not have permission to access apparmor.
-            disable_apparmor = false
-
-            # restrict_oom_score_adj indicates to limit the lower bound of OOMScoreAdj to
-            # the containerd's current OOMScoreAdj.
-            # This is useful when the containerd does not have permission to decrease OOMScoreAdj.
-            restrict_oom_score_adj = false
-
-            # max_concurrent_downloads restricts the number of concurrent downloads for each image.
-            max_concurrent_downloads = 3
-
-            # disable_proc_mount disables Kubernetes ProcMount support. This MUST be set to `true`
-            # when using containerd with Kubernetes <=1.11.
-            disable_proc_mount = false
-
-            # unset_seccomp_profile is the seccomp profile containerd/cri will use if the seccomp
-            # profile requested over CRI is unset (or nil) for a pod/container (otherwise if this field is not set the
-            # default unset profile will map to `unconfined`)
-              # Note: The default unset seccomp profile should not be confused with the seccomp profile
-              # used in CRI when the runtime default seccomp profile is requested. In the later case, the
-              # default is set by the following code (https://github.com/containerd/containerd/blob/main/contrib/seccomp/seccomp_default.go).
-              # To summarize, there are two different seccomp defaults, the unset default used when the CRI request is
-              # set to nil or `unconfined`, and the default used when the runtime default seccomp profile is requested.
-            unset_seccomp_profile = ""
-
-            # enable_unprivileged_ports configures net.ipv4.ip_unprivileged_port_start=0
-            # for all containers which are not using host network
-            # and if it is not overwritten by PodSandboxConfig
-            # Note that currently default is set to disabled but target change it in future, see:
-            #   [k8s discussion](https://github.com/kubernetes/kubernetes/issues/102612)
-            enable_unprivileged_ports = false
-
-            # enable_unprivileged_icmp configures net.ipv4.ping_group_range="0 2147483647"
-            # for all containers which are not using host network, are not running in user namespace
-            # and if it is not overwritten by PodSandboxConfig
-            # Note that currently default is set to disabled but target change it in future together with enable_unprivileged_ports
-            enable_unprivileged_icmp = false
-
-            # 'plugins."io.containerd.grpc.v1.cri".containerd' contains config related to containerd
-            [plugins."io.containerd.grpc.v1.cri".containerd]
-
-              # snapshotter is the snapshotter used by containerd.
-              snapshotter = "overlayfs"
-
-              # no_pivot disables pivot-root (linux only), required when running a container in a RamDisk with runc.
-              # This only works for runtime type "io.containerd.runtime.v1.linux".
-              no_pivot = false
-
-              # disable_snapshot_annotations disables to pass additional annotations (image
-              # related information) to snapshotters. These annotations are required by
-              # stargz snapshotter (https://github.com/containerd/stargz-snapshotter)
-              # changed to default true with https://github.com/containerd/containerd/pull/4665 and subsequent service refreshes.
-              disable_snapshot_annotations = true
-
-              # discard_unpacked_layers allows GC to remove layers from the content store after
-              # successfully unpacking these layers to the snapshotter.
-              discard_unpacked_layers = false
-
-              # default_runtime_name is the default runtime name to use.
-              default_runtime_name = "runc"
-
-              # ignore_rdt_not_enabled_errors disables RDT related errors when RDT
-              # support has not been enabled. Intel RDT is a technology for cache and
-              # memory bandwidth management. By default, trying to set the RDT class of
-              # a container via annotations produces an error if RDT hasn't been enabled.
-              # This config option practically enables a "soft" mode for RDT where these
-              # errors are ignored and the container gets no RDT class.
-              ignore_rdt_not_enabled_errors = false
-
-              # 'plugins."io.containerd.grpc.v1.cri".containerd.default_runtime' is the runtime to use in containerd.
-              # DEPRECATED: use `default_runtime_name` and `plugins."io.containerd.grpc.v1.cri".containerd.runtimes` instead.
-              [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
-
-              # 'plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime' is a runtime to run untrusted workloads on it.
-              # DEPRECATED: use `untrusted` runtime in `plugins."io.containerd.grpc.v1.cri".containerd.runtimes` instead.
-              [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
-
-              # 'plugins."io.containerd.grpc.v1.cri".containerd.runtimes' is a map from CRI RuntimeHandler strings, which specify types
-              # of runtime configurations, to the matching configurations.
-              # In this example, 'runc' is the RuntimeHandler string to match.
-              [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-                # runtime_type is the runtime type to use in containerd.
-                # The default value is "io.containerd.runc.v2" since containerd 1.4.
-                # The default value was "io.containerd.runc.v1" in containerd 1.3, "io.containerd.runtime.v1.linux" in prior releases.
-                runtime_type = "io.containerd.runc.v2"
-
-                # pod_annotations is a list of pod annotations passed to both pod
-                # sandbox as well as container OCI annotations. Pod_annotations also
-                # supports golang path match pattern - https://golang.org/pkg/path/#Match.
-                # e.g. ["runc.com.*"], ["*.runc.com"], ["runc.com/*"].
-                #
-                # For the naming convention of annotation keys, please reference:
-                # * Kubernetes: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
-                # * OCI: https://github.com/opencontainers/image-spec/blob/master/annotations.md
-                pod_annotations = []
-
-                # container_annotations is a list of container annotations passed through to the OCI config of the containers.
-                # Container annotations in CRI are usually generated by other Kubernetes node components (i.e., not users).
-                # Currently, only device plugins populate the annotations.
-                container_annotations = []
-
-                # privileged_without_host_devices allows overloading the default behaviour of passing host
-                # devices through to privileged containers. This is useful when using a runtime where it does
-                # not make sense to pass host devices to the container when privileged. Defaults to false -
-                # i.e pass host devices through to privileged containers.
-                privileged_without_host_devices = false
-
-                # base_runtime_spec is a file path to a JSON file with the OCI spec that will be used as the base spec that all
-                # container's are created from.
-                # Use containerd's `ctr oci spec > /etc/containerd/cri-base.json` to output initial spec file.
-                # Spec files are loaded at launch, so containerd daemon must be restarted on any changes to refresh default specs.
-                # Still running containers and restarted containers will still be using the original spec from which that container was created.
-                base_runtime_spec = ""
-
-                # conf_dir is the directory in which the admin places a CNI conf.
-                # this allows a different CNI conf for the network stack when a different runtime is being used.
-                cni_conf_dir = "/etc/cni/net.d"
-
-                # cni_max_conf_num specifies the maximum number of CNI plugin config files to
-                # load from the CNI config directory. By default, only 1 CNI plugin config
-                # file will be loaded. If you want to load multiple CNI plugin config files
-                # set max_conf_num to the number desired. Setting cni_max_config_num to 0 is
-                # interpreted as no limit is desired and will result in all CNI plugin
-                # config files being loaded from the CNI config directory.
-                cni_max_conf_num = 1
-
-                # 'plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options' is options specific to
-                # "io.containerd.runc.v1" and "io.containerd.runc.v2". Its corresponding options type is:
-                #   https://github.com/containerd/containerd/blob/v1.3.2/runtime/v2/runc/options/oci.pb.go#L26 .
-                [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
-                  # NoPivotRoot disables pivot root when creating a container.
-                  NoPivotRoot = false
-
-                  # NoNewKeyring disables new keyring for the container.
-                  NoNewKeyring = false
-
-                  # ShimCgroup places the shim in a cgroup.
-                  ShimCgroup = ""
-
-                  # IoUid sets the I/O's pipes uid.
-                  IoUid = 0
-
-                  # IoGid sets the I/O's pipes gid.
-                  IoGid = 0
-
-                  # BinaryName is the binary name of the runc binary.
-                  BinaryName = ""
-
-                  # Root is the runc root directory.
-                  Root = ""
-
-                  # CriuPath is the criu binary path.
-                  CriuPath = ""
-
-                  # SystemdCgroup enables systemd cgroups.
-                  SystemdCgroup = false
-
-                  # CriuImagePath is the criu image path
-                  CriuImagePath = ""
-
-                  # CriuWorkPath is the criu work path.
-                  CriuWorkPath = ""
-
-            # 'plugins."io.containerd.grpc.v1.cri".cni' contains config related to cni
-            [plugins."io.containerd.grpc.v1.cri".cni]
-              # bin_dir is the directory in which the binaries for the plugin is kept.
-              bin_dir = "/opt/cni/bin"
-
-              # conf_dir is the directory in which the admin places a CNI conf.
-              conf_dir = "/etc/cni/net.d"
-
-              # max_conf_num specifies the maximum number of CNI plugin config files to
-              # load from the CNI config directory. By default, only 1 CNI plugin config
-              # file will be loaded. If you want to load multiple CNI plugin config files
-              # set max_conf_num to the number desired. Setting max_config_num to 0 is
-              # interpreted as no limit is desired and will result in all CNI plugin
-              # config files being loaded from the CNI config directory.
-              max_conf_num = 1
-
-              # conf_template is the file path of golang template used to generate
-              # cni config.
-              # If this is set, containerd will generate a cni config file from the
-              # template. Otherwise, containerd will wait for the system admin or cni
-              # daemon to drop the config file into the conf_dir.
-              # This is a temporary backward-compatible solution for kubenet users
-              # who don't have a cni daemonset in production yet.
-              # This will be deprecated when kubenet is deprecated.
-              # See the "CNI Config Template" section for more details.
-              conf_template = ""
-              # ip_pref specifies the strategy to use when selecting the main IP address for a pod.
-              # options include:
-              # * ipv4, "" - (default) select the first ipv4 address
-              # * ipv6 - select the first ipv6 address
-              # * cni - use the order returned by the CNI plugins, returning the first IP address from the results
-              ip_pref = "ipv4"
-
-            # 'plugins."io.containerd.grpc.v1.cri".image_decryption' contains config related
-            # to handling decryption of encrypted container images.
-            [plugins."io.containerd.grpc.v1.cri".image_decryption]
-              # key_model defines the name of the key model used for how the cri obtains
-              # keys used for decryption of encrypted container images.
-              # The [decryption document](https://github.com/containerd/containerd/blob/main/docs/cri/decryption.md)
-              # contains additional information about the key models available.
-              #
-              # Set of available string options: {"", "node"}
-              # Omission of this field defaults to the empty string "", which indicates no key model,
-              # disabling image decryption.
-              #
-              # In order to use the decryption feature, additional configurations must be made.
-              # The [decryption document](https://github.com/containerd/containerd/blob/main/docs/cri/decryption.md)
-              # provides information of how to set up stream processors and the containerd imgcrypt decoder
-              # with the appropriate key models.
-              #
-              # Additional information:
-              # * Stream processors: https://github.com/containerd/containerd/blob/main/docs/stream_processors.md
-              # * Containerd imgcrypt: https://github.com/containerd/imgcrypt
-              key_model = "node"
-
-            # 'plugins."io.containerd.grpc.v1.cri".registry' contains config related to
-            # the registry
-            [plugins."io.containerd.grpc.v1.cri".registry]
-              # config_path specifies a directory to look for the registry hosts configuration.
-              #
-              # The cri plugin will look for and use config_path/host-namespace/hosts.toml
-              #   configs if present OR load certificate files as laid out in the Docker/Moby
-              #   specific layout https://docs.docker.com/engine/security/certificates/
-              #
-              # If config_path is not provided defaults are used.
-              #
-              # *** registry.configs and registry.mirrors that were a part of containerd 1.4
-              # are now DEPRECATED and will only be used if the config_path is not specified.
-              config_path = ""
+      [proxy_plugins]
+        [proxy_plugins."fuse-overlayfs"]
+          type = "snapshot"
+          address = "/var/run/chrome/containerd/fuse-overlayfs.sock"
     CONFIG_TOML_EOF
     File.write('config.toml', @config_toml)
-    system "sed -i 's,/var,#{CREW_PREFIX}/var,g' config.toml"
-    system "sed -i 's,/run,/var/run/chrome,g' config.toml"
-    system "sed -i 's,/etc,#{CREW_PREFIX}/etc,g' config.toml"
-    system "sed -i 's,/opt,#{CREW_PREFIX}/opt,g' config.toml"
-    case ARCH
-    when 'armv7l', 'aarch64'
-      @docker_platform = 'linux/arm/v7'
-    when 'x86_64'
-      @docker_platform = 'linux/amd64'
-    end
-    system "sed -i 's,linux/amd64,#{@docker_platform},g' config.toml"
+    # system "sed -i 's,/var,#{CREW_PREFIX}/var,g' config.toml"
+    # system "sed -i 's,/run,/var/run/chrome,g' config.toml"
+    # system "sed -i 's,/etc,#{CREW_PREFIX}/etc,g' config.toml"
+    # system "sed -i 's,/opt,#{CREW_PREFIX}/opt,g' config.toml"
+    # case ARCH
+    # when 'armv7l', 'aarch64'
+    # @docker_platform = 'linux/arm/v7'
+    # when 'x86_64'
+    # @docker_platform = 'linux/amd64'
+    # end
+    # system "sed -i 's,linux/amd64,#{@docker_platform},g' config.toml"
   end
 
   def self.install

--- a/packages/containerd.rb
+++ b/packages/containerd.rb
@@ -1,0 +1,56 @@
+# Adapted from Arch Linux containerd PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/containerd/trunk/PKGBUILD
+
+require 'package'
+
+class Containerd < Package
+  description 'An open and reliable container runtime'
+  homepage 'https://containerd.io/'
+  version '1.6.1'
+  license 'Apache'
+  compatibility 'all'
+  source_url 'https://github.com/containerd/containerd.git'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/containerd/1.6.1_armv7l/containerd-1.6.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/containerd/1.6.1_armv7l/containerd-1.6.1-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/containerd/1.6.1_x86_64/containerd-1.6.1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '3560445ba0e85f47cede9836cdcbfd34879251f60abb9ddb71cf8ad8e0cf403a',
+     armv7l: '3560445ba0e85f47cede9836cdcbfd34879251f60abb9ddb71cf8ad8e0cf403a',
+     x86_64: '6924a4ebf2d3f50a2e9d7f18e3c23a1733d9ad1441a5115e0810a070bc5a16e6'
+  })
+
+  git_hashtag "v#{version}"
+
+  depends_on 'runc'
+  depends_on 'go' => ':build'
+  depends_on 'btrfsprogs' => ':build'
+  # depends_on 'elogind' => ':build'
+  depends_on 'libseccomp' => ':build'
+  depends_on 'containers_common' => ':build'
+  depends_on 'go_md2man' => ':build'
+
+  def self.patch
+    system "sed -i 's,/sbin,#{CREW_PREFIX}/bin,g' containerd.service"
+  end
+
+  def self.build
+    system 'export '
+    system "GOFLAGS='-trimpath -mod=readonly -modcacherw' make VERSION=v1.6.1 GO_BUILD_FLAGS='-trimpath -mod=readonly -modcacherw' GO_GCFLAGS= EXTRA_LDFLAGS='-buildid='"
+    system "GOFLAGS='-trimpath -mod=readonly -modcacherw' make VERSION=v1.6.1 man"
+  end
+
+  def self.install
+    FileUtils.mkdir_p %W[
+      #{CREW_DEST_PREFIX}/etc/elogind
+      #{CREW_DEST_MAN_PREFIX}/man5
+      #{CREW_DEST_MAN_PREFIX}/man8
+    ]
+    system "make PREFIX=#{CREW_PREFIX} DESTDIR=#{CREW_DEST_DIR} install"
+    system "install -Dm644 containerd.service #{CREW_DEST_PREFIX}/etc/elogind/containerd.service"
+    system "install -Dm644 man/*.8 -t #{CREW_DEST_MAN_PREFIX}/man8"
+    system "install -Dm644 man/*.5 -t #{CREW_DEST_MAN_PREFIX}/man5"
+  end
+end

--- a/packages/containerd.rb
+++ b/packages/containerd.rb
@@ -7,8 +7,8 @@ class Containerd < Package
   description 'An open and reliable container runtime'
   homepage 'https://containerd.io/'
   version '1.6.1'
-  license 'Apache'
   compatibility 'all'
+  license 'Apache'
   source_url 'https://github.com/containerd/containerd.git'
   git_hashtag "v#{version}"
 
@@ -18,9 +18,9 @@ class Containerd < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/containerd/1.6.1_x86_64/containerd-1.6.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'd19580d750ecb5826eb5cacc1c623ecd2671d9d4cb1f75316c36e3c2a9336244',
-     armv7l: 'd19580d750ecb5826eb5cacc1c623ecd2671d9d4cb1f75316c36e3c2a9336244',
-     x86_64: '2afe2483029684e22b3090529a0b345c52b0d98605df7811656529b9fffcf81d'
+    aarch64: '7b6e3f286221f1fea542f6ab6d3e8d0a53f64c5209a350825bb9c19c5209bb0e',
+     armv7l: '7b6e3f286221f1fea542f6ab6d3e8d0a53f64c5209a350825bb9c19c5209bb0e',
+     x86_64: '3806d0395d8c649334eaf10da8d594a29a38cc89d3afdbf1ad7bc64cfac6ae9f'
   })
 
   depends_on 'docker_systemctl_replacement'
@@ -46,357 +46,358 @@ class Containerd < Package
     system "GOFLAGS='-trimpath -mod=readonly -modcacherw' make VERSION=v1.6.1 GO_BUILD_FLAGS='-trimpath -mod=readonly -modcacherw' GO_GCFLAGS= EXTRA_LDFLAGS='-buildid='"
     system "GOFLAGS='-trimpath -mod=readonly -modcacherw' make VERSION=v1.6.1 man"
     @config_toml = <<~'CONFIG_TOML_EOF'
-      root = "/var/lib/containerd"
-      state = "/run/containerd"
-      oom_score = 0
-      imports = ["/etc/containerd/runtime_*.toml", "./debug.toml"]
+          root = "/var/lib/containerd"
+          state = "/run/containerd"
+          oom_score = 0
+          imports = ["/etc/containerd/runtime_*.toml", "./debug.toml"]
 
-      [grpc]
-        address = "/run/containerd/containerd.sock"
-        uid = 0
-        gid = 0
+          [grpc]
+            address = "/run/containerd/containerd.sock"
+            uid = 0
+            gid = 0
 
-      [debug]
-        address = "/run/containerd/debug.sock"
-        uid = 0
-        gid = 0
-        level = "info"
+          [debug]
+            address = "/run/containerd/debug.sock"
+            uid = 0
+            gid = 0
+            level = "info"
 
-      [metrics]
-        address = ""
-        grpc_histogram = false
+          [metrics]
+            address = ""
+            grpc_histogram = false
 
-      [cgroup]
-        path = ""
+          [cgroup]
+            path = ""
 
-      [plugins]
-        [plugins.cgroups]
-          no_prometheus = false
-        [plugins.diff]
-          default = ["walking"]
-        [plugins.linux]
-          shim = "containerd-shim"
-          runtime = "runc"
-          runtime_root = ""
-          no_shim = false
-          shim_debug = false
-        [plugins.scheduler]
-          pause_threshold = 0.02
-          deletion_threshold = 0
-          mutation_threshold = 100
-          schedule_delay = 0
-          startup_delay = "100ms"
-        [plugins."io.containerd.runtime-shim.v2.shim"]
-          platforms = ["linux/amd64"]
-          sched_core = true
-        [plugins."io.containerd.service.v1.tasks-service"]
-          rdt_config_file = "/etc/rdt-config.yaml"
-      # Use config version 2 to enable new configuration fields.
-      # Config file is parsed as version 1 by default.
-      # Version 2 uses long plugin names, i.e. "io.containerd.grpc.v1.cri" vs "cri".
-      version = 2
+          [plugins]
+            [plugins.cgroups]
+              no_prometheus = false
+            [plugins.diff]
+              default = ["walking"]
+            [plugins.linux]
+              shim = "containerd-shim"
+              runtime = "runc"
+              runtime_root = ""
+              no_shim = false
+              shim_debug = false
+            [plugins.scheduler]
+              pause_threshold = 0.02
+              deletion_threshold = 0
+              mutation_threshold = 100
+              schedule_delay = 0
+              startup_delay = "100ms"
+            [plugins."io.containerd.runtime-shim.v2.shim"]
+              platforms = ["linux/amd64"]
+              sched_core = true
+            [plugins."io.containerd.service.v1.tasks-service"]
+              rdt_config_file = "/etc/rdt-config.yaml"
+          # Use config version 2 to enable new configuration fields.
+          # Config file is parsed as version 1 by default.
+          # Version 2 uses long plugin names, i.e. "io.containerd.grpc.v1.cri" vs "cri".
+          version = 2
+      compatibility 'all'
 
-      # The 'plugins."io.containerd.grpc.v1.cri"' table contains all of the server options.
-      [plugins."io.containerd.grpc.v1.cri"]
+          # The 'plugins."io.containerd.grpc.v1.cri"' table contains all of the server options.
+          [plugins."io.containerd.grpc.v1.cri"]
 
-        # disable_tcp_service disables serving CRI on the TCP server.
-        # Note that a TCP server is enabled for containerd if TCPAddress is set in section [grpc].
-        disable_tcp_service = true
+            # disable_tcp_service disables serving CRI on the TCP server.
+            # Note that a TCP server is enabled for containerd if TCPAddress is set in section [grpc].
+            disable_tcp_service = true
 
-        # stream_server_address is the ip address streaming server is listening on.
-        stream_server_address = "127.0.0.1"
+            # stream_server_address is the ip address streaming server is listening on.
+            stream_server_address = "127.0.0.1"
 
-        # stream_server_port is the port streaming server is listening on.
-        stream_server_port = "0"
+            # stream_server_port is the port streaming server is listening on.
+            stream_server_port = "0"
 
-        # stream_idle_timeout is the maximum time a streaming connection can be
-        # idle before the connection is automatically closed.
-        # The string is in the golang duration format, see:
-        #   https://golang.org/pkg/time/#ParseDuration
-        stream_idle_timeout = "4h"
+            # stream_idle_timeout is the maximum time a streaming connection can be
+            # idle before the connection is automatically closed.
+            # The string is in the golang duration format, see:
+            #   https://golang.org/pkg/time/#ParseDuration
+            stream_idle_timeout = "4h"
 
-        # enable_selinux indicates to enable the selinux support.
-        enable_selinux = false
+            # enable_selinux indicates to enable the selinux support.
+            enable_selinux = false
 
-        # selinux_category_range allows the upper bound on the category range to be set.
-        # if not specified or set to 0, defaults to 1024 from the selinux package.
-        selinux_category_range = 1024
+            # selinux_category_range allows the upper bound on the category range to be set.
+            # if not specified or set to 0, defaults to 1024 from the selinux package.
+            selinux_category_range = 1024
 
-        # sandbox_image is the image used by sandbox container.
-        sandbox_image = "k8s.gcr.io/pause:3.6"
+            # sandbox_image is the image used by sandbox container.
+            sandbox_image = "k8s.gcr.io/pause:3.6"
 
-        # stats_collect_period is the period (in seconds) of snapshots stats collection.
-        stats_collect_period = 10
+            # stats_collect_period is the period (in seconds) of snapshots stats collection.
+            stats_collect_period = 10
 
-        # enable_tls_streaming enables the TLS streaming support.
-        # It generates a self-sign certificate unless the following x509_key_pair_streaming are both set.
-        enable_tls_streaming = false
+            # enable_tls_streaming enables the TLS streaming support.
+            # It generates a self-sign certificate unless the following x509_key_pair_streaming are both set.
+            enable_tls_streaming = false
 
-        # tolerate_missing_hugetlb_controller if set to false will error out on create/update
-        # container requests with huge page limits if the cgroup controller for hugepages is not present.
-        # This helps with supporting Kubernetes <=1.18 out of the box. (default is `true`)
-        tolerate_missing_hugetlb_controller = true
+            # tolerate_missing_hugetlb_controller if set to false will error out on create/update
+            # container requests with huge page limits if the cgroup controller for hugepages is not present.
+            # This helps with supporting Kubernetes <=1.18 out of the box. (default is `true`)
+            tolerate_missing_hugetlb_controller = true
 
-        # ignore_image_defined_volumes ignores volumes defined by the image. Useful for better resource
-      	# isolation, security and early detection of issues in the mount configuration when using
-      	# ReadOnlyRootFilesystem since containers won't silently mount a temporary volume.
-        ignore_image_defined_volumes = false
+            # ignore_image_defined_volumes ignores volumes defined by the image. Useful for better resource
+          	# isolation, security and early detection of issues in the mount configuration when using
+          	# ReadOnlyRootFilesystem since containers won't silently mount a temporary volume.
+            ignore_image_defined_volumes = false
 
-        # netns_mounts_under_state_dir places all mounts for network namespaces under StateDir/netns
-        # instead of being placed under the hardcoded directory /var/run/netns. Changing this setting
-        # requires that all containers are deleted.
-        netns_mounts_under_state_dir = false
+            # netns_mounts_under_state_dir places all mounts for network namespaces under StateDir/netns
+            # instead of being placed under the hardcoded directory /var/run/netns. Changing this setting
+            # requires that all containers are deleted.
+            netns_mounts_under_state_dir = false
 
-        # 'plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming' contains a x509 valid key pair to stream with tls.
-        [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
-          # tls_cert_file is the filepath to the certificate paired with the "tls_key_file"
-          tls_cert_file = ""
+            # 'plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming' contains a x509 valid key pair to stream with tls.
+            [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
+              # tls_cert_file is the filepath to the certificate paired with the "tls_key_file"
+              tls_cert_file = ""
 
-          # tls_key_file is the filepath to the private key paired with the "tls_cert_file"
-          tls_key_file = ""
+              # tls_key_file is the filepath to the private key paired with the "tls_cert_file"
+              tls_key_file = ""
 
-        # max_container_log_line_size is the maximum log line size in bytes for a container.
-        # Log line longer than the limit will be split into multiple lines. -1 means no
-        # limit.
-        max_container_log_line_size = 16384
+            # max_container_log_line_size is the maximum log line size in bytes for a container.
+            # Log line longer than the limit will be split into multiple lines. -1 means no
+            # limit.
+            max_container_log_line_size = 16384
 
-        # disable_cgroup indicates to disable the cgroup support.
-        # This is useful when the daemon does not have permission to access cgroup.
-        disable_cgroup = false
+            # disable_cgroup indicates to disable the cgroup support.
+            # This is useful when the daemon does not have permission to access cgroup.
+            disable_cgroup = false
 
-        # disable_apparmor indicates to disable the apparmor support.
-        # This is useful when the daemon does not have permission to access apparmor.
-        disable_apparmor = false
+            # disable_apparmor indicates to disable the apparmor support.
+            # This is useful when the daemon does not have permission to access apparmor.
+            disable_apparmor = false
 
-        # restrict_oom_score_adj indicates to limit the lower bound of OOMScoreAdj to
-        # the containerd's current OOMScoreAdj.
-        # This is useful when the containerd does not have permission to decrease OOMScoreAdj.
-        restrict_oom_score_adj = false
+            # restrict_oom_score_adj indicates to limit the lower bound of OOMScoreAdj to
+            # the containerd's current OOMScoreAdj.
+            # This is useful when the containerd does not have permission to decrease OOMScoreAdj.
+            restrict_oom_score_adj = false
 
-        # max_concurrent_downloads restricts the number of concurrent downloads for each image.
-        max_concurrent_downloads = 3
+            # max_concurrent_downloads restricts the number of concurrent downloads for each image.
+            max_concurrent_downloads = 3
 
-        # disable_proc_mount disables Kubernetes ProcMount support. This MUST be set to `true`
-        # when using containerd with Kubernetes <=1.11.
-        disable_proc_mount = false
+            # disable_proc_mount disables Kubernetes ProcMount support. This MUST be set to `true`
+            # when using containerd with Kubernetes <=1.11.
+            disable_proc_mount = false
 
-        # unset_seccomp_profile is the seccomp profile containerd/cri will use if the seccomp
-        # profile requested over CRI is unset (or nil) for a pod/container (otherwise if this field is not set the
-        # default unset profile will map to `unconfined`)
-          # Note: The default unset seccomp profile should not be confused with the seccomp profile
-          # used in CRI when the runtime default seccomp profile is requested. In the later case, the
-          # default is set by the following code (https://github.com/containerd/containerd/blob/main/contrib/seccomp/seccomp_default.go).
-          # To summarize, there are two different seccomp defaults, the unset default used when the CRI request is
-          # set to nil or `unconfined`, and the default used when the runtime default seccomp profile is requested.
-        unset_seccomp_profile = ""
+            # unset_seccomp_profile is the seccomp profile containerd/cri will use if the seccomp
+            # profile requested over CRI is unset (or nil) for a pod/container (otherwise if this field is not set the
+            # default unset profile will map to `unconfined`)
+              # Note: The default unset seccomp profile should not be confused with the seccomp profile
+              # used in CRI when the runtime default seccomp profile is requested. In the later case, the
+              # default is set by the following code (https://github.com/containerd/containerd/blob/main/contrib/seccomp/seccomp_default.go).
+              # To summarize, there are two different seccomp defaults, the unset default used when the CRI request is
+              # set to nil or `unconfined`, and the default used when the runtime default seccomp profile is requested.
+            unset_seccomp_profile = ""
 
-        # enable_unprivileged_ports configures net.ipv4.ip_unprivileged_port_start=0
-        # for all containers which are not using host network
-        # and if it is not overwritten by PodSandboxConfig
-        # Note that currently default is set to disabled but target change it in future, see:
-        #   [k8s discussion](https://github.com/kubernetes/kubernetes/issues/102612)
-        enable_unprivileged_ports = false
+            # enable_unprivileged_ports configures net.ipv4.ip_unprivileged_port_start=0
+            # for all containers which are not using host network
+            # and if it is not overwritten by PodSandboxConfig
+            # Note that currently default is set to disabled but target change it in future, see:
+            #   [k8s discussion](https://github.com/kubernetes/kubernetes/issues/102612)
+            enable_unprivileged_ports = false
 
-        # enable_unprivileged_icmp configures net.ipv4.ping_group_range="0 2147483647"
-        # for all containers which are not using host network, are not running in user namespace
-        # and if it is not overwritten by PodSandboxConfig
-        # Note that currently default is set to disabled but target change it in future together with enable_unprivileged_ports
-        enable_unprivileged_icmp = false
+            # enable_unprivileged_icmp configures net.ipv4.ping_group_range="0 2147483647"
+            # for all containers which are not using host network, are not running in user namespace
+            # and if it is not overwritten by PodSandboxConfig
+            # Note that currently default is set to disabled but target change it in future together with enable_unprivileged_ports
+            enable_unprivileged_icmp = false
 
-        # 'plugins."io.containerd.grpc.v1.cri".containerd' contains config related to containerd
-        [plugins."io.containerd.grpc.v1.cri".containerd]
+            # 'plugins."io.containerd.grpc.v1.cri".containerd' contains config related to containerd
+            [plugins."io.containerd.grpc.v1.cri".containerd]
 
-          # snapshotter is the snapshotter used by containerd.
-          snapshotter = "overlayfs"
+              # snapshotter is the snapshotter used by containerd.
+              snapshotter = "overlayfs"
 
-          # no_pivot disables pivot-root (linux only), required when running a container in a RamDisk with runc.
-          # This only works for runtime type "io.containerd.runtime.v1.linux".
-          no_pivot = false
+              # no_pivot disables pivot-root (linux only), required when running a container in a RamDisk with runc.
+              # This only works for runtime type "io.containerd.runtime.v1.linux".
+              no_pivot = false
 
-          # disable_snapshot_annotations disables to pass additional annotations (image
-          # related information) to snapshotters. These annotations are required by
-          # stargz snapshotter (https://github.com/containerd/stargz-snapshotter)
-          # changed to default true with https://github.com/containerd/containerd/pull/4665 and subsequent service refreshes.
-          disable_snapshot_annotations = true
+              # disable_snapshot_annotations disables to pass additional annotations (image
+              # related information) to snapshotters. These annotations are required by
+              # stargz snapshotter (https://github.com/containerd/stargz-snapshotter)
+              # changed to default true with https://github.com/containerd/containerd/pull/4665 and subsequent service refreshes.
+              disable_snapshot_annotations = true
 
-          # discard_unpacked_layers allows GC to remove layers from the content store after
-          # successfully unpacking these layers to the snapshotter.
-          discard_unpacked_layers = false
+              # discard_unpacked_layers allows GC to remove layers from the content store after
+              # successfully unpacking these layers to the snapshotter.
+              discard_unpacked_layers = false
 
-          # default_runtime_name is the default runtime name to use.
-          default_runtime_name = "runc"
+              # default_runtime_name is the default runtime name to use.
+              default_runtime_name = "runc"
 
-          # ignore_rdt_not_enabled_errors disables RDT related errors when RDT
-          # support has not been enabled. Intel RDT is a technology for cache and
-          # memory bandwidth management. By default, trying to set the RDT class of
-          # a container via annotations produces an error if RDT hasn't been enabled.
-          # This config option practically enables a "soft" mode for RDT where these
-          # errors are ignored and the container gets no RDT class.
-          ignore_rdt_not_enabled_errors = false
+              # ignore_rdt_not_enabled_errors disables RDT related errors when RDT
+              # support has not been enabled. Intel RDT is a technology for cache and
+              # memory bandwidth management. By default, trying to set the RDT class of
+              # a container via annotations produces an error if RDT hasn't been enabled.
+              # This config option practically enables a "soft" mode for RDT where these
+              # errors are ignored and the container gets no RDT class.
+              ignore_rdt_not_enabled_errors = false
 
-          # 'plugins."io.containerd.grpc.v1.cri".containerd.default_runtime' is the runtime to use in containerd.
-          # DEPRECATED: use `default_runtime_name` and `plugins."io.containerd.grpc.v1.cri".containerd.runtimes` instead.
-          [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
+              # 'plugins."io.containerd.grpc.v1.cri".containerd.default_runtime' is the runtime to use in containerd.
+              # DEPRECATED: use `default_runtime_name` and `plugins."io.containerd.grpc.v1.cri".containerd.runtimes` instead.
+              [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
 
-          # 'plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime' is a runtime to run untrusted workloads on it.
-          # DEPRECATED: use `untrusted` runtime in `plugins."io.containerd.grpc.v1.cri".containerd.runtimes` instead.
-          [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
+              # 'plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime' is a runtime to run untrusted workloads on it.
+              # DEPRECATED: use `untrusted` runtime in `plugins."io.containerd.grpc.v1.cri".containerd.runtimes` instead.
+              [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
 
-          # 'plugins."io.containerd.grpc.v1.cri".containerd.runtimes' is a map from CRI RuntimeHandler strings, which specify types
-          # of runtime configurations, to the matching configurations.
-          # In this example, 'runc' is the RuntimeHandler string to match.
-          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-            # runtime_type is the runtime type to use in containerd.
-            # The default value is "io.containerd.runc.v2" since containerd 1.4.
-            # The default value was "io.containerd.runc.v1" in containerd 1.3, "io.containerd.runtime.v1.linux" in prior releases.
-            runtime_type = "io.containerd.runc.v2"
+              # 'plugins."io.containerd.grpc.v1.cri".containerd.runtimes' is a map from CRI RuntimeHandler strings, which specify types
+              # of runtime configurations, to the matching configurations.
+              # In this example, 'runc' is the RuntimeHandler string to match.
+              [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+                # runtime_type is the runtime type to use in containerd.
+                # The default value is "io.containerd.runc.v2" since containerd 1.4.
+                # The default value was "io.containerd.runc.v1" in containerd 1.3, "io.containerd.runtime.v1.linux" in prior releases.
+                runtime_type = "io.containerd.runc.v2"
 
-            # pod_annotations is a list of pod annotations passed to both pod
-            # sandbox as well as container OCI annotations. Pod_annotations also
-            # supports golang path match pattern - https://golang.org/pkg/path/#Match.
-            # e.g. ["runc.com.*"], ["*.runc.com"], ["runc.com/*"].
-            #
-            # For the naming convention of annotation keys, please reference:
-            # * Kubernetes: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
-            # * OCI: https://github.com/opencontainers/image-spec/blob/master/annotations.md
-            pod_annotations = []
+                # pod_annotations is a list of pod annotations passed to both pod
+                # sandbox as well as container OCI annotations. Pod_annotations also
+                # supports golang path match pattern - https://golang.org/pkg/path/#Match.
+                # e.g. ["runc.com.*"], ["*.runc.com"], ["runc.com/*"].
+                #
+                # For the naming convention of annotation keys, please reference:
+                # * Kubernetes: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
+                # * OCI: https://github.com/opencontainers/image-spec/blob/master/annotations.md
+                pod_annotations = []
 
-            # container_annotations is a list of container annotations passed through to the OCI config of the containers.
-            # Container annotations in CRI are usually generated by other Kubernetes node components (i.e., not users).
-            # Currently, only device plugins populate the annotations.
-            container_annotations = []
+                # container_annotations is a list of container annotations passed through to the OCI config of the containers.
+                # Container annotations in CRI are usually generated by other Kubernetes node components (i.e., not users).
+                # Currently, only device plugins populate the annotations.
+                container_annotations = []
 
-            # privileged_without_host_devices allows overloading the default behaviour of passing host
-            # devices through to privileged containers. This is useful when using a runtime where it does
-            # not make sense to pass host devices to the container when privileged. Defaults to false -
-            # i.e pass host devices through to privileged containers.
-            privileged_without_host_devices = false
+                # privileged_without_host_devices allows overloading the default behaviour of passing host
+                # devices through to privileged containers. This is useful when using a runtime where it does
+                # not make sense to pass host devices to the container when privileged. Defaults to false -
+                # i.e pass host devices through to privileged containers.
+                privileged_without_host_devices = false
 
-            # base_runtime_spec is a file path to a JSON file with the OCI spec that will be used as the base spec that all
-            # container's are created from.
-            # Use containerd's `ctr oci spec > /etc/containerd/cri-base.json` to output initial spec file.
-            # Spec files are loaded at launch, so containerd daemon must be restarted on any changes to refresh default specs.
-            # Still running containers and restarted containers will still be using the original spec from which that container was created.
-            base_runtime_spec = ""
+                # base_runtime_spec is a file path to a JSON file with the OCI spec that will be used as the base spec that all
+                # container's are created from.
+                # Use containerd's `ctr oci spec > /etc/containerd/cri-base.json` to output initial spec file.
+                # Spec files are loaded at launch, so containerd daemon must be restarted on any changes to refresh default specs.
+                # Still running containers and restarted containers will still be using the original spec from which that container was created.
+                base_runtime_spec = ""
 
-            # conf_dir is the directory in which the admin places a CNI conf.
-            # this allows a different CNI conf for the network stack when a different runtime is being used.
-            cni_conf_dir = "/etc/cni/net.d"
+                # conf_dir is the directory in which the admin places a CNI conf.
+                # this allows a different CNI conf for the network stack when a different runtime is being used.
+                cni_conf_dir = "/etc/cni/net.d"
 
-            # cni_max_conf_num specifies the maximum number of CNI plugin config files to
-            # load from the CNI config directory. By default, only 1 CNI plugin config
-            # file will be loaded. If you want to load multiple CNI plugin config files
-            # set max_conf_num to the number desired. Setting cni_max_config_num to 0 is
-            # interpreted as no limit is desired and will result in all CNI plugin
-            # config files being loaded from the CNI config directory.
-            cni_max_conf_num = 1
+                # cni_max_conf_num specifies the maximum number of CNI plugin config files to
+                # load from the CNI config directory. By default, only 1 CNI plugin config
+                # file will be loaded. If you want to load multiple CNI plugin config files
+                # set max_conf_num to the number desired. Setting cni_max_config_num to 0 is
+                # interpreted as no limit is desired and will result in all CNI plugin
+                # config files being loaded from the CNI config directory.
+                cni_max_conf_num = 1
 
-            # 'plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options' is options specific to
-            # "io.containerd.runc.v1" and "io.containerd.runc.v2". Its corresponding options type is:
-            #   https://github.com/containerd/containerd/blob/v1.3.2/runtime/v2/runc/options/oci.pb.go#L26 .
-            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
-              # NoPivotRoot disables pivot root when creating a container.
-              NoPivotRoot = false
+                # 'plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options' is options specific to
+                # "io.containerd.runc.v1" and "io.containerd.runc.v2". Its corresponding options type is:
+                #   https://github.com/containerd/containerd/blob/v1.3.2/runtime/v2/runc/options/oci.pb.go#L26 .
+                [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+                  # NoPivotRoot disables pivot root when creating a container.
+                  NoPivotRoot = false
 
-              # NoNewKeyring disables new keyring for the container.
-              NoNewKeyring = false
+                  # NoNewKeyring disables new keyring for the container.
+                  NoNewKeyring = false
 
-              # ShimCgroup places the shim in a cgroup.
-              ShimCgroup = ""
+                  # ShimCgroup places the shim in a cgroup.
+                  ShimCgroup = ""
 
-              # IoUid sets the I/O's pipes uid.
-              IoUid = 0
+                  # IoUid sets the I/O's pipes uid.
+                  IoUid = 0
 
-              # IoGid sets the I/O's pipes gid.
-              IoGid = 0
+                  # IoGid sets the I/O's pipes gid.
+                  IoGid = 0
 
-              # BinaryName is the binary name of the runc binary.
-              BinaryName = ""
+                  # BinaryName is the binary name of the runc binary.
+                  BinaryName = ""
 
-              # Root is the runc root directory.
-              Root = ""
+                  # Root is the runc root directory.
+                  Root = ""
 
-              # CriuPath is the criu binary path.
-              CriuPath = ""
+                  # CriuPath is the criu binary path.
+                  CriuPath = ""
 
-              # SystemdCgroup enables systemd cgroups.
-              SystemdCgroup = false
+                  # SystemdCgroup enables systemd cgroups.
+                  SystemdCgroup = false
 
-              # CriuImagePath is the criu image path
-              CriuImagePath = ""
+                  # CriuImagePath is the criu image path
+                  CriuImagePath = ""
 
-              # CriuWorkPath is the criu work path.
-              CriuWorkPath = ""
+                  # CriuWorkPath is the criu work path.
+                  CriuWorkPath = ""
 
-        # 'plugins."io.containerd.grpc.v1.cri".cni' contains config related to cni
-        [plugins."io.containerd.grpc.v1.cri".cni]
-          # bin_dir is the directory in which the binaries for the plugin is kept.
-          bin_dir = "/opt/cni/bin"
+            # 'plugins."io.containerd.grpc.v1.cri".cni' contains config related to cni
+            [plugins."io.containerd.grpc.v1.cri".cni]
+              # bin_dir is the directory in which the binaries for the plugin is kept.
+              bin_dir = "/opt/cni/bin"
 
-          # conf_dir is the directory in which the admin places a CNI conf.
-          conf_dir = "/etc/cni/net.d"
+              # conf_dir is the directory in which the admin places a CNI conf.
+              conf_dir = "/etc/cni/net.d"
 
-          # max_conf_num specifies the maximum number of CNI plugin config files to
-          # load from the CNI config directory. By default, only 1 CNI plugin config
-          # file will be loaded. If you want to load multiple CNI plugin config files
-          # set max_conf_num to the number desired. Setting max_config_num to 0 is
-          # interpreted as no limit is desired and will result in all CNI plugin
-          # config files being loaded from the CNI config directory.
-          max_conf_num = 1
+              # max_conf_num specifies the maximum number of CNI plugin config files to
+              # load from the CNI config directory. By default, only 1 CNI plugin config
+              # file will be loaded. If you want to load multiple CNI plugin config files
+              # set max_conf_num to the number desired. Setting max_config_num to 0 is
+              # interpreted as no limit is desired and will result in all CNI plugin
+              # config files being loaded from the CNI config directory.
+              max_conf_num = 1
 
-          # conf_template is the file path of golang template used to generate
-          # cni config.
-          # If this is set, containerd will generate a cni config file from the
-          # template. Otherwise, containerd will wait for the system admin or cni
-          # daemon to drop the config file into the conf_dir.
-          # This is a temporary backward-compatible solution for kubenet users
-          # who don't have a cni daemonset in production yet.
-          # This will be deprecated when kubenet is deprecated.
-          # See the "CNI Config Template" section for more details.
-          conf_template = ""
-          # ip_pref specifies the strategy to use when selecting the main IP address for a pod.
-          # options include:
-          # * ipv4, "" - (default) select the first ipv4 address
-          # * ipv6 - select the first ipv6 address
-          # * cni - use the order returned by the CNI plugins, returning the first IP address from the results
-          ip_pref = "ipv4"
+              # conf_template is the file path of golang template used to generate
+              # cni config.
+              # If this is set, containerd will generate a cni config file from the
+              # template. Otherwise, containerd will wait for the system admin or cni
+              # daemon to drop the config file into the conf_dir.
+              # This is a temporary backward-compatible solution for kubenet users
+              # who don't have a cni daemonset in production yet.
+              # This will be deprecated when kubenet is deprecated.
+              # See the "CNI Config Template" section for more details.
+              conf_template = ""
+              # ip_pref specifies the strategy to use when selecting the main IP address for a pod.
+              # options include:
+              # * ipv4, "" - (default) select the first ipv4 address
+              # * ipv6 - select the first ipv6 address
+              # * cni - use the order returned by the CNI plugins, returning the first IP address from the results
+              ip_pref = "ipv4"
 
-        # 'plugins."io.containerd.grpc.v1.cri".image_decryption' contains config related
-        # to handling decryption of encrypted container images.
-        [plugins."io.containerd.grpc.v1.cri".image_decryption]
-          # key_model defines the name of the key model used for how the cri obtains
-          # keys used for decryption of encrypted container images.
-          # The [decryption document](https://github.com/containerd/containerd/blob/main/docs/cri/decryption.md)
-          # contains additional information about the key models available.
-          #
-          # Set of available string options: {"", "node"}
-          # Omission of this field defaults to the empty string "", which indicates no key model,
-          # disabling image decryption.
-          #
-          # In order to use the decryption feature, additional configurations must be made.
-          # The [decryption document](https://github.com/containerd/containerd/blob/main/docs/cri/decryption.md)
-          # provides information of how to set up stream processors and the containerd imgcrypt decoder
-          # with the appropriate key models.
-          #
-          # Additional information:
-          # * Stream processors: https://github.com/containerd/containerd/blob/main/docs/stream_processors.md
-          # * Containerd imgcrypt: https://github.com/containerd/imgcrypt
-          key_model = "node"
+            # 'plugins."io.containerd.grpc.v1.cri".image_decryption' contains config related
+            # to handling decryption of encrypted container images.
+            [plugins."io.containerd.grpc.v1.cri".image_decryption]
+              # key_model defines the name of the key model used for how the cri obtains
+              # keys used for decryption of encrypted container images.
+              # The [decryption document](https://github.com/containerd/containerd/blob/main/docs/cri/decryption.md)
+              # contains additional information about the key models available.
+              #
+              # Set of available string options: {"", "node"}
+              # Omission of this field defaults to the empty string "", which indicates no key model,
+              # disabling image decryption.
+              #
+              # In order to use the decryption feature, additional configurations must be made.
+              # The [decryption document](https://github.com/containerd/containerd/blob/main/docs/cri/decryption.md)
+              # provides information of how to set up stream processors and the containerd imgcrypt decoder
+              # with the appropriate key models.
+              #
+              # Additional information:
+              # * Stream processors: https://github.com/containerd/containerd/blob/main/docs/stream_processors.md
+              # * Containerd imgcrypt: https://github.com/containerd/imgcrypt
+              key_model = "node"
 
-        # 'plugins."io.containerd.grpc.v1.cri".registry' contains config related to
-        # the registry
-        [plugins."io.containerd.grpc.v1.cri".registry]
-          # config_path specifies a directory to look for the registry hosts configuration.
-          #
-          # The cri plugin will look for and use config_path/host-namespace/hosts.toml
-          #   configs if present OR load certificate files as laid out in the Docker/Moby
-          #   specific layout https://docs.docker.com/engine/security/certificates/
-          #
-          # If config_path is not provided defaults are used.
-          #
-          # *** registry.configs and registry.mirrors that were a part of containerd 1.4
-          # are now DEPRECATED and will only be used if the config_path is not specified.
-          config_path = ""
+            # 'plugins."io.containerd.grpc.v1.cri".registry' contains config related to
+            # the registry
+            [plugins."io.containerd.grpc.v1.cri".registry]
+              # config_path specifies a directory to look for the registry hosts configuration.
+              #
+              # The cri plugin will look for and use config_path/host-namespace/hosts.toml
+              #   configs if present OR load certificate files as laid out in the Docker/Moby
+              #   specific layout https://docs.docker.com/engine/security/certificates/
+              #
+              # If config_path is not provided defaults are used.
+              #
+              # *** registry.configs and registry.mirrors that were a part of containerd 1.4
+              # are now DEPRECATED and will only be used if the config_path is not specified.
+              config_path = ""
     CONFIG_TOML_EOF
     File.write('config.toml', @config_toml)
     system "sed -i 's,/var,#{CREW_PREFIX}/var,g' config.toml"

--- a/packages/containerd.rb
+++ b/packages/containerd.rb
@@ -18,9 +18,9 @@ class Containerd < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/containerd/1.6.1_x86_64/containerd-1.6.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '3560445ba0e85f47cede9836cdcbfd34879251f60abb9ddb71cf8ad8e0cf403a',
-     armv7l: '3560445ba0e85f47cede9836cdcbfd34879251f60abb9ddb71cf8ad8e0cf403a',
-     x86_64: '6924a4ebf2d3f50a2e9d7f18e3c23a1733d9ad1441a5115e0810a070bc5a16e6'
+    aarch64: '8836c25633fa7ef919c248783998f2da5f7fdd71823bb639c9e8186cdeace15b',
+     armv7l: '8836c25633fa7ef919c248783998f2da5f7fdd71823bb639c9e8186cdeace15b',
+     x86_64: '30cb7cb071671835d9083de91cf2873737cde2b1d7448fcc98898156d654d92a'
   })
 
   depends_on 'docker_systemctl_replacement'
@@ -30,6 +30,7 @@ class Containerd < Package
   depends_on 'libseccomp' => ':build'
   depends_on 'containers_common' => ':build'
   depends_on 'go_md2man' => ':build'
+  no_fhs
 
   def self.patch
     system "sed -i 's,/sbin,#{CREW_PREFIX}/bin,g' containerd.service"

--- a/packages/containerd.rb
+++ b/packages/containerd.rb
@@ -10,7 +10,6 @@ class Containerd < Package
   license 'Apache'
   compatibility 'all'
   source_url 'https://github.com/containerd/containerd.git'
-  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/containerd/1.6.1_armv7l/containerd-1.6.1-chromeos-armv7l.tar.zst',
@@ -18,10 +17,11 @@ class Containerd < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/containerd/1.6.1_x86_64/containerd-1.6.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '8836c25633fa7ef919c248783998f2da5f7fdd71823bb639c9e8186cdeace15b',
-     armv7l: '8836c25633fa7ef919c248783998f2da5f7fdd71823bb639c9e8186cdeace15b',
-     x86_64: '30cb7cb071671835d9083de91cf2873737cde2b1d7448fcc98898156d654d92a'
+    aarch64: '8cff65fb4f5cae37d3c5a02adaca91828acd2278cd28ecc69ecec0c0ce3b8ef1',
+     armv7l: '8cff65fb4f5cae37d3c5a02adaca91828acd2278cd28ecc69ecec0c0ce3b8ef1',
+     x86_64: 'e0416b16cc9cad8052ce5f139d339ec766f26ef1a630e4cf44a37a160cbc45ec'
   })
+  git_hashtag "v#{version}"
 
   depends_on 'docker_systemctl_replacement'
   depends_on 'runc'
@@ -34,6 +34,8 @@ class Containerd < Package
 
   def self.patch
     system "sed -i 's,/sbin,#{CREW_PREFIX}/bin,g' containerd.service"
+    system "sed -i 's,TasksMax=,#TasksMax=,g' containerd.service"
+    system "sed -i '/modprobe/d' containerd.service"
     system "sed -i 's,/run,/var/run/chrome,g' defaults/defaults_unix.go"
     system "sed -i 's,/var,#{CREW_PREFIX}/var,g' defaults/defaults_unix.go"
     system "sed -i 's,/etc,#{CREW_PREFIX}/etc,g' defaults/defaults_unix.go"

--- a/packages/containerd.rb
+++ b/packages/containerd.rb
@@ -18,9 +18,9 @@ class Containerd < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/containerd/1.6.1_x86_64/containerd-1.6.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '8cff65fb4f5cae37d3c5a02adaca91828acd2278cd28ecc69ecec0c0ce3b8ef1',
-     armv7l: '8cff65fb4f5cae37d3c5a02adaca91828acd2278cd28ecc69ecec0c0ce3b8ef1',
-     x86_64: 'e0416b16cc9cad8052ce5f139d339ec766f26ef1a630e4cf44a37a160cbc45ec'
+    aarch64: 'd19580d750ecb5826eb5cacc1c623ecd2671d9d4cb1f75316c36e3c2a9336244',
+     armv7l: 'd19580d750ecb5826eb5cacc1c623ecd2671d9d4cb1f75316c36e3c2a9336244',
+     x86_64: '2afe2483029684e22b3090529a0b345c52b0d98605df7811656529b9fffcf81d'
   })
 
   depends_on 'docker_systemctl_replacement'
@@ -44,15 +44,382 @@ class Containerd < Package
   def self.build
     system "GOFLAGS='-trimpath -mod=readonly -modcacherw' make VERSION=v1.6.1 GO_BUILD_FLAGS='-trimpath -mod=readonly -modcacherw' GO_GCFLAGS= EXTRA_LDFLAGS='-buildid='"
     system "GOFLAGS='-trimpath -mod=readonly -modcacherw' make VERSION=v1.6.1 man"
+    @config_toml = <<~'CONFIG_TOML_EOF'
+      root = "/var/lib/containerd"
+      state = "/run/containerd"
+      oom_score = 0
+      imports = ["/etc/containerd/runtime_*.toml", "./debug.toml"]
+
+      [grpc]
+        address = "/run/containerd/containerd.sock"
+        uid = 0
+        gid = 0
+
+      [debug]
+        address = "/run/containerd/debug.sock"
+        uid = 0
+        gid = 0
+        level = "info"
+
+      [metrics]
+        address = ""
+        grpc_histogram = false
+
+      [cgroup]
+        path = ""
+
+      [plugins]
+        [plugins.cgroups]
+          no_prometheus = false
+        [plugins.diff]
+          default = ["walking"]
+        [plugins.linux]
+          shim = "containerd-shim"
+          runtime = "runc"
+          runtime_root = ""
+          no_shim = false
+          shim_debug = false
+        [plugins.scheduler]
+          pause_threshold = 0.02
+          deletion_threshold = 0
+          mutation_threshold = 100
+          schedule_delay = 0
+          startup_delay = "100ms"
+        [plugins."io.containerd.runtime-shim.v2.shim"]
+          platforms = ["linux/amd64"]
+          sched_core = true
+        [plugins."io.containerd.service.v1.tasks-service"]
+          rdt_config_file = "/etc/rdt-config.yaml"
+      # Use config version 2 to enable new configuration fields.
+      # Config file is parsed as version 1 by default.
+      # Version 2 uses long plugin names, i.e. "io.containerd.grpc.v1.cri" vs "cri".
+      version = 2
+
+      # The 'plugins."io.containerd.grpc.v1.cri"' table contains all of the server options.
+      [plugins."io.containerd.grpc.v1.cri"]
+
+        # disable_tcp_service disables serving CRI on the TCP server.
+        # Note that a TCP server is enabled for containerd if TCPAddress is set in section [grpc].
+        disable_tcp_service = true
+
+        # stream_server_address is the ip address streaming server is listening on.
+        stream_server_address = "127.0.0.1"
+
+        # stream_server_port is the port streaming server is listening on.
+        stream_server_port = "0"
+
+        # stream_idle_timeout is the maximum time a streaming connection can be
+        # idle before the connection is automatically closed.
+        # The string is in the golang duration format, see:
+        #   https://golang.org/pkg/time/#ParseDuration
+        stream_idle_timeout = "4h"
+
+        # enable_selinux indicates to enable the selinux support.
+        enable_selinux = false
+
+        # selinux_category_range allows the upper bound on the category range to be set.
+        # if not specified or set to 0, defaults to 1024 from the selinux package.
+        selinux_category_range = 1024
+
+        # sandbox_image is the image used by sandbox container.
+        sandbox_image = "k8s.gcr.io/pause:3.6"
+
+        # stats_collect_period is the period (in seconds) of snapshots stats collection.
+        stats_collect_period = 10
+
+        # enable_tls_streaming enables the TLS streaming support.
+        # It generates a self-sign certificate unless the following x509_key_pair_streaming are both set.
+        enable_tls_streaming = false
+
+        # tolerate_missing_hugetlb_controller if set to false will error out on create/update
+        # container requests with huge page limits if the cgroup controller for hugepages is not present.
+        # This helps with supporting Kubernetes <=1.18 out of the box. (default is `true`)
+        tolerate_missing_hugetlb_controller = true
+
+        # ignore_image_defined_volumes ignores volumes defined by the image. Useful for better resource
+      	# isolation, security and early detection of issues in the mount configuration when using
+      	# ReadOnlyRootFilesystem since containers won't silently mount a temporary volume.
+        ignore_image_defined_volumes = false
+
+        # netns_mounts_under_state_dir places all mounts for network namespaces under StateDir/netns
+        # instead of being placed under the hardcoded directory /var/run/netns. Changing this setting
+        # requires that all containers are deleted.
+        netns_mounts_under_state_dir = false
+
+        # 'plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming' contains a x509 valid key pair to stream with tls.
+        [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
+          # tls_cert_file is the filepath to the certificate paired with the "tls_key_file"
+          tls_cert_file = ""
+
+          # tls_key_file is the filepath to the private key paired with the "tls_cert_file"
+          tls_key_file = ""
+
+        # max_container_log_line_size is the maximum log line size in bytes for a container.
+        # Log line longer than the limit will be split into multiple lines. -1 means no
+        # limit.
+        max_container_log_line_size = 16384
+
+        # disable_cgroup indicates to disable the cgroup support.
+        # This is useful when the daemon does not have permission to access cgroup.
+        disable_cgroup = false
+
+        # disable_apparmor indicates to disable the apparmor support.
+        # This is useful when the daemon does not have permission to access apparmor.
+        disable_apparmor = false
+
+        # restrict_oom_score_adj indicates to limit the lower bound of OOMScoreAdj to
+        # the containerd's current OOMScoreAdj.
+        # This is useful when the containerd does not have permission to decrease OOMScoreAdj.
+        restrict_oom_score_adj = false
+
+        # max_concurrent_downloads restricts the number of concurrent downloads for each image.
+        max_concurrent_downloads = 3
+
+        # disable_proc_mount disables Kubernetes ProcMount support. This MUST be set to `true`
+        # when using containerd with Kubernetes <=1.11.
+        disable_proc_mount = false
+
+        # unset_seccomp_profile is the seccomp profile containerd/cri will use if the seccomp
+        # profile requested over CRI is unset (or nil) for a pod/container (otherwise if this field is not set the
+        # default unset profile will map to `unconfined`)
+          # Note: The default unset seccomp profile should not be confused with the seccomp profile
+          # used in CRI when the runtime default seccomp profile is requested. In the later case, the
+          # default is set by the following code (https://github.com/containerd/containerd/blob/main/contrib/seccomp/seccomp_default.go).
+          # To summarize, there are two different seccomp defaults, the unset default used when the CRI request is
+          # set to nil or `unconfined`, and the default used when the runtime default seccomp profile is requested.
+        unset_seccomp_profile = ""
+
+        # enable_unprivileged_ports configures net.ipv4.ip_unprivileged_port_start=0
+        # for all containers which are not using host network
+        # and if it is not overwritten by PodSandboxConfig
+        # Note that currently default is set to disabled but target change it in future, see:
+        #   [k8s discussion](https://github.com/kubernetes/kubernetes/issues/102612)
+        enable_unprivileged_ports = false
+
+        # enable_unprivileged_icmp configures net.ipv4.ping_group_range="0 2147483647"
+        # for all containers which are not using host network, are not running in user namespace
+        # and if it is not overwritten by PodSandboxConfig
+        # Note that currently default is set to disabled but target change it in future together with enable_unprivileged_ports
+        enable_unprivileged_icmp = false
+
+        # 'plugins."io.containerd.grpc.v1.cri".containerd' contains config related to containerd
+        [plugins."io.containerd.grpc.v1.cri".containerd]
+
+          # snapshotter is the snapshotter used by containerd.
+          snapshotter = "overlayfs"
+
+          # no_pivot disables pivot-root (linux only), required when running a container in a RamDisk with runc.
+          # This only works for runtime type "io.containerd.runtime.v1.linux".
+          no_pivot = false
+
+          # disable_snapshot_annotations disables to pass additional annotations (image
+          # related information) to snapshotters. These annotations are required by
+          # stargz snapshotter (https://github.com/containerd/stargz-snapshotter)
+          # changed to default true with https://github.com/containerd/containerd/pull/4665 and subsequent service refreshes.
+          disable_snapshot_annotations = true
+
+          # discard_unpacked_layers allows GC to remove layers from the content store after
+          # successfully unpacking these layers to the snapshotter.
+          discard_unpacked_layers = false
+
+          # default_runtime_name is the default runtime name to use.
+          default_runtime_name = "runc"
+
+          # ignore_rdt_not_enabled_errors disables RDT related errors when RDT
+          # support has not been enabled. Intel RDT is a technology for cache and
+          # memory bandwidth management. By default, trying to set the RDT class of
+          # a container via annotations produces an error if RDT hasn't been enabled.
+          # This config option practically enables a "soft" mode for RDT where these
+          # errors are ignored and the container gets no RDT class.
+          ignore_rdt_not_enabled_errors = false
+
+          # 'plugins."io.containerd.grpc.v1.cri".containerd.default_runtime' is the runtime to use in containerd.
+          # DEPRECATED: use `default_runtime_name` and `plugins."io.containerd.grpc.v1.cri".containerd.runtimes` instead.
+          [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
+
+          # 'plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime' is a runtime to run untrusted workloads on it.
+          # DEPRECATED: use `untrusted` runtime in `plugins."io.containerd.grpc.v1.cri".containerd.runtimes` instead.
+          [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
+
+          # 'plugins."io.containerd.grpc.v1.cri".containerd.runtimes' is a map from CRI RuntimeHandler strings, which specify types
+          # of runtime configurations, to the matching configurations.
+          # In this example, 'runc' is the RuntimeHandler string to match.
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+            # runtime_type is the runtime type to use in containerd.
+            # The default value is "io.containerd.runc.v2" since containerd 1.4.
+            # The default value was "io.containerd.runc.v1" in containerd 1.3, "io.containerd.runtime.v1.linux" in prior releases.
+            runtime_type = "io.containerd.runc.v2"
+
+            # pod_annotations is a list of pod annotations passed to both pod
+            # sandbox as well as container OCI annotations. Pod_annotations also
+            # supports golang path match pattern - https://golang.org/pkg/path/#Match.
+            # e.g. ["runc.com.*"], ["*.runc.com"], ["runc.com/*"].
+            #
+            # For the naming convention of annotation keys, please reference:
+            # * Kubernetes: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
+            # * OCI: https://github.com/opencontainers/image-spec/blob/master/annotations.md
+            pod_annotations = []
+
+            # container_annotations is a list of container annotations passed through to the OCI config of the containers.
+            # Container annotations in CRI are usually generated by other Kubernetes node components (i.e., not users).
+            # Currently, only device plugins populate the annotations.
+            container_annotations = []
+
+            # privileged_without_host_devices allows overloading the default behaviour of passing host
+            # devices through to privileged containers. This is useful when using a runtime where it does
+            # not make sense to pass host devices to the container when privileged. Defaults to false -
+            # i.e pass host devices through to privileged containers.
+            privileged_without_host_devices = false
+
+            # base_runtime_spec is a file path to a JSON file with the OCI spec that will be used as the base spec that all
+            # container's are created from.
+            # Use containerd's `ctr oci spec > /etc/containerd/cri-base.json` to output initial spec file.
+            # Spec files are loaded at launch, so containerd daemon must be restarted on any changes to refresh default specs.
+            # Still running containers and restarted containers will still be using the original spec from which that container was created.
+            base_runtime_spec = ""
+
+            # conf_dir is the directory in which the admin places a CNI conf.
+            # this allows a different CNI conf for the network stack when a different runtime is being used.
+            cni_conf_dir = "/etc/cni/net.d"
+
+            # cni_max_conf_num specifies the maximum number of CNI plugin config files to
+            # load from the CNI config directory. By default, only 1 CNI plugin config
+            # file will be loaded. If you want to load multiple CNI plugin config files
+            # set max_conf_num to the number desired. Setting cni_max_config_num to 0 is
+            # interpreted as no limit is desired and will result in all CNI plugin
+            # config files being loaded from the CNI config directory.
+            cni_max_conf_num = 1
+
+            # 'plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options' is options specific to
+            # "io.containerd.runc.v1" and "io.containerd.runc.v2". Its corresponding options type is:
+            #   https://github.com/containerd/containerd/blob/v1.3.2/runtime/v2/runc/options/oci.pb.go#L26 .
+            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+              # NoPivotRoot disables pivot root when creating a container.
+              NoPivotRoot = false
+
+              # NoNewKeyring disables new keyring for the container.
+              NoNewKeyring = false
+
+              # ShimCgroup places the shim in a cgroup.
+              ShimCgroup = ""
+
+              # IoUid sets the I/O's pipes uid.
+              IoUid = 0
+
+              # IoGid sets the I/O's pipes gid.
+              IoGid = 0
+
+              # BinaryName is the binary name of the runc binary.
+              BinaryName = ""
+
+              # Root is the runc root directory.
+              Root = ""
+
+              # CriuPath is the criu binary path.
+              CriuPath = ""
+
+              # SystemdCgroup enables systemd cgroups.
+              SystemdCgroup = false
+
+              # CriuImagePath is the criu image path
+              CriuImagePath = ""
+
+              # CriuWorkPath is the criu work path.
+              CriuWorkPath = ""
+
+        # 'plugins."io.containerd.grpc.v1.cri".cni' contains config related to cni
+        [plugins."io.containerd.grpc.v1.cri".cni]
+          # bin_dir is the directory in which the binaries for the plugin is kept.
+          bin_dir = "/opt/cni/bin"
+
+          # conf_dir is the directory in which the admin places a CNI conf.
+          conf_dir = "/etc/cni/net.d"
+
+          # max_conf_num specifies the maximum number of CNI plugin config files to
+          # load from the CNI config directory. By default, only 1 CNI plugin config
+          # file will be loaded. If you want to load multiple CNI plugin config files
+          # set max_conf_num to the number desired. Setting max_config_num to 0 is
+          # interpreted as no limit is desired and will result in all CNI plugin
+          # config files being loaded from the CNI config directory.
+          max_conf_num = 1
+
+          # conf_template is the file path of golang template used to generate
+          # cni config.
+          # If this is set, containerd will generate a cni config file from the
+          # template. Otherwise, containerd will wait for the system admin or cni
+          # daemon to drop the config file into the conf_dir.
+          # This is a temporary backward-compatible solution for kubenet users
+          # who don't have a cni daemonset in production yet.
+          # This will be deprecated when kubenet is deprecated.
+          # See the "CNI Config Template" section for more details.
+          conf_template = ""
+          # ip_pref specifies the strategy to use when selecting the main IP address for a pod.
+          # options include:
+          # * ipv4, "" - (default) select the first ipv4 address
+          # * ipv6 - select the first ipv6 address
+          # * cni - use the order returned by the CNI plugins, returning the first IP address from the results
+          ip_pref = "ipv4"
+
+        # 'plugins."io.containerd.grpc.v1.cri".image_decryption' contains config related
+        # to handling decryption of encrypted container images.
+        [plugins."io.containerd.grpc.v1.cri".image_decryption]
+          # key_model defines the name of the key model used for how the cri obtains
+          # keys used for decryption of encrypted container images.
+          # The [decryption document](https://github.com/containerd/containerd/blob/main/docs/cri/decryption.md)
+          # contains additional information about the key models available.
+          #
+          # Set of available string options: {"", "node"}
+          # Omission of this field defaults to the empty string "", which indicates no key model,
+          # disabling image decryption.
+          #
+          # In order to use the decryption feature, additional configurations must be made.
+          # The [decryption document](https://github.com/containerd/containerd/blob/main/docs/cri/decryption.md)
+          # provides information of how to set up stream processors and the containerd imgcrypt decoder
+          # with the appropriate key models.
+          #
+          # Additional information:
+          # * Stream processors: https://github.com/containerd/containerd/blob/main/docs/stream_processors.md
+          # * Containerd imgcrypt: https://github.com/containerd/imgcrypt
+          key_model = "node"
+
+        # 'plugins."io.containerd.grpc.v1.cri".registry' contains config related to
+        # the registry
+        [plugins."io.containerd.grpc.v1.cri".registry]
+          # config_path specifies a directory to look for the registry hosts configuration.
+          #
+          # The cri plugin will look for and use config_path/host-namespace/hosts.toml
+          #   configs if present OR load certificate files as laid out in the Docker/Moby
+          #   specific layout https://docs.docker.com/engine/security/certificates/
+          #
+          # If config_path is not provided defaults are used.
+          #
+          # *** registry.configs and registry.mirrors that were a part of containerd 1.4
+          # are now DEPRECATED and will only be used if the config_path is not specified.
+          config_path = ""
+    CONFIG_TOML_EOF
+    File.write('config.toml', @config_toml)
+    system "sed -i 's,/var,#{CREW_PREFIX}/var,g' config.toml"
+    system "sed -i 's,/run,/var/run/chrome,g' config.toml"
+    system "sed -i 's,/etc,#{CREW_PREFIX}/etc,g' config.toml"
+    system "sed -i 's,/opt,#{CREW_PREFIX}/opt,g' config.toml"
+    case ARCH
+    when 'armv7l', 'aarch64'
+      @docker_platform = 'linux/arm/v7'
+    when 'x86_64'
+      @docker_platform = 'linux/amd64'
+    end
+    system "sed -i 's,linux/amd64,#{@docker_platform},g' config.toml"
   end
 
   def self.install
     FileUtils.mkdir_p %W[
       #{CREW_DEST_PREFIX}/.config/systemd/user
+      #{CREW_DEST_PREFIX}/etc/containerd/certs.d
       #{CREW_DEST_MAN_PREFIX}/man5
       #{CREW_DEST_MAN_PREFIX}/man8
     ]
     system "make PREFIX=#{CREW_PREFIX} DESTDIR=#{CREW_DEST_DIR} install"
+    FileUtils.install 'config.toml', "#{CREW_DEST_PREFIX}/etc/containerd/config.toml", mode: 0o644
     FileUtils.install 'containerd.service', "#{CREW_DEST_PREFIX}/.config/systemd/user/containerd.service", mode: 0o644
     FileUtils.install Dir['man/*.5'], "#{CREW_DEST_MAN_PREFIX}/man5", mode: 0o644
     FileUtils.install Dir['man/*.8'], "#{CREW_DEST_MAN_PREFIX}/man8", mode: 0o644

--- a/packages/containerd.rb
+++ b/packages/containerd.rb
@@ -10,6 +10,7 @@ class Containerd < Package
   license 'Apache'
   compatibility 'all'
   source_url 'https://github.com/containerd/containerd.git'
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/containerd/1.6.1_armv7l/containerd-1.6.1-chromeos-armv7l.tar.zst',
@@ -21,7 +22,6 @@ class Containerd < Package
      armv7l: '8cff65fb4f5cae37d3c5a02adaca91828acd2278cd28ecc69ecec0c0ce3b8ef1',
      x86_64: 'e0416b16cc9cad8052ce5f139d339ec766f26ef1a630e4cf44a37a160cbc45ec'
   })
-  git_hashtag "v#{version}"
 
   depends_on 'docker_systemctl_replacement'
   depends_on 'runc'

--- a/packages/containerd.rb
+++ b/packages/containerd.rb
@@ -26,11 +26,11 @@ class Containerd < Package
   depends_on 'docker_systemctl_replacement'
   depends_on 'fuse_overlayfs'
   depends_on 'runc'
-  depends_on 'go' => ':build'
-  depends_on 'btrfsprogs' => ':build'
-  depends_on 'libseccomp' => ':build'
-  depends_on 'containers_common' => ':build'
-  depends_on 'go_md2man' => ':build'
+  depends_on 'go' => :build
+  depends_on 'btrfsprogs' => :build
+  depends_on 'libseccomp' => :build
+  depends_on 'containers_common' => :build
+  depends_on 'go_md2man' => :build
   no_fhs
 
   def self.patch

--- a/packages/containerd.rb
+++ b/packages/containerd.rb
@@ -24,6 +24,7 @@ class Containerd < Package
   })
 
   depends_on 'docker_systemctl_replacement'
+  depends_on 'fuse_overlayfs'
   depends_on 'runc'
   depends_on 'go' => ':build'
   depends_on 'btrfsprogs' => ':build'
@@ -420,6 +421,7 @@ class Containerd < Package
     ]
     system "make PREFIX=#{CREW_PREFIX} DESTDIR=#{CREW_DEST_DIR} install"
     FileUtils.install 'config.toml', "#{CREW_DEST_PREFIX}/etc/containerd/config.toml", mode: 0o644
+    FileUtils.install 'config.toml', "#{CREW_DEST_PREFIX}/etc/containerd/debug.toml", mode: 0o644
     FileUtils.install 'containerd.service', "#{CREW_DEST_PREFIX}/.config/systemd/user/containerd.service", mode: 0o644
     FileUtils.install Dir['man/*.5'], "#{CREW_DEST_MAN_PREFIX}/man5", mode: 0o644
     FileUtils.install Dir['man/*.8'], "#{CREW_DEST_MAN_PREFIX}/man8", mode: 0o644

--- a/packages/containers_common.rb
+++ b/packages/containers_common.rb
@@ -82,35 +82,34 @@ class Containers_common < Package
       # containers-mounts.conf for further information)
     MOUNTS_CONF_EOF
     File.write("#{CREW_DEST_PREFIX}/etc/containers/mounts.conf", @mounts_conf, perm: 0o644)
-    system "install -vDm 644 pkg/config/containers.conf -t #{CREW_DEST_PREFIX}/etc/containers/"
-    system "install -vDm 644 pkg/config/containers.conf -t #{CREW_DEST_PREFIX}/share/containers/"
-    system "install -vDm 644 pkg/seccomp/seccomp.json -t #{CREW_DEST_PREFIX}/etc/containers/"
-    system "install -vDm 644 pkg/seccomp/seccomp.json -t #{CREW_DEST_PREFIX}/share/containers/"
-    system "install -vDm 644 docs/*.5 -t #{CREW_DEST_MAN_PREFIX}/man5/"
+    FileUtils.install 'pkg/config/containers.conf', "#{CREW_DEST_PREFIX}/etc/containers/", mode: 0o644
+    FileUtils.install 'pkg/config/containers.conf', "#{CREW_DEST_PREFIX}/share/containers/", mode: 0o644
+    FileUtils.install 'pkg/seccomp/seccomp.json', "#{CREW_DEST_PREFIX}/etc/containers/", mode: 0o644
+    FileUtils.install 'pkg/seccomp/seccomp.json', "#{CREW_DEST_PREFIX}/share/containers/", mode: 0o644
+    FileUtils.install Dir['docs/*.5'], "#{CREW_DEST_MAN_PREFIX}/man5/", mode: 0o644
 
     Dir.chdir 'git' do
       Dir.chdir 'image' do
-        system "install -vDm 644 registries.conf -t #{CREW_DEST_PREFIX}/etc/containers/"
-
-        system "install -vDm 644 docs/*.1 -t #{CREW_DEST_MAN_PREFIX}/man1/"
-        system "install -vDm 644 docs/man5/*.5 -t #{CREW_DEST_MAN_PREFIX}/man5/"
+        FileUtils.install 'registries.conf', "#{CREW_DEST_PREFIX}/etc/containers/", mode: 0o644
+        FileUtils.install Dir['docs/*.1'], "#{CREW_DEST_MAN_PREFIX}/man1/", mode: 0o644
+        FileUtils.install Dir['docs/man5/*.5'], "#{CREW_DEST_MAN_PREFIX}/man5/", mode: 0o644
       end
       Dir.chdir 'podman' do
-        system "install -vDm 644 *.5 -t #{CREW_DEST_MAN_PREFIX}/man5/"
+        FileUtils.install Dir['*.5'], "#{CREW_DEST_MAN_PREFIX}/man5/", mode: 0o644
       end
 
       Dir.chdir 'shortnames' do
-        system "install -vDm 644 shortnames.conf #{CREW_DEST_PREFIX}/etc/containers/registries.conf.d/00-shortnames.conf"
+        FileUtils.install 'shortnames.conf', "#{CREW_DEST_PREFIX}/etc/containers/registries.conf.d/00-shortnames.conf", mode: 0o644
       end
       Dir.chdir 'skopeo' do
-        system "install -vDm 644 default-policy.json #{CREW_DEST_PREFIX}/etc/containers/policy.json"
-        system "install -vDm 644 default.yaml -t #{CREW_DEST_PREFIX}/etc/containers/registries.d/"
+        FileUtils.install 'default-policy.json', "#{CREW_DEST_PREFIX}/etc/containers/policy.json", mode: 0o644
+        FileUtils.install 'default.yaml', "#{CREW_DEST_PREFIX}/etc/containers/registries.d/", mode: 0o644
       end
       Dir.chdir 'storage' do
-        system "install -vDm 644 storage.conf -t #{CREW_DEST_PREFIX}/etc/containers/"
-        system "install -vDm 644 storage.conf -t #{CREW_DEST_PREFIX}/share/containers/"
-        system "install -vDm 644 docs/*.1 -t #{CREW_DEST_MAN_PREFIX}/man1/"
-        system "install -vDm 644 docs/*.5 -t #{CREW_DEST_MAN_PREFIX}/man5/"
+        FileUtils.install 'storage.conf', "#{CREW_DEST_PREFIX}/etc/containers/", mode: 0o644
+        FileUtils.install 'storage.conf', "#{CREW_DEST_PREFIX}/share/containers/", mode: 0o644
+        FileUtils.install Dir['docs/*.1'], "#{CREW_DEST_MAN_PREFIX}/man1/", mode: 0o644
+        FileUtils.install Dir['docs/*.5'], "#{CREW_DEST_MAN_PREFIX}/man5/", mode: 0o644
       end
     end
   end

--- a/packages/containers_common.rb
+++ b/packages/containers_common.rb
@@ -1,0 +1,117 @@
+# Adapted from Arch Linux containers-common PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/containers-common/trunk/PKGBUILD
+
+require 'package'
+
+class Containers_common < Package
+  description 'Configuration files and manpages for containers'
+  homepage 'https://github.com/containers'
+  version '0.47.4'
+  license 'Apache'
+  compatibility 'all'
+  source_url 'https://github.com/containers/common.git'
+  git_hashtag "v#{version}"
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/containers_common/0.47.4_armv7l/containers_common-0.47.4-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/containers_common/0.47.4_armv7l/containers_common-0.47.4-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/containers_common/0.47.4_x86_64/containers_common-0.47.4-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '653d744a20a0d5be563586212b7813887b15b4e56b8c6344a078fa99e764e6f9',
+     armv7l: '653d744a20a0d5be563586212b7813887b15b4e56b8c6344a078fa99e764e6f9',
+     x86_64: '21dfc889cc2fcd41ff44ce30c7aa900d2ffa0a3d9a48f22b732ddbeae0c52afe'
+  })
+
+  depends_on 'netavark'
+  depends_on 'go_md2man' => ':build'
+
+  def self.build
+    @image_version = 'v5.20.0'
+    @podman_version = 'v4.0.2'
+    @shortnames_version = 'v2022.02.08'
+    @skopeo_version = 'v1.6.1'
+    @storage_version = 'v1.38.2'
+    Dir.chdir 'docs' do
+      system 'for _man_page in *.md
+      do
+        go-md2man -in $_man_page -out ${_man_page//.md}
+      done'
+    end
+    FileUtils.mkdir_p 'git'
+    Dir.chdir 'git' do
+      system "git clone --depth 1 --branch #{@image_version} https://github.com/containers/image.git"
+      Dir.chdir 'image/docs' do
+        FileUtils.mkdir_p 'man5'
+        FileUtils.mv Dir.glob('*.5.md'), 'man5/'
+        system 'for _man_page in *.md
+        do
+          go-md2man -in $_man_page -out ${_man_page//.md}.1
+        done'
+        system 'for _man_page in man5/*.md
+        do
+          go-md2man -in $_man_page -out ${_man_page//.md}
+        done'
+      end
+      system "git clone --depth 1 --branch #{@podman_version} https://github.com/containers/podman.git"
+      Dir.chdir 'podman' do
+        system 'go-md2man -in pkg/hooks/docs/oci-hooks.5.md -out oci-hooks.5'
+      end
+      system "git clone --depth 1 --branch #{@shortnames_version} https://github.com/containers/shortnames.git"
+      system "git clone --depth 1 --branch #{@skopeo_version} https://github.com/containers/skopeo.git"
+      system "git clone --depth 1 --branch #{@storage_version} https://github.com/containers/storage.git"
+      Dir.chdir 'storage' do
+        FileUtils.mkdir_p 'tests/tools/build/'
+        FileUtils.ln_s "#{CREW_PREFIX}/bin/go-md2man", 'tests/tools/build/'
+        system 'make -C docs'
+      end
+    end
+  end
+
+  def self.install
+    FileUtils.mkdir_p %W[
+      #{CREW_DEST_PREFIX}/etc/containers/oci/hooks.d/
+      #{CREW_DEST_PREFIX}/etc/containers/registries.conf.d/
+      #{CREW_DEST_PREFIX}/share/containers/oci/hooks.d/
+      #{CREW_DEST_PREFIX}/var/lib/containers/
+      #{CREW_DEST_MAN_PREFIX}/man1/
+      #{CREW_DEST_MAN_PREFIX}/man5/
+    ]
+    @mounts_conf = <<~'MOUNTS_CONF_EOF'
+      # Configuration file for default mounts in containers (see man 5
+      # containers-mounts.conf for further information)
+    MOUNTS_CONF_EOF
+    File.write("#{CREW_DEST_PREFIX}/etc/containers/mounts.conf", @mounts_conf, perm: 0o644)
+    system "install -vDm 644 pkg/config/containers.conf -t #{CREW_DEST_PREFIX}/etc/containers/"
+    system "install -vDm 644 pkg/config/containers.conf -t #{CREW_DEST_PREFIX}/share/containers/"
+    system "install -vDm 644 pkg/seccomp/seccomp.json -t #{CREW_DEST_PREFIX}/etc/containers/"
+    system "install -vDm 644 pkg/seccomp/seccomp.json -t #{CREW_DEST_PREFIX}/share/containers/"
+    system "install -vDm 644 docs/*.5 -t #{CREW_DEST_MAN_PREFIX}/man5/"
+
+    Dir.chdir 'git' do
+      Dir.chdir 'image' do
+        system "install -vDm 644 registries.conf -t #{CREW_DEST_PREFIX}/etc/containers/"
+
+        system "install -vDm 644 docs/*.1 -t #{CREW_DEST_MAN_PREFIX}/man1/"
+        system "install -vDm 644 docs/man5/*.5 -t #{CREW_DEST_MAN_PREFIX}/man5/"
+      end
+      Dir.chdir 'podman' do
+        system "install -vDm 644 *.5 -t #{CREW_DEST_MAN_PREFIX}/man5/"
+      end
+
+      Dir.chdir 'shortnames' do
+        system "install -vDm 644 shortnames.conf #{CREW_DEST_PREFIX}/etc/containers/registries.conf.d/00-shortnames.conf"
+      end
+      Dir.chdir 'skopeo' do
+        system "install -vDm 644 default-policy.json #{CREW_DEST_PREFIX}/etc/containers/policy.json"
+        system "install -vDm 644 default.yaml -t #{CREW_DEST_PREFIX}/etc/containers/registries.d/"
+      end
+      Dir.chdir 'storage' do
+        system "install -vDm 644 storage.conf -t #{CREW_DEST_PREFIX}/etc/containers/"
+        system "install -vDm 644 storage.conf -t #{CREW_DEST_PREFIX}/share/containers/"
+        system "install -vDm 644 docs/*.1 -t #{CREW_DEST_MAN_PREFIX}/man1/"
+        system "install -vDm 644 docs/*.5 -t #{CREW_DEST_MAN_PREFIX}/man5/"
+      end
+    end
+  end
+end

--- a/packages/containers_common.rb
+++ b/packages/containers_common.rb
@@ -32,7 +32,7 @@ class Containers_common < Package
     @shortnames_version = 'v2022.02.08'
     @skopeo_version = 'v1.6.1'
     @storage_version = 'v1.38.2'
-    
+
     Dir.glob('docs/*.md') do |_man_page|
       system "go-md2man -in #{_man_page} -out #{File.basename(_man_page, '.md')}"
     end

--- a/packages/docker.rb
+++ b/packages/docker.rb
@@ -23,16 +23,17 @@ class Docker < Package
      x86_64: 'fe2a39d90ef0b37c33125cdcbdccf7a8b26255dff3ac46e790fa02126482ba69'
   })
 
-  depends_on 'docker_systemctl_replacement'
   depends_on 'bridge_utils'
   depends_on 'containerd'
+  depends_on 'docker_systemctl_replacement'
   depends_on 'eudev'
+  depends_on 'fuse_overlayfs'
   depends_on 'iproute2'
   depends_on 'lvm2'
   depends_on 'sqlite'
-  depends_on 'go' => ':build'
   depends_on 'btrfsprogs' => ':build'
   depends_on 'elogind' => ':build'
+  depends_on 'go' => ':build'
   depends_on 'go_md2man' => ':build'
   no_env_options
   no_fhs

--- a/packages/docker.rb
+++ b/packages/docker.rb
@@ -10,6 +10,7 @@ class Docker < Package
   license 'Apache'
   compatibility 'all'
   source_url 'https://github.com/docker/cli.git'
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/docker/20.10.12_armv7l/docker-20.10.12-chromeos-armv7l.tar.zst',
@@ -17,13 +18,12 @@ class Docker < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/docker/20.10.12_x86_64/docker-20.10.12-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'e1aab9dc93822aa0b2ccf2c87f943801ca927dad0635141b4c014d73ad482805',
-     armv7l: 'e1aab9dc93822aa0b2ccf2c87f943801ca927dad0635141b4c014d73ad482805',
-     x86_64: 'f9e243148e09d240855ffef68f04c4716142612d30f0d541c186840c7dc1114b'
+    aarch64: '9dd56bf70a05ba13eb636ec1755b0460e3676b843ccfbc4969446fbb8e2098d2',
+     armv7l: '9dd56bf70a05ba13eb636ec1755b0460e3676b843ccfbc4969446fbb8e2098d2',
+     x86_64: 'fe2a39d90ef0b37c33125cdcbdccf7a8b26255dff3ac46e790fa02126482ba69'
   })
 
-  git_hashtag "v#{version}"
-
+  depends_on 'docker_systemctl_replacement'
   depends_on 'bridge_utils'
   depends_on 'containerd'
   depends_on 'eudev'
@@ -35,6 +35,7 @@ class Docker < Package
   depends_on 'elogind' => ':build'
   depends_on 'go_md2man' => ':build'
   no_env_options
+  no_fhs
 
   def self.build
     @cli_version = git_hashtag
@@ -70,6 +71,7 @@ class Docker < Package
     Dir.chdir 'src/github.com/docker/' do
       system "git clone --depth 1 --branch #{@moby_version} https://github.com/moby/moby.git docker"
       Dir.chdir 'docker' do
+        system "sed -i 's,/usr,#{CREW_PREFIX},g' contrib/init/systemd/docker.service"
         system "GOPATH=#{@gopath} \
         CGO_CPPFLAGS='#{CREW_COMMON_FLAGS.gsub('-flto', '')}' \
         CGO_CFLAGS='#{CREW_COMMON_FLAGS.gsub('-flto', '')}' \
@@ -120,31 +122,39 @@ class Docker < Package
 
   def self.install
     FileUtils.mkdir_p %W[
-      #{CREW_DEST_PREFIX}/bin
-      #{CREW_DEST_PREFIX}/etc/elogind
-      #{CREW_DEST_PREFIX}/etc/udev/rules.d
-      #{CREW_DEST_PREFIX}/etc/sysusers.d
-      #{CREW_DEST_PREFIX}/share/bash-completion/completions
-      #{CREW_DEST_PREFIX}/share/zsh/site-functions
-      #{CREW_DEST_PREFIX}/share/fish/vendor_completions.d
+      #{CREW_DEST_LIB_PREFIX}/docker/cli-plugins
       #{CREW_DEST_MAN_PREFIX}/man1
       #{CREW_DEST_MAN_PREFIX}/man5
       #{CREW_DEST_MAN_PREFIX}/man8
-      #{CREW_DEST_LIB_PREFIX}/docker/cli-plugins
+      #{CREW_DEST_PREFIX}/bin
+      #{CREW_DEST_PREFIX}/.config/systemd/user
+      #{CREW_DEST_PREFIX}/etc/sysusers.d
+      #{CREW_DEST_PREFIX}/etc/udev/rules.d
+      #{CREW_DEST_PREFIX}/share/bash-completion/completions
+      #{CREW_DEST_PREFIX}/share/fish/vendor_completions.d
+      #{CREW_DEST_PREFIX}/share/zsh/site-functions
     ]
-    system "install -Dm755 src/github.com/docker/libnetwork/proxy #{CREW_DEST_PREFIX}/bin/docker-proxy"
-    system "install -Dm755 src/github.com/docker/tini/tini-static #{CREW_DEST_PREFIX}/bin/docker-init"
-    system "install -Dm755 src/github.com/docker/docker/bundles/dynbinary-daemon/dockerd #{CREW_DEST_PREFIX}/bin/dockerd"
-    system "install -Dm644 'src/github.com/docker/docker/contrib/init/systemd/docker.service' #{CREW_DEST_PREFIX}/etc/elogind/docker.service"
-    system "install -Dm644 'src/github.com/docker/docker/contrib/init/systemd/docker.socket' #{CREW_DEST_PREFIX}/etc/elogind/docker.socket"
-    system "install -Dm644 'src/github.com/docker/docker/contrib/udev/80-docker.rules' #{CREW_DEST_PREFIX}/etc/udev/rules.d/80-docker.rules"
+    FileUtils.install 'src/github.com/docker/libnetwork/proxy', "#{CREW_DEST_PREFIX}/bin/docker-proxy", mode: 0o755
+    FileUtils.install 'src/github.com/docker/tini/tini-static', "#{CREW_DEST_PREFIX}/bin/docker-init", mode: 0o755
+    FileUtils.install 'src/github.com/docker/docker/bundles/dynbinary-daemon/dockerd',
+                      "#{CREW_DEST_PREFIX}/bin/dockerd", mode: 0o755
+    FileUtils.install 'src/github.com/docker/docker/contrib/init/systemd/docker.service',
+                      "#{CREW_DEST_PREFIX}/.config/systemd/user/docker.service", mode: 0o644
+    FileUtils.install 'src/github.com/docker/docker/contrib/init/systemd/docker.socket',
+                      "#{CREW_DEST_PREFIX}/.config/systemd/user/docker.socket", mode: 0o644
+    FileUtils.install 'src/github.com/docker/docker/contrib/udev/80-docker.rules',
+                      "#{CREW_DEST_PREFIX}/etc/udev/rules.d/80-docker.rules", mode: 0o644
     @docker_sysusers = 'g chronos - -'
     File.write("#{CREW_DEST_PREFIX}/etc/sysusers.d/docker.conf", @docker_sysusers, perm: 0o644)
-    system "install -Dm755 build/docker #{CREW_DEST_PREFIX}/bin/docker"
-    system "install -Dm644 'contrib/completion/bash/docker' #{CREW_DEST_PREFIX}/share/bash-completion/completions/docker"
-    system "install -Dm644 'contrib/completion/zsh/_docker' #{CREW_DEST_PREFIX}/share/zsh/site-functions/_docker"
-    system "install -Dm644 'contrib/completion/fish/docker.fish' #{CREW_DEST_PREFIX}/share/fish/vendor_completions.d/docker.fish"
+    FileUtils.install 'build/docker', "#{CREW_DEST_PREFIX}/bin/docker", mode: 0o755
+    FileUtils.install 'contrib/completion/bash/docker',
+                      "#{CREW_DEST_PREFIX}/share/bash-completion/completions/dockeres", mode: 0o644
+    FileUtils.install 'contrib/completion/zsh/_docker', "#{CREW_DEST_PREFIX}/share/zsh/site-functions/_docker",
+                      mode: 0o644
+    FileUtils.install 'contrib/completion/fish/docker.fish',
+                      "#{CREW_DEST_PREFIX}/share/fish/vendor_completions.d/docker.fish", mode: 0o644
     FileUtils.cp_r Dir.glob('man/man*'), "#{CREW_DEST_MAN_PREFIX}/"
-    system "install -Dm755 src/github.com/docker/buildx/docker-buildx #{CREW_DEST_LIB_PREFIX}/docker/cli-plugins/docker-buildx"
+    FileUtils.install 'src/github.com/docker/buildx/docker-buildx',
+                      "#{CREW_DEST_LIB_PREFIX}/docker/cli-plugins/docker-buildx", mode: 0o755
   end
 end

--- a/packages/docker.rb
+++ b/packages/docker.rb
@@ -31,10 +31,10 @@ class Docker < Package
   depends_on 'iproute2'
   depends_on 'lvm2'
   depends_on 'sqlite'
-  depends_on 'btrfsprogs' => ':build'
-  depends_on 'elogind' => ':build'
-  depends_on 'go' => ':build'
-  depends_on 'go_md2man' => ':build'
+  depends_on 'btrfsprogs' => :build
+  depends_on 'elogind' => :build
+  depends_on 'go' => :build
+  depends_on 'go_md2man' => :build
   no_env_options
   no_fhs
 

--- a/packages/docker.rb
+++ b/packages/docker.rb
@@ -1,0 +1,149 @@
+# Adapted from Arch Linux docker PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/docker/trunk/PKGBUILD
+
+require 'package'
+
+class Docker < Package
+  description 'Pack, ship and run any application as a lightweight container'
+  homepage 'https://www.docker.com/'
+  version '20.10.12'
+  license 'Apache'
+  compatibility 'all'
+  source_url 'https://github.com/docker/cli.git'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/docker/20.10.12_armv7l/docker-20.10.12-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/docker/20.10.12_armv7l/docker-20.10.12-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/docker/20.10.12_x86_64/docker-20.10.12-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: 'e1aab9dc93822aa0b2ccf2c87f943801ca927dad0635141b4c014d73ad482805',
+     armv7l: 'e1aab9dc93822aa0b2ccf2c87f943801ca927dad0635141b4c014d73ad482805',
+     x86_64: 'f9e243148e09d240855ffef68f04c4716142612d30f0d541c186840c7dc1114b'
+  })
+
+  git_hashtag "v#{version}"
+
+  depends_on 'bridge_utils'
+  depends_on 'eudev'
+  depends_on 'iproute2'
+  depends_on 'lvm2'
+  depends_on 'sqlite'
+  depends_on 'go' => ':build'
+  depends_on 'btrfsprogs' => ':build'
+  depends_on 'elogind' => ':build'
+  depends_on 'go_md2man' => ':build'
+  no_env_options
+
+  def self.build
+    @cli_version = git_hashtag
+    @moby_version = git_hashtag
+    @libnetwork_version = '64b7a4574d1426139437d20e81c0b6d391130ec8'
+    @tini_version = 'de40ad007797e0dcd8b7126f27bb87401d224240'
+    @buildx_version = '05846896d149da05f3d6fd1e7770da187b52a247'
+    @gopath = `pwd`.chomp
+    FileUtils.mkdir_p 'src/github.com/docker'
+    FileUtils.ln_s @gopath, 'src/github.com/docker/cli'
+    Dir.chdir 'src/github.com/docker/cli' do
+      system "GOPATH=#{@gopath} \
+      CGO_CPPFLAGS='#{CREW_COMMON_FLAGS}' \
+      CGO_CFLAGS='#{CREW_COMMON_FLAGS}' \
+      CGO_CXXFLAGS='#{CREW_COMMON_FLAGS}' \
+      CGO_LDFLAGS='#{CREW_LDFLAGS}' \
+      LDFLAGS='' \
+      GOFLAGS='-buildmode=pie -trimpath -mod=readonly -modcacherw -ldflags=-linkmode=external' \
+      GO111MODULE=off \
+      DISABLE_WARN_OUTSIDE_CONTAINER=1 \
+      make VERSION=#{version} dynbinary"
+      system "GOPATH=#{@gopath} \
+      CGO_CPPFLAGS='#{CREW_COMMON_FLAGS}' \
+      CGO_CFLAGS='#{CREW_COMMON_FLAGS}' \
+      CGO_CXXFLAGS='#{CREW_COMMON_FLAGS}' \
+      CGO_LDFLAGS='#{CREW_LDFLAGS}' \
+      LDFLAGS='' \
+      GOFLAGS='-buildmode=pie -trimpath -mod=readonly -modcacherw -ldflags=-linkmode=external' \
+      GO111MODULE=off \
+      DISABLE_WARN_OUTSIDE_CONTAINER=1 \
+      make manpages"
+    end
+    Dir.chdir 'src/github.com/docker/' do
+      system "git clone --depth 1 --branch #{@moby_version} https://github.com/moby/moby.git docker"
+      Dir.chdir 'docker' do
+        system "GOPATH=#{@gopath} \
+        CGO_CPPFLAGS='#{CREW_COMMON_FLAGS.gsub('-flto', '')}' \
+        CGO_CFLAGS='#{CREW_COMMON_FLAGS.gsub('-flto', '')}' \
+        CGO_CXXFLAGS='#{CREW_COMMON_FLAGS.gsub('-flto', '')}' \
+        CGO_LDFLAGS='' \
+        LDFLAGS='' \
+        GOFLAGS='-buildmode=pie -trimpath -mod=readonly -modcacherw -ldflags=-linkmode=external' \
+        GO111MODULE=off \
+        DISABLE_WARN_OUTSIDE_CONTAINER=1 \
+        DOCKER_GITCOMMIT=\$(git rev-parse --short HEAD) \
+        DOCKER_BUILDTAGS='seccomp apparmor' \
+        VERSION=#{version} \
+        hack/make.sh dynbinary"
+      end
+      system 'git clone https://github.com/docker/libnetwork.git'
+      Dir.chdir 'libnetwork' do
+        system "git checkout #{@libnetwork_version}"
+        system "GOPATH=#{@gopath} \
+        CGO_CPPFLAGS='#{CREW_COMMON_FLAGS}' \
+        CGO_CFLAGS='#{CREW_COMMON_FLAGS}' \
+        CGO_CXXFLAGS='#{CREW_COMMON_FLAGS}' \
+        CGO_LDFLAGS='#{CREW_LDFLAGS}' \
+        LDFLAGS='' \
+        GOFLAGS='-buildmode=pie -trimpath -mod=readonly -modcacherw -ldflags=-linkmode=external' \
+        GO111MODULE=off \
+        DISABLE_WARN_OUTSIDE_CONTAINER=1 \
+        go build github.com/docker/libnetwork/cmd/proxy"
+      end
+      system 'git clone https://github.com/krallin/tini.git'
+      Dir.chdir 'tini' do
+        system "git checkout #{@tini_version}"
+        system "cmake #{CREW_CMAKE_OPTIONS} ."
+        system 'make tini-static'
+      end
+      system 'git clone https://github.com/docker/buildx.git'
+      Dir.chdir 'buildx' do
+        system "git checkout #{@buildx_version}"
+        @buildx_r = 'github.com/docker/buildx'
+        system "GOPATH=#{@gopath} \
+          GO111MODULE=on go build -mod=vendor -o docker-buildx -ldflags \"-linkmode=external \
+          -X #{@buildx_r}/version.Version=\$(git describe --match 'v[0-9]*' --always --tags)-docker \
+          -X #{@buildx_r}/version.Revision=\$(git rev-parse HEAD) \
+          -X #{@buildx_r}/version.Package=#{@buildx_r}\" \
+          ./cmd/buildx"
+      end
+    end
+  end
+
+  def self.install
+    FileUtils.mkdir_p %W[
+      #{CREW_DEST_PREFIX}/bin
+      #{CREW_DEST_PREFIX}/etc/elogind
+      #{CREW_DEST_PREFIX}/etc/udev/rules.d
+      #{CREW_DEST_PREFIX}/etc/sysusers.d
+      #{CREW_DEST_PREFIX}/share/bash-completion/completions
+      #{CREW_DEST_PREFIX}/share/zsh/site-functions
+      #{CREW_DEST_PREFIX}/share/fish/vendor_completions.d
+      #{CREW_DEST_MAN_PREFIX}/man1
+      #{CREW_DEST_MAN_PREFIX}/man5
+      #{CREW_DEST_MAN_PREFIX}/man8
+      #{CREW_DEST_LIB_PREFIX}/docker/cli-plugins
+    ]
+    system "install -Dm755 src/github.com/docker/libnetwork/proxy #{CREW_DEST_PREFIX}/bin/docker-proxy"
+    system "install -Dm755 src/github.com/docker/tini/tini-static #{CREW_DEST_PREFIX}/bin/docker-init"
+    system "install -Dm755 src/github.com/docker/docker/bundles/dynbinary-daemon/dockerd #{CREW_DEST_PREFIX}/bin/dockerd"
+    system "install -Dm644 'src/github.com/docker/docker/contrib/init/systemd/docker.service' #{CREW_DEST_PREFIX}/etc/elogind/docker.service"
+    system "install -Dm644 'src/github.com/docker/docker/contrib/init/systemd/docker.socket' #{CREW_DEST_PREFIX}/etc/elogind/docker.socket"
+    system "install -Dm644 'src/github.com/docker/docker/contrib/udev/80-docker.rules' #{CREW_DEST_PREFIX}/etc/udev/rules.d/80-docker.rules"
+    @docker_sysusers = 'g chronos - -'
+    File.write("#{CREW_DEST_PREFIX}/etc/sysusers.d/docker.conf", @docker_sysusers, perm: 0o644)
+    system "install -Dm755 build/docker #{CREW_DEST_PREFIX}/bin/docker"
+    system "install -Dm644 'contrib/completion/bash/docker' #{CREW_DEST_PREFIX}/share/bash-completion/completions/docker"
+    system "install -Dm644 'contrib/completion/zsh/_docker' #{CREW_DEST_PREFIX}/share/zsh/site-functions/_docker"
+    system "install -Dm644 'contrib/completion/fish/docker.fish' #{CREW_DEST_PREFIX}/share/fish/vendor_completions.d/docker.fish"
+    FileUtils.cp_r Dir.glob('man/man*'), "#{CREW_DEST_MAN_PREFIX}/"
+    system "install -Dm755 src/github.com/docker/buildx/docker-buildx #{CREW_DEST_LIB_PREFIX}/docker/cli-plugins/docker-buildx"
+  end
+end

--- a/packages/docker.rb
+++ b/packages/docker.rb
@@ -25,6 +25,7 @@ class Docker < Package
   git_hashtag "v#{version}"
 
   depends_on 'bridge_utils'
+  depends_on 'containerd'
   depends_on 'eudev'
   depends_on 'iproute2'
   depends_on 'lvm2'

--- a/packages/docker_systemctl_replacement.rb
+++ b/packages/docker_systemctl_replacement.rb
@@ -1,0 +1,41 @@
+require 'package'
+
+class Docker_systemctl_replacement < Package
+  description 'docker systemctl replacement'
+  homepage 'https://github.com/gdraheim/docker-systemctl-replacement'
+  version '9cbe1a0'
+  license 'EUPL'
+  compatibility 'all'
+  source_url 'https://github.com/gdraheim/docker-systemctl-replacement.git'
+  git_hashtag '9cbe1a00eb4bdac6ff05b96ca34ec9ed3d8fc06c'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/docker_systemctl_replacement/9cbe1a0_armv7l/docker_systemctl_replacement-9cbe1a0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/docker_systemctl_replacement/9cbe1a0_armv7l/docker_systemctl_replacement-9cbe1a0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/docker_systemctl_replacement/9cbe1a0_i686/docker_systemctl_replacement-9cbe1a0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/docker_systemctl_replacement/9cbe1a0_x86_64/docker_systemctl_replacement-9cbe1a0-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '66715b93dee98fd66b2fd9c7452290923b2675d5a4793f5b66e6ae6dc9325962',
+     armv7l: '66715b93dee98fd66b2fd9c7452290923b2675d5a4793f5b66e6ae6dc9325962',
+       i686: '86175ac25ede6fb8e31bbc419ae0177b3acf41fd3f9e513744ccaf4418255260',
+     x86_64: '56f4b32b29628ea1ab280b5c81a186f8f9fd83c114282858b7cced24324f13cf'
+  })
+
+  depends_on 'python3'
+  no_fhs
+
+  def self.patch
+    system "sed -i 's,/usr/bin/python3,#{CREW_PREFIX}/bin/python3,g' files/docker/systemctl3.py"
+  end
+
+  def self.install
+    # Systemd units should go in "{XDG_CONFIG_HOME}/systemd/user"
+    # Units can be accessed via "systemctl status --user unitname"
+    FileUtils.mkdir_p %W[
+      #{CREW_DEST_PREFIX}/bin
+      #{CREW_DEST_PREFIX}/.config/systemd/user
+    ]
+    FileUtils.install 'files/docker/systemctl3.py', "#{CREW_DEST_PREFIX}/bin/systemctl", mode: 0o755
+  end
+end

--- a/packages/fuse3.rb
+++ b/packages/fuse3.rb
@@ -3,7 +3,7 @@ require 'package'
 class Fuse3 < Package
   description 'The reference implementation of the Linux FUSE (Filesystem in Userspace) interface.'
   homepage 'https://github.com/libfuse/libfuse/'
-  @_ver = '3.10.4'
+  @_ver = '3.10.5'
   version @_ver
   license 'GPL-2+'
   compatibility 'all'
@@ -11,16 +11,16 @@ class Fuse3 < Package
   git_hashtag "fuse-#{@_ver}"
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fuse3/3.10.2_i686/fuse3-3.10.2-chromeos-i686.tar.xz',
- aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fuse3/3.10.4_armv7l/fuse3-3.10.4-chromeos-armv7l.tpxz',
-  armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fuse3/3.10.4_armv7l/fuse3-3.10.4-chromeos-armv7l.tpxz',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fuse3/3.10.4_x86_64/fuse3-3.10.4-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fuse3/3.10.5_armv7l/fuse3-3.10.5-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fuse3/3.10.5_armv7l/fuse3-3.10.5-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fuse3/3.10.5_i686/fuse3-3.10.5-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fuse3/3.10.5_x86_64/fuse3-3.10.5-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: 'd202035312895ee3bd9d260775cabba729d67996b3a3c1ce3786c83120515efa',
- aarch64: 'a2bdd79da18341278a512a50406faa3fdb8bd400a508706fe5c8a9fdacf1ffb5',
-  armv7l: 'a2bdd79da18341278a512a50406faa3fdb8bd400a508706fe5c8a9fdacf1ffb5',
-  x86_64: '1930e0a48097c5e85a4f8b82acfa1e55c579d20677d5cdf6731dcca745bf6556'
+    aarch64: 'd14bba8e1c8af4cdebbf02f4be6ee860c7351c2ceb0a53a67606d26dfb76f3bc',
+     armv7l: 'd14bba8e1c8af4cdebbf02f4be6ee860c7351c2ceb0a53a67606d26dfb76f3bc',
+       i686: 'd0ec9909aa08547edc2371507e4c371ff9df9ba18330ba70ada4fd11979dd5ef',
+     x86_64: '95849855fa8d643efb20145cc25d4752ef10376d6656fda2d7f755bc5ac6977b'
   })
 
   depends_on 'py3_pytest' => :build

--- a/packages/fuse_overlayfs.rb
+++ b/packages/fuse_overlayfs.rb
@@ -1,0 +1,45 @@
+# Adapted from Arch Linux fuse-overlayfs PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/fuse-overlayfs/trunk/PKGBUILD
+
+require 'package'
+
+class Fuse_overlayfs < Package
+  description 'FUSE implementation of overlayfs'
+  homepage 'https://github.com/containers/fuse-overlayfs'
+  version '1.8.2'
+  license 'GPL3'
+  compatibility 'all'
+  source_url 'https://github.com/containers/fuse-overlayfs.git'
+  git_hashtag "v#{version}"
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fuse_overlayfs/1.8.2_armv7l/fuse_overlayfs-1.8.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fuse_overlayfs/1.8.2_armv7l/fuse_overlayfs-1.8.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fuse_overlayfs/1.8.2_i686/fuse_overlayfs-1.8.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fuse_overlayfs/1.8.2_x86_64/fuse_overlayfs-1.8.2-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '743fab0fb1b5b0870bcf6b039e4584864f29e3515feb9c7d8e1452933d053db8',
+     armv7l: '743fab0fb1b5b0870bcf6b039e4584864f29e3515feb9c7d8e1452933d053db8',
+       i686: 'd9202201b363ab5f15999622c853a246f218d73a842c5d2bfd8c9017784bee7f',
+     x86_64: '88862153fb47b449e2689208068fd41f18e2bb516330a4bc78775a40f5ac1394'
+  })
+
+  depends_on 'fuse3'
+  depends_on 'go_md2man' => :build
+
+  def self.build
+    system 'autoreconf -fiv'
+    system "./configure #{CREW_OPTIONS} \
+      --sbindir=#{CREW_PREFIX}/bin"
+    system 'make'
+  end
+
+  def self.check
+    system 'make check'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end

--- a/packages/go_md2man.rb
+++ b/packages/go_md2man.rb
@@ -18,9 +18,9 @@ class Go_md2man < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/go_md2man/2.0.1_x86_64/go_md2man-2.0.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '4074c6158cb50c394690443722a06e90f385b886ecfaaf4c9c8395eb639f5351',
-     armv7l: '4074c6158cb50c394690443722a06e90f385b886ecfaaf4c9c8395eb639f5351',
-     x86_64: 'ba48983b018cbf9d7e985e987dca4bb7ac6216064373b5a69a57c42ffc4ff56b'
+    aarch64: 'e12a504971810dee421ca4657a4af3c1be3ca82d4e319896e48d180c708e7679',
+     armv7l: 'e12a504971810dee421ca4657a4af3c1be3ca82d4e319896e48d180c708e7679',
+     x86_64: 'e1980595f9ff429ed47c7d8a2f57e5bf8a20e1d83277c0331d330d98b8558e97'
   })
 
   depends_on 'go'
@@ -31,7 +31,11 @@ class Go_md2man < Package
   end
 
   def self.install
-    system "install -Dm755 go-md2man #{CREW_DEST_PREFIX}/bin/go-md2man"
-    system "install -Dm755 go-md2man.1 #{CREW_DEST_MAN_PREFIX}/man1/go-md2man.1"
+    FileUtils.mkdir_p %W[
+      #{CREW_DEST_PREFIX}/bin
+      #{CREW_DEST_MAN_PREFIX}/man1
+    ]
+    FileUtils.install 'go-md2man', "#{CREW_DEST_PREFIX}/bin/go-md2man", mode: 0o755
+    FileUtils.install 'go-md2man.1', "#{CREW_DEST_MAN_PREFIX}/man1/go-md2man.1", mode: 0o644
   end
 end

--- a/packages/go_md2man.rb
+++ b/packages/go_md2man.rb
@@ -23,7 +23,7 @@ class Go_md2man < Package
      x86_64: 'e1980595f9ff429ed47c7d8a2f57e5bf8a20e1d83277c0331d330d98b8558e97'
   })
 
-  depends_on 'go'
+  depends_on 'go' => :build
 
   def self.build
     system "GOFLAGS='-buildmode=pie -mod=vendor -trimpath' CGO_LDFLAGS=$LDFLAGS go build -o go-md2man ."

--- a/packages/go_md2man.rb
+++ b/packages/go_md2man.rb
@@ -1,0 +1,37 @@
+# Adapted from Arch Linux go-md2man PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/go-md2man/trunk/PKGBUILD
+
+require 'package'
+
+class Go_md2man < Package
+  description 'A markdown to manpage generator'
+  homepage 'https://github.com/cpuguy83/go-md2man'
+  version '2.0.1'
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://github.com/cpuguy83/go-md2man/archive/v2.0.1.tar.gz'
+  source_sha256 '889309ecf43e40d3a76d666b0259dcd71b340ea0fad003784ff3fe0b6c21990e'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/go_md2man/2.0.1_armv7l/go_md2man-2.0.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/go_md2man/2.0.1_armv7l/go_md2man-2.0.1-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/go_md2man/2.0.1_x86_64/go_md2man-2.0.1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '4074c6158cb50c394690443722a06e90f385b886ecfaaf4c9c8395eb639f5351',
+     armv7l: '4074c6158cb50c394690443722a06e90f385b886ecfaaf4c9c8395eb639f5351',
+     x86_64: 'ba48983b018cbf9d7e985e987dca4bb7ac6216064373b5a69a57c42ffc4ff56b'
+  })
+
+  depends_on 'go'
+
+  def self.build
+    system "GOFLAGS='-buildmode=pie -mod=vendor -trimpath' CGO_LDFLAGS=$LDFLAGS go build -o go-md2man ."
+    system './go-md2man -in=go-md2man.1.md -out=go-md2man.1'
+  end
+
+  def self.install
+    system "install -Dm755 go-md2man #{CREW_DEST_PREFIX}/bin/go-md2man"
+    system "install -Dm755 go-md2man.1 #{CREW_DEST_MAN_PREFIX}/man1/go-md2man.1"
+  end
+end

--- a/packages/iproute2.rb
+++ b/packages/iproute2.rb
@@ -1,0 +1,150 @@
+# Adapted from Arch Linux iproute2 PKGBUILD at:
+# https://github.com/archlinux/svntogit-packages/raw/packages/iproute2/trunk/PKGBUILD
+
+require 'package'
+
+class Iproute2 < Package
+  description 'IP Routing Utilities'
+  homepage 'https://git.kernel.org/pub/scm/network/iproute2/iproute2.git'
+  version '5.16.0'
+  license 'GPL2'
+  compatibility 'all'
+  source_url 'https://www.kernel.org/pub/linux/utils/net/iproute2/iproute2-5.16.0.tar.xz'
+  source_sha256 'c064b66f6b001c2a35aa5224b5b1ac8aa4bee104d7dce30d6f10a84cb8b01e2f'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/iproute2/5.16.0_armv7l/iproute2-5.16.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/iproute2/5.16.0_armv7l/iproute2-5.16.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/iproute2/5.16.0_i686/iproute2-5.16.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/iproute2/5.16.0_x86_64/iproute2-5.16.0-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: 'ce61bbe2bd40484edcafd1acad7a1a57a0a4666ff283055141093c48d2bfa709',
+     armv7l: 'ce61bbe2bd40484edcafd1acad7a1a57a0a4666ff283055141093c48d2bfa709',
+       i686: '42422341af0c46a6fea69cd03a46f31d9ed58c1755de34b516123d5b231f9b1f',
+     x86_64: '849fcfd35a20595c20683b143d4bc49a13322b638ab92fec37dfbfdd7e480ea2'
+  })
+
+  depends_on 'iptables'
+  depends_on 'elfutils'
+
+  def self.patch
+    @iproute2_fhs_patch = <<~'IPROUTE2_FHS_EOF'
+      From f0624f6cc656cb177b64e2664f2a806221bfab58 Mon Sep 17 00:00:00 2001
+      From: Christian Hesse <mail@eworm.de>
+      Date: Thu, 28 Jul 2016 08:49:20 +0200
+      Subject: [PATCH 1/1] make iproute2 fhs compliant
+
+      Signed-off-by: Christian Hesse <mail@eworm.de>
+      ---
+       Makefile       |  2 +-
+       netem/Makefile |  4 ++--
+       tc/q_netem.c   |  2 +-
+       tc/tc_util.c   | 15 +++++++++++++++
+       tc/tc_util.h   |  1 +
+       5 files changed, 20 insertions(+), 4 deletions(-)
+
+      diff --git a/Makefile b/Makefile
+      index eb571a5..db0a04c 100644
+      --- a/Makefile
+      +++ b/Makefile
+      @@ -14,7 +14,7 @@ DBM_INCLUDE:=$(DESTDIR)/usr/include
+       
+       SHARED_LIBS = y
+       
+      -DEFINES= -DRESOLVE_HOSTNAMES -DLIBDIR=\"$(LIBDIR)\"
+      +DEFINES= -DRESOLVE_HOSTNAMES -DLIBDIR=\"$(LIBDIR)\" -DDATADIR=\"$(DATADIR)\"
+       ifneq ($(SHARED_LIBS),y)
+       DEFINES+= -DNO_SHARED_LIBS
+       endif
+      diff --git a/netem/Makefile b/netem/Makefile
+      index e52e125..5b4d283 100644
+      --- a/netem/Makefile
+      +++ b/netem/Makefile
+      @@ -20,9 +20,9 @@ stats: stats.c
+       	$(HOSTCC) $(CCOPTS) -I../include -o $@ $@.c -lm
+       
+       install: all
+      -	mkdir -p $(DESTDIR)$(LIBDIR)/tc
+      +	mkdir -p $(DESTDIR)$(DATADIR)/tc
+       	for i in $(DISTDATA); \
+      -	do install -m 644 $$i $(DESTDIR)$(LIBDIR)/tc; \
+      +	do install -m 644 $$i $(DESTDIR)$(DATADIR)/tc; \
+       	done
+       
+       clean:
+      diff --git a/tc/q_netem.c b/tc/q_netem.c
+      index 8fe2204..a15a5c7 100644
+      --- a/tc/q_netem.c
+      +++ b/tc/q_netem.c
+      @@ -113,7 +113,7 @@ static int get_distribution(const char *type, __s16 *data, int maxdata)
+       	char *line = NULL;
+       	char name[128];
+       
+      -	snprintf(name, sizeof(name), "%s/%s.dist", get_tc_lib(), type);
+      +	snprintf(name, sizeof(name), "%s/%s.dist", get_tc_datadir(), type);
+       	if ((f = fopen(name, "r")) == NULL) {
+       		fprintf(stderr, "No distribution data for %s (%s: %s)\n",
+       			type, name, strerror(errno));
+      diff --git a/tc/tc_util.c b/tc/tc_util.c
+      index afc4cf5..728b854 100644
+      --- a/tc/tc_util.c
+      +++ b/tc/tc_util.c
+      @@ -32,6 +32,10 @@
+       #define LIBDIR "/usr/lib"
+       #endif
+       
+      +#ifndef DATADIR
+      +#define DATADIR "/usr/share"
+      +#endif
+      +
+       static struct db_names *cls_names;
+       
+       #define NAMES_DB "/etc/iproute2/tc_cls"
+      @@ -73,6 +77,17 @@ const char *get_tc_lib(void)
+       	return lib_dir;
+       }
+       
+      +const char *get_tc_datadir(void)
+      +{
+      +	const char *data_dir;
+      +
+      +	data_dir = getenv("TC_DATA_DIR");
+      +	if (!data_dir)
+      +		data_dir = DATADIR "/tc/";
+      +
+      +	return data_dir;
+      +}
+      +
+       int get_qdisc_handle(__u32 *h, const char *str)
+       {
+       	__u32 maj;
+      diff --git a/tc/tc_util.h b/tc/tc_util.h
+      index 61e60b1..6d448de 100644
+      --- a/tc/tc_util.h
+      +++ b/tc/tc_util.h
+      @@ -55,6 +55,7 @@ struct exec_util {
+       };
+       
+       const char *get_tc_lib(void);
+      +const char *get_tc_datadir(void);
+       
+       struct qdisc_util *get_qdisc_kind(const char *str);
+       struct filter_util *get_filter_kind(const char *str);
+    IPROUTE2_FHS_EOF
+    File.write('0001-make-iproute2-fhs-compliant.patch', @iproute2_fhs_patch)
+    system 'patch -Np1 -i 0001-make-iproute2-fhs-compliant.patch'
+    system "sed -i 's/-Werror//' Makefile"
+  end
+
+  def self.build
+    system './configure'
+    system 'make'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} SBINDIR=#{CREW_PREFIX}/bin install"
+    system "install -Dm0644 include/libnetlink.h #{CREW_DEST_PREFIX}/include/libnetlink.h"
+    system "install -Dm0644 lib/libnetlink.a #{CREW_DEST_LIB_PREFIX}/libnetlink.a"
+  end
+end

--- a/packages/iproute2.rb
+++ b/packages/iproute2.rb
@@ -143,8 +143,12 @@ class Iproute2 < Package
   end
 
   def self.install
+    FileUtils.mkdir_p %W[
+    #{CREW_DEST_PREFIX}/include
+    #{CREW_DEST_LIB_PREFIX}
+    ]
     system "make DESTDIR=#{CREW_DEST_DIR} SBINDIR=#{CREW_PREFIX}/bin install"
-    system "install -Dm0644 include/libnetlink.h #{CREW_DEST_PREFIX}/include/libnetlink.h"
-    system "install -Dm0644 lib/libnetlink.a #{CREW_DEST_LIB_PREFIX}/libnetlink.a"
+    FileUtils.install 'include/libnetlink.h', "#{CREW_DEST_PREFIX}/include/libnetlink.h", mode: 0o644
+    FileUtils.install 'lib/libnetlink.a', "#{CREW_DEST_LIB_PREFIX}/libnetlink.a", mode: 0o644
   end
 end

--- a/packages/libbpf.rb
+++ b/packages/libbpf.rb
@@ -24,7 +24,7 @@ class Libbpf < Package
   })
 
   depends_on 'elfutils'
-  depends_on 'rsync' => ':build'
+  depends_on 'rsync' => :build
 
   def self.patch
     system "sed -i 's,PREFIX ?= /usr,PREFIX ?= #{CREW_PREFIX},g' src/Makefile"

--- a/packages/libbpf.rb
+++ b/packages/libbpf.rb
@@ -1,0 +1,41 @@
+# Adapted from Arch Linux libbpf PKGBUILD at:
+# https://github.com/archlinux/svntogit-packages/raw/packages/libbpf/trunk/PKGBUILD
+
+require 'package'
+
+class Libbpf < Package
+  description 'Library for loading eBPF programs and reading and manipulating eBPF objects from user-space'
+  homepage 'https://github.com/libbpf/libbpf'
+  version '0.7.0'
+  license 'LGPL2.1'
+  compatibility 'all'
+  source_url 'https://github.com/libbpf/libbpf/archive/v0.7.0/libbpf-0.7.0.tar.gz'
+  source_sha256 '5083588ce5a3a620e395ee1e596af77b4ec5771ffc71cff2af49dfee38c06361'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libbpf/0.7.0_armv7l/libbpf-0.7.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libbpf/0.7.0_armv7l/libbpf-0.7.0-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libbpf/0.7.0_x86_64/libbpf-0.7.0-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '3428813d83b350dc34a7d3b924234c27c85b1fcd09d62ee8ed9810607d93163f',
+     armv7l: '3428813d83b350dc34a7d3b924234c27c85b1fcd09d62ee8ed9810607d93163f',
+     x86_64: 'e9a7dadae061accb7a6a303be994d82bc16cac80c9bd5fb893277ae7b3ca5f47'
+  })
+
+  depends_on 'elfutils'
+  depends_on 'rsync' => ':build'
+
+  def self.patch
+    system "sed -i 's,PREFIX ?= /usr,PREFIX ?= #{CREW_PREFIX},g' src/Makefile"
+  end
+
+  def self.build
+    system 'make -C src'
+  end
+
+  def self.install
+    system "make -C src DESTDIR=#{CREW_DEST_DIR} LIBSUBDIR=#{ARCH_LIB} install install_headers"
+    system "install -Dm 644 README.md -t #{CREW_DEST_PREFIX}/share/doc/libbpf"
+  end
+end

--- a/packages/libdb.rb
+++ b/packages/libdb.rb
@@ -3,30 +3,32 @@ require 'package'
 class Libdb < Package
   description 'Berkeley DB is a family of embedded key-value database libraries providing scalable high-performance data management services to applications.'
   homepage 'https://github.com/berkeleydb/libdb'
-  version '5.3.28'
+  version '5.3.28-1'
   license 'ASM, BSD, CDDL, custom and SPL.'
   compatibility 'all'
   source_url 'https://github.com/berkeleydb/libdb/releases/download/v5.3.28/db-5.3.28.tar.gz'
   source_sha256 'e0a992d740709892e81f9d93f06daf305cf73fb81b545afe72478043172c3628'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdb/5.3.28_armv7l/libdb-5.3.28-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdb/5.3.28_armv7l/libdb-5.3.28-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdb/5.3.28_i686/libdb-5.3.28-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdb/5.3.28_x86_64/libdb-5.3.28-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdb/5.3.28-1_armv7l/libdb-5.3.28-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdb/5.3.28-1_armv7l/libdb-5.3.28-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdb/5.3.28-1_i686/libdb-5.3.28-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdb/5.3.28-1_x86_64/libdb-5.3.28-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'bf1e26d40554e30404c8eaba250eb008561113f8742f4d9d07999687881c642d',
-     armv7l: 'bf1e26d40554e30404c8eaba250eb008561113f8742f4d9d07999687881c642d',
-       i686: '5371ea9f3d3fc18d38bd31dbd97854f4d6a06d995a58776ec1e3c94fbf29dc54',
-     x86_64: '0e51467868c7ea8fdf9916bf2ee1b3500b8ea7f0f5cd8f9ec4c9f3a3aafc2213'
+    aarch64: '29f77d25f61cd4492244121f23872e7248d91ae08b12cc479706ef63fdebdae3',
+     armv7l: '29f77d25f61cd4492244121f23872e7248d91ae08b12cc479706ef63fdebdae3',
+       i686: 'a813b4c1bcd84254e9f1fb45ecb37b6f1d7ca60beb3b435759338e4d1914d3d7',
+     x86_64: 'c3af1fe7d33a0453e7bf33425a310666cd6239be1d38729c69af52350cc350aa'
   })
 
   depends_on 'glibc' # R
 
   def self.build
     Dir.chdir 'build_unix' do
-      system "../dist/configure #{CREW_OPTIONS} --enable-dbm"
+      system "../dist/configure #{CREW_OPTIONS} \
+      --enable-compat185 \
+      --enable-dbm"
       system 'make'
     end
   end

--- a/packages/mandown.rb
+++ b/packages/mandown.rb
@@ -1,0 +1,38 @@
+# Adapted from Arch Linux mandown PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/mandown/trunk/PKGBUILD
+
+require 'package'
+
+class Mandown < Package
+  description 'Create man pages from markdown markup'
+  homepage 'https://gitlab.com/kornelski/mandown'
+  version '0.1.2'
+  license 'Apache'
+  compatibility 'all'
+  source_url 'https://gitlab.com/kornelski/mandown.git'
+  git_hashtag version
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mandown/0.1.2_armv7l/mandown-0.1.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mandown/0.1.2_armv7l/mandown-0.1.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mandown/0.1.2_i686/mandown-0.1.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mandown/0.1.2_x86_64/mandown-0.1.2-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '9f4efe76ecd382186577c77742743227fce401bd5e26ccda4abd1db62caa5b3e',
+     armv7l: '9f4efe76ecd382186577c77742743227fce401bd5e26ccda4abd1db62caa5b3e',
+       i686: '9393b4c96cf55dd80af49742481889554776baef3f6450494ea15fee1f7192f4',
+     x86_64: '921636c6aefbba2ab7a1fcc0e27f577b02b40ffbe841f6e837ff676a11b9d52e'
+  })
+
+  depends_on 'rust' => ':build'
+
+  def self.build
+    system 'cargo build --release --all-features --target-dir=target'
+  end
+
+  def self.install
+    system 'cargo build --release --locked --all-features --target-dir=target'
+    system "install -Dm 755 target/release/mandown -t #{CREW_DEST_PREFIX}/bin"
+  end
+end

--- a/packages/mandown.rb
+++ b/packages/mandown.rb
@@ -25,7 +25,7 @@ class Mandown < Package
      x86_64: '921636c6aefbba2ab7a1fcc0e27f577b02b40ffbe841f6e837ff676a11b9d52e'
   })
 
-  depends_on 'rust' => ':build'
+  depends_on 'rust' => :build
 
   def self.build
     system 'cargo build --release --all-features --target-dir=target'

--- a/packages/mandown.rb
+++ b/packages/mandown.rb
@@ -33,6 +33,7 @@ class Mandown < Package
 
   def self.install
     system 'cargo build --release --locked --all-features --target-dir=target'
-    system "install -Dm 755 target/release/mandown -t #{CREW_DEST_PREFIX}/bin"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    FileUtils.install 'target/release/mandown', "#{CREW_DEST_PREFIX}/bin/", mode: 0o755
   end
 end

--- a/packages/netavark.rb
+++ b/packages/netavark.rb
@@ -37,8 +37,8 @@ class Netavark < Package
 
   def self.install
     FileUtils.mkdir_p %W[{CREW_DEST_LIB_PREFIX}/podman #{CREW_DEST_PREFIX}/share/doc/netavark]
-    system "install -vDm 755 target/release/netavark -t #{CREW_DEST_LIB_PREFIX}/podman/"
     system "make DESTDIR=#{CREW_DEST_DIR} PREFIX=#{CREW_PREFIX} install -C docs"
-    system "install -vDm 644 README.md -t #{CREW_DEST_PREFIX}/share/doc/netavark/"
+    FileUtils.install 'target/release/netavark', "#{CREW_DEST_LIB_PREFIX}/podman/", mode: 0o755
+    FileUtils.install 'README.md', "#{CREW_DEST_PREFIX}/share/doc/netavark/", mode: 0o644
   end
 end

--- a/packages/netavark.rb
+++ b/packages/netavark.rb
@@ -1,0 +1,44 @@
+# Adapted from Arch Linux netavark PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/netavark/trunk/PKGBUILD
+
+require 'package'
+
+class Netavark < Package
+  description 'Container network stack'
+  homepage 'https://github.com/containers/netavark'
+  version '1.0.1'
+  license 'Apache'
+  compatibility 'all'
+  source_url 'https://github.com/containers/netavark.git'
+  git_hashtag "v#{version}"
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/netavark/1.0.1_armv7l/netavark-1.0.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/netavark/1.0.1_armv7l/netavark-1.0.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/netavark/1.0.1_i686/netavark-1.0.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/netavark/1.0.1_x86_64/netavark-1.0.1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '5278c97de9d0e0d550d74e59bcda1250789a02f111dd2c5ab6ac6661d1a3d8dc',
+     armv7l: '5278c97de9d0e0d550d74e59bcda1250789a02f111dd2c5ab6ac6661d1a3d8dc',
+       i686: 'd6b6e5ae80e4a06f894850f871ffdf57460a605a7ccfc24c8ecab69e667b14b2',
+     x86_64: '78b18d0e1c2271b376b9ed5173185b39e109dd50140d5f8ba71177d4b8f46410'
+  })
+
+  depends_on 'libgit2' => ':build'
+  depends_on 'mandown' => ':build'
+
+  def self.build
+    @carch = ARCH == 'aarch64' || ARCH == 'armv7l' ? 'armv7-unknown-linux-gnueabihf' : "#{ARCH}-unknown-linux-gnu"
+    system "cargo fetch --locked --target #{@carch}"
+    system 'CARGO_TARGET_DIR=target cargo build --frozen --release --all-features'
+    system 'make -C docs'
+  end
+
+  def self.install
+    FileUtils.mkdir_p %W[{CREW_DEST_LIB_PREFIX}/podman #{CREW_DEST_PREFIX}/share/doc/netavark]
+    system "install -vDm 755 target/release/netavark -t #{CREW_DEST_LIB_PREFIX}/podman/"
+    system "make DESTDIR=#{CREW_DEST_DIR} PREFIX=#{CREW_PREFIX} install -C docs"
+    system "install -vDm 644 README.md -t #{CREW_DEST_PREFIX}/share/doc/netavark/"
+  end
+end

--- a/packages/netavark.rb
+++ b/packages/netavark.rb
@@ -25,8 +25,8 @@ class Netavark < Package
      x86_64: '78b18d0e1c2271b376b9ed5173185b39e109dd50140d5f8ba71177d4b8f46410'
   })
 
-  depends_on 'libgit2' => ':build'
-  depends_on 'mandown' => ':build'
+  depends_on 'libgit2' => :build
+  depends_on 'mandown' => :build
 
   def self.build
     @carch = ARCH == 'aarch64' || ARCH == 'armv7l' ? 'armv7-unknown-linux-gnueabihf' : "#{ARCH}-unknown-linux-gnu"

--- a/packages/runc.rb
+++ b/packages/runc.rb
@@ -1,0 +1,48 @@
+# Adapted from Arch Linux runc PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/runc/trunk/PKGBUILD
+
+require 'package'
+
+class Runc < Package
+  description 'CLI tool for managing OCI compliant containers'
+  homepage 'https://runc.io/'
+  version '1.1.0'
+  license 'Apache'
+  compatibility 'all'
+  source_url 'https://github.com/opencontainers/runc.git'
+  git_hashtag "v#{version}"
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/runc/1.1.0_armv7l/runc-1.1.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/runc/1.1.0_armv7l/runc-1.1.0-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/runc/1.1.0_x86_64/runc-1.1.0-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '9b52e4e308ee6f28bfcad10dc3aed23543d6c323199a8ebdd5d9262b80f0438d',
+     armv7l: '9b52e4e308ee6f28bfcad10dc3aed23543d6c323199a8ebdd5d9262b80f0438d',
+     x86_64: '5652d483b9512919ebd0afb8095dc267368307e6ae592f8edcbc87caeab41289'
+  })
+
+  depends_on 'libseccomp'
+  depends_on 'go' => ':build'
+  depends_on 'go_md2man' => ':build'
+
+  def self.build
+    system "BUILDTAGS='seccomp apparmor' \
+      CGO_CPPFLAGS=${CPPFLAGS} \
+      CGO_CFLAGS=${CFLAGS} \
+      CGO_CXXFLAGS=${CXXFLAGS} \
+      CGO_LDFLAGS=${LDFLAGS} \
+      GOFLAGS='-trimpath -mod=readonly -modcacherw' \
+      make runc man"
+  end
+
+  def self.install
+    FileUtils.mkdir_p %W[#{CREW_DEST_PREFIX}/bin/ #{CREW_DEST_MAN_PREFIX}/man8
+                         #{CREW_DEST_PREFIX}/share/bash-completion/completions]
+    system "install -Dm755 runc #{CREW_DEST_PREFIX}/bin/runc"
+    system "install -Dm644 contrib/completions/bash/runc \
+      #{CREW_DEST_PREFIX}/share/bash-completion/completions/runc"
+    system "install -m644 man/man8/*.8 #{CREW_DEST_MAN_PREFIX}/man8"
+  end
+end

--- a/packages/runc.rb
+++ b/packages/runc.rb
@@ -24,8 +24,8 @@ class Runc < Package
   })
 
   depends_on 'libseccomp'
-  depends_on 'go' => ':build'
-  depends_on 'go_md2man' => ':build'
+  depends_on 'go' => :build
+  depends_on 'go_md2man' => :build
 
   def self.build
     system "BUILDTAGS='seccomp apparmor' \


### PR DESCRIPTION
- This PR contains prereqs and packages for docker, as well as for bst.
- Also rebuilds libdb to add `compat185` headers.
- While these packages build fine, they have NOT been tested on actual hardware.
- They could also be further rubified. Please DO edit the package files in this PR to make that happen.
- Please DO test these binaries and make any suggestions  for changes which might make them work better.
- The i686 builds for this are obviously partial. If there isn't a i686 binary, the package just didn't build for i686. I will spend no more time on getting these packages to work for i686.

Builds properly:
- [x] x86_64
- [x] armv7l
- [ ] i686 (some do, some don't)

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=docker CREW_TESTING=1 crew update
```
