### PR TITLE
Rsync deps updated/rebuilt with xz packaging.

### DIFF
--- a/packages/acl.rb
+++ b/packages/acl.rb
@@ -3,34 +3,34 @@ require 'package'
 class Acl < Package
   description 'Commands for Manipulating POSIX Access Control Lists.'
   homepage 'http://savannah.nongnu.org/projects/acl'
-  version '2.3.1'
+  version '2.3.1-1'
   license 'LGPL-2.1'
   compatibility 'all'
   source_url 'https://bigsearcher.com/mirrors/nongnu/acl/acl-2.3.1.tar.xz'
   source_sha256 'c0234042e17f11306c23c038b08e5e070edb7be44bef6697fb8734dcff1c66b1'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/acl/2.3.1_armv7l/acl-2.3.1-chromeos-armv7l.tpxz',
-    armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/acl/2.3.1_armv7l/acl-2.3.1-chromeos-armv7l.tpxz',
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/acl/2.3.1_i686/acl-2.3.1-chromeos-i686.tpxz',
-    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/acl/2.3.1_x86_64/acl-2.3.1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/acl/2.3.1-1_armv7l/acl-2.3.1-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/acl/2.3.1-1_armv7l/acl-2.3.1-1-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/acl/2.3.1-1_i686/acl-2.3.1-1-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/acl/2.3.1-1_x86_64/acl-2.3.1-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '53eddf80135a3265f01a90ffd9b71c9453b95d432260aea6d8331514fe4af2eb',
-    armv7l: '53eddf80135a3265f01a90ffd9b71c9453b95d432260aea6d8331514fe4af2eb',
-    i686: 'e96e13e6cce5e572a12e9aa3b1e0190fb8cb95712492dfe219aa3b7c69c971e8',
-    x86_64: 'ced96737007afe57d6ee741165e8c409ad2ea8bb361b8356197d1bd4f2c782c0'
+    aarch64: 'd0c1f4730b03f83d15867b9a71b4dbf1ed27f03e2029a052e50b3da854c597bf',
+     armv7l: 'd0c1f4730b03f83d15867b9a71b4dbf1ed27f03e2029a052e50b3da854c597bf',
+       i686: 'a09785c84da91c6869db8ca47c295bde5cdd69982854c6edadf3fe975652cd75',
+     x86_64: '68f41aa3f486043fe7979efdce5348e414a643a908cf2483b179623a4ca1c179'
   })
 
   depends_on 'attr'
+  no_zstd
 
   def self.patch
     system 'filefix'
   end
 
   def self.build
-    system "env #{CREW_ENV_OPTIONS} \
-      ./configure \
+    system "./configure \
       #{CREW_OPTIONS}"
     system 'make'
   end

--- a/packages/attr.rb
+++ b/packages/attr.rb
@@ -3,28 +3,30 @@ require 'package'
 class Attr < Package
   description 'Commands for Manipulating Filesystem Extended Attributes.'
   homepage 'http://savannah.nongnu.org/projects/attr'
-  version '2.5.1'
+  version '2.5.1-1'
   license 'LGPL-2.1'
   compatibility 'all'
   source_url 'https://download.savannah.gnu.org/releases/attr/attr-2.5.1.tar.xz'
   source_sha256 'db448a626f9313a1a970d636767316a8da32aede70518b8050fa0de7947adc32'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/attr/2.5.1_armv7l/attr-2.5.1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/attr/2.5.1_armv7l/attr-2.5.1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/attr/2.5.1_i686/attr-2.5.1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/attr/2.5.1_x86_64/attr-2.5.1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/attr/2.5.1-1_armv7l/attr-2.5.1-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/attr/2.5.1-1_armv7l/attr-2.5.1-1-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/attr/2.5.1-1_i686/attr-2.5.1-1-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/attr/2.5.1-1_x86_64/attr-2.5.1-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'da212fa1e85d525d438aa7c0a63ff094d158f241c8f359bad17e4c0932b1b5fa',
