### PR TITLE
ffmpeg -> 5.1, avisynth -> 3.7.2, tesseract -> 5.2.0

### DIFF
--- a/packages/avisynthplus.rb
+++ b/packages/avisynthplus.rb
@@ -3,23 +3,23 @@ require 'package'
 class Avisynthplus < Package
   description 'An improved version of the AviSynth frameserver'
   homepage 'https://avs-plus.net/'
-  version '3.7.0'
+  version '3.7.2'
   license 'GPL-2 and GPL-2-with-linking-exception'
   compatibility 'all'
-  source_url 'https://github.com/AviSynth/AviSynthPlus/archive/v3.7.0/avisynthplus-3.7.0.tar.gz'
-  source_sha256 '8906d9e46dc90a194413d69b710e3106c0aafddc0c5c62004885d0c3beb79862'
+  source_url 'https://github.com/AviSynth/AviSynthPlus/archive/v3.7.2/avisynthplus-3.7.2.tar.gz'
+  source_sha256 '6159fd976dffa62d5db5277cbb0b3b7f7a4ee92fc8667edd32da9840a669ccc1'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/avisynthplus/3.7.0_armv7l/avisynthplus-3.7.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/avisynthplus/3.7.0_armv7l/avisynthplus-3.7.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/avisynthplus/3.7.0_i686/avisynthplus-3.7.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/avisynthplus/3.7.0_x86_64/avisynthplus-3.7.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/avisynthplus/3.7.2_armv7l/avisynthplus-3.7.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/avisynthplus/3.7.2_armv7l/avisynthplus-3.7.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/avisynthplus/3.7.2_i686/avisynthplus-3.7.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/avisynthplus/3.7.2_x86_64/avisynthplus-3.7.2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '041ab6c783a42f1ffa0ecbb27b5fee4b49a1e5083b00a48454fc5a29069264ef',
-     armv7l: '041ab6c783a42f1ffa0ecbb27b5fee4b49a1e5083b00a48454fc5a29069264ef',
-       i686: 'a94ac5f71b9dba1fb0175d828effe302603fa7b72efa09683660ddc9e992d2cd',
-     x86_64: '84f41b0ea157e9f53267f9e9212c9ad5eea5ee31d2cb1dc7cd516475e10e04ba'
+    aarch64: '33a07e40e5de09d4b6a3c932c3a7c05d9e809bf388950ed69d2127d24a7d5ac5',
+     armv7l: '33a07e40e5de09d4b6a3c932c3a7c05d9e809bf388950ed69d2127d24a7d5ac5',
+       i686: 'e97386b6df6772e0e495f29260091fac407cb50203ae9b0e41ecf9e94458a047',
+     x86_64: '122650ad7a858af46806c779da6e045c43bc267a004b2de255b947def1d4cff5'
   })
 
   depends_on 'devil' => :build
@@ -27,10 +27,7 @@ class Avisynthplus < Package
   def self.build
     Dir.mkdir 'builddir'
     Dir.chdir 'builddir' do
-      system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto -I#{CREW_PREFIX}/include/harfbuzz' \
-      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      cmake \
+      system "cmake \
         -G Ninja \
         #{CREW_CMAKE_OPTIONS} \
         -DBUILD_SHARED_LIBS=ON \

--- a/packages/ffmpeg.rb
+++ b/packages/ffmpeg.rb
@@ -3,7 +3,7 @@ require 'package'
 class Ffmpeg < Package
   description 'Complete solution to record, convert and stream audio and video'
   homepage 'https://ffmpeg.org/'
-  @_ver = '5.0.1'
+  @_ver = '5.1'
   version @_ver.to_s
   license 'LGPL-2,1, GPL-2, GPL-3, and LGPL-3' # When changing ffmpeg's configure options, make sure this variable is still accurate.
   compatibility 'all'
