### PR TITLE
Xorg Server -> 21.1.4

### DIFF
--- a/packages/xorg_server.rb
+++ b/packages/xorg_server.rb
@@ -3,7 +3,7 @@ require 'package'
 class Xorg_server < Package
   description 'The Xorg Server is the core of the X Window system.'
   homepage 'https://www.x.org'
-  @_ver = '21.1.2'
+  @_ver = '21.1.4'
   version @_ver
   license 'BSD-3, MIT, BSD-4, MIT-with-advertising, ISC and custom'
   compatibility 'all'
@@ -11,16 +11,16 @@ class Xorg_server < Package
   git_hashtag "xorg-server-#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.2_armv7l/xorg_server-21.1.2-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.2_armv7l/xorg_server-21.1.2-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.2_i686/xorg_server-21.1.2-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.2_x86_64/xorg_server-21.1.2-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.4_armv7l/xorg_server-21.1.4-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.4_armv7l/xorg_server-21.1.4-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.4_i686/xorg_server-21.1.4-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.4_x86_64/xorg_server-21.1.4-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'c28d99744f20b7b13ebafb15b9dfb3d5ff98151b406ecaf829fb7f2577e2c5a5',
-     armv7l: 'c28d99744f20b7b13ebafb15b9dfb3d5ff98151b406ecaf829fb7f2577e2c5a5',
-       i686: '78521b219039d6406e53be51e8bb9aa46791ad12f703e3eaae7ef6bf7267936a',
-     x86_64: 'a1a23a460d7d78d534f68b1a9e49f3aa3ea57994a98602738e08a1030730344c'
+    aarch64: '91416891d077c48cd4f1f4091d3f5517b5f00c02835632742671f257cc3ebb6e',
+     armv7l: '91416891d077c48cd4f1f4091d3f5517b5f00c02835632742671f257cc3ebb6e',
+       i686: '43f95cb97da63890363d4db67806cd15033f83b7a7b25ba705552019e35f868e',
+     x86_64: '9f0a81171130931ab006419baa15e9822121c5bcdc0bb615d5461fd57d5fccc9'
   })
 
   depends_on 'libepoxy'
@@ -58,7 +58,7 @@ class Xorg_server < Package
   when 'armv7l', 'aarch64'
     @peer_cmd_prefix = '/lib/ld-linux-armhf.so.3'
   when 'i686'
-    @peer_cmd_prefix = '/lib/ld-linux-i686.so.2'
+    @peer_cmd_prefix = '/lib/ld-linux.so.2'
   when 'x86_64'
     @peer_cmd_prefix = '/lib64/ld-linux-x86-64.so.2'
   end
@@ -89,7 +89,7 @@ class Xorg_server < Package
     # Get these from xwayland package
     @deletefiles = %W[#{CREW_DEST_PREFIX}/bin/Xwayland #{CREW_DEST_LIB_PREFIX}/xorg/protocol.txt]
     @deletefiles.each do |f|
-      FileUtils.rm f if  File.exist?(f)
+      FileUtils.rm_f f
     end
   end
 end


### PR DESCRIPTION
- X.Org Security Advisory: https://lists.x.org/archives/xorg/2022-July/061035.html

Builds properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=xorgserver2114 CREW_TESTING=1 crew update
```
