### PR TITLE
Add Crosvm, minijail, update vulkan_headers, vulkan_icd_loader, virglrenderer, libdrm

### DIFF
--- a/packages/crosvm.rb
+++ b/packages/crosvm.rb
@@ -28,7 +28,7 @@ class Crosvm < Package
   def self.build
     @pwd = `pwd`.chomp
     FileUtils.mkdir 'build_bin'
-    FileUtils.ln_s "#{CREW_PREFIX}/bin/gcc",'build_bin/arm-linux-gnueabihf-gcc' if ARCH == 'armv7l'
+    FileUtils.ln_s "#{CREW_PREFIX}/bin/gcc", 'build_bin/arm-linux-gnueabihf-gcc' if ARCH == 'armv7l'
     system "PATH=#{@pwd}/build_bin:$PATH cargo build --release"
   end
 

--- a/packages/crosvm.rb
+++ b/packages/crosvm.rb
@@ -1,0 +1,41 @@
+# Adapted from Arch Linux crosvm-git PKGBUILD at:
+# https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=crosvm-git
+
+require 'package'
+
+class Crosvm < Package
+  description 'The Chrome OS Virtual Machine Monitor'
+  homepage 'https://chromium.googlesource.com/crosvm/crosvm'
+  version '7b5f6b1'
+  license 'custom:chromiumos'
+  compatibility 'x86_64'
+  source_url 'https://chromium.googlesource.com/crosvm/crosvm.git'
+  git_hashtag '7b5f6b198fa2e3acc797175670fad8686db3e72e'
+
+  binary_url({
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/crosvm/7b5f6b1_x86_64/crosvm-7b5f6b1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    x86_64: '6c33130dd77e022f159e537ce7795a67100fc6edf6e4ac2956de593f0ebec201'
+  })
+
+  depends_on 'libcap'
+  depends_on 'dtc'
+  depends_on 'protobuf'
+  depends_on 'rust' => :build
+  depends_on 'wayland_protocols' => :build
+
+  def self.build
+    @pwd = `pwd`.chomp
+    FileUtils.mkdir 'build_bin'
+    FileUtils.ln_s "#{CREW_PREFIX}/bin/gcc",'build_bin/arm-linux-gnueabihf-gcc' if ARCH == 'armv7l'
+    system "PATH=#{@pwd}/build_bin:$PATH cargo build --release"
+  end
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin/"
+    FileUtils.install 'target/release/crosvm', "#{CREW_DEST_PREFIX}/bin/crosvm", mode: 0o755
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/policy/crosvm/"
+    FileUtils.cp_r Dir.glob("seccomp/#{ARCH}/*"), "#{CREW_DEST_PREFIX}/share/policy/crosvm/" if ARCH == 'x86_64'
+  end
+end

--- a/packages/crosvm.rb
+++ b/packages/crosvm.rb
@@ -6,36 +6,38 @@ require 'package'
 class Crosvm < Package
   description 'The Chrome OS Virtual Machine Monitor'
   homepage 'https://chromium.googlesource.com/crosvm/crosvm'
-  version '7b5f6b1'
+  version '379dd2d'
   license 'custom:chromiumos'
   compatibility 'x86_64'
   source_url 'https://chromium.googlesource.com/crosvm/crosvm.git'
-  git_hashtag '7b5f6b198fa2e3acc797175670fad8686db3e72e'
+  git_hashtag '379dd2dfecf1a0c06adf0f6e257a5ebc75374cb8'
 
   binary_url({
-    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/crosvm/7b5f6b1_x86_64/crosvm-7b5f6b1-chromeos-x86_64.tar.zst'
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/crosvm/379dd2d_x86_64/crosvm-379dd2d-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    x86_64: '6c33130dd77e022f159e537ce7795a67100fc6edf6e4ac2956de593f0ebec201'
+    x86_64: '0292c2ccfc2261c756aeb82e48a6cac14efdf4fff2483950eacc05cd040451d4'
   })
 
   depends_on 'libcap'
+  depends_on 'dbus'
   depends_on 'dtc'
   depends_on 'protobuf'
   depends_on 'rust' => :build
