### PR TITLE
rsync -> 3.2.5, remove @_ver from git package

### DIFF
--- a/packages/git.rb
+++ b/packages/git.rb
@@ -3,8 +3,7 @@ require 'package'
 class Git < Package
   description 'Git is a free and open source distributed version control system designed to handle everything from small to very large projects with speed and efficiency.'
   homepage 'https://git-scm.com/'
-  @_ver = '2.37.2'
-  version @_ver.to_s
+  version '2.37.2'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.37.2.tar.xz'

--- a/packages/rsync.rb
+++ b/packages/rsync.rb
@@ -3,24 +3,23 @@ require 'package'
 class Rsync < Package
   description 'rsync is an open source utility that provides fast incremental file transfer.'
   homepage 'https://rsync.samba.org/'
-  @_ver = '3.2.4'
-  version "#{@_ver}-1"
+  version '3.2.5'
   license 'GPL-3'
   compatibility 'all'
   source_url "http://rsync.samba.org/ftp/rsync/src/rsync-#{@_ver}.tar.gz"
-  source_sha256 '6f761838d08052b0b6579cf7f6737d93e47f01f4da04c5d24d3447b7f2a5fad1'
+  source_sha256 '2ac4d21635cdf791867bc377c35ca6dda7f50d919a58be45057fd51600c69aba'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.4-1_armv7l/rsync-3.2.4-1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.4-1_armv7l/rsync-3.2.4-1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.4-1_i686/rsync-3.2.4-1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.4-1_x86_64/rsync-3.2.4-1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.5_armv7l/rsync-3.2.5-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.5_armv7l/rsync-3.2.5-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.5_i686/rsync-3.2.5-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rsync/3.2.5_x86_64/rsync-3.2.5-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '2a4989c4fa43820963420a96d3e09ce59ed4f34e65663445bd0f1769de404396',
-     armv7l: '2a4989c4fa43820963420a96d3e09ce59ed4f34e65663445bd0f1769de404396',
-       i686: 'd093d62e8a946f2adefa5b68fd542e04323b7e541f8a3e7e73ca6ad87af2348a',
-     x86_64: 'aac8a471eea2128805b2323353e9d856f95bf49ff3258be83dc859c226e95b44'
+    aarch64: 'a2b1a6ed4614b1fd9bb41914669bb30783d70ad5719c13760ed0fbce9be0aae3',
+     armv7l: 'a2b1a6ed4614b1fd9bb41914669bb30783d70ad5719c13760ed0fbce9be0aae3',
+       i686: 'f026e547aeeb952b75df5e710f64e6cb54a7ad6a845f3443dc601d93b1bed31e',
+     x86_64: '02db82ac18ab11be2e081cb1c909d93694eeb78e7b5d198287b1b872095912c0'
   })
 
   depends_on 'acl' # R
@@ -32,6 +31,7 @@ class Rsync < Package
   depends_on 'xxhash' # R
   depends_on 'zstd' # R
   no_patchelf
+  no_zstd
 
   def self.build
     system "./configure #{CREW_OPTIONS} --disable-maintainer-mode"


### PR DESCRIPTION
- rsync -> 3.2.5
- remove @_ver from git package

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=rsync  CREW_TESTING=1 crew update
```
