### PR TITLE
libiconv -> 1.17

### DIFF
--- a/packages/libiconv.rb
+++ b/packages/libiconv.rb
@@ -3,29 +3,27 @@ require 'package'
 class Libiconv < Package
   description 'GNU charset conversion library for libc which does not implement it.'
   homepage 'https://www.gnu.org/software/libiconv/'
-  version '1.16-4'
+  version '1.17'
   license 'LGPL-2+ and GPL-3+'
   compatibility 'all'
-  source_url 'https://ftpmirror.gnu.org/libiconv/libiconv-1.16.tar.gz'
-  source_sha256 'e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04'
+  source_url 'https://ftpmirror.gnu.org/libiconv/libiconv-1.17.tar.gz'
+  source_sha256 '8f74213b56238c85a50a5329f77e06198771e70dd9a739779f4c02f65d971313'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libiconv/1.16-4_armv7l/libiconv-1.16-4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libiconv/1.16-4_armv7l/libiconv-1.16-4-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libiconv/1.16-4_i686/libiconv-1.16-4-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libiconv/1.16-4_x86_64/libiconv-1.16-4-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libiconv/1.17_armv7l/libiconv-1.17-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libiconv/1.17_armv7l/libiconv-1.17-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libiconv/1.17_i686/libiconv-1.17-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libiconv/1.17_x86_64/libiconv-1.17-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '3328a5694b7eb6d44bfad79129aacb36f564ed597f31aafb54615635d50e1560',
-     armv7l: '3328a5694b7eb6d44bfad79129aacb36f564ed597f31aafb54615635d50e1560',
-       i686: 'efb5c2b71144f1cd413360a87634cf4a81dbcad568186315fb3d127460b68e65',
-     x86_64: '378d0566c86141072f0b57f7aaf1e3bc7cac4c5dc88b4f9a441b5302fa549cc6'
+    aarch64: '641ca4cfd2a72330fa741c17b3bf657db3a688ed097cf75c1a1a0c3fe04b56dc',
+     armv7l: '641ca4cfd2a72330fa741c17b3bf657db3a688ed097cf75c1a1a0c3fe04b56dc',
+       i686: 'd4f65cc6d4a00b825003fc05a2eb847fb650d85d8b9b19094d7cd990055ec464',
+     x86_64: '5b6dea457a565ee6fca3346a74d2aab7241c9556a2afab3bcb2accb589d6da92'
   })
 
   def self.build
-    system "env CFLAGS='-flto=auto -ltinfo' CXXFLAGS='-flto=auto' \
-        LDFLAGS='-flto=auto' \
-        ./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_OPTIONS} \
         --includedir=#{CREW_PREFIX}/include/gnu-libiconv \
         --enable-static \
         --enable-relocatable \
@@ -36,6 +34,10 @@ class Libiconv < Package
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     FileUtils.mv "#{CREW_DEST_PREFIX}/bin/iconv", "#{CREW_DEST_PREFIX}/bin/gnu-libiconv-iconv"
+    FileUtils.mv "#{CREW_DEST_MAN_PREFIX}/man3/iconv_close.3", "#{CREW_DEST_MAN_PREFIX}/man3/gnu-libiconv-iconv_close.3"
+    FileUtils.mv "#{CREW_DEST_MAN_PREFIX}/man3/iconv.3", "#{CREW_DEST_MAN_PREFIX}/man3/gnu-libiconv-iconv.3"
+    FileUtils.mv "#{CREW_DEST_MAN_PREFIX}/man3/iconv_open.3", "#{CREW_DEST_MAN_PREFIX}/man3/gnu-libiconv-iconv_open.3"
+    FileUtils.mv "#{CREW_DEST_MAN_PREFIX}/man1/iconv.1", "#{CREW_DEST_MAN_PREFIX}/man1/gnu-libiconv-iconv.1"
     # Header files are moved to #{CREW_PREFIX}/include/gnu-libiconv
     # to avoid conflict with versions from glibc
   end


### PR DESCRIPTION


Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmanduchromebrew.git CREW_TESTING_BRANCH=libiconv  CREW_TESTING=1 crew update
```