+  depends_on 'virglrenderer'
   depends_on 'wayland_protocols' => :build
 
   def self.build
     @pwd = Dir.pwd
     FileUtils.mkdir 'build_bin'
     FileUtils.ln_s "#{CREW_PREFIX}/bin/gcc", 'build_bin/arm-linux-gnueabihf-gcc' if ARCH == 'armv7l'
-    system "PATH=#{@pwd}/build_bin:$PATH cargo build --release"
+    system "PATH=#{@pwd}/build_bin:$PATH cargo build --release --features=virgl_renderer"
   end
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin/"
     FileUtils.install 'target/release/crosvm', "#{CREW_DEST_PREFIX}/bin/crosvm", mode: 0o755
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/policy/crosvm/"
-    FileUtils.cp_r Dir.glob("seccomp/#{ARCH}/*"), "#{CREW_DEST_PREFIX}/share/policy/crosvm/" if ARCH == 'x86_64'
+    FileUtils.cp_r Dir["seccomp/#{ARCH}/*"], "#{CREW_DEST_PREFIX}/share/policy/crosvm/" if ARCH == 'x86_64'
   end
 end

--- a/packages/crosvm.rb
+++ b/packages/crosvm.rb
@@ -26,7 +26,7 @@ class Crosvm < Package
   depends_on 'wayland_protocols' => :build
 
   def self.build
-    @pwd = `pwd`.chomp
+    @pwd = Dir.pwd
     FileUtils.mkdir 'build_bin'
     FileUtils.ln_s "#{CREW_PREFIX}/bin/gcc", 'build_bin/arm-linux-gnueabihf-gcc' if ARCH == 'armv7l'
     system "PATH=#{@pwd}/build_bin:$PATH cargo build --release"

--- a/packages/crosvm.rb
+++ b/packages/crosvm.rb
@@ -30,7 +30,7 @@ class Crosvm < Package
   def self.build
     @pwd = Dir.pwd
     FileUtils.mkdir 'build_bin'
-    FileUtils.ln_s "#{CREW_PREFIX}/bin/gcc", 'build_bin/arm-linux-gnueabihf-gcc' if ARCH == 'armv7l'
+    FileUtils.ln_s "#{CREW_PREFIX}/bin/gcc", 'build_bin/arm-linux-gnueabihf-gcc' if (ARCH == 'aarch64') || (ARCH == 'armv7l')
     system "PATH=#{@pwd}/build_bin:$PATH cargo build --release --features=virgl_renderer"
   end
 

--- a/packages/libdrm.rb
+++ b/packages/libdrm.rb
@@ -3,7 +3,7 @@ require 'package'
 class Libdrm < Package
   description 'Cross-driver middleware for DRI protocol.'
   homepage 'https://dri.freedesktop.org'
-  @_ver = '2.4.110'
+  @_ver = '2.4.112'
   version @_ver
   license 'MIT'
   compatibility 'all'
@@ -11,16 +11,16 @@ class Libdrm < Package
   git_hashtag "libdrm-#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.110_armv7l/libdrm-2.4.110-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.110_armv7l/libdrm-2.4.110-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.110_i686/libdrm-2.4.110-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.110_x86_64/libdrm-2.4.110-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.112_armv7l/libdrm-2.4.112-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.112_armv7l/libdrm-2.4.112-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.112_i686/libdrm-2.4.112-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdrm/2.4.112_x86_64/libdrm-2.4.112-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '17358ed1f87950f483410a3079757d77c7d62f8893571b61e4b93a24e0f50b9a',
-     armv7l: '17358ed1f87950f483410a3079757d77c7d62f8893571b61e4b93a24e0f50b9a',
-       i686: 'b9dff811d3f6a7fc04e2abb259d1e3f1f5486b1609d21e2cd11f5d31435f472e',
-     x86_64: '64ff40876627b172d3d3a92d641e38bffebb4363a52cb1dbc281f09afa0863a1'
+    aarch64: '80aaba199fd6f8c788e07cb1dc1d77b77318d810d7d7593a24d7d422d927b798',
+     armv7l: '80aaba199fd6f8c788e07cb1dc1d77b77318d810d7d7593a24d7d422d927b798',
+       i686: '280ee9624f654a35e16f77a053488e13d9b1f2e7f51b1c060abb286636c76749',
+     x86_64: '6f0aca30b18bd101dcc1e38d888e2c734b260291a9d2d19076dd540919ed0cdd'
   })
 
   depends_on 'libpciaccess' # R
