### PR TITLE
libxml2 -> 2.10.0, py3_libxml2 -> 2.10.0

### DIFF
--- a/packages/libxml2.rb
+++ b/packages/libxml2.rb
@@ -10,16 +10,16 @@ class Libxml2 < Package
   source_sha256 'c44124d025162767a1d3fe35b556c5855e6be7240e3dc3159490e91d5cadbba3'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.9.12-1_armv7l/libxml2-2.9.12-1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.9.12-1_armv7l/libxml2-2.9.12-1-chromeos-armv7l.tpxz',
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.10.0_armv7l/libxml2-2.10.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.10.0_armv7l/libxml2-2.10.0-chromeos-armv7l.tar.zst',
        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.10.0_i686/libxml2-2.10.0-chromeos-i686.tar.zst',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.10.0_x86_64/libxml2-2.10.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'a625e8e0e08c69f0bf0d77c8207ffc17504f6cd9dd417d309740ca8ddcfb888b',
-     armv7l: 'a625e8e0e08c69f0bf0d77c8207ffc17504f6cd9dd417d309740ca8ddcfb888b',
-       i686: '602ec20ae5de3ee3cd20aa7b084a29503c01876959e71dcab6ec4a5e77b94066',
-     x86_64: '14eab43697a8d3cc844ecad6f2ce85491ba0808866cf42d3191b0eb7b405d7da'
+    aarch64: 'ef7e24bb4d42f795fe30b040bf4b9fb3e0edd1df7fe96f4bf34ce13c673bf178',
+     armv7l: 'ef7e24bb4d42f795fe30b040bf4b9fb3e0edd1df7fe96f4bf34ce13c673bf178',
+       i686: '0de66dfa80be15da9282743da640cea6d4f17c92b8d8eccaa1c119fe17fbc00b',
+     x86_64: '6e838bd7d320bc13666834eb97bd6f1532e1971a83609d0a0b522e3b78e00e7b'
   })
 
   depends_on 'gcc'
@@ -36,7 +36,7 @@ class Libxml2 < Package
     # libxml2-python built in another package (py3_libxml2)
     system "./autogen.sh \
       #{CREW_OPTIONS} \
-      #{CREW_ENV_OPTIONS} \
+      #{CREW_ENV_OPTIONS.gsub('-fuse-ld=mold', '-fuse-ld=gold')} \
       --enable-shared \
       --enable-static \
       --with-pic \

--- a/packages/libxml2.rb
+++ b/packages/libxml2.rb
@@ -3,23 +3,23 @@ require 'package'
 class Libxml2 < Package
   description 'Libxml2 is the XML C parser and toolkit developed for the Gnome project.'
   homepage 'http://xmlsoft.org/'
-  version '2.9.12'
+  version '2.10.0'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.9.12/libxml2-v2.9.12.tar.bz2'
-  source_sha256 'bb5ea084617e2bc706cd1f0c9b36328950c9d802a16ff52795e5f13bae900ca8'
+  source_url 'https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.10.0/libxml2-v2.10.0.tar.bz2'
+  source_sha256 'c44124d025162767a1d3fe35b556c5855e6be7240e3dc3159490e91d5cadbba3'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.9.12_armv7l/libxml2-2.9.12-chromeos-armv7l.tpxz',
-    armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.9.12_armv7l/libxml2-2.9.12-chromeos-armv7l.tpxz',
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.9.12_i686/libxml2-2.9.12-chromeos-i686.tpxz',
-    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.9.12_x86_64/libxml2-2.9.12-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.9.12-1_armv7l/libxml2-2.9.12-1-chromeos-armv7l.tpxz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.9.12-1_armv7l/libxml2-2.9.12-1-chromeos-armv7l.tpxz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.10.0_i686/libxml2-2.10.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.10.0_x86_64/libxml2-2.10.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'a6315954148a4ec7f7867031c282c967b198ea494f81d28f1eef8cd2e3c65e36',
-    armv7l: 'a6315954148a4ec7f7867031c282c967b198ea494f81d28f1eef8cd2e3c65e36',
-    i686: '52be8e1e0497dafbb0f92847342353ce22e104a388a30d075b1de32129089686',
-    x86_64: 'ebb3b81155231be702617246a78945a3698142f63b3138c5763b9813d57dbe19'
+    aarch64: 'a625e8e0e08c69f0bf0d77c8207ffc17504f6cd9dd417d309740ca8ddcfb888b',
+     armv7l: 'a625e8e0e08c69f0bf0d77c8207ffc17504f6cd9dd417d309740ca8ddcfb888b',
+       i686: '602ec20ae5de3ee3cd20aa7b084a29503c01876959e71dcab6ec4a5e77b94066',
+     x86_64: '14eab43697a8d3cc844ecad6f2ce85491ba0808866cf42d3191b0eb7b405d7da'
   })
 
   depends_on 'gcc'

--- a/packages/py3_libxml2.rb
+++ b/packages/py3_libxml2.rb
@@ -3,24 +3,23 @@ require 'package'
 class Py3_libxml2 < Package
   description 'Libxml2-python provides access to libxml2 and libxslt in Python.'
   homepage 'https://gitlab.gnome.org/GNOME/libxml2/'
-  @_ver = '2.9.12'
-  version "#{@_ver}-1"
+  version '2.10.0'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://gitlab.gnome.org/GNOME/libxml2.git'
-  git_hashtag "v#{@_ver}"
+  source_url 'https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.10.0/libxml2-v2.10.0.tar.bz2'
+  source_sha256 'c44124d025162767a1d3fe35b556c5855e6be7240e3dc3159490e91d5cadbba3'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_libxml2/2.9.12-1_armv7l/py3_libxml2-2.9.12-1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_libxml2/2.9.12-1_armv7l/py3_libxml2-2.9.12-1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_libxml2/2.9.12-1_i686/py3_libxml2-2.9.12-1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_libxml2/2.9.12-1_x86_64/py3_libxml2-2.9.12-1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_libxml2/2.10.0_armv7l/py3_libxml2-2.10.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_libxml2/2.10.0_armv7l/py3_libxml2-2.10.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_libxml2/2.10.0_i686/py3_libxml2-2.10.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_libxml2/2.10.0_x86_64/py3_libxml2-2.10.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '2bee7439421a391a1f43595d9d840d90b5ca88d0c863655b5e6cff1b9888c616',
-     armv7l: '2bee7439421a391a1f43595d9d840d90b5ca88d0c863655b5e6cff1b9888c616',
-       i686: '04a9be201cb9309b0718663f6988aa412cf97c0f7c672332f53031aab5d310d9',
-     x86_64: '4e428d28cb7445a6955f09fc3d7bf8995764f073278dd9d507cdd7f1bedcf0d4'
+    aarch64: 'f8a22b53605a67930373f64af313ffe448ccd6596f276b5af257057280f8b445',
+     armv7l: 'f8a22b53605a67930373f64af313ffe448ccd6596f276b5af257057280f8b445',
+       i686: 'de352c024364b3dc0ca187df68e6e2c397c1886aa13a886938aace1b1e7556ec',
+     x86_64: '34f173dbe2b29e9eb1e72e96b6629f92ae0d5cd5da795f3d9915054425f80dff'
   })
 
   depends_on 'libxml2'


### PR DESCRIPTION
Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=libxml2_2.10.0  CREW_TESTING=1 crew update
```
