### PR TITLE
Remove `glibc` dependency in all packages

### DIFF
--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -12,8 +12,10 @@ class Buildessential < Package
   # Make sure core is installed
   depends_on 'core'
 
-  # install first to get ldconfig
+  # install libc header
   depends_on 'glibc'
+
+  # install first to get ldconfig
   depends_on 'gcc'
   depends_on 'gmp'
   depends_on 'mpfr'

--- a/packages/core.rb
+++ b/packages/core.rb
@@ -23,7 +23,6 @@ class Core < Package
   depends_on 'gdbm'
   depends_on 'gettext'
   depends_on 'git'
-  depends_on 'glibc'
   depends_on 'gnutls'
   depends_on 'groff'
   depends_on 'icu4c'

--- a/packages/faac.rb
+++ b/packages/faac.rb
@@ -25,12 +25,9 @@ class Faac < Package
      x86_64: 'fdea955a9dfd5732dc22a40ec8ff8aef47c153b5f34b7cff7f2aa9d6e0e3f05a'
   })
 
-  depends_on 'glibc'
-
   def self.build
     system 'autoreconf -vfi'
-    system "env #{CREW_ENV_OPTIONS} \
-      ./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_OPTIONS}"
     system 'make'
   end
 

--- a/packages/gcc.rb
+++ b/packages/gcc.rb
@@ -24,7 +24,6 @@ class Gcc < Package
 
   depends_on 'ccache' => :build
   depends_on 'dejagnu' => :build # for test
-  depends_on 'glibc' => :build
   depends_on 'gmp' # R
   depends_on 'isl' # R
   depends_on 'mpc' # R

--- a/packages/gnu_time.rb
+++ b/packages/gnu_time.rb
@@ -25,15 +25,13 @@ class Gnu_time < Package
      x86_64: 'f042a1fe4d36029d2cc90a79bdc4014c0b6324008bbc971d35fb0001216a2562'
   })
 
-  depends_on 'glibc'
-
   def self.patch
     system "sed -i 's,/build-aux,,' .gitignore"
   end
 
   def self.build
     system './bootstrap --no-git --gnulib-srcdir=./gnulib'
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} --infodir=#{CREW_PREFIX}/share/info"
+    system "./configure #{CREW_OPTIONS} --infodir=#{CREW_PREFIX}/share/info"
     system 'make'
   end
 

--- a/packages/libcap.rb
+++ b/packages/libcap.rb
@@ -23,7 +23,6 @@ class Libcap < Package
      x86_64: 'cc6593f845dfc3adc63cfd5dadaf23117c646ae5d37442961380fe0f82295fe3'
   })
 
-  depends_on 'glibc' # R
   depends_on 'gperf' => :build
   depends_on 'linux_pam'
 

--- a/packages/libcurl.rb
+++ b/packages/libcurl.rb
@@ -41,7 +41,7 @@ class Libcurl < Package
   depends_on 'zstd' # R
 
   def self.build
-    libssh = (ARCH == 'i686') ? '--without-libssh' : '--with-libssh'
+    libssh_opt = (ARCH == 'i686') ? '--without-libssh' : '--with-libssh'
 
     system '[ -x configure ] || autoreconf -fvi'
     system 'filefix'

--- a/packages/libcurl.rb
+++ b/packages/libcurl.rb
@@ -26,7 +26,6 @@ class Libcurl < Package
   depends_on 'brotli' # R
   depends_on 'ca_certificates' => :build
   depends_on 'c_ares' # R
-  depends_on 'glibc' # R
   depends_on 'libcyrussasl' # R
   depends_on 'libidn2' # R
   depends_on 'libnghttp2' # R
@@ -42,27 +41,27 @@ class Libcurl < Package
   depends_on 'zstd' # R
 
   def self.build