@@ -39,7 +39,6 @@ class Libdrm < Package
       -Dvc4=true \
       -Dfreedreno=true \
       -Detnaviv=true \
-      -Dlibkms=true \
       -Dexynos=true \
       -Dudev=true \
       builddir"

--- a/packages/minijail.rb
+++ b/packages/minijail.rb
@@ -12,13 +12,15 @@ class Minijail < Package
   source_url 'https://android.googlesource.com/platform/external/minijail.git'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/minijail/81e4b0e2_armv7l/minijail-81e4b0e2-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/minijail/81e4b0e2_armv7l/minijail-81e4b0e2-chromeos-armv7l.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/minijail/81e4b0e2_x86_64/minijail-81e4b0e2-chromeos-x86_64.tar.zst'
+    aarch64: 'file:///usr/local/tmp/packages/minijail-81e4b0e2-chromeos-armv7l.tar.zst',
+     armv7l: 'file:///usr/local/tmp/packages/minijail-81e4b0e2-chromeos-armv7l.tar.zst',
+       i686: 'file:///usr/local/tmp/packages/minijail-81e4b0e2-chromeos-i686.tar.zst',
+     x86_64: 'file:///usr/local/tmp/packages/minijail-81e4b0e2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
     aarch64: '4abb6b16d341150f99c59d35c2eea53e16295f7011db633f3dfe6a09a5ae7584',
      armv7l: '4abb6b16d341150f99c59d35c2eea53e16295f7011db633f3dfe6a09a5ae7584',
+       i686: '5090b7a0bc486e585bfeefe2491948a44fcccd06b4193a1e9a10de075b566bc7',
      x86_64: '9d4bedd9892f1a24d8c9ca4e2cb98fb41d9d0c5e7efff39f0a66816aa4ac5d8f'
   })
 

--- a/packages/minijail.rb
+++ b/packages/minijail.rb
@@ -1,0 +1,56 @@
+# Adapted from Arch Linux minijail PKGBUILD at:
+# https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=minijail
+
+require 'package'
+
+class Minijail < Package
+  description 'Tool to run a process in jailed environment'
+  homepage 'https://google.github.io/minijail/'
+  version '81e4b0e2'
+  license 'custom:chromiumos'
+  compatibility 'all'
+  source_url 'https://android.googlesource.com/platform/external/minijail.git'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/minijail/81e4b0e2_armv7l/minijail-81e4b0e2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/minijail/81e4b0e2_armv7l/minijail-81e4b0e2-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/minijail/81e4b0e2_x86_64/minijail-81e4b0e2-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '4abb6b16d341150f99c59d35c2eea53e16295f7011db633f3dfe6a09a5ae7584',
+     armv7l: '4abb6b16d341150f99c59d35c2eea53e16295f7011db633f3dfe6a09a5ae7584',
+     x86_64: '9d4bedd9892f1a24d8c9ca4e2cb98fb41d9d0c5e7efff39f0a66816aa4ac5d8f'
+  })
+
+  git_hashtag '81e4b0e245f6fef9a82800d3f182e73127bfa2fe'
+
+  depends_on 'libcap'
+
+  def self.build
+    system 'make'
+    @minijailversion = `grep -o "version=.*" setup.py | sed 's/,//' | sed "s/'//g" | sed "s/version=//"`.chomp
+    @minijail_pc = <<~MINIJAIL_PC_EOF
+      prefix=#{CREW_PREFIX}
+      libdir=#{CREW_LIB_PREFIX}
+      includedir=\${prefix}/include
+
+      Name: libminijail
+      Description: Minijail shared library
+      URL: https://google.github.io/minijail/
+      Version: #{@minijail_version}
+      Libs: -L\${libdir} -lminijail
+      Cflags: -I\${includedir}
+    MINIJAIL_PC_EOF
+  end
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_LIB_PREFIX}/pkgconfig/"
+    File.write("#{CREW_DEST_LIB_PREFIX}/pkgconfig/libminijail.pc", @minijail_pc)
+    system "install -m755 -D libminijail.so #{CREW_DEST_LIB_PREFIX}/libminijail.so"
+    system "install -m755 -D libminijailpreload.so #{CREW_DEST_LIB_PREFIX}/libminijailpreload.so"
+    system "install -m644 -D libminijail.h #{CREW_DEST_PREFIX}/include/libminijail.h"
+    system "install -m644 -D minijail0.1 #{CREW_DEST_MAN_PREFIX}/man1/minijail0.1"
+    system "install -m644 -D minijail0.5 #{CREW_DEST_MAN_PREFIX}/man5/minijail0.5"
+    system "install -m644 -D NOTICE #{CREW_DEST_PREFIX}/share/licenses/minijail/NOTICE"
+  end
+end

