### PR TITLE
updates for gobject_instrospection, gdk_pixbuf, py3_docutils

### DIFF
--- a/packages/gdk_pixbuf.rb
+++ b/packages/gdk_pixbuf.rb
@@ -3,7 +3,7 @@ require 'package'
 class Gdk_pixbuf < Package
   description 'GdkPixbuf is a library for image loading and manipulation.'
   homepage 'https://developer.gnome.org/gdk-pixbuf'
-  @_ver = '2.42.6'
+  @_ver = '2.42.9'
   version "#{@_ver}-1"
   license 'LGPL-2.1+'
   compatibility 'all'
@@ -11,16 +11,16 @@ class Gdk_pixbuf < Package
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.6-1_armv7l/gdk_pixbuf-2.42.6-1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.6-1_armv7l/gdk_pixbuf-2.42.6-1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.6-1_i686/gdk_pixbuf-2.42.6-1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.6-1_x86_64/gdk_pixbuf-2.42.6-1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.9-1_armv7l/gdk_pixbuf-2.42.9-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.9-1_armv7l/gdk_pixbuf-2.42.9-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.9-1_i686/gdk_pixbuf-2.42.9-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.9-1_x86_64/gdk_pixbuf-2.42.9-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '1c577ba59a852aaaffd4612ef72396b2d37f44c3cf81fcee85376b8b14b3bb7f',
-     armv7l: '1c577ba59a852aaaffd4612ef72396b2d37f44c3cf81fcee85376b8b14b3bb7f',
-       i686: '4aa97c61517ec11c151336b3a9ec9cd64db27f79bff70f321b0807effd5f663e',
-     x86_64: '441ce2ef5883ca7f98671f44498cc66f7f2be344473fd911c307d06c794e0f0f'
+    aarch64: 'e52abe3bc1922618fda217215f5defef83f40b6cbe21737f50ed653ee9001d4a',
+     armv7l: 'e52abe3bc1922618fda217215f5defef83f40b6cbe21737f50ed653ee9001d4a',
+       i686: '47693eb2d34477b97ccb6cd29ab50890dcb383d19bd30b4ac60a606a0ddc77d2',
+     x86_64: '72f1a9e8c7f3e3c44aed7b21a07ad7f200207c1f0c759be2622e999c92b4b1df'
   })
 
   depends_on 'glib' # R
@@ -30,74 +30,13 @@ class Gdk_pixbuf < Package
   # depends_on 'libtiff' # R This drags gtk3 into the deps via libwebp
   # depends_on 'libwebp' => :build This drags gtk3 into the deps.
   depends_on 'pango' => :build
+  depends_on 'py3_docutils' => :build
+  depends_on 'py3_jinja2' => :build
   depends_on 'py3_markdown' => :build
+  depends_on 'py3_pygments' => :build
   depends_on 'py3_six' => :build
+  depends_on 'py3_toml' => :build
   depends_on 'py3_typogrify' => :build
