### PR TITLE
smbclient -> 4.16.4 + dependency updates

### DIFF
--- a/packages/ldb.rb
+++ b/packages/ldb.rb
@@ -6,23 +6,23 @@ require 'package'
 class Ldb < Package
   description 'Schema-less, ldap like, API and database'
   homepage 'https://ldb.samba.org/'
-  version '2.5.0'
+  version '2.5.2'
   license 'GPLv3'
   compatibility 'all'
   source_url "https://samba.org/ftp/ldb/ldb-#{version}.tar.gz"
-  source_sha256 '583ec548fc9cac4596dcd8b510408cdda2a8f85c02e672d0f9dce6a7364faa5e'
+  source_sha256 '6fada72274b648799d33f851d9edbbb1b31389910c207e111b597f97bf83a0e4'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ldb/2.5.0_armv7l/ldb-2.5.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ldb/2.5.0_armv7l/ldb-2.5.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ldb/2.5.0_i686/ldb-2.5.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ldb/2.5.0_x86_64/ldb-2.5.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ldb/2.5.2_armv7l/ldb-2.5.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ldb/2.5.2_armv7l/ldb-2.5.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ldb/2.5.2_i686/ldb-2.5.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ldb/2.5.2_x86_64/ldb-2.5.2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'c07b01c496e6ec532e654ca9d7f22aeca3d8ef79645ada44fd6457b4a64f4bb7',
-     armv7l: 'c07b01c496e6ec532e654ca9d7f22aeca3d8ef79645ada44fd6457b4a64f4bb7',
-       i686: 'd0de89fd2485e5963f9ee7f0626c2057fc8b52685003963ab75ce43f4c06d08b',
-     x86_64: '5e714041f50e093916d5ec22760b40342dee7340ddd75cf3f0952dcc3e6e03ad'
+    aarch64: '57f2e721b730b444473d6ccb66e4d5c15a472f59f0c717febae4a70770844472',
+     armv7l: '57f2e721b730b444473d6ccb66e4d5c15a472f59f0c717febae4a70770844472',
+       i686: '5a66f1dda57ea412737b74801d9f169a164d5247c9a0baca64a15dc52a0ee0f0',
+     x86_64: '8bb8be2f0274e8938cd30a27d7faae28cc00819cec978ae4ee1ced75026972ac'
   })
 
   depends_on 'cmocka' => :build

--- a/packages/smbclient.rb
+++ b/packages/smbclient.rb
@@ -3,23 +3,23 @@ require 'package'
 class Smbclient < Package
   description 'Tools to access a servers filespace and printers via SMB'
   homepage 'https://www.samba.org'
-  version '4.16.0'
+  version '4.16.4'
   license 'GPLv3'
   compatibility 'all'
-  source_url 'https://download.samba.org/pub/samba/stable/samba-4.16.0.tar.gz'
-  source_sha256 '97c47de35915d1637b254f02643c3230c3e73617851700edc7a2a8c958a3310c'
+  source_url 'https://download.samba.org/pub/samba/stable/samba-4.16.4.tar.gz'
+  source_sha256 '9532f848fb125a17e4e5d98e1ae8b42f210ed4433835e815b97c5dde6dc4702f'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/smbclient/4.16.0_armv7l/smbclient-4.16.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/smbclient/4.16.0_armv7l/smbclient-4.16.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/smbclient/4.16.0_i686/smbclient-4.16.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/smbclient/4.16.0_x86_64/smbclient-4.16.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/smbclient/4.16.4_armv7l/smbclient-4.16.4-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/smbclient/4.16.4_armv7l/smbclient-4.16.4-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/smbclient/4.16.4_i686/smbclient-4.16.4-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/smbclient/4.16.4_x86_64/smbclient-4.16.4-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '984271933e93cff22899d51494abceccce92aa98b94d040ed7f8159ae890ef2a',
-     armv7l: '984271933e93cff22899d51494abceccce92aa98b94d040ed7f8159ae890ef2a',
-       i686: '050592f2bab1c417a23b1d6571330e97ac644d0dceadbbcffd0cca5c71b434db',
-     x86_64: 'cf2a5478cec8d024f85dc5fdf22bd802d0c99afbb231157fad47370bcc8d73e4'
+    aarch64: '13db8144966947e8a3d308021c397d4a43f080d812e30c773ef6013eb28d50ce',
+     armv7l: '13db8144966947e8a3d308021c397d4a43f080d812e30c773ef6013eb28d50ce',
+       i686: '2a3238c55a2727d837d99afbded7ea7a54edf9eb15e951fff48a421d9a27c6cc',
+     x86_64: '00d317e6601217874a2b7f5947ded2191c703b1469455031f554d1e53b95908d'
   })
 
   depends_on 'avahi' # R