--- a/packages/minijail.rb
+++ b/packages/minijail.rb
@@ -10,12 +10,13 @@ class Minijail < Package
   license 'custom:chromiumos'
   compatibility 'all'
   source_url 'https://android.googlesource.com/platform/external/minijail.git'
+  git_hashtag '81e4b0e245f6fef9a82800d3f182e73127bfa2fe'
 
   binary_url({
-    aarch64: 'file:///usr/local/tmp/packages/minijail-81e4b0e2-chromeos-armv7l.tar.zst',
-     armv7l: 'file:///usr/local/tmp/packages/minijail-81e4b0e2-chromeos-armv7l.tar.zst',
-       i686: 'file:///usr/local/tmp/packages/minijail-81e4b0e2-chromeos-i686.tar.zst',
-     x86_64: 'file:///usr/local/tmp/packages/minijail-81e4b0e2-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/minijail/81e4b0e2_armv7l/minijail-81e4b0e2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/minijail/81e4b0e2_armv7l/minijail-81e4b0e2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/minijail/81e4b0e2_i686/minijail-81e4b0e2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/minijail/81e4b0e2_x86_64/minijail-81e4b0e2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
     aarch64: '4abb6b16d341150f99c59d35c2eea53e16295f7011db633f3dfe6a09a5ae7584',
@@ -23,8 +24,6 @@ class Minijail < Package
        i686: '5090b7a0bc486e585bfeefe2491948a44fcccd06b4193a1e9a10de075b566bc7',
      x86_64: '9d4bedd9892f1a24d8c9ca4e2cb98fb41d9d0c5e7efff39f0a66816aa4ac5d8f'
   })
-
-  git_hashtag '81e4b0e245f6fef9a82800d3f182e73127bfa2fe'
 
   depends_on 'libcap'
 

--- a/packages/virglrenderer.rb
+++ b/packages/virglrenderer.rb
@@ -8,6 +8,7 @@ class Virglrenderer < Package
   license 'MIT'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/virgl/virglrenderer.git'
+  git_hashtag '486d891a9242d978cef6bb5ae80d0d9b6aa420c8'
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/virglrenderer/0.9.1-486d891_armv7l/virglrenderer-0.9.1-486d891-chromeos-armv7l.tar.zst',
@@ -19,7 +20,6 @@ class Virglrenderer < Package
      armv7l: '662b56e9402ba14b88877a5d05ee968f7912236115fc489228da21bf79802495',
      x86_64: 'b50b3677447bd9385bdc2eeab64a5c88cbaa9d2e63a1266826d170dcce2e1bd1'
   })
-  git_hashtag '486d891a9242d978cef6bb5ae80d0d9b6aa420c8'
 
   depends_on 'libva'
   depends_on 'mesa'

--- a/packages/virglrenderer.rb
+++ b/packages/virglrenderer.rb
@@ -3,30 +3,47 @@ require 'package'
 class Virglrenderer < Package
   description 'Virtual OpenGL renderer for QEMU virtual machines'
   homepage 'https://virgil3d.github.io/'
-  @_ver = '0.8.2'
+  @_ver = '0.9.1-486d891'
   version @_ver
   license 'MIT'
   compatibility 'all'
