### PR TITLE
remmina, freerdp, vte updates

### DIFF
--- a/packages/freerdp.rb
+++ b/packages/freerdp.rb
@@ -3,23 +3,21 @@ require 'package'
 class Freerdp < Package
   description 'FreeRDP is a free implementation of the Remote Desktop Protocol.'
   homepage 'https://www.freerdp.com/'
-  version '2.3.2'
+  version '2.8.0'
   license 'Apache-2.0'
-  compatibility 'all'
+  compatibility 'x86_64 armv7l aarch64'
   source_url "https://github.com/FreeRDP/FreeRDP/archive/refs/tags/#{version}.tar.gz"
-  source_sha256 'a1f52f0d9569b418a555ffe4d15a3782712198be47308e9514d20ca5af41a1b1'
+  source_sha256 '86f1ce8ef71aff73881a48b40d31dda2fc2a94bdbe37e1c1af8447a0e4fa5cc8'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freerdp/2.3.2_armv7l/freerdp-2.3.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freerdp/2.3.2_armv7l/freerdp-2.3.2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freerdp/2.3.2_i686/freerdp-2.3.2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freerdp/2.3.2_x86_64/freerdp-2.3.2-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freerdp/2.8.0_armv7l/freerdp-2.8.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freerdp/2.8.0_armv7l/freerdp-2.8.0-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/freerdp/2.8.0_x86_64/freerdp-2.8.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'dd2db88bb1442ed6d8d37d064ed5701087e339008b91314916b69b0f0f127ca6',
-     armv7l: 'dd2db88bb1442ed6d8d37d064ed5701087e339008b91314916b69b0f0f127ca6',
-       i686: 'fd935d4def75b22e6ad98c2435c2ccae461c689be480dfe9b7afd49a6fef3798',
-     x86_64: '46cf60d78f89cd9adab7d71a8d2d204a0633efef5362eacf8d1085f131bc0eac'
+    aarch64: '9395c3882984fc0155cd2489546b1717d04483583cd517ddddc7ea9bd04f710a',
+     armv7l: '9395c3882984fc0155cd2489546b1717d04483583cd517ddddc7ea9bd04f710a',
+     x86_64: '87dcb6d9b28405fe2879dd2862de3c06d1c4981cfede0aaec760a14005d25bc0'
   })
 
   depends_on 'cairo'

--- a/packages/remmina.rb
+++ b/packages/remmina.rb
@@ -3,21 +3,21 @@ require 'package'
 class Remmina < Package
   description 'The GTK Remmina Remote Desktop Client'
   homepage 'https://remmina.org/'
-  version '1.4.25'
+  version '1.4.27'
   license 'GPL-2+-with-openssl-exception'
-  compatibility 'x86_64 aarch64 armv7l'
+  compatibility 'x86_64 armv7l aarch64'
   source_url "https://gitlab.com/Remmina/Remmina/-/archive/v#{version}/Remmina-v#{version}.tar.bz2"
-  source_sha256 'a730d5927232818d55c8e094dba69d504faacabab2288d0c5c0c30ee7e89be46'
+  source_sha256 '6e93f18a4930ca194d3651a7a0cedf1cf92e761884952d5651fc1e985daa9c5a'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/remmina/1.4.25_armv7l/remmina-1.4.25-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/remmina/1.4.25_armv7l/remmina-1.4.25-chromeos-armv7l.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/remmina/1.4.25_x86_64/remmina-1.4.25-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/remmina/1.4.27_armv7l/remmina-1.4.27-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/remmina/1.4.27_armv7l/remmina-1.4.27-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/remmina/1.4.27_x86_64/remmina-1.4.27-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'c2a51556cb206a0a2d82daf8859b33e68c5141fa87b62ad3f700ec2a43cac6e3',
-     armv7l: 'c2a51556cb206a0a2d82daf8859b33e68c5141fa87b62ad3f700ec2a43cac6e3',
-     x86_64: '6b280475ba0d8778b5be2be2d697968ce893b12fbf78d448d7431770e8fb718c'
+    aarch64: '8604a9830b7dca6eb39e4dbe456c80a95f6be267afb649960591b13afccc367d',
+     armv7l: '8604a9830b7dca6eb39e4dbe456c80a95f6be267afb649960591b13afccc367d',
+     x86_64: 'ef7a269e329ef4793cb61e2e7e0fc3e7453ba7d3dcddd353398611965a2c9597'
   })
 
   depends_on 'avahi'

--- a/packages/vte.rb
+++ b/packages/vte.rb
@@ -3,7 +3,7 @@ require 'package'
 class Vte < Package
   description 'Virtual Terminal Emulator widget for use with GTK'
   homepage 'https://wiki.gnome.org/Apps/Terminal/VTE'
-  @_ver = '0.67.90'
+  @_ver = '0.69.92'
   version @_ver
   license 'LGPL-2+ and GPL-3+'
   compatibility 'all'
@@ -11,16 +11,16 @@ class Vte < Package
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vte/0.67.90_armv7l/vte-0.67.90-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vte/0.67.90_armv7l/vte-0.67.90-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vte/0.67.90_i686/vte-0.67.90-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vte/0.67.90_x86_64/vte-0.67.90-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vte/0.69.92_armv7l/vte-0.69.92-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vte/0.69.92_armv7l/vte-0.69.92-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vte/0.69.92_i686/vte-0.69.92-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vte/0.69.92_x86_64/vte-0.69.92-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'dcfdd849cf41e7eebdbf4898736f3a4a4110bce26bdfb46fb8b2e2ed6abca976',
-     armv7l: 'dcfdd849cf41e7eebdbf4898736f3a4a4110bce26bdfb46fb8b2e2ed6abca976',
-       i686: 'df376361939b8573ab907b9a2be807c1086bf37b9979829153d8f73194ca3fa4',
-     x86_64: '646cc0968db68d6db74c294a134ad05a1b3b04af0661416b0f19997e6492867b'
+    aarch64: 'c7b015afc564f5ca0f50328ca1ae8f1e27bbc8d9f5d389feb783f9d36986e9d7',
+     armv7l: 'c7b015afc564f5ca0f50328ca1ae8f1e27bbc8d9f5d389feb783f9d36986e9d7',
+       i686: '9f6840aeb382b7bfcdf089f2f50aa3edfe9993c6c657bc6e9c87b9256f0d27f8',
+     x86_64: 'e3958e79e715ca4b03fbb25c03bb728db4c0c7f92e97b57dba62410c18979546'
   })
 
   depends_on 'gobject_introspection' => :build


### PR DESCRIPTION

- vte -> 0.69.92
- freerdp -> 2.8.0
- remmina -> 1.4.27

Builds properly:
- [x] `x86_64`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=remmina CREW_TESTING=1 crew update
```
