### PR TITLE
gl.sh: Add progress bar to uploads.

### DIFF
--- a/tools/gl.sh
+++ b/tools/gl.sh
@@ -84,11 +84,11 @@ for package in ${packages}; do
     fi
     echo "Generating sha256sum ..."
     new_sha256=$(sha256sum ${new_tarfile} | cut -d' ' -f1)
-    echo
     noname="${new_tarfile#*-}"
+    echo "Uploading ${package}/${noname} ..."
     new_version="${noname%-chromeos*}"
     new_url=$(echo "${BASE_URL}/${package}/${new_version}_${arch}/${new_tarfile}" | sed "s,../release/${arch}/,,")
-    curl --header "DEPLOY-TOKEN: ${GITLAB_TOKEN}" --upload-file "${new_tarfile}" "${new_url}"
+    curl -# --header "DEPLOY-TOKEN: ${GITLAB_TOKEN}" --upload-file "${new_tarfile}" "${new_url}" | cat
     if [ -n "${old_url}" ]; then
       if [[ ${old_url} != ${new_url} ]]; then
         echo "Updating binary_url in ${pkgfile}..."


### PR DESCRIPTION
- Make `gl.sh` output more verbose, to indicate when uploads are occurring.
- We need the `| cat` in the `curl` commandline because otherwise `curl` doesn't show the progress bar.

Works properly:
- [x] `x86_64`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=gl_edit CREW_TESTING=1 crew update
```
