### PR TITLE
install.sh: Use system zstd if it exists to extract bootstrap packages.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -220,14 +220,12 @@ function extract_install () {
     if [[ "$2" == *".zst" ]];then
       if [[ -e /usr/bin/zstd ]]; then
         PATH=/usr/bin:/usr/local/share/musl/bin:$PATH tar -Izstd -xpf ../"${2}"
-      else
-        if (LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} "${CREW_PREFIX}"/bin/zstd --version &> /dev/null) || \
+      elif (LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} "${CREW_PREFIX}"/bin/zstd --version &> /dev/null) || \
            (LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} "${CREW_PREFIX}"/share/musl/bin/zstd --version &> /dev/null); then
-          LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} tar -Izstd -xpf ../"${2}"
-        else
-          echo "Zstd is broken or nonfunctional, and packages can not be extracted properly."
-          exit 1
-        fi
+        LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} tar -Izstd -xpf ../"${2}"
+      else
+        echo "Zstd is broken or nonfunctional, and packages can not be extracted properly."
+        exit 1
       fi
     elif [[ "$2" == *".tpxz" ]];then
       if ! LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} pixz -h &> /dev/null; then

--- a/install.sh
+++ b/install.sh
@@ -218,7 +218,17 @@ function extract_install () {
     #extract and install
     echo_intra "Extracting ${1} ..."
     if [[ "$2" == *".zst" ]];then
-      LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} tar -Izstd -xpf ../"${2}"
+      if [[ -e /usr/bin/zstd ]]; then
+        PATH=/usr/bin:/usr/local/share/musl/bin:$PATH tar -Izstd -xpf ../"${2}"
+      else
+        if (LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} "${CREW_PREFIX}"/bin/zstd --version &> /dev/null) || \
+           (LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} "${CREW_PREFIX}"/share/musl/bin/zstd --version &> /dev/null); then
+          LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} tar -Izstd -xpf ../"${2}"
+        else
+          echo "Zstd is broken or nonfunctional, and packages can not be extracted properly."
+          exit 1
+        fi
+      fi
     elif [[ "$2" == *".tpxz" ]];then
       if ! LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} pixz -h &> /dev/null; then
         tar xpf ../"${2}"


### PR DESCRIPTION
Fixes #7233 #7229 (But does not fix the musl binaries on AMD machines issue.)

- By using the system `zstd` we can get AMD installs to extract all bootstrap packages. If we don't end up having a working `zstd` binary, exit with an error message.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