@@ -11,16 +11,16 @@ class Ffmpeg < Package
   git_hashtag "n#{@_ver}"
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ffmpeg/5.0-1_i686/ffmpeg-5.0-1-chromeos-i686.tar.zst',
- aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ffmpeg/5.0.1_armv7l/ffmpeg-5.0.1-chromeos-armv7l.tar.zst',
-  armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ffmpeg/5.0.1_armv7l/ffmpeg-5.0.1-chromeos-armv7l.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ffmpeg/5.0.1_x86_64/ffmpeg-5.0.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ffmpeg/5.1_armv7l/ffmpeg-5.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ffmpeg/5.1_armv7l/ffmpeg-5.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ffmpeg/5.1_i686/ffmpeg-5.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ffmpeg/5.1_x86_64/ffmpeg-5.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: '91e328f13cdaa3e433ed1a3ebe862b2b81e1c689ba5babc6e7787ba688bfb1b6',
- aarch64: '94ab8e4974898ccfbc1cc59104de69014faee16e7b42777f20466fe43c2ece33',
-  armv7l: '94ab8e4974898ccfbc1cc59104de69014faee16e7b42777f20466fe43c2ece33',
-  x86_64: 'bc52e2af52e1158a2b9c86efc992bbd098745b7ab7b34bd9136dcb6a16fab26c'
+    aarch64: '413dc87eaee7d62f18b0f0b49881a2f2077300180a1e0a0b0114c77b7f362797',
+     armv7l: '413dc87eaee7d62f18b0f0b49881a2f2077300180a1e0a0b0114c77b7f362797',
+       i686: '27939661f0e7007f86b6776f3095d82faf620e4522bef990995da1b0317b95d1',
+     x86_64: '5379186833678f5de1b0ec673d3389176ff5b90b8ab2903abe102e1ae8e455b6'
   })
 
   depends_on 'avisynthplus' # ?

--- a/packages/tesseract.rb
+++ b/packages/tesseract.rb
@@ -3,7 +3,7 @@ require 'package'
 class Tesseract < Package
   description 'A neural net (LSTM) based OCR engine which is focused on line recognition & an older OCR engine which recognizes character patterns.'
   homepage 'https://github.com/tesseract-ocr/tesseract'
-  @_ver = '5.1.0'
+  @_ver = '5.2.0'
   version @_ver
   license 'Apache-2.0'
   compatibility 'all'
@@ -11,16 +11,16 @@ class Tesseract < Package
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tesseract/5.1.0_armv7l/tesseract-5.1.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tesseract/5.1.0_armv7l/tesseract-5.1.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tesseract/5.1.0_i686/tesseract-5.1.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tesseract/5.1.0_x86_64/tesseract-5.1.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tesseract/5.2.0_armv7l/tesseract-5.2.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tesseract/5.2.0_armv7l/tesseract-5.2.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tesseract/5.2.0_i686/tesseract-5.2.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tesseract/5.2.0_x86_64/tesseract-5.2.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '866199b054c0f0b73da596873330d161512a8c78be8f73157732aee7186887d3',
-     armv7l: '866199b054c0f0b73da596873330d161512a8c78be8f73157732aee7186887d3',
-       i686: 'aa036d11efbddd231af55bede9ac2a6cb3c97729727dbd4f1c572888f0e4f030',
-     x86_64: '769d295e22bd108230cceab03b1ea3bc0daf88c6140166883e671339955f7566'
+    aarch64: '90a31af33fa1feafd1b6cf00a305b0784c68ec85c31198de07504e13875a98d0',
+     armv7l: '90a31af33fa1feafd1b6cf00a305b0784c68ec85c31198de07504e13875a98d0',
+       i686: 'b3b505c0cd92bbf38b630d9cbb09f76bf9840652990c9ecc1cf8435df129967f',
+     x86_64: '91ae4ed96c145f57ebf565b9f7d26d2498f30aac2102d4668b47915f39cc9da7'
   })
 
   depends_on 'asciidoc' => :build
@@ -33,6 +33,7 @@ class Tesseract < Package
   depends_on 'libarchive'
   depends_on 'libcurl'
   depends_on 'libjpeg'
+  depends_on 'openldap'
   depends_on 'harfbuzz'
   depends_on 'libtiff'
   depends_on 'pango'
@@ -45,7 +46,7 @@ class Tesseract < Package
     # XML_CATALOG_FILES=#{CREW_PREFIX}/etc/xml/catalog does not get set
     # in the Makefile without this, which results in errors at install
     system "find . -name 'Makefile' -exec sed -i 's,XML_CATALOG_FILES = ,XML_CATALOG_FILES = #{CREW_PREFIX}/etc/xml/catalog,g' {} +"
-    system 'make'
+    system 'make || make'
     system 'make training'
   end
 


### PR DESCRIPTION
- ffmpeg update + dep updates to fix broken tesseract dependency

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=ffmpeg CREW_TESTING=1 crew update
```