### PR TITLE
mold -> 1.4.1-14c8a11

### DIFF
--- a/packages/mold.rb
+++ b/packages/mold.rb
@@ -6,22 +6,22 @@ require 'package'
 class Mold < Package
   description 'A Modern Linker'
   homepage 'https://github.com/rui314/mold'
-  version '1.4.1'
+  version '1.4.1-14c8a11'
   compatibility 'all'
   source_url 'https://github.com/rui314/mold.git'
-  git_hashtag "v#{version}"
+  git_hashtag '14c8a119f43fb46aba55bc89cf8a76a778906dca'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.4.1_armv7l/mold-1.4.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.4.1_armv7l/mold-1.4.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.4.1_i686/mold-1.4.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.4.1_x86_64/mold-1.4.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.4.1-14c8a11_armv7l/mold-1.4.1-14c8a11-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.4.1-14c8a11_armv7l/mold-1.4.1-14c8a11-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.4.1-14c8a11_i686/mold-1.4.1-14c8a11-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.4.1-14c8a11_x86_64/mold-1.4.1-14c8a11-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'c0a7e8aef0e1819104f611c083aae26e0eb5d5905cad61c0043d7db85e85c695',
-     armv7l: 'c0a7e8aef0e1819104f611c083aae26e0eb5d5905cad61c0043d7db85e85c695',
-       i686: '5b9f9ba38052b8486c9890b6276315e1ba9ef7785f4434b3b5da4723bec7453a',
-     x86_64: '15f7b7f2b3fc95213d28bdf301d32cff22ff77becb3ca60e9e0c21dc1f547dca'
+    aarch64: '63df64b06817b3b656536a71e4fb02a663bec75a65690bd2307e63ca739f3236',
+     armv7l: '63df64b06817b3b656536a71e4fb02a663bec75a65690bd2307e63ca739f3236',
+       i686: '113f27b534d847c92e08dcfea9487bbce2424c00012aad4828d95f53418e78d7',
+     x86_64: '266bd742e87b81e8d04d2abc95c99a48407d21eaac0be5e6e46bf905f25cabf5'
   })
 
   depends_on 'zlibpkg' # R
@@ -31,17 +31,20 @@ class Mold < Package
   depends_on 'xxhash' => :build
   no_env_options
 
-  def self.patch
-    system "sed -i 's,PREFIX = /usr/local,PREFIX = #{CREW_PREFIX},g' Makefile"
-    system "sed -i 's,/usr/bin/python3,#{CREW_PREFIX}/bin/python3,g' update-git-hash.py"
-    system "sed -i 's,LIBDIR = \$(PREFIX)/lib,LIBDIR = #{CREW_LIB_PREFIX},g' Makefile"
-  end
-
   def self.build
-    system "CXXFLAGS='-fuse-ld=mold' CFLAGS='-fuse-ld=mold' make LTO=1"
+    FileUtils.mkdir_p 'builddir'
+    Dir.chdir('builddir') do
+      system "cmake #{CREW_CMAKE_OPTIONS} \
+        -DBUILD_TESTING=OFF \
+        -DMOLD_USE_MOLD=ON \
+        -DMOLD_LTO=ON \
+        -Wno-dev \
+        ../ -G Ninja"
+    end
+    system 'samu -C builddir'
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
   end
 end


### PR DESCRIPTION

- fix arm32 code generation issue
- remove patches due to fixed cmake package build generation

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=mold1.4.1-14c8a11 CREW_TESTING=1 crew update
```
