### PR TITLE
Add kupfer package + py3_dbus_python and py3_pyxdg dependencies

### DIFF
--- a/packages/kupfer.rb
+++ b/packages/kupfer.rb
@@ -1,0 +1,40 @@
+require 'package'
+
+class Kupfer < Package
+  description 'a smart, quick launcher'
+  homepage 'https://kupferlauncher.github.io/'
+  version 'v321'
+  license 'GPL-3.0'
+  compatibility 'x86_64'
+  source_url 'https://github.com/kupferlauncher/kupfer.git'
+  git_hashtag version
+
+  depends_on 'desktop_file_utils'
+  depends_on 'shared_mime_info'
+  depends_on 'py3_dbus_python'
+  depends_on 'py3_pyxdg'
+  depends_on 'py3_docutils' => :build
+  depends_on 'py3_setuptools' => :build
+  depends_on 'sommelier'
+
+  binary_url({
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/kupfer/v321_x86_64/kupfer-v321-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    x86_64: '453db640d22278269b89a31f07543abba98b06bc026665314dbe26ba56b7d542'
+  })
+
+  def self.build
+    system "./waf configure --prefix=#{CREW_PREFIX}"
+    system "./waf -j#{CREW_NPROC}"
+  end
+
+  def self.install
+    system './waf', "--destdir=#{CREW_DEST_DIR}", 'install'
+  end
+
+  def self.postinstall
+    system "update-desktop-database #{CREW_PREFIX}/share/applications"
+    system "update-mime-database #{CREW_PREFIX}/share/mime"
+  end
+end

--- a/packages/py3_dbus_python.rb
+++ b/packages/py3_dbus_python.rb
@@ -1,0 +1,36 @@
+require 'package'
+
+class Py3_dbus_python < Package
+  description 'libdbus language binding (wrapper) for CPython'
+  homepage 'https://gitlab.freedesktop.org/dbus/dbus-python'
+  @_ver = '1.2.18'
+  version @_ver
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://gitlab.freedesktop.org/dbus/dbus-python.git'
+  git_hashtag "dbus-python-#{@_ver}"
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_dbus_python/1.2.18_armv7l/py3_dbus_python-1.2.18-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_dbus_python/1.2.18_armv7l/py3_dbus_python-1.2.18-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_dbus_python/1.2.18_i686/py3_dbus_python-1.2.18-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_dbus_python/1.2.18_x86_64/py3_dbus_python-1.2.18-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: 'a27b5684646d29eff8f8f394c219e7499bcc38c5d14da2e38a2fb20a5980d90d',
+     armv7l: 'a27b5684646d29eff8f8f394c219e7499bcc38c5d14da2e38a2fb20a5980d90d',
+       i686: '7f4ed8709baa910b0fb983d3109d87c1252d4dc9ff61f6fa91a4dd230f250dff',
+     x86_64: '07902001348df9983ad0eb42d6c6b04abe18cf5e48ba0f039f6629d677353b0d'
+  })
+
+  depends_on 'autoconf_archive' => :build
+  depends_on 'py3_setuptools' => :build
+
+  def self.build
+    system "python3 setup.py build #{PY3_SETUP_BUILD_OPTIONS}"
+  end
+
+  def self.install
+    system "python3 setup.py install #{PY_SETUP_INSTALL_OPTIONS}"
+  end
+end

--- a/packages/py3_pyxdg.rb
+++ b/packages/py3_pyxdg.rb
@@ -1,0 +1,24 @@
+require 'package'
+
+class Py3_pyxdg < Package
+  description 'PyXDG contains implementations of freedesktop.org standards in python.'
+  homepage 'https://freedesktop.org/wiki/Software/pyxdg/'
+  @_ver = '0.28'
+  version @_ver
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://github.com/takluyver/pyxdg.git'
+  git_hashtag "rel-#{@_ver}"
+
+  depends_on 'py3_setuptools' => :build
+
+  no_compile_needed
+
+  def self.build
+    system "python3 setup.py build #{PY3_SETUP_BUILD_OPTIONS}"
+  end
+
+  def self.install
+    system "python3 setup.py install #{PY_SETUP_INSTALL_OPTIONS}"
+  end
+end


### PR DESCRIPTION
Kupfer is an interface for quick and convenient access to applications and their documents.

The most typical use is to find a specific application and launch it. We have tried to make Kupfer easy to extend with plugins so that this quick-access paradigm can be extended to many more objects than just applications.

Only works on x86_64.