### PR TITLE
lib/downloader: Fix `securerandom` error

### DIFF
--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -6,6 +6,8 @@ require_relative 'convert_size'
 
 begin
   require 'securerandom'
+  require 'uri'
+  require 'resolv-replace'
 rescue RuntimeError => e
   # hide the error message and fallback to curl if securerandom raise an error
   if e.message == 'failed to get urandom'
@@ -16,9 +18,7 @@ rescue RuntimeError => e
   end
 end
 
-require 'net/http'
 require 'uri'
-require 'resolv-replace'
 
 def setTermSize
   # setTermSize: set progress bar size based on terminal width


### PR DESCRIPTION
Didn't notice that `securerandom` is also required by `resolv-replace` before😅

This puts the `require 'resolv-replace'` line to the exception catching block to ensure `securerandom` only `require` once by `require 'securerandom'`

Fixes #7205 