### PR TITLE
Refactor CREW_COMMON_FLAGS to benefit meson builds

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -131,8 +131,9 @@ else
 end
 CREW_LINKER_FLAGS = ENV['CREW_LINKER_FLAGS']
 
-CREW_COMMON_FLAGS = "-O2 -pipe -flto -ffat-lto-objects -fPIC -fuse-ld=#{CREW_LINKER} #{CREW_LINKER_FLAGS}"
-CREW_COMMON_FNO_LTO_FLAGS = "-O2 -pipe -fno-lto -fPIC -fuse-ld=#{CREW_LINKER} #{CREW_LINKER_FLAGS}"
+CREW_CORE_FLAGS= "-O2 -pipe -ffat-lto-objects -fPIC -fuse-ld=#{CREW_LINKER} #{CREW_LINKER_FLAGS}"
+CREW_COMMON_FLAGS = "#{CREW_CORE_FLAGS} -flto"
+CREW_COMMON_FNO_LTO_FLAGS = "#{CREW_CORE_FLAGS} -fno-lto"
 CREW_LDFLAGS = "-flto #{CREW_LINKER_FLAGS}"
 CREW_FNO_LTO_LDFLAGS = '-fno-lto'
 
@@ -179,8 +180,8 @@ CREW_MESON_OPTIONS = <<~OPT.chomp
   -Db_lto=true \
   -Dstrip=true \
   -Db_pie=true \
-  -Dcpp_args='#{CREW_COMMON_FNO_LTO_FLAGS}' \
-  -Dc_args='#{CREW_COMMON_FNO_LTO_FLAGS}'
+  -Dcpp_args='#{CREW_CORE_FLAGS}' \
+  -Dc_args='#{CREW_CORE_FLAGS}'
 OPT
 
 CREW_MESON_FNO_LTO_OPTIONS = <<~OPT.chomp
@@ -191,8 +192,8 @@ CREW_MESON_FNO_LTO_OPTIONS = <<~OPT.chomp
   -Db_lto=false \
   -Dstrip=true \
   -Db_pie=true \
-  -Dcpp_args='#{CREW_COMMON_FNO_LTO_FLAGS} \
-  -Dc_args='#{CREW_COMMON_FNO_LTO_FLAGS}
+  -Dcpp_args='#{CREW_CORE_FLAGS}' \
+  -Dc_args='#{CREW_CORE_FLAGS}'
 OPT
 
 # Use ninja or samurai

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.25.1'
+CREW_VERSION = '1.24.1'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines
@@ -179,8 +179,8 @@ CREW_MESON_OPTIONS = <<~OPT.chomp
   -Db_lto=true \
   -Dstrip=true \
   -Db_pie=true \
-  -Dcpp_args='-O2' \
-  -Dc_args='-O2'
+  -Dcpp_args='-O2 -fuse-ld=#{CREW_LINKER} #{CREW_LINKER_FLAGS}' \
+  -Dc_args='-O2 -fuse-ld=#{CREW_LINKER} #{CREW_LINKER_FLAGS}'
 OPT
 
 CREW_MESON_FNO_LTO_OPTIONS = <<~OPT.chomp
@@ -191,8 +191,8 @@ CREW_MESON_FNO_LTO_OPTIONS = <<~OPT.chomp
   -Db_lto=false \
   -Dstrip=true \
   -Db_pie=true \
-  -Dcpp_args='-O2' \
-  -Dc_args='-O2'
+  -Dcpp_args='-O2 -fuse-ld=#{CREW_LINKER} #{CREW_LINKER_FLAGS}' \
+  -Dc_args='-O2 -fuse-ld=#{CREW_LINKER} #{CREW_LINKER_FLAGS}'
 OPT
 
 # Use ninja or samurai

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.24.1'
+CREW_VERSION = '1.25.2'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -179,8 +179,8 @@ CREW_MESON_OPTIONS = <<~OPT.chomp
   -Db_lto=true \
   -Dstrip=true \
   -Db_pie=true \
-  -Dcpp_args='-O2 -fuse-ld=#{CREW_LINKER} #{CREW_LINKER_FLAGS}' \
-  -Dc_args='-O2 -fuse-ld=#{CREW_LINKER} #{CREW_LINKER_FLAGS}'
+  -Dcpp_args='#{CREW_COMMON_FNO_LTO_FLAGS}' \
+  -Dc_args='#{CREW_COMMON_FNO_LTO_FLAGS}'
 OPT
 
 CREW_MESON_FNO_LTO_OPTIONS = <<~OPT.chomp
@@ -191,8 +191,8 @@ CREW_MESON_FNO_LTO_OPTIONS = <<~OPT.chomp
   -Db_lto=false \
   -Dstrip=true \
   -Db_pie=true \
-  -Dcpp_args='-O2 -fuse-ld=#{CREW_LINKER} #{CREW_LINKER_FLAGS}' \
-  -Dc_args='-O2 -fuse-ld=#{CREW_LINKER} #{CREW_LINKER_FLAGS}'
+  -Dcpp_args='#{CREW_COMMON_FNO_LTO_FLAGS} \
+  -Dc_args='#{CREW_COMMON_FNO_LTO_FLAGS}
 OPT
 
 # Use ninja or samurai


### PR DESCRIPTION
Currently many packages use `#{CREW_ENV_OPTIONS}` in meson builds, but we really don't want to do that as that means `flto` is used during configure, which is a waste of CPU cycles. Instead, just put all the relevant (non-lto) meson options into the `CREW_MESON_OPTIONS`. 

What I've done here is move the non-universal lto options to `CREW_CORE_FLAGS` and made `CREW_COMMON_FLAGS` and `CREW_COMMON_FNO_LTO_FLAGS`supersets of that. This way, we can just add `CREW_COMMON_FLAGS` to CREW_MESON_OPTIONS`, where the `-flto` toggle is already expressed through a meson option. This also automatically puts the default mold linker cflags in the right place.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=meson_mold CREW_TESTING=1 crew update
```