-  source_url "https://gitlab.freedesktop.org/virgl/virglrenderer/-/archive/virglrenderer-#{@_ver}/virglrenderer-virglrenderer-#{@_ver}.tar.gz"
-  source_sha256 '9fa93095cd9a3e5b13c740e5e3b656a989356732bdaf3e22acb7c38a1f1f4411'
+  source_url 'https://gitlab.freedesktop.org/virgl/virglrenderer.git'
 
-  binary_url ({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/virglrenderer/0.8.2_armv7l/virglrenderer-0.8.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/virglrenderer/0.8.2_armv7l/virglrenderer-0.8.2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/virglrenderer/0.8.2_i686/virglrenderer-0.8.2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/virglrenderer/0.8.2_x86_64/virglrenderer-0.8.2-chromeos-x86_64.tar.xz',
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/virglrenderer/0.9.1-486d891_armv7l/virglrenderer-0.9.1-486d891-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/virglrenderer/0.9.1-486d891_armv7l/virglrenderer-0.9.1-486d891-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/virglrenderer/0.9.1-486d891_x86_64/virglrenderer-0.9.1-486d891-chromeos-x86_64.tar.zst'
   })
-  binary_sha256 ({
-    aarch64: '8f46f083b032dec6c8e9c2627e94315c45f535ec8288d3b8c323af763d49b9d1',
-     armv7l: '8f46f083b032dec6c8e9c2627e94315c45f535ec8288d3b8c323af763d49b9d1',
-       i686: '7e5c6d1f4b0353e6c0e58ac61f0f52471df71b42230cd3510c9045c94dd04b54',
-     x86_64: 'f14a81a9209bbd1cf6b3127512dc489e6971db28b84f8a56bb14e324561c5094',
+  binary_sha256({
+    aarch64: '662b56e9402ba14b88877a5d05ee968f7912236115fc489228da21bf79802495',
+     armv7l: '662b56e9402ba14b88877a5d05ee968f7912236115fc489228da21bf79802495',
+     x86_64: 'b50b3677447bd9385bdc2eeab64a5c88cbaa9d2e63a1266826d170dcce2e1bd1'
   })
+  git_hashtag '486d891a9242d978cef6bb5ae80d0d9b6aa420c8'
 
+  depends_on 'libva'
   depends_on 'mesa'
+  depends_on 'minijail'
+  depends_on 'libepoxy'
+  depends_on 'vulkan_icd_loader'
+
+  def self.patch
+    # threads.h was introduced in glibc 2.28. This is a workaround for
+    # pre-M92 systems.
+    return unless LIBC_VERSION < '2.28'
+
+    downloader 'https://github.com/jtsiomb/c11threads/raw/a0158141b42ebe7a75aaf139e119e82453469125/c11threads.h',
+               'c945fd352449174d3b6107c715b622206ebb81694ac23239637439d78e33ee5a', 'threads.h'
+  end
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} builddir"
+    system "meson setup #{CREW_MESON_OPTIONS.sub("-Dcpp_args='-O2'", '')} \
+      -Ddrm-msm-experimental=true \
+      -Dvenus-experimental=true \
+      -Drender-server=true \
+      -Drender-server-worker=minijail \
+      -Dvideo=true \
+      builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
   end

--- a/packages/vulkan_headers.rb
+++ b/packages/vulkan_headers.rb
@@ -10,16 +10,16 @@ class Vulkan_headers < Package
   source_url 'https://github.com/KhronosGroup/Vulkan-Headers.git'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.2.200_i686/vulkan_headers-1.2.200-chromeos-i686.tpxz',
- aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.224_armv7l/vulkan_headers-1.3.224-chromeos-armv7l.tar.zst',
-  armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.224_armv7l/vulkan_headers-1.3.224-chromeos-armv7l.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.224_x86_64/vulkan_headers-1.3.224-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.224_armv7l/vulkan_headers-1.3.224-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.224_armv7l/vulkan_headers-1.3.224-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.224_i686/vulkan_headers-1.3.224-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.224_x86_64/vulkan_headers-1.3.224-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: 'c2013362fec23d3c98168f15eb333819e7dc4e2d5727514231a6698765c99e4f',
- aarch64: '07d06412605ad77da5eb584ff0004ca8bd375facdec7f208cc8507d87574770a',
-  armv7l: '07d06412605ad77da5eb584ff0004ca8bd375facdec7f208cc8507d87574770a',
-  x86_64: '20e3b90d93447e620d730bfe3f0f55d97cfd19134ed275b5672f5d962863118a'
+    aarch64: '07d06412605ad77da5eb584ff0004ca8bd375facdec7f208cc8507d87574770a',
+     armv7l: '07d06412605ad77da5eb584ff0004ca8bd375facdec7f208cc8507d87574770a',
+       i686: '09b838eacafe97c1471f3da15a82fef46bbd895b443f50f0cefb080b4e513595',
+     x86_64: '20e3b90d93447e620d730bfe3f0f55d97cfd19134ed275b5672f5d962863118a'
   })
 
   git_hashtag "v#{@_ver}"

