### PR TITLE
rust -> 1.63.0

### DIFF
--- a/packages/rust.rb
+++ b/packages/rust.rb
@@ -3,23 +3,23 @@ require 'package'
 class Rust < Package
   description 'Rust is a systems programming language that runs blazingly fast, prevents segfaults, and guarantees thread safety.'
   homepage 'https://www.rust-lang.org/'
-  @_ver = '1.62.0'
+  @_ver = '1.63.0'
   version @_ver
   license 'Apache-2.0 and MIT'
   compatibility 'all'
   source_url 'SKIP'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.62.0_armv7l/rust-1.62.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.62.0_armv7l/rust-1.62.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.62.0_i686/rust-1.62.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.62.0_x86_64/rust-1.62.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.63.0_armv7l/rust-1.63.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.63.0_armv7l/rust-1.63.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.63.0_i686/rust-1.63.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.63.0_x86_64/rust-1.63.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '21d46c4f893c5cefced0270d0b367968dbb448b8c31c6d8cf832b2b3a72f303d',
-     armv7l: '21d46c4f893c5cefced0270d0b367968dbb448b8c31c6d8cf832b2b3a72f303d',
-       i686: 'e04a05d20eb6746e254da39b740b8bb0e7866ca5a216f8294765f021fada108f',
-     x86_64: 'f46971a19f5d0e5640d328f1f664eb0d93dc6ba23fa0c0b4358fdbff6205dc8a'
+    aarch64: '7239562f0e94934dafc016e291376d496721a47372f0e137e7005e99286351de',
+     armv7l: '7239562f0e94934dafc016e291376d496721a47372f0e137e7005e99286351de',
+       i686: 'ff2319cf9dd994751c0cbab115b4d04b2f793e1282c5e3757f50321c5ed4b7b8',
+     x86_64: '4839343d25a8823fa831feae250057475dd8ad0a1bb41f0a4e3c0c21e739c3f7'
   })
 
   def self.install
@@ -27,7 +27,7 @@ class Rust < Package
     ENV['CARGO_HOME'] = "#{CREW_DEST_PREFIX}/share/cargo"
     ENV['RUSTUP_HOME'] = "#{CREW_DEST_PREFIX}/share/rustup"
     default_host = ARCH == 'aarch64' || ARCH == 'armv7l' ? 'armv7-unknown-linux-gnueabihf' : "#{ARCH}-unknown-linux-gnu"
-    downloader 'https://sh.rustup.rs', 'a3cb081f88a6789d104518b30d4aa410009cd08c3822a1226991d6cf0442a0f8', 'rustup.sh'
+    downloader 'https://sh.rustup.rs', '173f4881e2de99ba9ad1acb59e65be01b2a44979d83b6ec648d0d22f8654cbce', 'rustup.sh'
     system "sed -i 's,\$(mktemp -d 2>/dev/null || ensure mktemp -d -t rustup),#{CREW_PREFIX}/tmp,' rustup.sh"
     FileUtils.mkdir_p(CREW_DEST_HOME)
     FileUtils.mkdir_p("#{CREW_DEST_PREFIX}/bin")


### PR DESCRIPTION

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=rust_163 CREW_TESTING=1 crew update
```