-     armv7l: 'da212fa1e85d525d438aa7c0a63ff094d158f241c8f359bad17e4c0932b1b5fa',
-       i686: '13b8ad2172c3cd53e1670a8c9fe890ce9c72b3291f24392b4690ad656c969e61',
-     x86_64: '8f78f7cede30f6be0035f3c3a51a0323e94c7e74dc907302abaf04bc4d3a5ccd'
+    aarch64: '064c27a5daaecabe639c40b1b307bdc7711e7132903d300de699219dc8d00685',
+     armv7l: '064c27a5daaecabe639c40b1b307bdc7711e7132903d300de699219dc8d00685',
+       i686: 'fb434974fc3a48c3122785de09515115762555e9c7551db8734e54f251db6c51',
+     x86_64: '690156378a76ac649c3fd780c517042f74ef812da45e9f84274b2ce5e80b3978'
   })
 
+  depends_on 'libcap' => :build
+  no_zstd
+
   def self.build
-    system "env #{CREW_ENV_OPTIONS} \
-      ./configure \
+    system "./configure \
       #{CREW_OPTIONS}"
     system 'make'
   end

--- a/packages/libcap.rb
+++ b/packages/libcap.rb
@@ -3,29 +3,29 @@ require 'package'
 class Libcap < Package
   description 'Libcap implements the user-space interfaces to the POSIX 1003.1e capabilities available in Linux kernels.'
   homepage 'https://directory.fsf.org/wiki/Libcap/'
-  @_ver = '2.64'
-  version @_ver
+  version '2.65'
   license 'GPL-2 or BSD'
   compatibility 'all'
   source_url 'https://git.kernel.org/pub/scm/libs/libcap/libcap.git'
-  git_hashtag "libcap-#{@_ver}"
+  git_hashtag "libcap-#{version}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.64_armv7l/libcap-2.64-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.64_armv7l/libcap-2.64-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.64_i686/libcap-2.64-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.64_x86_64/libcap-2.64-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.65_armv7l/libcap-2.65-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.65_armv7l/libcap-2.65-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.65_i686/libcap-2.65-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.65_x86_64/libcap-2.65-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '03701822e8ae9cfee9ea023b377499797b037372c204f27c755bf68a01dddd4c',
-     armv7l: '03701822e8ae9cfee9ea023b377499797b037372c204f27c755bf68a01dddd4c',
-       i686: '4032d0a74b1b6a23da3d97643f14c830d7499c7b3d8677715bb369e77054a655',
-     x86_64: 'cc6593f845dfc3adc63cfd5dadaf23117c646ae5d37442961380fe0f82295fe3'
+    aarch64: '85f64941fe9c6854f2e96fd6b8cda6f9ffdf0340d3c36bfdc0aa705b85af8193',
+     armv7l: '85f64941fe9c6854f2e96fd6b8cda6f9ffdf0340d3c36bfdc0aa705b85af8193',
+       i686: '8bb0641494740536c12ae91e0c91a3aaec3051116ff916dba8ba258f3ac543e4',
+     x86_64: '29070edba9fce8f5dfa9175296316e3978341065f314d10b394c2f7476da50ca'
   })
 
   depends_on 'glibc' # R
   depends_on 'gperf' => :build
   depends_on 'linux_pam'
+  no_zstd
 
   def self.patch
     # add includes option to make it work with gperf-3.1
@@ -37,10 +37,7 @@ class Libcap < Package
     # set exec_prefix
     system "sed -i 's,^exec_prefix=,exec_prefix=\$(prefix),g' Make.Rules"
     # use system libdir
-    case ARCH
-    when 'armv7l', 'aarch64'
-      system "sed -i 's,^lib_prefix=\$(exec_prefix),lib_prefix=#{CREW_LIB_PREFIX},g' Make.Rules"
-    end
+    system "sed -i 's,^lib_prefix=\$(exec_prefix),lib_prefix=#{CREW_LIB_PREFIX},g' Make.Rules"
     # http://git.yoctoproject.org/cgit.cgi/poky/plain/meta/recipes-support/libcap/files/0001-ensure-the-XATTR_NAME_CAPS-is-defined-when-it-is-use.patch
     system 'sed -i "s,^\#ifdef VFS_CAP_U32,\#if defined (VFS_CAP_U32) \&\& defined (XATTR_NAME_CAPS),g" libcap/cap_file.c'
   end

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -4,27 +4,28 @@ class Openssl < Package
   description 'The Open Source toolkit for Secure Sockets Layer and Transport Layer Security'
   homepage 'https://www.openssl.org'
   @_ver = '1.1.1q'
