### PR TITLE
Add curtail package and dependencies

### DIFF
--- a/packages/curtail.rb
+++ b/packages/curtail.rb
@@ -1,0 +1,41 @@
+require 'package'
+
+class Curtail < Package
+  description 'Curtail (previously ImCompressor) is an useful image compressor, supporting PNG, JPEG and WEBP file types.'
+  homepage 'https://github.com/Huluti/Curtail'
+  version '1.3.0'
+  license 'GPL-3'
+  compatibility 'all'
+  source_url 'https://github.com/Huluti/Curtail/archive/1.3.0.tar.gz'
+  source_sha256 '56859211b1b147aec677a00295e524b6beabcdf415938db1bd8ca4dae79409cf'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curtail/1.3.0_armv7l/curtail-1.3.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curtail/1.3.0_armv7l/curtail-1.3.0-chromeos-armv7l.tar.zst',
+      i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curtail/1.3.0_i686/curtail-1.3.0-chromeos-i686.tar.zst',
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curtail/1.3.0_x86_64/curtail-1.3.0-chromeos-x86_64.tar.zst',
+  })
+  binary_sha256({
+    aarch64: '6d5947e652598d3e7aac80193bbb5a51e3b4bd2678ed8ed1f459e63b68c74da0',
+     armv7l: '6d5947e652598d3e7aac80193bbb5a51e3b4bd2678ed8ed1f459e63b68c74da0',
+      i686: '2643affd0cc34358f1b3540f7701313e699401975d242f5128b856b742cd7699',
+    x86_64: '8fab707529ff0e2d8db29045a9e05a91a30d8b66d738dde84a5ca12145a0d6fa',
+  })
+
+  depends_on 'gtk3'
+  depends_on 'optipng'
+  depends_on 'pngquant'
+  depends_on 'jpegoptim'
+  depends_on 'libwebp'
+
+  gnome
+
+  def self.build
+    system "meson #{CREW_MESON_OPTIONS} build"
+    system 'ninja -C build'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C build install"
+  end
+end

--- a/packages/jpegoptim.rb
+++ b/packages/jpegoptim.rb
@@ -1,0 +1,36 @@
+require 'package'
+
+class Jpegoptim < Package
+  description 'Utility to optimize/compress JPEG files'
+  homepage 'https://github.com/tjko/jpegoptim'
+  version '1.4.7'
+  license 'GPL-3.0'
+  compatibility 'all'
+  source_url 'https://github.com/tjko/jpegoptim/archive/v1.4.7.tar.gz'
+  source_sha256 'c52616f2fb8d481315871680f9943b0f58c553d1e0c49a6bd4691a3e66d7e6de'
+
+  binary_url ({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jpegoptim/1.4.7_armv7l/jpegoptim-1.4.7-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jpegoptim/1.4.7_armv7l/jpegoptim-1.4.7-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jpegoptim/1.4.7_i686/jpegoptim-1.4.7-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jpegoptim/1.4.7_x86_64/jpegoptim-1.4.7-chromeos-x86_64.tar.zst',
+  })
+  binary_sha256 ({
+    aarch64: '8e2fb70c56a4d0afd63a766bb3baa8d9bd17be103393aef137d4026511e84edc',
+     armv7l: '8e2fb70c56a4d0afd63a766bb3baa8d9bd17be103393aef137d4026511e84edc',
+       i686: '0502e5b79febacbdb1d0469c6a1951e8b1b7fe004fc3ebe3ffc4f6a32f6c802a',
+     x86_64: '9c3f331ec059b3f6f9580845be871658467ae7ee00fed66021bdbeee497c3a82',
+  })
+
+  depends_on 'libjpeg'
+
+  def self.build
+    system "./configure #{CREW_OPTIONS}"
+    system 'make'
+    system 'make', 'strip'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/pngquant.rb
+++ b/packages/pngquant.rb
@@ -1,0 +1,36 @@
+require 'package'
+
+class Pngquant < Package
+  description 'Command-line utility and a library for lossy compression of PNG images.'
+  homepage 'https://pngquant.org/'
+  version '2.17.0'
+  license 'GPL-3.0'
+  compatibility 'all'
+  source_url 'https://github.com/kornelski/pngquant.git'
+  git_hashtag version
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pngquant/2.17.0_armv7l/pngquant-2.17.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pngquant/2.17.0_armv7l/pngquant-2.17.0-chromeos-armv7l.tar.zst',
+      i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pngquant/2.17.0_i686/pngquant-2.17.0-chromeos-i686.tar.zst',
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pngquant/2.17.0_x86_64/pngquant-2.17.0-chromeos-x86_64.tar.zst',
+  })
+  binary_sha256({
+    aarch64: 'fdddb92cbb12abd1e267330768c58a0d31e8c743831dc2eff820d3b214af9e94',
+     armv7l: 'fdddb92cbb12abd1e267330768c58a0d31e8c743831dc2eff820d3b214af9e94',
+      i686: '38b281e502240992f6b27455d70211b08dfc5fa47f1b2d0a8fe2be687cca569a',
+    x86_64: 'ed9748591b5eb81fc5565a003ee55549136d5d87052ad1b41ed9c0adf2e99457',
+  })
+
+  depends_on 'lcms'
+  depends_on 'rust' => :build
+
+  def self.build
+    system 'cargo build --release --features=lcms2'
+  end
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    FileUtils.install 'target/release/pngquant', "#{CREW_DEST_PREFIX}/bin/pngquant", mode: 0o755
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -1024,6 +1024,11 @@ url: https://github.com/apple/cups/releases
 activity: medium
 ---
 kind: url
+name: curtail
+url: https://github.com/Huluti/Curtail/releases
+activity: low
+---
+kind: url
 name: cvs
 url: https://ftp.gnu.org/non-gnu/cvs/source/stable
 activity: none
@@ -3076,6 +3081,11 @@ activity: medium
 kind: url
 name: jp2a
 url: https://github.com/Talinx/jp2a/releases
+activity: low
+---
+kind: url
+name: jpegoptim
+url: https://github.com/tjko/jpegoptim/releases
 activity: low
 ---
 kind: url
@@ -6082,6 +6092,11 @@ kind: url
 name: pngcheck
 url: https://sourceforge.net/projects/png-mng/files/pngcheck/
 activity: none
+---
+kind: url
+name: pngquant
+url: https://github.com/kornelski/pngquant/tags
+activity: low
 ---
 kind: url
 name: podofo


### PR DESCRIPTION
Curtail (previously ImCompressor) is an useful image compressor, supporting PNG, JPEG and WEBP file types.  Tested on x86_64.  Unable to test on arm since sommelier is broken but the builds were successful.

New dependencies include:
pngquant - Command-line utility and a library for lossy compression of PNG images.
jpegoptim - Utility to optimize/compress JPEG files.