-
-  def self.patch
-    @gif_overflow_patch = <<~'PATCH_EOF'
-      From 0cf97225c9c227d11fc4ddf9cba8e8480672ee1b Mon Sep 17 00:00:00 2001
-      From: Robert Ancell <robert.ancell@canonical.com>
-      Date: Wed, 2 Feb 2022 12:38:45 +1300
-      Subject: [PATCH 2/4] Add an assertion that checks for maximum LZW code size
-
-      ---
-       gdk-pixbuf/lzw.c | 2 ++
-       1 file changed, 2 insertions(+)
-
-      diff --git a/gdk-pixbuf/lzw.c b/gdk-pixbuf/lzw.c
-      index 105daf2b1..15293560b 100644
-      --- a/gdk-pixbuf/lzw.c
-      +++ b/gdk-pixbuf/lzw.c
-      @@ -121,6 +121,8 @@ lzw_decoder_new (guint8 code_size)
-               LZWDecoder *self;
-               int i;
-       
-      +        g_return_val_if_fail (code_size <= LZW_CODE_MAX, NULL);
-      +
-               self = g_object_new (lzw_decoder_get_type (), NULL);
-       
-               self->min_code_size = code_size;
-      -- 
-      GitLab
-
-
-      From 19ebba03117aefc9d0312f675f3a210ffdcc4907 Mon Sep 17 00:00:00 2001
-      From: Robert Ancell <robert.ancell@canonical.com>
-      Date: Wed, 2 Feb 2022 14:03:13 +1300
-      Subject: [PATCH 3/4] Fix the check for maximum value of LZW initial code size.
-
-      This value is the number of bits for each symbol (i.e. colour index) decoded via LZW.
-      The maximum LZW code is specified as 12 bits, so the value here can only be 11 as two additional code words are required (clear and end of information) that immediately uses an additional bit.
-      This implementation has always been wrong, and the Firefox implementation has the same issue so it seems a common misinterpretation of the spec.
-      This has been changed here to avoid an assertion later in the LZW decoder.
-      Note that there is never any reason for a GIF to be encoded with more than 8 bits of colour information, as the colour tables only support up to 8 bits.
-      ---
-       gdk-pixbuf/io-gif.c | 4 ++--
-       1 file changed, 2 insertions(+), 2 deletions(-)
-
-      diff --git a/gdk-pixbuf/io-gif.c b/gdk-pixbuf/io-gif.c
-      index 1befba155..310bdff6a 100644
-      --- a/gdk-pixbuf/io-gif.c
-      +++ b/gdk-pixbuf/io-gif.c
-      @@ -499,8 +499,8 @@ gif_prepare_lzw (GifContext *context)
-       		/*g_message (_("GIF: EOF / read error on image data\n"));*/
-       		return -1;
-       	}
-      -        
-      -        if (context->lzw_set_code_size > 12) {
-      +
-      +        if (context->lzw_set_code_size >= 12) {
-                       g_set_error_literal (context->error,
-                                            GDK_PIXBUF_ERROR,
-                                            GDK_PIXBUF_ERROR_CORRUPT_IMAGE,
-      -- 
-      GitLab
-
-    PATCH_EOF
-    File.write('gif_overflow.patch', @gif_overflow_patch)
-    system 'patch -p1 -i gif_overflow.patch || true'
-  end
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \

--- a/packages/gobject_introspection.rb
+++ b/packages/gobject_introspection.rb
@@ -3,30 +3,30 @@ require 'package'
 class Gobject_introspection < Package
   description 'GObject introspection is a middleware layer between C libraries (using GObject) and language bindings.'
   homepage 'https://wiki.gnome.org/action/show/Projects/GObjectIntrospection'
-  @_ver = '1.70.0'
-  version "#{@_ver}-1"
+  @_ver = '1.73.0'
+  version @_ver.to_s
   license 'LGPL-2+ and GPL-2+'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/gobject-introspection.git'
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gobject_introspection/1.70.0-1_armv7l/gobject_introspection-1.70.0-1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gobject_introspection/1.70.0-1_armv7l/gobject_introspection-1.70.0-1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gobject_introspection/1.70.0-1_i686/gobject_introspection-1.70.0-1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gobject_introspection/1.70.0-1_x86_64/gobject_introspection-1.70.0-1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gobject_introspection/1.73.0_armv7l/gobject_introspection-1.73.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gobject_introspection/1.73.0_armv7l/gobject_introspection-1.73.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gobject_introspection/1.73.0_i686/gobject_introspection-1.73.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gobject_introspection/1.73.0_x86_64/gobject_introspection-1.73.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '5eb28e864dbaead1f78ef2caeb00c57d42ced3d9c044e2b30179a3fd529b3f30',
-     armv7l: '5eb28e864dbaead1f78ef2caeb00c57d42ced3d9c044e2b30179a3fd529b3f30',
-       i686: '70f5c4b09aa0ad77d820b00463d4ea7fec479e4c2773f3a879d6437fc30c19ec',
-     x86_64: 'b44fc8463ff340776c2038da369277fda23d7c1d5fe95f138a666b0204817995'
+    aarch64: '7314c1f2b339c804ae2a2f6d6796bdc0e7dcc100ef6996e0da1f1543dc95c008',
+     armv7l: '7314c1f2b339c804ae2a2f6d6796bdc0e7dcc100ef6996e0da1f1543dc95c008',
+       i686: '51d59a3021eebc098d69cbff7e895743bf66c0f04b180fa78af3273e418b8249',
+     x86_64: '8ae83a1eee02a8f95c6d95be86ac44420eb4008a03df1bcce3fd13677d103cda'
   })
 
   depends_on 'glib'
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} meson #{CREW_MESON_OPTIONS} \
+    system "meson #{CREW_MESON_OPTIONS} \
       builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/py3_docutils.rb
