### PR TITLE
Update fmt to 8.1.1

### DIFF
--- a/packages/libfmt.rb
+++ b/packages/libfmt.rb
@@ -3,24 +3,11 @@ require 'package'
 class Libfmt < Package
   description 'A modern formatting library'
   homepage 'https://fmt.dev'
-  version '7.1.3'
+  version '8.1.1'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://github.com/fmtlib/fmt/releases/download/7.1.3/fmt-7.1.3.zip'
-  source_sha256 '5d98c504d0205f912e22449ecdea776b78ce0bb096927334f80781e720084c9f'
-
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libfmt/7.1.3_armv7l/libfmt-7.1.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libfmt/7.1.3_armv7l/libfmt-7.1.3-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libfmt/7.1.3_i686/libfmt-7.1.3-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libfmt/7.1.3_x86_64/libfmt-7.1.3-chromeos-x86_64.tar.xz',
-  })
-  binary_sha256 ({
-    aarch64: '26bb8f4333716d1ccce3a479b040e326bdb833483098064d20ef28a53d5068b1',
-     armv7l: '26bb8f4333716d1ccce3a479b040e326bdb833483098064d20ef28a53d5068b1',
-       i686: 'c395953aa8d320e73529488802c7ce418e0902d279102b55722bb6831ae827b7',
-     x86_64: 'cf283994f84edf3b0e7e299ee01fb748f1f8e366f2f30444908cbd2100fa2951',
-  })
+  source_url 'https://github.com/fmtlib/fmt/releases/download/8.1.1/fmt-8.1.1.zip'
+  source_sha256 '23778bad8edba12d76e4075da06db591f3b0e3c6c04928ced4a7282ca3400e5d'
 
   def self.build
     Dir.mkdir "builddir"

--- a/packages/libfmt.rb
+++ b/packages/libfmt.rb
@@ -9,25 +9,38 @@ class Libfmt < Package
   source_url 'https://github.com/fmtlib/fmt/releases/download/8.1.1/fmt-8.1.1.zip'
   source_sha256 '23778bad8edba12d76e4075da06db591f3b0e3c6c04928ced4a7282ca3400e5d'
 
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libfmt/8.1.1_armv7l/libfmt-8.1.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libfmt/8.1.1_armv7l/libfmt-8.1.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libfmt/8.1.1_i686/libfmt-8.1.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libfmt/8.1.1_x86_64/libfmt-8.1.1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: 'a1580b9b29d179ac82030a7590d53fc12e986c355a650bf2f11481ca7948971e',
+     armv7l: 'a1580b9b29d179ac82030a7590d53fc12e986c355a650bf2f11481ca7948971e',
+       i686: 'e2f30b8f2a2de5f62fbc4d7f1289cd1740f1738c357d0aaee298f146566510e4',
+     x86_64: '7ad502f9ffe1781f22ccaf4fdef738de743568e8017cf38fbec8fbcf6a2c4043'
+  })
+
   def self.build
-    Dir.mkdir "builddir"
-    Dir.chdir "builddir" do
+    Dir.mkdir 'builddir'
+    Dir.chdir 'builddir' do
       system "cmake #{CREW_CMAKE_OPTIONS} \
               -DBUILD_SHARED_LIBS=TRUE \
               .."
-      system "make"
+      system 'make'
     end
   end
 
   def self.install
-    Dir.chdir "builddir" do
-      system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+    Dir.chdir 'builddir' do
+      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     end
   end
 
   def self.check
-    Dir.chdir "builddir" do
-      system "make", "test"
+    Dir.chdir 'builddir' do
+      system 'make', 'test'
     end
   end
 end


### PR DESCRIPTION
## Description
Update libfmt to 8.1.1.

## Works properly:
Had package conflict errors in the chroot despite not having libfmt installed, they persisted through a couple of builds so I don't know if this is an actual problem with the package or just my enviro.
- [ ] `x86_64`
- [ ] `i686`
- [ ] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=fmt8 CREW_TESTING=1 crew update
```