### PR TITLE
crew_profile_base: Fix "add to `~/.bashrc`" logic in `self.postinstall`

### DIFF
--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -50,9 +50,12 @@ class Crew_profile_base < Package
 
     CREW_PROFILE_EOF
 
-    # append our #{crew_rcfile} to shell rc file
-    [ '.bashrc', '.zshrc' ].select {|rc| File.exist?(rc) } .each do |rc|
+    # append our #{crew_rcfile} to shell rc files (if exist)
+    [ '.bashrc', '.zshrc' ].each do |rc|
       rc_path = File.join(HOME, rc)
+
+      next unless File.exist?(rc_path)
+
       rc_file = File.readlines(rc_path, chomp: true)
 
       # remove duplicated `source` lines (if any)
@@ -64,7 +67,7 @@ class Crew_profile_base < Package
         rc_file.delete(crew_rc_source_line)
 
         # re-add the first `source` line
-        rc_file.append(first_source_line_index, crew_rc_source_line)
+        rc_file.insert(first_source_line_index, crew_rc_source_line)
       end
 
       # append our rc string to the beginning of the rc file (if not exist)

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -57,6 +57,7 @@ class Crew_profile_base < Package
 
       # remove duplicated `source` lines (if any)
       if rc_file.count(crew_rc_source_line) > 1
+        puts "Removing duplicated `source` line in #{rc_path}...".yellow
         first_source_line_index = rc_file.find_index(crew_rc_source_line)
 
         # delete all `source` lines
@@ -68,6 +69,7 @@ class Crew_profile_base < Package
 
       # append our rc string to the beginning of the rc file (if not exist)
       if rc_file.none? {|line| line == "source #{CREW_PREFIX}/etc/profile" }
+        puts "Appending `#{crew_rc_source_line}` to the beginning of #{rc_path}...".yellow
         rc_file.unshift( crew_rcfile.lines(chomp: true) )
       end
 

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -3,11 +3,14 @@ require 'package'
 class Crew_profile_base < Package
   description 'Crew-profile-base sets up Chromebrew\'s environment capabilities.'
   homepage 'https://github.com/chromebrew/crew-profile-base'
-  version '0.0.4'
   license 'GPL-3+'
   compatibility 'all'
+
+  @_ver = '0.0.4'
+  version @_ver + '-1'
+
   source_url 'https://github.com/chromebrew/crew-profile-base.git'
-  git_hashtag version
+  git_hashtag @_ver
 
   no_compile_needed
   no_patchelf
@@ -37,10 +40,11 @@ class Crew_profile_base < Package
 
   def self.postinstall
     # Write our rc files
+    crew_rc_source_line = "source #{CREW_PREFIX}/etc/profile"
     crew_rcfile = <<~CREW_PROFILE_EOF
       # DO NOT DELETE THIS LINE
       # See #{CREW_PREFIX}/etc/profile for further details
-      source #{CREW_PREFIX}/etc/profile
+      #{crew_rc_source_line}
 
       # Put your stuff under this comment
 
@@ -48,12 +52,27 @@ class Crew_profile_base < Package
 
     # append our #{crew_rcfile} to shell rc file
     [ '.bashrc', '.zshrc' ].select {|rc| File.exist?(rc) } .each do |rc|
-      if File.readlines(rc, chomp: true).any? {|line| line == "source #{CREW_PREFIX}/etc/profile" }
-        # Must write directly to HOME and not CREW_DEST_HOME to prevent chromebrew from
-        # removing ~/.{bash,zsh}rc during reinstall
-        orig_rc = File.read("#{HOME}/#{rc}")
-        File.write("#{HOME}/.bashrc", crew_rcfile + orig_rc)
+      rc_path = File.join(HOME, rc)
+      rc_file = File.readlines(rc_path, chomp: true)
+
+      # remove duplicated `source` lines (if any)
+      if rc_file.count(crew_rc_source_line) > 1
+        first_source_line_index = rc_file.find_index(crew_rc_source_line)
+
+        # delete all `source` lines
+        rc_file.delete(crew_rc_source_line)
+
+        # re-add the first `source` line
+        rc_file.append(first_source_line_index, crew_rc_source_line)
       end
+
+      # append our rc string to the beginning of the rc file (if not exist)
+      if rc_file.none? {|line| line == "source #{CREW_PREFIX}/etc/profile" }
+        rc_file.unshift( crew_rcfile.lines(chomp: true) )
+      end
+
+      # save changes
+      File.write rc_path, rc_file.join("\n")
     end
   end
 end

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -3,11 +3,10 @@ require 'package'
 class Crew_profile_base < Package
   description 'Crew-profile-base sets up Chromebrew\'s environment capabilities.'
   homepage 'https://github.com/chromebrew/crew-profile-base'
-  license 'GPL-3+'
-  compatibility 'all'
-
   @_ver = '0.0.4'
   version @_ver + '-1'
+  license 'GPL-3+'
+  compatibility 'all'
 
   source_url 'https://github.com/chromebrew/crew-profile-base.git'
   git_hashtag @_ver

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -60,7 +60,7 @@ class Crew_profile_base < Package
 
       # remove duplicated `source` lines (if any)
       if rc_file.count(crew_rc_source_line) > 1
-        puts "Removing duplicated `source` line in #{rc_path}...".yellow
+        puts "Removing duplicated `source` lines in #{rc_path}...".yellow
         first_source_line_index = rc_file.find_index(crew_rc_source_line)
 
         # delete all `source` lines


### PR DESCRIPTION
The current "add to `~/.bashrc`" logic in `self.postinstall` might not work when the user has an empty `.{bash,zsh}rc` file, this PR fixes it

Tested on `x86_64`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/supechicken/chromebrew.git CREW_TESTING_BRANCH=crew_profile_base_fix CREW_TESTING=1 crew update
```
