### PR TITLE
Refactor install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Open the terminal with Ctrl+Alt+T and type `shell`. If this command returns `ERR
 Then download and run the installation script below:
 
 ```bash
-curl -Ls git.io/vddgY | bash
+exec bash --init-file <(curl -Ls git.io/vddgY)
 ```
 
 ## Help

--- a/install.sh
+++ b/install.sh
@@ -1,21 +1,25 @@
 #!/bin/bash
 
-# exit on fail
+# Exit on fail.
 set -e
 
-#chromebrew directories
+# Default chromebrew repo values.
+
 : "${OWNER:=chromebrew}"
 : "${REPO:=chromebrew}"
 : "${BRANCH:=master}"
-URL="https://raw.githubusercontent.com/${OWNER}/${REPO}/${BRANCH}"
+
+# Chromebrew directories
 : "${CREW_PREFIX:=/usr/local}"
 CREW_LIB_PATH="${CREW_PREFIX}/lib/crew"
 CREW_CONFIG_PATH="${CREW_PREFIX}/etc/crew"
 CREW_BREW_DIR="${CREW_PREFIX}/tmp/crew"
 CREW_DEST_DIR="${CREW_BREW_DIR}/dest"
-CREW_PACKAGES_PATH="${CREW_LIB_PATH}/packages"
 : "${CURL:=/usr/bin/curl}"
 : "${CREW_CACHE_DIR:=$CREW_PREFIX/tmp/packages}"
+
+# Architecture
+
 # For container usage, where we want to specify i686 arch
 # on a x86_64 host by setting ARCH=i686.
 : "${ARCH:=$(uname -m)}"
@@ -30,26 +34,19 @@ else
   USER_SPACE_ARCH="${ARCH}"
 fi
 
-# BOOTSTRAP_PACKAGES cannot depend on crew_profile_base for their core operations (completion scripts are fine)
-BOOTSTRAP_PACKAGES="crew_mvdir pixz ca_certificates ruby openssl"
-[ -x /usr/bin/zstd ] || BOOTSTRAP_PACKAGES="zstd ${BOOTSTRAP_PACKAGES}" # use system zstd if available
-[ -x "${CREW_PREFIX}"/bin/xz ] && rm "${CREW_PREFIX}"/bin/xz # remove local xz if installed
+if [[ "$ARCH" == "x86_64" ]]; then
+  LIB_SUFFIX='64'
+fi
 
-RED='\e[1;91m';    # Use Light Red for errors.
-YELLOW='\e[1;33m'; # Use Yellow for informational messages.
-GREEN='\e[1;32m';  # Use Green for success messages.
-BLUE='\e[1;34m';   # Use Blue for intrafunction messages.
-GRAY='\e[0;37m';   # Use Gray for program output.
-MAGENTA='\e[1;35m';
+
 RESET='\e[0m'
 
 # Simplify colors and print errors to stderr (2).
-echo_error() { echo -e "${RED}${*}${RESET}" >&2; }
-echo_info() { echo -e "${YELLOW}${*}${RESET}" >&1; }
-echo_success() { echo -e "${GREEN}${*}${RESET}" >&1; }
-echo_intra() { echo -e "${BLUE}${*}${RESET}" >&1; }
-echo_out() { echo -e "${GRAY}${*}${RESET}" >&1; }
-echo_other() { echo -e "${MAGENTA}${*}${RESET}" >&2; }
+echo_error() { echo -e "\e[1;91m${*}${RESET}" >&2; } # Use Light Red for errors.
+echo_info() { echo -e "\e[1;33m${*}${RESET}" >&1; } # Use Yellow for informational messages.
+echo_success() { echo -e "\e[1;32m${*}${RESET}" >&1; } # Use Green for success messages.
+echo_intra() { echo -e "\e[1;34m${*}${RESET}" >&1; } # Use Blue for intrafunction messages.
+echo_out() { echo -e "\e[0;37m${*}${RESET}" >&1; } # Use Gray for program output.
 
 # Skip all checks if running on a docker container.
 [[ -f "/.dockerenv" ]] && CREW_FORCE_INSTALL=1
@@ -57,21 +54,22 @@ echo_other() { echo -e "${MAGENTA}${*}${RESET}" >&2; }
 # Reject crostini.
 if [[ -d /opt/google/cros-containers && "${CREW_FORCE_INSTALL}" != '1' ]]; then
   echo_error "Crostini containers are not supported by Chromebrew :/"
-  echo_info "Run 'curl -Ls git.io/vddgY | CREW_FORCE_INSTALL=1 bash' to perform install anyway"
+  echo_info "Run 'CREW_FORCE_INSTALL=1 exec bash --init-file <(curl -Ls git.io/vddgY)' to perform install anyway"
   exit 1
 fi
 
-# Disallow non-stable channels Chrome OS.
+# Reject non-stable Chrome OS channels.
 if [ -f /etc/lsb-release ]; then
   if [[ ! "$(< /etc/lsb-release)" =~ CHROMEOS_RELEASE_TRACK=stable-channel$'\n' && "${CREW_FORCE_INSTALL}" != '1' ]]; then
     echo_error "The beta, dev, and canary channel are unsupported by Chromebrew"
-    echo_info "Run 'curl -Ls git.io/vddgY | CREW_FORCE_INSTALL=1 bash' to perform install anyway"
+    echo_info "Run 'CREW_FORCE_INSTALL=1 exec bash --init-file <(curl -Ls git.io/vddgY)' to perform install anyway"
     exit 1
   fi
 else
   echo_info "Unable to detect system information, installation will continue."
 fi
 
+# Check if the script is being run as root.
 if [ "${EUID}" == "0" ]; then
   echo_error "Chromebrew should not be installed or run as root."
   exit 1;
@@ -79,7 +77,7 @@ fi
 
 echo_success "Welcome to Chromebrew!"
 
-# Prompt user to enter the sudo password if it set.
+# Prompt user to enter the sudo password if it is set.
 # If the PASSWD_FILE specified by chromeos-setdevpasswd exist, that means a sudo password is set.
 if [[ "$(< /usr/sbin/chromeos-setdevpasswd)" =~ PASSWD_FILE=\'([^\']+) ]] && [ -f "${BASH_REMATCH[1]}" ]; then
   echo_intra "Please enter the developer mode password"
@@ -95,7 +93,7 @@ function curl () {
   # the 'curl: (7) Couldn't connect to server' error, a for loop is used
   # here.
   for (( i = 0; i < 4; i++ )); do
-    # force TLS as we know GitLab supports it
+    # Force TLS as we know GitLab supports it
     env -u LD_LIBRARY_PATH "${CURL}" --ssl-reqd --tlsv1.2 -C - "${@}" && return 0
     echo_info "Retrying, $((3-i)) retries left."
   done
@@ -104,108 +102,107 @@ function curl () {
   return 1
 }
 
-case "${ARCH}" in
-"i686"|"x86_64"|"armv7l"|"aarch64")
-  LIB_SUFFIX=
-  # See https://superuser.com/a/1369875
-  # If /bin/bash is 64-bit, then set LIB_SUFFIX, as this is true on both
-  # x86_64 and aarch64 userspace
-  # shellcheck disable=SC2046
-  [ $(od -An -t x1 -j 4 -N 1  /bin/bash) == 02 ] && LIB_SUFFIX='64'
-  if [[ $LIB_SUFFIX == '64' ]] && { [[ "$ARCH" =~ ^(armv7l|armv81|aarch64)$ ]]; }; then
+if [[ "$USER_SPACE_ARCH" == 'armv7l' ]] && [[ "$ARCH" == 'aarch64' ]]; then
     echo_error "Your device is not supported by Chromebrew yet, installing as armv7l."
-    LIB_SUFFIX=
-    ARMV7LONAARCH64=1
+    exit 1
+fi
+
+if [ -d "${CREW_PREFIX}" ]; then
+  if [ "$(ls -A "${CREW_PREFIX}")" ]; then
+    echo_error "${CREW_PREFIX} is not empty, would you like it to be cleared?"
+    echo_info "This will delete ALL files in ${CREW_PREFIX}!"
+    echo_info "Continue?"
+    select continue in "Yes" "No"; do
+      if [[ "${continue}" == "Yes" ]]; then
+        sudo find "${CREW_PREFIX}" -mindepth 1 -delete
+        break 2
+      else
+        exit 1
+      fi
+    done
   fi
-  ;;
-*)
-  echo_error "Your device is not supported by Chromebrew yet :/"
-  exit 1
-  ;;
-esac
-
-# Older i686 systems.
-[[ "${ARCH}" == "i686" ]] && BOOTSTRAP_PACKAGES+=" gcc_lib"
-libc_version=$(/lib"$LIB_SUFFIX"/libc.so.6 | head -n 1 | sed -E 's/.*(stable release version.*) (.*)./\2/')
-case ${libc_version} in
-  # Prepend the correct packages for M113 onwards systems.
-  "2.35") BOOTSTRAP_PACKAGES="glibc_lib235 zlibpkg gmp ${BOOTSTRAP_PACKAGES}";;
-esac
-
-echo_info "\n\nDoing initial setup for install in ${CREW_PREFIX}."
-echo_info "This may take a while if there are preexisting files in ${CREW_PREFIX}...\n"
+else
+  sudo mkdir "${CREW_PREFIX}"
+fi
 
 # This will allow things to work without sudo.
-crew_folders="bin cache doc docbook etc include lib lib$LIB_SUFFIX libexec man sbin share tmp var"
-for folder in $crew_folders
-do
-  if [ -d "${CREW_PREFIX}"/"${folder}" ]; then
-    echo_intra "Resetting ownership of ${CREW_PREFIX}/${folder}"
-    sudo chown -R "$(id -u)":"$(id -g)" "${CREW_PREFIX}"/"${folder}"
-  fi
-done
 sudo chown "$(id -u)":"$(id -g)" "${CREW_PREFIX}"
+# This will create the directories.
+crew_folders="bin cache doc docbook include lib/crew/packages lib$LIB_SUFFIX libexec man sbin share var etc/crew/meta etc/env.d tmp/crew/dest"
+# shellcheck disable=SC2086
+# Quoting crew_folders leads to breakage
+(cd "${CREW_PREFIX}"; mkdir -p ${crew_folders})
 
-# Delete ${CREW_PREFIX}/{var,local} symlinks on some Chromium OS distro
-# if they exist.
-[ -L "${CREW_PREFIX}/var" ] && sudo rm -f "${CREW_PREFIX}/var"
-[ -L "${CREW_PREFIX}/local" ] && sudo rm -f "${CREW_PREFIX}/local"
 
-# Prepare directories.
-for dir in "${CREW_CONFIG_PATH}/meta" "${CREW_DEST_DIR}" "${CREW_PACKAGES_PATH}" "${CREW_CACHE_DIR}" ; do
-  if [ ! -d "${dir}" ]; then
-    mkdir -p "${dir}"
-  fi
-done
+# Remove old git config directories if they exist.
+find "${CREW_LIB_PATH}" -mindepth 1 -delete
 
-if [[ "$ARMV7LONAARCH64" == '1' ]]; then
-  mkdir -p "${CREW_PREFIX}/etc/env.d/"
-  echo "export LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}"> "${CREW_PREFIX}/etc/env.d/00-library"
-fi
-echo_info "\nDownloading information for Bootstrap packages..."
-echo -en "${GRAY}"
-# Use parallel mode if available.
-CURL_OPTS="-OL"
-[[ "$(curl --help curl)" =~ --parallel ]] && CURL_OPTS+="Z"
-BOOTSTRAP_PKGS="${BOOTSTRAP_PACKAGES// /.rb,}.rb"
-cd "${CREW_PACKAGES_PATH}" && curl "${CURL_OPTS}" "${URL}/packages/{${BOOTSTRAP_PKGS}}"
-echo -e "${RESET}"
+# Download the chromebrew repository.
+${CURL} -L --progress-bar https://github.com/"${OWNER}"/"${REPO}"/tarball/"${BRANCH}" | tar -xz --strip-components=1 -C "${CREW_LIB_PATH}"
 
-# Prepare url and sha256.
+# Prepare urls and sha256s variables.
 urls=()
 sha256s=()
 
-if ! type "xz" > /dev/null; then
-  if [[ "${USER_SPACE_ARCH}" == "armv7l" ]]; then
-    urls+=('https://github.com/snailium/chrome-cross/releases/download/v1.8.1/xz-5.2.3-chromeos-armv7l.tar.gz')
-    sha256s+=('4dc9f086ee7613ab0145ec0ed5ac804c80c620c92f515cb62bae8d3c508cbfe7')
+BOOTSTRAP_PACKAGES="zstd crew_mvdir ruby git ca_certificates openssl"
+
+# Older i686 systems.
+[[ "${ARCH}" == "i686" ]] && BOOTSTRAP_PACKAGES+=" gcc_lib"
+
+
+libc_version=$(/lib"$LIB_SUFFIX"/libc.so.6 | head -n 1 | sed -E 's/.*(stable release version.*) (.*)./\2/')
+case ${libc_version} in
+  # Append the correct packages for M113 onwards systems.
+  "2.35") BOOTSTRAP_PACKAGES="${BOOTSTRAP_PACKAGES} glibc_lib235 zlibpkg gmp";;
+esac
+
+# Get the URLs and hashes of the bootstrap packages.
+for package in $BOOTSTRAP_PACKAGES; do
+  cd "${CREW_LIB_PATH}/packages"
+  [[ "$(sed -n '/binary_sha256/,/}/p' "${package}.rb")" =~ .*${ARCH}:[[:blank:]]*[\'\"]([^\'\"]*) ]]
+    sha256s+=("${BASH_REMATCH[1]}")
+
+  nln=$(nl -b a -n ln "${package}.rb" | sed -n '/class/p' | head -1 | cut -c 1)
+  vln=$(nl -b a -n ln "${package}.rb" | sed -n '/  version/p' | head -1 | cut -c 1)
+  name=$(sed -n "${nln}s/class\(.*\)<.*/\L\1/;${nln}s/^[ \t]*//;${nln}s/[ \t]*$//p" "${package}.rb")
+  version=$(sed -n "${vln}s/version \(.*\)/\1/;${vln}s/^[ \t]*//;${vln}s/[ \t]*$//;${vln}s/ *#.*//p" "${package}.rb" | tr -d "'")
+
+  # This is really ugly, FIXME after #7082 is merged.
+  if [[ "${package}" == "zstd" ]] || [[ "${package}" == "crew_mvdir" ]] || [[ "${package}" == "gmp" ]]; then
+    if [[ "$ARCH" == "aarch64" ]]; then
+      urls+=("https://gitlab.com/api/v4/projects/26210301/packages/generic/${name}/${version}_armv7l/${name}-${version}-chromeos-armv7l.tar.xz")
+    else
+      urls+=("https://gitlab.com/api/v4/projects/26210301/packages/generic/${name}/${version}_${ARCH}/${name}-${version}-chromeos-${ARCH}.tar.xz")
+    fi
+  else
+    [[ "${package}" == "glibc_lib235" ]] && name="glibc_lib"
+    if [[ "$ARCH" == "aarch64" ]]; then
+      urls+=("https://gitlab.com/api/v4/projects/26210301/packages/generic/${name}/${version}_armv7l/${name}-${version}-chromeos-armv7l.tar.zst")
+    else
+      urls+=("https://gitlab.com/api/v4/projects/26210301/packages/generic/${name}/${version}_${ARCH}/${name}-${version}-chromeos-${ARCH}.tar.zst")
+    fi
   fi
-fi
+
+done
 
 # Create the device.json file if it doesn't exist.
-cd "${CREW_CONFIG_PATH}"
-if [ ! -f device.json ]; then
+if [ ! -f "${CREW_CONFIG_PATH}/device.json" ]; then
+  cd "${CREW_CONFIG_PATH}"
   echo_info "\nCreating new device.json."
   jq --arg key0 'architecture' --arg value0 "${ARCH}" \
     --arg key1 'installed_packages' \
     '. | .[$key0]=$value0 | .[$key1]=[]' <<<'{}' > device.json
 fi
 
-for package in ${BOOTSTRAP_PACKAGES}; do
-  pkgfile="${CREW_PACKAGES_PATH}/${package}.rb"
-
-  [[ "$(sed -n '/binary_sha256/,/}/p' "${pkgfile}")" =~ .*${ARCH}:[[:blank:]]*[\'\"]([^\'\"]*) ]]
-    sha256s+=("${BASH_REMATCH[1]}")
-
-  [[ "$(sed -n '/binary_url/,/}/p' "${pkgfile}")" =~ .*${ARCH}:[[:blank:]]*[\'\"]([^\'\"]*) ]]
-    urls+=("${BASH_REMATCH[1]}")
-done
+# Functions to maintain packages
 
 # These functions are for handling packages.
 function download_check () {
     cd "$CREW_BREW_DIR"
-    # Use cached file if available and caching enabled.
+    # Use cached file if available and caching is enabled.
     if [ -n "$CREW_CACHE_ENABLED" ] && [[ -f "$CREW_CACHE_DIR/${3}" ]] ; then
+      mkdir -p "$CREW_CACHE_DIR"
+      sudo chown -R "$(id -u)":"$(id -g)" "$CREW_CACHE_DIR" || true
       echo_intra "Verifying cached ${1}..."
       echo_success "$(echo "${4}" "$CREW_CACHE_DIR/${3}" | sha256sum -c -)"
       case "${?}" in
@@ -217,11 +214,11 @@ function download_check () {
         echo_error "Verification of cached ${1} failed, downloading."
       esac
     fi
-    #download
+    # Download
     echo_intra "Downloading ${1}..."
     curl '-#' -L "${2}" -o "${3}"
 
-    #verify
+    # Verify
     echo_intra "Verifying ${1}..."
     echo_success "$(echo "${4}" "${3}" | sha256sum -c -)"
     case "${?}" in
@@ -243,31 +240,15 @@ function extract_install () {
     mkdir "${CREW_DEST_DIR}"
     cd "${CREW_DEST_DIR}"
 
-    #Extract and install.
+    # Extract and install.
     echo_intra "Extracting ${1} ..."
-    case "${2}" in
-    *.zst)
-      if [[ -e /usr/bin/zstd ]]; then
-        tar -I /usr/bin/zstd -xpf ../"${2}"
-      elif ("${CREW_PREFIX}"/bin/zstd --version &> /dev/null); then
-        tar -I "${CREW_PREFIX}"/bin/zstd -xpf ../"${2}"
-      else
-        echo "Zstd is broken or nonfunctional, and some packages can not be extracted properly."
-        exit 1
-      fi
-    ;;
-    *.tpxz)
-      if "${CREW_PREFIX}"/bin/pixz -h &> /dev/null; then
-        tar -I "${CREW_PREFIX}"/bin/pixz -xpf ../"${2}"
-      else
-        echo "Pixz is broken or nonfunctional, and some packages can not be extracted properly."
-        exit 1
-      fi
-    ;;
-    *)
+    # This could be avoided if our zstd was compiled with lzma support.
+    if [[ "${2##*.}" == "zst" ]]; then
+      tar -I zstd -xpf ../"${2}"
+    else
       tar xpf ../"${2}"
-    ;;
-    esac
+    fi
+
     echo_intra "Installing ${1} ..."
     tar cpf - ./*/* | (cd /; tar xp --keep-directory-symlink -m -f -)
     mv ./dlist "${CREW_CONFIG_PATH}/meta/${1}.directorylist"
@@ -287,6 +268,7 @@ function update_device_json () {
     cat <<< "${new_info}" > device.json
   fi
 }
+
 echo_info "Downloading Bootstrap packages...\n"
 # Extract, install and register packages.
 for i in $(seq 0 $((${#urls[@]} - 1))); do
@@ -295,42 +277,45 @@ for i in $(seq 0 $((${#urls[@]} - 1))); do
   tarfile=$(basename "${url}")
   name="${tarfile%%-*}"   # extract string before first '-'
   rest="${tarfile#*-}"    # extract string after first '-'
-  version="${rest%%-chromeos*}"
-                          # extract string between first '-' and "-chromeos"
+  version="${rest%%-chromeos*}" # extract string between first '-' and "-chromeos"
 
   download_check "${name}" "${url}" "${tarfile}" "${sha256}"
   extract_install "${name}" "${tarfile}"
   update_device_json "${name}" "${version}"
 done
 
-echo_info "\nCreating symlink to 'crew' in ${CREW_PREFIX}/bin/"
-echo -e "${GRAY}"
+# Work around https://github.com/chromebrew/chromebrew/issues/3305.
+# shellcheck disable=SC2024
+sudo ldconfig &> /tmp/crew_ldconfig || true
+
+echo_out "\nCreating symlink to 'crew' in ${CREW_PREFIX}/bin/"
 ln -sfv "../lib/crew/bin/crew" "${CREW_PREFIX}/bin/"
-echo -e "${RESET}"
 
-echo_info "Setup and synchronize local package repo..."
-echo -e "${GRAY}"
-
-# Remove old git config directories if they exist.
-find "${CREW_LIB_PATH}" -mindepth 1 -delete
-
-curl -L --progress-bar https://github.com/"${OWNER}"/"${REPO}"/tarball/"${BRANCH}" | tar -xz --strip-components=1 -C "${CREW_LIB_PATH}"
+echo_out "Set up and synchronize local package repo..."
 
 # Set LD_LIBRARY_PATH so crew doesn't break on i686 and
-# the mandb install doesn't fail.
-export LD_LIBRARY_PATH="${CREW_PREFIX}/lib${LIB_SUFFIX}"
+# the mandb postinstall doesn't fail.
+echo "LD_LIBRARY_PATH=$CREW_PREFIX/lib:$CREW_PREFIX/lib$LIB_SUFFIX" >> "$CREW_PREFIX"/etc/env.d/00-library
+export LD_LIBRARY_PATH=$CREW_PREFIX/lib:$CREW_PREFIX/lib$LIB_SUFFIX
 
-# Since we just downloaded the package repo, just update package
-# compatibility information.
+# Add the CREW_PREFIX bin and musl bin directories to PATH.
+echo "PATH=$CREW_PREFIX/bin:$CREW_PREFIX/sbin:$CREW_PREFIX/share/musl/bin:$PATH" >> "$CREW_PREFIX"/etc/env.d/path
+export PATH=$CREW_PREFIX/bin:$CREW_PREFIX/share/musl/bin:$PATH
+
+echo "export CREW_PREFIX=${CREW_PREFIX}" >> "${CREW_PREFIX}/etc/env.d/profile"
+
+# Since we downloaded the package repo, just update package compatibility information.
 crew update compatible
 
 echo_info "Installing core Chromebrew packages...\n"
+# We need these to install core.
+yes | crew install pixz
 yes | crew install core
 
 echo_info "\nRunning Bootstrap package postinstall scripts...\n"
+# Due to a bug in crew where it accepts spaces in package files names rather than
+# splitting strings at spaces, we cannot quote ${BOOTSTRAP_PACKAGES}
 # shellcheck disable=SC2086
-# Do NOT quote BOOTSTRAP_PACKAGES, otherwise crew thinks the list of
-# packages passed to crew postinstall is a single package.
 crew postinstall ${BOOTSTRAP_PACKAGES}
 
 if ! "${CREW_PREFIX}"/bin/git version &> /dev/null; then
@@ -339,28 +324,19 @@ if ! "${CREW_PREFIX}"/bin/git version &> /dev/null; then
   echo_error "https://github.com/chromebrew/chromebrew/issues\n\n"
 else
   echo_info "Synchronizng local package repo..."
-  # First clear out temporary package repo so we can replace it with the
-  # repo downloaded via git.
-  find "${CREW_LIB_PATH}" -mindepth 1 -delete
-
-  # Do a minimal clone, which also sets origin to the master/main branch
-  # by default. For more on why this setup might be useful see:
-  # https://github.blog/2020-01-17-bring-your-monorepo-down-to-size-with-sparse-checkout/
-  # If using alternate branch don't use depth=1 .
-  if [[ "$BRANCH" == "master" ]]; then
-    git clone --depth=1 --filter=blob:none --no-checkout "https://github.com/${OWNER}/${REPO}.git" "${CREW_LIB_PATH}"
-  else
-    git clone --filter=blob:none --no-checkout "https://github.com/${OWNER}/${REPO}.git" "${CREW_LIB_PATH}"
-  fi
 
   cd "${CREW_LIB_PATH}"
 
+  # Setup the folder with git information.
+  git init
+  git remote add origin "https://github.com/${OWNER}/${REPO}"
+
   # Checkout, overwriting local files.
-  [[ "$BRANCH" != "master" ]] && git fetch --all
-  git checkout "${BRANCH}"
+  git fetch --all
+  git checkout -f "${BRANCH}"
 
   # Set sparse-checkout folders.
-  git sparse-checkout set packages lib bin crew tools
+  git sparse-checkout set packages "manifest/${USER_SPACE_ARCH}" lib bin crew tools
   git reset --hard origin/"${BRANCH}"
 fi
 echo -e "${RESET}"
@@ -394,31 +370,12 @@ echo "  ___ _                               _
  \___/|   |_/   |_/\__/  |  |  |_/|__/\__/   |_/|__/  \_/ \_/
 "
 
-if [[ "${CREW_PREFIX}" != "/usr/local" ]]; then
-  echo_info "\n$
-Since you have installed Chromebrew in a directory other than '/usr/local',
-you need to run these commands to complete your installation:
-"
+echo_info "Please run 'source ~/.bashrc' to set up the profile environment."
 
-  echo_intra "
-echo 'export CREW_PREFIX=${CREW_PREFIX}' >> ~/.bashrc
-echo 'export PATH=\"\${CREW_PREFIX}/bin:\${CREW_PREFIX}/sbin:\${PATH}\"' >> ~/.bashrc
-echo 'export LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}' >> ~/.bashrc
-source ~/.bashrc"
-fi
 echo_intra "
 Edit ${CREW_PREFIX}/etc/env.d/03-pager to change the default PAGER.
 most is used by default
-
 You may wish to edit the ${CREW_PREFIX}/etc/env.d/02-editor file for an editor default.
-
 Chromebrew provides nano, vim and emacs as default TUI editor options."
 
 echo_success "Chromebrew installed successfully and package lists updated."
-if [[ "$ARMV7LONAARCH64" == '1' ]]; then
-  echo_other "\n
-Since you have installed an armv7l Chromebrew on an aarch64 userspace
-system, you MUST run this command to complete your installation:
-"
-  echo_info "source ~/.bashrc"
-fi


### PR DESCRIPTION
Option 3.

In order for this to work, the ruby binary needs to be reuploaded as `.tar.xz`. I am aware that changing ruby to `.tar.xz` will lead to slower decompression, but it is the neatest and simplest way to make this work.

This refactors some of install.sh to be much slimmer, and makes some minor style changes. `install.sh` is pretty inconsistent when it comes to style overall, so these style changes were only for comments. I do think we should have a consistent style across the board, but that is for another PR.

The main purpose of this PR is to enable #7082, which is what the changes in `core.rb` and `ruby.rb` are for. 

Not even remotely tested.
### Run the following to get this pull request's changes locally for testing.
```
exec bash --init-file <(curl -Ls https://raw.githubusercontent.com/Zopolis4/chromebrew/betterstall/install.sh)
```
