### PR TITLE
crew_profile_base => 0.0.4, cleanup

### DIFF
--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -20,7 +20,7 @@ class Crew_profile_base < Package
     FileUtils.rm_f './src/env.d/03-dbus'
 
     # Don't overwrite custom changes
-    [ '00-locale', '01-editor', '02-pager', '99-custom' ].each do |custom_files|
+    [ '01-locale', '02-editor', '03-pager', '99-custom' ].each do |custom_files|
       FileUtils.rm "./src/env.d/#{custom_files}" if File.exist?("#{CREW_PREFIX}/etc/env.d/#{custom_files}")
     end
 

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -46,7 +46,6 @@ class Crew_profile_base < Package
 
     CREW_PROFILE_EOF
 
-
     # append our #{crew_rcfile} to shell rc file
     [ '.bashrc', '.zshrc' ].select {|rc| File.exist?(rc) } .each do |rc|
       if File.readlines(rc, chomp: true).any? {|line| line == "source #{CREW_PREFIX}/etc/profile" }

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -3,82 +3,57 @@ require 'package'
 class Crew_profile_base < Package
   description 'Crew-profile-base sets up Chromebrew\'s environment capabilities.'
   homepage 'https://github.com/chromebrew/crew-profile-base'
-  version '0.0.2'
+  version '0.0.4'
   license 'GPL-3+'
   compatibility 'all'
-  source_url 'SKIP'
+  source_url 'https://github.com/chromebrew/crew-profile-base.git'
+  git_hashtag version
 
   no_compile_needed
-  no_patchelf
 
   def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/env.d"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/profile.d"
+
+    # dbus file moved to dbus package, so remove it.
+    FileUtils.rm_f './src/env.d/env.d/03-dbus'
+    FileUtils.rm_f "#{CREW_PREFIX}/etc/env.d/03-dbus"
+
+    # Don't overwrite custom changes
+    FileUtils.rm [ './src/env.d/99-custom', './src/profile.d/99-custom' ]
+
+    [ '00-locale', '01-editor', '02-pager' ].each do |custom_env|
+      # do not override the file if the current one exists
+      FileUtils.rm "./src/env.d/#{custom_env}" if File.exist?("#{CREW_PREFIX}/etc/env.d/#{custom_env}")
+    end
+
+    FileUtils.cp_r Dir['./src/*'], "#{CREW_PREFIX}/etc/"
   end
 
   def self.postinstall
-    # Extract as module in postinstall to avoid creating package binaries.
-    # Turn off git warnings.
-    system 'git config --global advice.detachedHead false'
-    system 'git config --global init.defaultBranch main'
-    @git_dir = 'crew_profile_base_git'
-    @git_hash = version
-    @git_url = 'https://github.com/chromebrew/crew-profile-base'
-    FileUtils.rm_rf(@git_dir)
-    FileUtils.mkdir_p(@git_dir)
-    Dir.chdir @git_dir do
-      system 'git init'
-      system "git remote add origin #{@git_url}"
-      system "git fetch --depth 1 origin #{@git_hash}"
-      system 'git checkout FETCH_HEAD'
+    # create custom files if not exist
+    FileUtils.touch "#{CREW_PREFIX}/etc/env.d/99-custom"
+    FileUtils.touch "#{CREW_PREFIX}/etc/profile.d/99-custom"
 
-      # Don't overwrite custom changes
-      FileUtils.rm './src/env.d/99-custom' if File.exist? "#{CREW_PREFIX}/etc/env.d/99-custom"
-      FileUtils.rm './src/profile.d/99-custom' if File.exist? "#{CREW_PREFIX}/etc/profile.d/99-custom"
-      # Custom changes should only go in the above two files.
-      # FileUtils.rm './src/env.d/00-locale' if File.exist? "#{CREW_PREFIX}/etc/env.d/00-locale"
-      # FileUtils.rm './src/env.d/01-editor' if File.exist? "#{CREW_PREFIX}/etc/env.d/01-editor"
-      # FileUtils.rm './src/env.d/02-pager' if File.exist? "#{CREW_PREFIX}/etc/env.d/02-pager"
+    # Write our rc files
+    crew_rcfile = <<~CREW_PROFILE_EOF
+      # DO NOT DELETE THIS LINE
+      # See #{CREW_PREFIX}/etc/profile for further details
+      source #{CREW_PREFIX}/etc/profile
 
-      FileUtils.mkdir_p "#{CREW_PREFIX}/etc/"
-      FileUtils.cp_r Dir.glob('./src/*'), "#{CREW_PREFIX}/etc/"
+      # Put your stuff under this comment
 
-      # Remove stale files from the last install
-      FileUtils.rm "#{HOME}/.bashrc.bak" if File.exist? "#{HOME}/.bashrc.bak"
-      FileUtils.rm "#{HOME}/.zshrc.bak" if File.exist? "#{HOME}/.zshrc.bak"
+    CREW_PROFILE_EOF
 
-      # dbus file moved to dbus package, so remove it.
-      FileUtils.rm_f './src/env.d/env.d/03-dbus'
-      FileUtils.rm_f "#{CREW_PREFIX}/etc/env.d/03-dbus"
 
