### PR TITLE
crew: Isolate package classes from global scope

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -14,6 +14,7 @@ require_relative '../lib/util'
 require_relative '../lib/convert_size'
 require_relative '../lib/downloader'
 require_relative '../lib/deb_utils'
+require_relative '../lib/package'
 
 # Add lib to LOAD_PATH
 $LOAD_PATH.unshift "#{CREW_LIB_PATH}lib"
@@ -185,21 +186,12 @@ end
 
 def set_package(pkgName, pkgPath)
   begin
-    require_relative pkgPath
+    @pkg = Package.load_package(pkgPath, pkgName)
   rescue SyntaxError => e
-    puts "#{e.class}: #{e.message}".red
+    warn "#{e.class}: #{e.message}".red
   end
 
-  # add `PKG_` to the beginning of class name if it starts with a digit
-  if pkgName =~ /^[0-9]/
-    className = 'PKG_' + pkgName
-  else
-    className = pkgName.capitalize
-  end
-
-  @pkg = Object.const_get(className)
   @pkg.build_from_source = true if @opt_recursive
-  @pkg.name = pkgName
 end
 
 def list_packages

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.24.0'
+CREW_VERSION = '1.25.0'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -28,10 +28,12 @@ class Package
   def self.load_package ( pkgFile, pkgName = File.basename(pkgFile, '.rb') )
     # self.load_package: load a package under 'Package' class scope
     #
-    # read and eval package script under 'Package' class
-    class_eval( File.read(pkgFile) )
+    className = pkgName.capitalize
 
-    pkgObj = const_get(pkgName.capitalize)
+    # read and eval package script under 'Package' class
+    class_eval( File.read(pkgFile), pkgFile ) unless const_defined?("Package::#{className}")
+
+    pkgObj = const_get(className)
     pkgObj.name = pkgName
 
     return pkgObj

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -32,7 +32,7 @@ class Package
     class_eval( File.read(pkgFile) )
 
     pkgObj = const_get(pkgName.capitalize)
-    pkgObj.name = name
+    pkgObj.name = pkgName
 
     return pkgObj
   end

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -1,4 +1,4 @@
-require 'package_helpers'
+require_relative 'package_helpers'
 
 class Package
   property :description, :homepage, :version, :license, :compatibility,

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -6,7 +6,7 @@ class Package
            :git_branch, :git_hashtag
 
   boolean_property = %i[conflicts_ok git_fetchtags gnome is_fake is_musl
-                        is_static no_compile_needed no_env_options no_fhs
+                        is_static no_compile_needed no_env_options no_fhs 
                         no_patchelf no_zstd patchelf git_clone_deep
                         no_git_submodules]
 
@@ -23,6 +23,18 @@ class Package
 
   class << self
     attr_accessor :name, :is_dep, :in_build, :build_from_source, :in_upgrade
+  end
+
+  def self.load_package ( pkgFile, pkgName = File.basename(pkgFile, '.rb') )
+    # self.load_package: load a package under 'Package' class scope
+    #
+    # read and eval package script under 'Package' class
+    class_eval( File.read(pkgFile) )
+
+    pkgObj = const_get(pkgName.capitalize)
+    pkgObj.name = name
+
+    return pkgObj
   end
 
   def self.dependencies
@@ -47,7 +59,7 @@ class Package
     #   highlight_build_deps: include corresponding symbols in return value, you can convert it to actual ascii color codes later
     # exclude_buildessential: do not insert `buildessential` dependency automatically
     #
-    #              top_level: if set to true, return satisfied dependencies
+    #              top_level: if set to true, return satisfied dependencies 
     #                         (dependencies that might be a sub-dependency of a dependency that checked before),
     #                         always set to false if this function is called in recursive loop (see `expandedDeps` below)
     #
@@ -56,7 +68,7 @@ class Package
     # add current package to @checked_list for preventing extra checks
     @checked_list.merge!({ pkgName => pkgTags })
 
-    pkgObj = Object.const_get(pkgName.capitalize)
+    pkgObj = load_package("#{CREW_PACKAGES_PATH}/#{pkgName}.rb")
     is_source = pkgObj.is_source?(ARCH.to_sym) or pkgObj.build_from_source
     deps = pkgObj.dependencies
 
@@ -81,7 +93,6 @@ class Package
                        tags = (pkgTags.include?(:build)) ? pkgTags : depTags
 
                        if @checked_list.keys.none?(dep)
-                         require_relative "#{CREW_PACKAGES_PATH}/#{dep}.rb"
                          # check dependency by calling this function recursively
                          next send(__method__, dep,
                                                      hash: hash,

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,9 +20,10 @@ A simple example of a test script called `my_test` is below:
 #!/usr/bin/env ruby
 
 # Makes sure buildessential package depends on gcc
+require_relative "../lib/package"
 
-require_relative("../packages/buildessential")
-pkg = Object.const_get('Buildessential')
+pkg = Package.load_package('../package/buildessential.rb')
+
 if pkg.dependencies and pkg.dependencies.has_key?('gcc') then
 	puts "Everything works properly.".lightgreen
 else

--- a/tests/cycle_test
+++ b/tests/cycle_test
@@ -5,6 +5,7 @@
 require 'find'
 require_relative '../lib/const'
 require_relative '../lib/color'
+require_relative '../lib/package'
 
 @all_pkgs = {}
 
@@ -13,11 +14,9 @@ $LOAD_PATH.unshift '../lib'
 puts "Running dependency cycle tests...\n".yellow
 
 # Loads all packages
-Dir.glob('../packages/*.rb').each do |filename|
+Dir['../packages/*.rb'].each do |filename|
   name = File.basename(filename, '.rb')
-  require_relative("../packages/#{name}")
-  pkg = Object.const_get(name.capitalize)
-  pkg.name = name
+  pkg = Package.load_package(filename, name)
   @all_pkgs[name] = pkg
 end
 


### PR DESCRIPTION
To prevent the package's class from overriding ruby's built-in modules/constants due to the identical name, this pr changes all `require_relative <packageFile>` to `Package.class_eval( File.read(<packageFile>) )` so that all package classes will be under the `Package` class scope

Actually there have a package that is already facing this problem:
```ruby
Readline # => The built-in ruby Readline module

# the crew readline package
require_relative 'readline.rb'

Readline # => Covered, now is the class of the readline package
```

In this pr, all package classes will be under the `Package` class now:
```ruby
# before
require_relative '<packageFile>'
# now we have the `PackageName` class in global scope (Object::PackageName) (`Object` is the main scope)
# and it can be referred by Object.const_get
@pkg = Object.const_get('PackageName') # (@pkg is Object::PackageName)




# after
# we need to require the `Package` class in order to import package classes into it
require_relative 'lib/package.rb'

# load the package with the newly added function in package.rb.
# basicly it loads the content of the package recipe under the `Package` class scope
# by using `class_eval()` and `File.read()`
#
# This function will also do the `const_get` part for us
@pkg = Package.load_package(<packageFile>)

# Now we have the `PackageName` class in `Package` scope (Object::Package::PackageName)
# @pkg is Object::Package::PackageName
```

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/supechicken/chromebrew.git CREW_TESTING_BRANCH=isolate_pkg_class CREW_TESTING=1 crew update
```

Tested on `x86_64`