-  version "#{@_ver}-1"
+  version "#{@_ver}-2"
   license 'openssl'
   compatibility 'all'
   source_url "https://www.openssl.org/source/openssl-#{@_ver}.tar.gz"
   source_sha256 'd7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1q-1_armv7l/openssl-1.1.1q-1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1q-1_armv7l/openssl-1.1.1q-1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1q-1_i686/openssl-1.1.1q-1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1q-1_x86_64/openssl-1.1.1q-1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1q-2_armv7l/openssl-1.1.1q-2-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1q-2_armv7l/openssl-1.1.1q-2-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1q-2_i686/openssl-1.1.1q-2-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1q-2_x86_64/openssl-1.1.1q-2-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '8f9592bac4167da9829dcac529e98cded31c8d6824d691efff68220917d1bce7',
-     armv7l: '8f9592bac4167da9829dcac529e98cded31c8d6824d691efff68220917d1bce7',
-       i686: '2eabf1ab141f5873407cda3507456e9ab758fd69f44e8b76808cefa0dfe4a82a',
-     x86_64: '78029b1bc2e02065713748a6dc649c8cde34e28df6f7347a9916b4121782f43d'
+    aarch64: 'ce7b09378b0604b14a6f66f09d7b797001be0a2037ab73c0acd7614f6844dffc',
+     armv7l: 'ce7b09378b0604b14a6f66f09d7b797001be0a2037ab73c0acd7614f6844dffc',
+       i686: '9490d940c0eb928a70b2043932d41d2fd5f486b86067616ed76cb591cb6e4c3b',
+     x86_64: 'b408d3943acd24811104f30f4de07ef64df56a8a44467e113418fcf86906a4ee'
   })
 
   depends_on 'ccache' => :build
   no_patchelf
+  no_zstd
 
   case ARCH
   when 'aarch64', 'armv7l'
@@ -32,12 +33,12 @@ class Openssl < Package
     @arch_cxx_flags = '-fPIC -march=armv7-a -mfloat-abi=hard -fuse-ld=mold'
     @openssl_configure_target = 'linux-generic32'
   when 'i686'
-    @arch_c_flags = '-fPIC'
-    @arch_cxx_flags = '-fPIC'
+    @arch_c_flags = '-fPIC -fuse-ld=mold'
+    @arch_cxx_flags = '-fPIC -fuse-ld=mold'
     @openssl_configure_target = 'linux-x86'
   when 'x86_64'
-    @arch_c_flags = '-fPIC'
-    @arch_cxx_flags = '-fPIC'
+    @arch_c_flags = '-fPIC -fuse-ld=mold'
+    @arch_cxx_flags = '-fPIC -fuse-ld=mold'
     @openssl_configure_target = 'linux-x86_64'
   end
   @ARCH_LDFLAGS = '-flto'

--- a/packages/popt.rb
+++ b/packages/popt.rb
@@ -10,21 +10,22 @@ class Popt < Package
   git_hashtag '7182e4618ad5a0186145fc2aa4a98c2229afdfa8'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18-7182e46-1_armv7l/popt-1.18-7182e46-1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18-7182e46-1_armv7l/popt-1.18-7182e46-1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18-7182e46-1_i686/popt-1.18-7182e46-1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18-7182e46-1_x86_64/popt-1.18-7182e46-1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18-7182e46-1_armv7l/popt-1.18-7182e46-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18-7182e46-1_armv7l/popt-1.18-7182e46-1-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18-7182e46-1_i686/popt-1.18-7182e46-1-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/popt/1.18-7182e46-1_x86_64/popt-1.18-7182e46-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '7f4e3731424ab89c32d4d492715b421f7a2e08ff3722f42db56c116abed0afde',
