### PR TITLE
crew: Update `git` command used in `crew sysinfo`

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1853,7 +1853,7 @@ def sysinfo_command(args)
     lsb_release = ENV
   end
 
-  git_commit_message_format = '%C(yellow)%h%C(reset)  %s  %C(brightcyan)(%cr)%C(reset)'
+  git_commit_message_format = '%h  %s  (%cr)'
 
   puts <<~MD
     - Architecture: `#{ARCH_ACTUAL}` (`#{ARCH}`)
@@ -1863,7 +1863,7 @@ def sysinfo_command(args)
     - Chromebrew prefix: `#{CREW_PREFIX}`
     - Chromebrew libdir: `#{CREW_LIB_PREFIX}`
 
-    - Last update in local repository: `#{`git show --color=always -s --format='#{git_commit_message_format}'`.chomp}`
+    - Last update in local repository: `#{`git show -s --format='#{git_commit_message_format}' '#{CREW_LIB_PATH}'`.chomp}`
 
     - OS variant: `#{lsb_release['CHROMEOS_RELEASE_NAME']}`
     - OS version: `#{lsb_release['CHROMEOS_RELEASE_BUILDER_PATH']}`

--- a/bin/crew
+++ b/bin/crew
@@ -1853,6 +1853,8 @@ def sysinfo_command(args)
     lsb_release = ENV
   end
 
+  git_commit_message_format = '%C(yellow)%h%C(reset)  %s  %C(brightcyan)(%cr)%C(reset)'
+
   puts <<~MD
     - Architecture: `#{ARCH_ACTUAL}` (`#{ARCH}`)
     - Kernel version: `#{`uname -r`.chomp}`
@@ -1861,7 +1863,7 @@ def sysinfo_command(args)
     - Chromebrew prefix: `#{CREW_PREFIX}`
     - Chromebrew libdir: `#{CREW_LIB_PREFIX}`
 
-    - Last update in local repository: `#{`git show --color=always -s --format='%C(yellow)%h%C(reset)  %s  %C(brightcyan)(%cr)%C(reset)'`}`
+    - Last update in local repository: `#{`git show --color=always -s --format='#{git_commit_message_format}'`.chomp}`
 
     - OS variant: `#{lsb_release['CHROMEOS_RELEASE_NAME']}`
     - OS version: `#{lsb_release['CHROMEOS_RELEASE_BUILDER_PATH']}`

--- a/bin/crew
+++ b/bin/crew
@@ -1853,7 +1853,7 @@ def sysinfo_command(args)
     lsb_release = ENV
   end
 
-  git_commit_message_format = '%h  %s  (%cr)'
+  git_commit_message_format = '%h `%s (%cr)`'
 
   puts <<~MD
     - Architecture: `#{ARCH_ACTUAL}` (`#{ARCH}`)
@@ -1863,7 +1863,7 @@ def sysinfo_command(args)
     - Chromebrew prefix: `#{CREW_PREFIX}`
     - Chromebrew libdir: `#{CREW_LIB_PREFIX}`
 
-    - Last update in local repository: `#{`git show -s --format='#{git_commit_message_format}' '#{CREW_LIB_PATH}'`.chomp}`
+    - Last update in local repository: #{`git show -s --format='#{git_commit_message_format}' '#{CREW_LIB_PATH}'`.chomp}
 
     - OS variant: `#{lsb_release['CHROMEOS_RELEASE_NAME']}`
     - OS version: `#{lsb_release['CHROMEOS_RELEASE_BUILDER_PATH']}`

--- a/bin/crew
+++ b/bin/crew
@@ -1861,6 +1861,8 @@ def sysinfo_command(args)
     - Chromebrew prefix: `#{CREW_PREFIX}`
     - Chromebrew libdir: `#{CREW_LIB_PREFIX}`
 
+    - Last update in local repository: `#{`git show --color=always -s --format='%C(yellow)%h%C(reset)  %s  %C(brightcyan)(%cr)%C(reset)'`}`
+
     - OS variant: `#{lsb_release['CHROMEOS_RELEASE_NAME']}`
     - OS version: `#{lsb_release['CHROMEOS_RELEASE_BUILDER_PATH']}`
     - OS channel: `#{lsb_release['CHROMEOS_RELEASE_TRACK']}`

--- a/bin/crew
+++ b/bin/crew
@@ -1861,8 +1861,6 @@ def sysinfo_command(args)
     - Chromebrew prefix: `#{CREW_PREFIX}`
     - Chromebrew libdir: `#{CREW_LIB_PREFIX}`
 
-    - Last update in local repository: `#{`cd #{CREW_LIB_PATH}; git log --pretty=format:"%h: %s" HEAD^..HEAD`}`
-
     - OS variant: `#{lsb_release['CHROMEOS_RELEASE_NAME']}`
     - OS version: `#{lsb_release['CHROMEOS_RELEASE_BUILDER_PATH']}`
     - OS channel: `#{lsb_release['CHROMEOS_RELEASE_TRACK']}`

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.24.0'
+CREW_VERSION = '1.24.1'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
Seems the `git` command that uses to get the latest commit time does not work on every system, weird...