-    @libssh = '--with-libssh'
-    case ARCH
-    when 'i686'
-      @libssh = '--without-libssh'
-    end
+    libssh = (ARCH == 'i686') ? '--without-libssh' : '--with-libssh'
 
     system '[ -x configure ] || autoreconf -fvi'
     system 'filefix'
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
-      --disable-maintainer-mode \
-      --enable-ares \
-      --enable-ipv6 \
-      --enable-ldap \
-      --enable-unix-sockets \
-      --with-ca-bundle=#{CREW_PREFIX}/etc/ssl/certs/ca-certificates.crt \
-      --with-ca-fallback \
-      --with-ca-path=#{CREW_PREFIX}/etc/ssl/certs \
-      #{@libssh} \
-      --with-openssl \
-      --without-gnutls \
-      --without-librtmp"
+
+    system <<~BUILD
+      ./configure #{CREW_OPTIONS} \
+        --disable-maintainer-mode \
+        --enable-ares \
+        --enable-ipv6 \
+        --enable-ldap \
+        --enable-unix-sockets \
+        --with-ca-bundle=#{CREW_PREFIX}/etc/ssl/certs/ca-certificates.crt \
+        --with-ca-fallback \
+        --with-ca-path=#{CREW_PREFIX}/etc/ssl/certs \
+        #{libssh_opt} \
+        --with-openssl \
+        --without-gnutls \
+        --without-librtmp
+    BUILD
+
     system 'make'
   end
 

--- a/packages/libseccomp.rb
+++ b/packages/libseccomp.rb
@@ -23,13 +23,11 @@ class Libseccomp < Package
      x86_64: '1097b0549a2f0210fa15ca54f7916b9927363534913dbc3030270c39c2559d3d'
   })
 
-  depends_on 'glibc' # R
   depends_on 'gperf' => :build
 
   def self.build
     system './autogen.sh'
-    system "./configure \
-      #{CREW_OPTIONS}"
+    system "./configure #{CREW_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libssp.rb
+++ b/packages/libssp.rb
@@ -24,7 +24,6 @@ class Libssp < Package
 
   depends_on 'ccache' => :build
   depends_on 'dejagnu' => :build # for test
-  depends_on 'glibc' # R
   patchelf
 
   @gcc_name = 'libssp'

--- a/packages/libunistring.rb
+++ b/packages/libunistring.rb
@@ -22,12 +22,12 @@ class Libunistring < Package
      x86_64: '3073ee4151dd8c96b87c21cb1f1e183c29c0da7c5a8e51f45641387c237b316c'
   })
 
-  depends_on 'glibc'
-
   def self.build
-    system "./configure #{CREW_ENV_OPTIONS} #{CREW_OPTIONS} \
-      --enable-static \
-      --enable-shared"
+    system <<~BUILD
+      ./configure #{CREW_OPTIONS} \
+        --enable-static \
+        --enable-shared
+    BUILD
     system 'make'
   end
 

--- a/packages/linux_pam.rb
+++ b/packages/linux_pam.rb
@@ -22,7 +22,6 @@ class Linux_pam < Package
      x86_64: '81a43a40a39d742a56fc74716e91098f4497c5f1b1f702de0791bdf6fe5e95aa'
   })
 
-  depends_on 'glibc' # R
   depends_on 'libdb' # libdb needs to be built with "--enable-dbm"
 
   def self.build

--- a/packages/mandb.rb
+++ b/packages/mandb.rb
@@ -24,7 +24,6 @@ class Mandb < Package
   })
 
   depends_on 'gdbm'
-  depends_on 'glibc'
   depends_on 'groff'
   depends_on 'libpipeline'
   depends_on 'libseccomp'

--- a/packages/mold.rb
+++ b/packages/mold.rb
@@ -26,7 +26,6 @@ class Mold < Package
   })
 
   depends_on 'zlibpkg' # R
-  depends_on 'glibc' # R
   depends_on 'openssl' # R
   depends_on 'gcc' # R
   depends_on 'xxhash' => :build

--- a/packages/openldap.rb
+++ b/packages/openldap.rb
@@ -23,7 +23,6 @@ class Openldap < Package
      x86_64: '4549a1d764ad469b8bffaba66bb291d68ba7bd20deeb8b8b286bc65f825d71a9'
   })
 
-  depends_on 'glibc' # R
   depends_on 'libcyrussasl' # R
   depends_on 'krb5' # R
   depends_on 'e2fsprogs' # R

--- a/packages/pax_utils.rb
+++ b/packages/pax_utils.rb
@@ -24,7 +24,6 @@ class Pax_utils < Package
   # The following two are only needed for build with autogen.sh
   # depends_on 'gnulib_git' => :build
   # depends_on 'xmlto' => :build
-  depends_on 'glibc' # R
   depends_on 'py3_pyelftools'
   depends_on 'libcap' => :build
   depends_on 'libseccomp' => :build