-     armv7l: '7f4e3731424ab89c32d4d492715b421f7a2e08ff3722f42db56c116abed0afde',
-       i686: '1d7715334c368c049386f977c50a234f1f9204c829301b1a5482740d526acefe',
-     x86_64: 'f97c13e9e22bda93cc219dd899947f2269c2a2e997e713810e9603ad8ba69d6b'
+    aarch64: '9cefdde6c7c465b26348751ddd4d90c21483e31771237534a583fdc95ade39b5',
+     armv7l: '9cefdde6c7c465b26348751ddd4d90c21483e31771237534a583fdc95ade39b5',
+       i686: '8cbf20d99228e07d40c79f580f3d6f8ba84f9a402acd93203ace8b8248d8037e',
+     x86_64: 'a9c888f6b22b88eb5635e17df8c3b2eab6e91539e1a58696336722b0530c5eda'
   })
 
   depends_on 'glibc' # R
   depends_on 'gcc' unless ARCH == 'x86_64' # R
   no_patchelf
+  no_zstd
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'

--- a/packages/rsync.rb
+++ b/packages/rsync.rb
@@ -40,7 +40,7 @@ class Rsync < Package
   end
 
   def self.check
-        system 'make check'
+    system 'make check'
   end
 
   def self.install

--- a/packages/rsync.rb
+++ b/packages/rsync.rb
@@ -28,6 +28,7 @@ class Rsync < Package
   depends_on 'lz4' # R
   depends_on 'openssl' # R
   depends_on 'popt' # R
+  depends_on 'py3_cmarkgfm' => :build
   depends_on 'xxhash' # R
   depends_on 'zstd' # R
   no_patchelf
@@ -36,6 +37,10 @@ class Rsync < Package
   def self.build
     system "./configure #{CREW_OPTIONS} --disable-maintainer-mode"
     system 'make'
+  end
+
+  def self.check
+        system 'make check'
   end
 
   def self.install

--- a/packages/xxhash.rb
+++ b/packages/xxhash.rb
@@ -3,26 +3,27 @@ require 'package'
 class Xxhash < Package
   description 'xxHash is an extremely fast non-cryptographic hash algorithm, working at speeds close to RAM limits.'
   homepage 'https://cyan4973.github.io/xxHash/'
-  version '0.8.0-1'
+  version '0.8.1'
   license 'BSD-2 and GPL-2+'
   compatibility 'all'
-  source_url 'https://github.com/Cyan4973/xxHash/archive/v0.8.0.tar.gz'
-  source_sha256 '7054c3ebd169c97b64a92d7b994ab63c70dd53a06974f1f630ab782c28db0f4f'
+  source_url 'https://github.com/Cyan4973/xxHash.git'
+  git_hashtag "v#{version}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xxhash/0.8.0-1_armv7l/xxhash-0.8.0-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xxhash/0.8.0-1_armv7l/xxhash-0.8.0-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xxhash/0.8.0-1_i686/xxhash-0.8.0-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xxhash/0.8.0-1_x86_64/xxhash-0.8.0-1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xxhash/0.8.1_armv7l/xxhash-0.8.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xxhash/0.8.1_armv7l/xxhash-0.8.1-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xxhash/0.8.1_i686/xxhash-0.8.1-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xxhash/0.8.1_x86_64/xxhash-0.8.1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '3b84bfc646e491a012434a68aebd38c10a7c667096b7ba9aba0fd1d8899a34f6',
-     armv7l: '3b84bfc646e491a012434a68aebd38c10a7c667096b7ba9aba0fd1d8899a34f6',
-       i686: '341858534ccf356d1b6a7313b07f36c42da188a2055ac610bb8dd715ada0227d',
-     x86_64: 'a6d0d300a1e11a255d545f759598c35b280083055954765c4f68e5c733e74ecc'
+    aarch64: '7ad8cdd3611bf8336070ec55d92c30cae584656c3720ca2368101826ca089c4a',
+     armv7l: '7ad8cdd3611bf8336070ec55d92c30cae584656c3720ca2368101826ca089c4a',
+       i686: '5d70bb5ac38e15afd006ac0c6957ef81cfae0a05d27428ffbc3501b7b899cd10',
+     x86_64: 'c1f0005397d8433a33ab6195f82d7f17e6271530599ad52538c6550360b97afc'
   })
 
   no_patchelf
+  no_zstd
 
   def self.build
     system 'make', "PREFIX=#{CREW_PREFIX}", "LIBDIR=#{CREW_LIB_PREFIX}"


### PR DESCRIPTION
- Done in service of getting rsync working with https://github.com/chromebrew/chromebrew/pull/7297
- Also Add self check section to rsync to catch issues on build.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=rsync_deps CREW_TESTING=1 crew update
```