--- a/packages/vulkan_headers.rb
+++ b/packages/vulkan_headers.rb
@@ -8,6 +8,7 @@ class Vulkan_headers < Package
   license 'Apache-2.0'
   compatibility 'all'
   source_url 'https://github.com/KhronosGroup/Vulkan-Headers.git'
+  git_hashtag "v#{@_ver}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.224_armv7l/vulkan_headers-1.3.224-chromeos-armv7l.tar.zst',
@@ -21,8 +22,6 @@ class Vulkan_headers < Package
        i686: '09b838eacafe97c1471f3da15a82fef46bbd895b443f50f0cefb080b4e513595',
      x86_64: '20e3b90d93447e620d730bfe3f0f55d97cfd19134ed275b5672f5d962863118a'
   })
-
-  git_hashtag "v#{@_ver}"
 
   def self.build
     Dir.mkdir 'builddir'

--- a/packages/vulkan_headers.rb
+++ b/packages/vulkan_headers.rb
@@ -3,25 +3,26 @@ require 'package'
 class Vulkan_headers < Package
   description 'Vulkan header files'
   homepage 'https://github.com/KhronosGroup/Vulkan-Headers'
-  @_ver = '1.2.200'
+  @_ver = '1.3.224'
   version @_ver
   license 'Apache-2.0'
   compatibility 'all'
   source_url 'https://github.com/KhronosGroup/Vulkan-Headers.git'
-  git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.2.200_armv7l/vulkan_headers-1.2.200-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.2.200_armv7l/vulkan_headers-1.2.200-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.2.200_i686/vulkan_headers-1.2.200-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.2.200_x86_64/vulkan_headers-1.2.200-chromeos-x86_64.tpxz'
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.2.200_i686/vulkan_headers-1.2.200-chromeos-i686.tpxz',
+ aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.224_armv7l/vulkan_headers-1.3.224-chromeos-armv7l.tar.zst',
+  armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.224_armv7l/vulkan_headers-1.3.224-chromeos-armv7l.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.224_x86_64/vulkan_headers-1.3.224-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '5a5667d6e87c10b44ce1f8b753ab1b262c3f9080f54ce7813bb0073e8b84bcd1',
-     armv7l: '5a5667d6e87c10b44ce1f8b753ab1b262c3f9080f54ce7813bb0073e8b84bcd1',
-       i686: 'c2013362fec23d3c98168f15eb333819e7dc4e2d5727514231a6698765c99e4f',
-     x86_64: 'a08323b44455380865c5d034bba4f9ebaffa4731612ec9c15f1ed2241b9de402'
+    i686: 'c2013362fec23d3c98168f15eb333819e7dc4e2d5727514231a6698765c99e4f',
+ aarch64: '07d06412605ad77da5eb584ff0004ca8bd375facdec7f208cc8507d87574770a',
+  armv7l: '07d06412605ad77da5eb584ff0004ca8bd375facdec7f208cc8507d87574770a',
+  x86_64: '20e3b90d93447e620d730bfe3f0f55d97cfd19134ed275b5672f5d962863118a'
   })
+
+  git_hashtag "v#{@_ver}"
 
   def self.build
     Dir.mkdir 'builddir'