--- a/packages/pkgconf.rb
+++ b/packages/pkgconf.rb
@@ -22,16 +22,16 @@ class Pkgconf < Package
      x86_64: '014ca1e27dae6c162677a12ed73138631bb81f3749cfe093987208f84eaebcf1',
   })
 
-  depends_on 'glibc'
+  # Can be enabled for packages by setting
+  # ENV['PKG_CONFIG'] = "#{CREW_PREFIX}/bin/pkgconf"
 
-# Can be enabled for packages by setting
-# ENV['PKG_CONFIG'] = "#{CREW_PREFIX}/bin/pkgconf"
-
-def self.build
+  def self.build
     system "./autogen.sh"
-    system "./configure #{CREW_OPTIONS} \
-    --with-system-libdir=#{CREW_LIB_PREFIX} \
-    --with-system-includedir=#{CREW_PREFIX}/include"
+    system <<~BUILD
+      ./configure #{CREW_OPTIONS} \
+        --with-system-libdir=#{CREW_LIB_PREFIX} \
+        --with-system-includedir=#{CREW_PREFIX}/include
+    BUILD
     system "make"
   end
 

--- a/packages/popt.rb
+++ b/packages/popt.rb
@@ -22,7 +22,6 @@ class Popt < Package
      x86_64: 'f97c13e9e22bda93cc219dd899947f2269c2a2e997e713810e9603ad8ba69d6b'
   })
 
-  depends_on 'glibc' # R
   depends_on 'gcc' unless ARCH == 'x86_64' # R
   no_patchelf
 

--- a/packages/pulseaudio.rb
+++ b/packages/pulseaudio.rb
@@ -32,7 +32,6 @@ class Pulseaudio < Package
   depends_on 'elogind' => :build
   depends_on 'eudev' # R
   depends_on 'gcc' # R
-  depends_on 'glibc' # R
   depends_on 'glib' # R
   depends_on 'gsettings_desktop_schemas' # L
   depends_on 'jack' # R

--- a/packages/py3_pyelftools.rb
+++ b/packages/py3_pyelftools.rb
@@ -23,7 +23,6 @@ class Py3_pyelftools < Package
      x86_64: 'a43b98cb137c5c8093a497a39ae63d79d9c2ad0ef4ec08391392e099a962f5a4'
   })
 
-  depends_on 'glibc' # R
   depends_on 'python3' # R
   depends_on 'py3_setuptools' => :build
 

--- a/packages/python2.rb
+++ b/packages/python2.rb
@@ -24,7 +24,6 @@ class Python2 < Package
 
   depends_on 'bz2' # R
   depends_on 'expat' # R
-  depends_on 'glibc' # R
   depends_on 'libdb' # R
   depends_on 'libffi' # R
   depends_on 'ncurses' # R

--- a/packages/python3.rb
+++ b/packages/python3.rb
@@ -29,7 +29,6 @@ class Python3 < Package
   depends_on 'bz2' # R
   depends_on 'expat' # R
   depends_on 'gdbm' # R
-  depends_on 'glibc' # R
   depends_on 'libdb' # R
   depends_on 'libffi' # R
   depends_on 'mpdecimal' # R

--- a/packages/rsync.rb
+++ b/packages/rsync.rb
@@ -25,7 +25,6 @@ class Rsync < Package
 
   depends_on 'acl' # R
   depends_on 'attr' # R
-  depends_on 'glibc' # R
   depends_on 'lz4' # R
   depends_on 'openssl' # R
   depends_on 'popt' # R

--- a/packages/ruby.rb
+++ b/packages/ruby.rb
@@ -24,7 +24,6 @@ class Ruby < Package
   })
 
   depends_on 'zlibpkg' # R
-  depends_on 'glibc' # R
   depends_on 'gmp' # R
   depends_on 'gcc' # R
   depends_on 'libffi' # R

--- a/packages/zsh.rb
+++ b/packages/zsh.rb
@@ -24,7 +24,6 @@ class Zsh < Package
   })
 
   depends_on 'gdbm' # R
-  depends_on 'glibc' # R
   depends_on 'ncurses' # R
   depends_on 'gcc' # R
   depends_on 'libcap' # R


### PR DESCRIPTION
Since all libraries provided by the `glibc` package are also available from the system as well, there is no need to include `glibc` as a runtime dependency (the only usage of this package is to provide header files for building so I moved it to `buildessential.rb`)

### Changes
- Remove `glibc` dependency from `core` and all packages
- Add `glibc` to `buildessential.rb` as a dependency