### PR TITLE
ruby.rb: Delete `=` from `version`

### DIFF
--- a/packages/ruby.rb
+++ b/packages/ruby.rb
@@ -3,7 +3,7 @@ require 'package'
 class Ruby < Package
   description 'Ruby is a dynamic, open source programming language with a focus on simplicity and productivity.'
   homepage 'https://www.ruby-lang.org/en/'
-  version = '3.1.2-3'
+  version '3.1.2-3'
   license 'Ruby-BSD and BSD-2'
   compatibility 'all'
   source_url 'https://github.com/ruby/ruby.git'


### PR DESCRIPTION
Fixes #7303 #7305 

See #7303 for more info