-      # Don't overwrite a custom shell rc
-      @_str = "source #{CREW_PREFIX}/etc/profile"
-
-      # Write our rc files
-      @crew_rcfile = <<~CREW_PROFILE_EOF
-        # DO NOT DELETE THIS LINE
-        # See #{CREW_PREFIX}/etc/profile for further details
-        source #{CREW_PREFIX}/etc/profile
-
-        # Put your stuff under this comment
-
-      CREW_PROFILE_EOF
-      # Must write directly to HOME and not CREW_DEST_HOME to prevent chromebrew from removing ~/.bashrc during reinstall
-      if File.exist? "#{HOME}/.bashrc"
-        if `grep -c "#{@_str}" #{HOME}/.bashrc`.to_i.zero?
-          old_bashrc = IO.read "#{HOME}/.bashrc"
-          IO.write "#{HOME}/.bashrc", @crew_rcfile + old_bashrc
-        end
-      else
-        IO.write("#{HOME}/.bashrc", @crew_rcfile)
-      end
-      if File.exist? "#{HOME}/.zshrc"
-        if `grep -c "#{@_str}" #{HOME}/.zshrc`.to_i.zero?
-          old_zshrc = IO.read "#{HOME}/.zshrc"
-          IO.write "#{HOME}/.zshrc", @crew_rcfile + old_zshrc
-        end
-      else
-        IO.write("#{HOME}/.zshrc", @crew_rcfile)
+    # append our #{crew_rcfile} to shell rc file
+    [ '.bashrc', '.zshrc' ].select {|rc| File.exist?(rc) } .each do |rc|
+      if File.readlines(rc, chomp: true).any? {|line| line == "source #{CREW_PREFIX}/etc/profile" }
+        # Must write directly to HOME and not CREW_DEST_HOME to prevent chromebrew from
+        # removing ~/.{bash,zsh}rc during reinstall
+        orig_rc = File.read("#{HOME}/#{rc}")
+        File.write("#{HOME}/.bashrc", crew_rcfile + orig_rc)
       end
     end
   end

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -10,6 +10,7 @@ class Crew_profile_base < Package
   git_hashtag version
 
   no_compile_needed
+  no_patchelf
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/"

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -25,7 +25,7 @@ class Crew_profile_base < Package
       FileUtils.rm "./src/env.d/#{custom_files}" if File.exist?("#{CREW_PREFIX}/etc/env.d/#{custom_files}")
     end
 
-    FileUtils.cp_r Dir['./src/*'], "#{CREW_PREFIX}/etc/"
+    FileUtils.cp_r Dir['./src/*'], "#{CREW_DEST_PREFIX}/etc/"
   end
 
   def self.postinstall

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -17,25 +17,17 @@ class Crew_profile_base < Package
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/profile.d"
 
     # dbus file moved to dbus package, so remove it.
-    FileUtils.rm_f './src/env.d/env.d/03-dbus'
-    FileUtils.rm_f "#{CREW_PREFIX}/etc/env.d/03-dbus"
+    FileUtils.rm_f './src/env.d/03-dbus'
 
     # Don't overwrite custom changes
-    FileUtils.rm [ './src/env.d/99-custom', './src/profile.d/99-custom' ]
-
-    [ '00-locale', '01-editor', '02-pager' ].each do |custom_env|
-      # do not override the file if the current one exists
-      FileUtils.rm "./src/env.d/#{custom_env}" if File.exist?("#{CREW_PREFIX}/etc/env.d/#{custom_env}")
+    [ '00-locale', '01-editor', '02-pager', '99-custom' ].each do |custom_files|
+      FileUtils.rm "./src/env.d/#{custom_files}" if File.exist?("#{CREW_PREFIX}/etc/env.d/#{custom_files}")
     end
 
     FileUtils.cp_r Dir['./src/*'], "#{CREW_PREFIX}/etc/"
   end
 
   def self.postinstall
-    # create custom files if not exist
-    FileUtils.touch "#{CREW_PREFIX}/etc/env.d/99-custom"
-    FileUtils.touch "#{CREW_PREFIX}/etc/profile.d/99-custom"
-
     # Write our rc files
     crew_rcfile = <<~CREW_PROFILE_EOF
       # DO NOT DELETE THIS LINE

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -18,7 +18,7 @@ class Crew_profile_base < Package
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/profile.d"
 
     # dbus file moved to dbus package, so remove it.
-    FileUtils.rm_f './src/env.d/03-dbus'
+    FileUtils.rm_f './src/env.d/04-dbus'
 
     # Don't overwrite custom changes
     [ '01-locale', '02-editor', '03-pager', '99-custom' ].each do |custom_files|

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -12,6 +12,13 @@ class Crew_profile_base < Package
   no_compile_needed
   no_patchelf
 
+  def self.patch
+    # TODO: fix this bug
+    # stat: cannot statx '': No such file or directory
+    # bash: [: : integer expression expected
+    system 'sed', '-i', 's,${TMPDIR},${TMPDIR:-/usr/local/tmp},g', './src/env.d/00-path'
+  end
+
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/env.d"


### PR DESCRIPTION
Fixes #6970 

See chromebrew/crew-profile-base#7 for more info

@saltedcoffii: Seems that your changes in chromebrew/crew-profile-base#6 cause errors due to undefined `TMPDIR` (in `00-path`), I added a temporary fix for it in `self.patch` part

Tested on `x86_64`