--- a/packages/vulkan_icd_loader.rb
+++ b/packages/vulkan_icd_loader.rb
@@ -10,16 +10,16 @@ class Vulkan_icd_loader < Package
   source_url 'https://github.com/KhronosGroup/Vulkan-Loader.git'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.2.199_i686/vulkan_icd_loader-1.2.199-chromeos-i686.tpxz',
- aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.224_armv7l/vulkan_icd_loader-1.3.224-chromeos-armv7l.tar.zst',
-  armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.224_armv7l/vulkan_icd_loader-1.3.224-chromeos-armv7l.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.224_x86_64/vulkan_icd_loader-1.3.224-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.224_armv7l/vulkan_icd_loader-1.3.224-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.224_armv7l/vulkan_icd_loader-1.3.224-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.224_i686/vulkan_icd_loader-1.3.224-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.224_x86_64/vulkan_icd_loader-1.3.224-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: 'c1d9c5e78dd8d0898257babaa5914583e57fc764b0a18d5bc9f94e96bfb4cbcc',
- aarch64: '15b9c5272c0a2a8adcafd5984da16738a3a7032479b38f9ce77a3b4ddaf187e5',
-  armv7l: '15b9c5272c0a2a8adcafd5984da16738a3a7032479b38f9ce77a3b4ddaf187e5',
-  x86_64: '53fdaa92fb1e31410c6ebd50f1661f8b99b3a62a2f1bc33be123b2fff7a3f2da'
+    aarch64: '15b9c5272c0a2a8adcafd5984da16738a3a7032479b38f9ce77a3b4ddaf187e5',
+     armv7l: '15b9c5272c0a2a8adcafd5984da16738a3a7032479b38f9ce77a3b4ddaf187e5',
+       i686: 'c0c0c5a6fed09d2515de58c8f2af31081133fe8bc292d445b7bf5ce8676a4239',
+     x86_64: '53fdaa92fb1e31410c6ebd50f1661f8b99b3a62a2f1bc33be123b2fff7a3f2da'
   })
 
   git_hashtag "v#{@_ver}"

--- a/packages/vulkan_icd_loader.rb
+++ b/packages/vulkan_icd_loader.rb
@@ -8,6 +8,7 @@ class Vulkan_icd_loader < Package
   license 'Apache-2.0'
   compatibility 'all'
   source_url 'https://github.com/KhronosGroup/Vulkan-Loader.git'
+  git_hashtag "v#{@_ver}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.224_armv7l/vulkan_icd_loader-1.3.224-chromeos-armv7l.tar.zst',
@@ -21,8 +22,6 @@ class Vulkan_icd_loader < Package
        i686: 'c0c0c5a6fed09d2515de58c8f2af31081133fe8bc292d445b7bf5ce8676a4239',
      x86_64: '53fdaa92fb1e31410c6ebd50f1661f8b99b3a62a2f1bc33be123b2fff7a3f2da'
   })
-
-  git_hashtag "v#{@_ver}"
 
   depends_on 'libx11'
   depends_on 'libxrandr'

--- a/packages/vulkan_icd_loader.rb
+++ b/packages/vulkan_icd_loader.rb
@@ -3,25 +3,26 @@ require 'package'
 class Vulkan_icd_loader < Package
   description 'Vulkan Installable Client Driver ICD Loader'
   homepage 'https://github.com/KhronosGroup/Vulkan-Loader'
-  @_ver = '1.2.199'
+  @_ver = '1.3.224'
   version @_ver
   license 'Apache-2.0'
   compatibility 'all'
   source_url 'https://github.com/KhronosGroup/Vulkan-Loader.git'