+++ b/packages/py3_docutils.rb
@@ -3,24 +3,24 @@ require 'package'
 class Py3_docutils < Package
   description 'Docutils is an open-source text processing system for processing plaintext documentation into useful formats, such as HTML, LaTeX, man-pages, open-document or XML.'
   homepage 'http://docutils.sourceforge.net/'
-  @_ver = '0.17.1'
-  version "#{@_ver}-1"
+  @_ver = '0.19'
+  version @_ver.to_s
   license 'BSD-2, GPL-3 and public-domain'
   compatibility 'all'
-  source_url 'https://files.pythonhosted.org/packages/4c/17/559b4d020f4b46e0287a2eddf2d8ebf76318fd3bd495f1625414b052fdc9/docutils-0.17.1.tar.gz'
-  source_sha256 '686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125'
+  source_url 'https://files.pythonhosted.org/packages/6b/5c/330ea8d383eb2ce973df34d1239b3b21e91cd8c865d21ff82902d952f91f/docutils-0.19.tar.gz'
+  source_sha256 '33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_docutils/0.17.1-1_armv7l/py3_docutils-0.17.1-1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_docutils/0.17.1-1_armv7l/py3_docutils-0.17.1-1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_docutils/0.17.1-1_i686/py3_docutils-0.17.1-1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_docutils/0.17.1-1_x86_64/py3_docutils-0.17.1-1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_docutils/0.19_armv7l/py3_docutils-0.19-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_docutils/0.19_armv7l/py3_docutils-0.19-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_docutils/0.19_i686/py3_docutils-0.19-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_docutils/0.19_x86_64/py3_docutils-0.19-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '89a62ed3b047061fe765329171a91e76d7e113006136fbbb25311f6ce1692309',
-     armv7l: '89a62ed3b047061fe765329171a91e76d7e113006136fbbb25311f6ce1692309',
-       i686: 'a906df40046622e6b6e13220da7b03a5adcf677127d9da6ebe1bba3734aa683b',
-     x86_64: '5db96f75f85e79f9f69fed41f4c5739996626d1a288fbd35ef9a22c10d169b75'
+    aarch64: 'e5105f54a9ced471b418123b1a9f8132bb872ea8341b089f2ba2804edbe14d2a',
+     armv7l: 'e5105f54a9ced471b418123b1a9f8132bb872ea8341b089f2ba2804edbe14d2a',
+       i686: '6132c1d239cd79e5d8a249bff6e0fa3976910d930aaaa1211a3318e0b507722b',
+     x86_64: 'd3c4af2bcf3e87c14aca985ada99faaa3af70ad6f7068bff0becf603c97fd82e'
   })
 
   depends_on 'py3_setuptools' => :build
@@ -31,5 +31,7 @@ class Py3_docutils < Package
 
   def self.install
     system "python3 setup.py install #{PY_SETUP_INSTALL_OPTIONS}"
+    # Needed for gdk_pixbuf build.
+    FileUtils.ln "#{CREW_DEST_PREFIX}/bin/rst2man.py", "#{CREW_DEST_PREFIX}/bin/rst2man"
   end
 end


### PR DESCRIPTION
-`gobject_instrospection` => 1.73.0
-`gdk_pixbuf` => 2.42.9
-`py3_docutils` => 0.19 (needed a rst2man binary for the gdk_pixbuf build.)

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=gnome_updates CREW_TESTING=1 crew update
```