@@ -35,6 +35,7 @@ class Smbclient < Package
   depends_on 'liburing' => :build
   depends_on 'linux_pam' # R
   depends_on 'lmdb' => :build
+  depends_on 'openldap' # R
   depends_on 'perl_json' => :build
   depends_on 'perl_parse_yapp' => :build
   depends_on 'popt' => :build
@@ -52,7 +53,7 @@ class Smbclient < Package
                        smbcquotas smbget net nmblookup smbtar]
   @smbclient_pkgconfig = %w[smbclient netapi wbclient]
 
-  @xml_catalog_files = ENV['XML_CATALOG_FILES']
+  @xml_catalog_files = ENV.fetch('XML_CATALOG_FILES', nil)
 
   def self.patch
     system "sed -e 's:<gpgme\.h>:<gpgme/gpgme.h>:' \

--- a/packages/talloc.rb
+++ b/packages/talloc.rb
@@ -6,23 +6,23 @@ require 'package'
 class Talloc < Package
   description 'Hierarchical pool based memory allocator with destructors'
   homepage 'https://talloc.samba.org/'
-  version '2.3.3'
+  version '2.3.4'
   license 'LGPL'
   compatibility 'all'
   source_url "https://www.samba.org/ftp/talloc/talloc-#{version}.tar.gz"
-  source_sha256 '6be95b2368bd0af1c4cd7a88146eb6ceea18e46c3ffc9330bf6262b40d1d8aaa'
+  source_sha256 '179f9ebe265e67e4ab2c26cad2b7de4b6a77c6c212f966903382869f06be6505'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/talloc/2.3.3_armv7l/talloc-2.3.3-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/talloc/2.3.3_armv7l/talloc-2.3.3-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/talloc/2.3.3_i686/talloc-2.3.3-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/talloc/2.3.3_x86_64/talloc-2.3.3-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/talloc/2.3.4_armv7l/talloc-2.3.4-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/talloc/2.3.4_armv7l/talloc-2.3.4-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/talloc/2.3.4_i686/talloc-2.3.4-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/talloc/2.3.4_x86_64/talloc-2.3.4-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'a723d57e1400894c112f6480effb852195b9d1edd56ca6692b42747d56af0b80',
-     armv7l: 'a723d57e1400894c112f6480effb852195b9d1edd56ca6692b42747d56af0b80',
-       i686: 'c8c43903f11e03ef117f72e3ddf9d4fe4f5ffe1e800f9789001fb049d51c480a',
-     x86_64: '983230c12d39e40265a18aebd25440bd6561d7cc09327622555c4674df438d8c'
+    aarch64: '4e8214c3b9f7e072b8ff7d8727673f7a66483ee06ec062cab80f2b8ea1d4173b',
+     armv7l: '4e8214c3b9f7e072b8ff7d8727673f7a66483ee06ec062cab80f2b8ea1d4173b',
+       i686: '9a4b85aa6ec7afee4b5d3b527a35965870cc2a43c04df9559129b58211baba62',
+     x86_64: 'b437d15d5afc458ed6317a420a1cf13b206fb34259b2070f0da5f5d27644475d'
   })
 
   depends_on 'libbsd'

--- a/packages/tdb.rb
+++ b/packages/tdb.rb
@@ -3,23 +3,23 @@ require 'package'
 class Tdb < Package
   description 'tdb is a simple database API for sharing structures between parts of Samba'
   homepage 'https://tdb.samba.org/'
-  version '1.4.6'
+  version '1.4.7'
   license 'GPL-3'
   compatibility 'all'
   source_url "https://www.samba.org/ftp/tdb/tdb-#{version}.tar.gz"
