### PR TITLE
Add gosu package

### DIFF
--- a/packages/gosu.rb
+++ b/packages/gosu.rb
@@ -1,0 +1,28 @@
+require 'package'
+
+class Gosu < Package
+  description 'Simple Go-based setuid+setgid+setgroups+exec'
+  homepage 'https://github.com/tianon/gosu'
+  version '1.14'
+  license 'Apache-2.0'
+  compatibility 'all'
+  source_url ({
+    aarch64: 'https://github.com/tianon/gosu/releases/download/1.14/gosu-armhf',
+     armv7l: 'https://github.com/tianon/gosu/releases/download/1.14/gosu-armhf',
+       i686: 'https://github.com/tianon/gosu/releases/download/1.14/gosu-i386',
+     x86_64: 'https://github.com/tianon/gosu/releases/download/1.14/gosu-amd64'
+  })
+  source_sha256 ({
+    aarch64: 'abb1489357358b443789571d52b5410258ddaca525ee7ac3ba0dd91d34484589',
+     armv7l: 'abb1489357358b443789571d52b5410258ddaca525ee7ac3ba0dd91d34484589',
+       i686: 'fa12da9c07783fe5fb2c2a81b5d4277eec7615c957a0b0cce3f14802ff9372e7',
+     x86_64: 'bd8be776e97ec2b911190a82d9ab3fa6c013ae6d3121eea3d0bfd5c82a0eaf8c'
+  })
+
+  no_compile_needed
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    FileUtils.install Dir['gosu-*'][0], "#{CREW_DEST_PREFIX}/bin/gosu", mode: 0o755
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -2399,6 +2399,11 @@ url: https://ftp.gnome.org/pub/gnome/sources/gobject-introspection/
 activity: medium
 ---
 kind: url
+name: gosu
+url: https://github.com/tianon/gosu/releases
+activity: low
+---
+kind: url
 name: gox
 url: https://github.com/mitchellh/gox/releases
 activity: low


### PR DESCRIPTION
This is a simple tool grown out of the simple fact that su and sudo have very strange and often annoying TTY and signal-forwarding behavior. They're also somewhat complex to setup and use (especially in the case of sudo), which allows for a great deal of expressivity, but falls flat if all you need is "run this specific application as this specific user and get out of the pipeline".

The core of how gosu works is stolen directly from how Docker/libcontainer itself starts an application inside a container (and in fact, is using the /etc/passwd processing code directly from libcontainer's codebase).
```
$ gosu
Usage: gosu user-spec command [args]
   eg: gosu tianon bash
       gosu nobody:root bash -c 'whoami && id'
       gosu 1000:1 id

gosu version: 1.14 (go1.16.7 on linux/amd64; gc)
gosu license: Apache-2.0 (full text at https://github.com/tianon/gosu)
```
Once the user/group is processed, we switch to that user, then we exec the specified process and gosu itself is no longer resident or involved in the process lifecycle at all. This avoids all the issues of signal passing and TTY, and punts them to the process invoking gosu and the process being invoked by gosu, where they belong.

See https://github.com/tianon/gosu.