### PR TITLE
OpenSSL -> 1.1.1q, Musl OpenSSL -> 3.0.5

### DIFF
--- a/packages/musl_openssl.rb
+++ b/packages/musl_openssl.rb
@@ -3,24 +3,24 @@ require 'package'
 class Musl_openssl < Package
   description 'The Open Source toolkit for Secure Sockets Layer and Transport Layer Security'
   homepage 'https://www.openssl.org'
-  @_ver = '3.0.4'
-  version @_ver.to_s
+  @_ver = '3.0.5'
+  version @_ver
   license 'openssl'
   compatibility 'all'
   source_url "https://www.openssl.org/source/openssl-#{@_ver}.tar.gz"
-  source_sha256 '2831843e9a668a0ab478e7020ad63d2d65e51f72977472dc73efcefbafc0c00f'
+  source_sha256 'aa7d8d9bef71ad6525c55ba11e5f4397889ce49c2c9349dcea6d3e4f0b024a7a'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.4_armv7l/musl_openssl-3.0.4-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.4_armv7l/musl_openssl-3.0.4-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.4_i686/musl_openssl-3.0.4-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.4_x86_64/musl_openssl-3.0.4-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.5_armv7l/musl_openssl-3.0.5-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.5_armv7l/musl_openssl-3.0.5-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.5_i686/musl_openssl-3.0.5-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.5_x86_64/musl_openssl-3.0.5-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '52f4a01d851567a1486125eceec055ad1982741e33d02a66075050182d5a1621',
-     armv7l: '52f4a01d851567a1486125eceec055ad1982741e33d02a66075050182d5a1621',
-       i686: 'a74cf389fcdf8626548d241e3ab018d9e63360d4d1f48f0632f9752e6ccc4d2e',
-     x86_64: '8d1a7ae7ff7e9303a3c329b32bca0efd354595a78e715e1a49586de125d3c3e1'
+    aarch64: '3ebcd412658d981868446b6f981a0cad2c1d2a4d071551a5ec9bc08b260d152f',
+     armv7l: '3ebcd412658d981868446b6f981a0cad2c1d2a4d071551a5ec9bc08b260d152f',
+       i686: '682ee9aecdfd610a3578edc9b1d6250bf927d368711dde8acd16fedb771b0c62',
+     x86_64: 'c90fa52f2088f1d5b4c442807cd75b128f2b9b798eb4020a9f4af4b81b07cffe'
   })
 
   depends_on 'musl_native_toolchain' => :build

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -3,24 +3,24 @@ require 'package'
 class Openssl < Package
   description 'The Open Source toolkit for Secure Sockets Layer and Transport Layer Security'
   homepage 'https://www.openssl.org'
-  @_ver = '1.1.1p'
-  version @_ver.to_s
+  @_ver = '1.1.1q'
+  version @_ver
   license 'openssl'
   compatibility 'all'
   source_url "https://www.openssl.org/source/openssl-#{@_ver}.tar.gz"
-  source_sha256 'bf61b62aaa66c7c7639942a94de4c9ae8280c08f17d4eac2e44644d9fc8ace6f'
+  source_sha256 'd7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1p_armv7l/openssl-1.1.1p-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1p_armv7l/openssl-1.1.1p-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1p_i686/openssl-1.1.1p-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1p_x86_64/openssl-1.1.1p-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1q_armv7l/openssl-1.1.1q-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1q_armv7l/openssl-1.1.1q-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1q_i686/openssl-1.1.1q-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1q_x86_64/openssl-1.1.1q-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '738d788a6a681e4509735f7fdc7b7639047228875573e2ef8c707f9250235d52',
-     armv7l: '738d788a6a681e4509735f7fdc7b7639047228875573e2ef8c707f9250235d52',
-       i686: 'b44fa7593a7ef2886b593eeeac9dd703945ea350dbe467cfb528f846bccf0602',
-     x86_64: '5e85227ee00f2cc8d0ed63c63c085490bae00b9ad43ece3f805f64215b3a8119'
+    aarch64: '8b8f0c8ac1ec7600555987adad2ac475d7fb57184613249ada2ec12ea45d8b1f',
+     armv7l: '8b8f0c8ac1ec7600555987adad2ac475d7fb57184613249ada2ec12ea45d8b1f',
+       i686: '205055f11a4d9a9349f8d7327cc90e0ef5dc15e3e6bce02688d1788a2a68c928',
+     x86_64: 'afd2b5294d3e4a16895e7bacf831c9e396e2533ed1b8bd939daca7a2e13d02a0'
   })
 
   depends_on 'ccache' => :build


### PR DESCRIPTION
- High Severity Security Update (for newer x86_64 cpus) : https://www.openssl.org/news/secadv/20220705.txt

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=openssl_jul22 
CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