-  source_sha256 'd6892bd8befe04a77642a1dd56e4a879349bf1cf5b2c0bf5fb841061938def0b'
+  source_sha256 'a4fb168def533f31ff2c07f7d9844bb3131e6799f094ebe77d0380adc987c20e'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tdb/1.4.6_armv7l/tdb-1.4.6-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tdb/1.4.6_armv7l/tdb-1.4.6-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tdb/1.4.6_i686/tdb-1.4.6-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tdb/1.4.6_x86_64/tdb-1.4.6-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tdb/1.4.7_armv7l/tdb-1.4.7-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tdb/1.4.7_armv7l/tdb-1.4.7-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tdb/1.4.7_i686/tdb-1.4.7-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tdb/1.4.7_x86_64/tdb-1.4.7-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '8396dd401979dd2865079e3b4b14b36026f1b9d74f0a555fa382355f9eca3dc6',
-     armv7l: '8396dd401979dd2865079e3b4b14b36026f1b9d74f0a555fa382355f9eca3dc6',
-       i686: '37f60900b780ddeda64dd2dd0d9739266a0f27ef6ebbb9b6079dd1dccc3099df',
-     x86_64: 'd3e0bf820e71c2a0c6a8630eb215b41049a6595619b0bcc679e615581d6d9904'
+    aarch64: '27f08ebcd4a5a1e68afe3fc1db7af459720a8fd7fd9f893412d8d8e148021f41',
+     armv7l: '27f08ebcd4a5a1e68afe3fc1db7af459720a8fd7fd9f893412d8d8e148021f41',
+       i686: '2e07007ce032d5c36ba0817accfc8217cf106022663891e90ed60057cfa2104d',
+     x86_64: '73c44eab45e9b417b60521602631c1c7e31f1ea2d3337abe8ad094146d5009b7'
   })
 
   depends_on 'docbook_xsl' => :build

--- a/packages/tevent.rb
+++ b/packages/tevent.rb
@@ -6,23 +6,23 @@ require 'package'
 class Tevent < Package
   description 'Event system based on the talloc memory management library'
   homepage 'https://tevent.samba.org/'
-  version '0.11.0'
+  version '0.13.0'
   license 'LGPL'
   compatibility 'all'
   source_url "https://samba.org/ftp/tevent/tevent-#{version}.tar.gz"
-  source_sha256 'ee9a86c8e808aac2fe1e924eaa139ff7f0269d0e8e4fafa850ae5c7489bc82ba'
+  source_sha256 'b9437a917fa55344361beb64ec9e0042e99cae8879882a62dd38f6abe2371d0c'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tevent/0.11.0_armv7l/tevent-0.11.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tevent/0.11.0_armv7l/tevent-0.11.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tevent/0.11.0_i686/tevent-0.11.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tevent/0.11.0_x86_64/tevent-0.11.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tevent/0.13.0_armv7l/tevent-0.13.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tevent/0.13.0_armv7l/tevent-0.13.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tevent/0.13.0_i686/tevent-0.13.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tevent/0.13.0_x86_64/tevent-0.13.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '9a72a1bbba9fdb0d298b91b687f2457b216d4b961649d1f8dbacd75a5b1e96ab',
-     armv7l: '9a72a1bbba9fdb0d298b91b687f2457b216d4b961649d1f8dbacd75a5b1e96ab',
-       i686: 'd1d1947c895da8b5aad1fe8241de4e20d7d5f176adc0b9803151eb426615ed4f',
-     x86_64: '3939c1757d7eded3e66c70ba63a00c6cd37390bd1e1ac02da00a33916f13f0af'
+    aarch64: '6882e33fce796b68aea820e56f502a0fbca16b366bcdeedced2b0d11a1e2bc96',
+     armv7l: '6882e33fce796b68aea820e56f502a0fbca16b366bcdeedced2b0d11a1e2bc96',
+       i686: '6b144a691f72dbc6161dcc6c3a90080aa5a980ae53fe0db79b5365a716fcd780',
+     x86_64: '8f7afd3c02a9f6832c0bdae29b9ab629b5aa205433bd0f9f4fbbb617dffa62e9'
   })
 
   depends_on 'libbsd'


### PR DESCRIPTION
- smbclient needed a rebuild due to a broken openldap library dependency.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=smbclient  CREW_TESTING=1 crew update
```
