### PR TITLE
binutils => 2.39 + required texinfo rebuild

### DIFF
--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -3,24 +3,24 @@ require 'package'
 class Binutils < Package
   description 'The GNU Binutils are a collection of binary tools.'
   homepage 'https://www.gnu.org/software/binutils/'
-  @_ver = '2.38'
+  @_ver = '2.39'
   version @_ver.to_s
   license 'GPL-3+'
   compatibility 'all'
   source_url "https://ftpmirror.gnu.org/binutils/binutils-#{@_ver}.tar.xz"
-  source_sha256 'e316477a914f567eccc34d5d29785b8b0f5a10208d36bbacedcc39048ecfe024'
+  source_sha256 '645c25f563b8adc0a81dbd6a41cffbf4d37083a382e02d5d3df4f65c09516d00'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/binutils/2.38_armv7l/binutils-2.38-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/binutils/2.38_armv7l/binutils-2.38-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/binutils/2.38_i686/binutils-2.38-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/binutils/2.38_x86_64/binutils-2.38-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/binutils/2.39_armv7l/binutils-2.39-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/binutils/2.39_armv7l/binutils-2.39-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/binutils/2.39_i686/binutils-2.39-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/binutils/2.39_x86_64/binutils-2.39-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '650576bdad8a9c92b1042778ba0ff39b014a8843c034117f8fcaa0e21c6d482d',
-     armv7l: '650576bdad8a9c92b1042778ba0ff39b014a8843c034117f8fcaa0e21c6d482d',
-       i686: '380788b1c83444a3d399f96a74aa87ea74f7198d81d9828e3ef566b2521b84f1',
-     x86_64: '551130879ce51ae3e5fe7a2695d48279b5de0b317fa2ea3a76077e71c5e52228'
+    aarch64: '8432ae6977b5cb0bac2a197cb20372652ac218d37ccf1f3b2eaa2994498f792d',
+     armv7l: '8432ae6977b5cb0bac2a197cb20372652ac218d37ccf1f3b2eaa2994498f792d',
+       i686: '43a6b790fb88e7f4458816115e58f58ca3e90233c740ffd736cabbac52ce7cdf',
+     x86_64: '441b6efece778075bf55b36b70a42379d2bd3ae056bf8a6edef5ea6989cdc95d'
   })
 
   def self.prebuild

--- a/packages/texinfo.rb
+++ b/packages/texinfo.rb
@@ -3,34 +3,40 @@ require 'package'
 class Texinfo < Package
   description 'Texinfo is the official documentation format of the GNU project.'
   homepage 'https://www.gnu.org/software/texinfo/'
-  version '6.8'
+  version '6.8-1'
   license 'GPL-3'
   compatibility 'all'
   source_url 'https://ftpmirror.gnu.org/texinfo/texinfo-6.8.tar.xz'
   source_sha256 '8eb753ed28bca21f8f56c1a180362aed789229bd62fff58bf8368e9beb59fec4'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/texinfo/6.8_armv7l/texinfo-6.8-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/texinfo/6.8_armv7l/texinfo-6.8-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/texinfo/6.8_i686/texinfo-6.8-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/texinfo/6.8_x86_64/texinfo-6.8-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/texinfo/6.8-1_armv7l/texinfo-6.8-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/texinfo/6.8-1_armv7l/texinfo-6.8-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/texinfo/6.8-1_i686/texinfo-6.8-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/texinfo/6.8-1_x86_64/texinfo-6.8-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '8ab8c07b8df6060de246818fe5c94d8fb52c1c16789eddc1ecdcf47d77a53e71',
-     armv7l: '8ab8c07b8df6060de246818fe5c94d8fb52c1c16789eddc1ecdcf47d77a53e71',
-       i686: 'd0a9f83f9314f21775cdddf404dfd63117ad55a22bfc2c2134c22e045ed7e1ac',
-     x86_64: '9b3df80fbebafc830f9ad99c73ab8aaaa3ad0d0ca13cf33a6a4ed9fb737e8ed3'
+    aarch64: 'b74885ef4051db9e1706e77f7ec58747ad1f4de3901c08f28831b07fd7f0f6b4',
+     armv7l: 'b74885ef4051db9e1706e77f7ec58747ad1f4de3901c08f28831b07fd7f0f6b4',
+       i686: '1a199141340ffa01dcb0287e590ad5844f70ce1dc9b5df9459df486aec420ce0',
+     x86_64: '6a6c3c50dfbd0fbc32552308d45ba48cf44e55fd7c29563aabbaefa9b3726bfe'
   })
 
+  depends_on 'perl'
   depends_on 'perl_locale_messages'
   depends_on 'perl_text_unidecode'
   depends_on 'perl_unicode_eastasianwidth'
 
   def self.build
     # configure and make
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
+    # LDflags set to workaround i686 build issues.
+    @ldflags = ''
+    @ldflags = 'LDFLAGS=-static' if ARCH == 'i686'
+    system "#{@ldflags} ./configure #{CREW_OPTIONS} \
       --with-external-Text-Unidecode \
       --with-external-Unicode-EastAsianWidth"
+    # Fix broken i686 build.
+    system "sed -i 's/-static//' info/Makefile" if ARCH == 'i686'
     system 'make'
   end
 


### PR DESCRIPTION
- `texinfo` needed a rebuild with the current `perl` for binutils to build.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=binutils_2.39  CREW_TESTING=1 crew update
```