### PR TITLE
librsvg -> 2.54.4

### DIFF
--- a/packages/librsvg.rb
+++ b/packages/librsvg.rb
@@ -3,23 +3,23 @@ require 'package'
 class Librsvg < Package
   description 'SVG library for GNOME'
   homepage 'https://wiki.gnome.org/Projects/LibRsvg'
-  version '2.52.8'
+  version '2.54.4'
   license 'LGPL-2+'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/librsvg.git'
   git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.52.8_armv7l/librsvg-2.52.8-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.52.8_armv7l/librsvg-2.52.8-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.52.8_i686/librsvg-2.52.8-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.52.8_x86_64/librsvg-2.52.8-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.54.4_armv7l/librsvg-2.54.4-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.54.4_armv7l/librsvg-2.54.4-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.54.4_i686/librsvg-2.54.4-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librsvg/2.54.4_x86_64/librsvg-2.54.4-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '3445bbd63ea8dd5c37285cb822cedaf9eb48fe040bbf40f46dbbb8e59c336d81',
-     armv7l: '3445bbd63ea8dd5c37285cb822cedaf9eb48fe040bbf40f46dbbb8e59c336d81',
-       i686: '50eef90138769cda46c1ab822bc756aa877f548026050e629d2654964060215b',
-     x86_64: 'f84307e2d4c55dbd92d11e0b9184918304733b4c70ef7ffe09b183258de91bdf'
+    aarch64: '58760d1112269cead225097aaac939ea5be45e2b10616bb8dff6ffbe421a68df',
+     armv7l: '58760d1112269cead225097aaac939ea5be45e2b10616bb8dff6ffbe421a68df',
+       i686: '01233045873ee26b638876acd32697ca2b9c5d80327c6aff04d6bdd840831527',
+     x86_64: 'c8d079c44fe9017d16ec1b32aecd0c6e00e6143f02bd0a124fb9eb683d29a5a8'
   })
 
   depends_on 'fontconfig'


### PR DESCRIPTION

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=librsvg CREW_TESTING=1 crew update
```