-  git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.2.199_armv7l/vulkan_icd_loader-1.2.199-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.2.199_armv7l/vulkan_icd_loader-1.2.199-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.2.199_i686/vulkan_icd_loader-1.2.199-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.2.199_x86_64/vulkan_icd_loader-1.2.199-chromeos-x86_64.tpxz'
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.2.199_i686/vulkan_icd_loader-1.2.199-chromeos-i686.tpxz',
+ aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.224_armv7l/vulkan_icd_loader-1.3.224-chromeos-armv7l.tar.zst',
+  armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.224_armv7l/vulkan_icd_loader-1.3.224-chromeos-armv7l.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.224_x86_64/vulkan_icd_loader-1.3.224-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '61ff085298ade5bb89bdddd79f62f1fbcccba4642af0dd93925de1fc5afba005',
-     armv7l: '61ff085298ade5bb89bdddd79f62f1fbcccba4642af0dd93925de1fc5afba005',
-       i686: 'c1d9c5e78dd8d0898257babaa5914583e57fc764b0a18d5bc9f94e96bfb4cbcc',
-     x86_64: 'cb836195b0cd06b554db8e426665f980ac0757b1a3ae682a90fec215188dd5dc'
+    i686: 'c1d9c5e78dd8d0898257babaa5914583e57fc764b0a18d5bc9f94e96bfb4cbcc',
+ aarch64: '15b9c5272c0a2a8adcafd5984da16738a3a7032479b38f9ce77a3b4ddaf187e5',
+  armv7l: '15b9c5272c0a2a8adcafd5984da16738a3a7032479b38f9ce77a3b4ddaf187e5',
+  x86_64: '53fdaa92fb1e31410c6ebd50f1661f8b99b3a62a2f1bc33be123b2fff7a3f2da'
   })
+
+  git_hashtag "v#{@_ver}"
 
   depends_on 'libx11'
   depends_on 'libxrandr'

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -990,7 +990,7 @@ activity: medium
 ---
 kind: url
 name: crosvm
-url: https://chromium.googlesource.com/crosvm/crosvm.
+url: https://chromium.googlesource.com/crosvm/crosvm
 activity: high
 ---
 kind: url

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -989,6 +989,11 @@ url: https://github.com/crossmob/CrossMobile/releases/
 activity: medium
 ---
 kind: url
+name: crosvm
+url: https://chromium.googlesource.com/crosvm/crosvm.
+activity: high
+---
+kind: url
 name: cryptsetup
 url: https://www.kernel.org/pub/linux/utils/cryptsetup/
 activity: low

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -5029,6 +5029,11 @@ url: https://github.com/Anaconda-Platform/anaconda-project/releases
 activity: low
 ---
 kind: url
+name: minijail
+url: https://google.github.io/minijail/
+activity: medium
+---
+kind: url
 name: miniupnpc
 url: https://github.com/miniupnp/miniupnp/releases
 activity: high


### PR DESCRIPTION
- only for `x86_64` (work on getting this to work on arm chromebooks would be welcomed.)
- depends on https://github.com/chromebrew/chromebrew/pull/7280
```
chronos@localhost /usr/local/lib/crew/packages (master *%|SPARSE=)$ crosvm --help
Usage: crosvm [--extended-status] [--log-level <log-level>] [--syslog-tag <TAG>] [--no-syslog] <command> [<args>]

crosvm

Options:
  --extended-status use extended exit status
  --log-level       specify log level, eg "off", "error", "debug,disk=off", etc
  --syslog-tag      when logging to syslog, use the provided tag
  --no-syslog       disable output to syslog
  --help            display usage information

Commands:
  balloon           Set balloon size of the crosvm instance to `SIZE` bytes
  balloon_stats     Prints virtio balloon statistics for a `VM_SOCKET`
  battery           Modify battery
  create_qcow2      Create Qcow2 image given path and size
  device            Start a device process
  disk              Manage attached virtual disk devices
  make_rt           Enables real-time vcpu priority for crosvm instances started
                    with `--delay-rt`
  resume            Resumes the crosvm instance
  run               Start a new crosvm instance
  stop              Stops crosvm instances via their control sockets
  suspend           Suspends the crosvm instance
  powerbtn          Triggers a power button event in the crosvm instance
  sleepbtn          Triggers a sleep button event in the crosvm instance
  gpe               Injects a general-purpose event into the crosvm instance
  usb               Manage attached virtual USB devices.
  version           Show package version.
  vfio              add/remove host vfio pci device into guest
  devices           Start one or several jailed device processes.

chronos@localhost /usr/local/lib/crew/packages (master *%|SPARSE=)$ crosvm version
crosvm 0.1.0
[2022-08-17T15:01:45.794402455+00:00 INFO  crosvm] exiting with success
```

Works properly:
- [x] `x86_64`


### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=crosvm CREW_TESTING=1 crew update
```
