### PR TITLE
Fix rubocop errors that snuck in in #7320

### DIFF
--- a/lib/package.rb
+++ b/lib/package.rb
@@ -32,7 +32,7 @@ class Package
     className = pkgName.capitalize
 
     # read and eval package script under 'Package' class
-    class_eval( File.read(pkgFile, encoding: Encoding::UTF_8), pkgFile ) unless const_defined?("Package::#{className}")
+    class_eval(File.read(pkgFile, encoding: Encoding::UTF_8), pkgFile) unless const_defined?("Package::#{className}")
 
     pkgObj = const_get(className)
     pkgObj.name = pkgName


### PR DESCRIPTION
PR's that did not rebase on master after the rubocop CI was working are not tested on it, and as such can sneak in rubocop errors that will punish innocent PR's. I caught one in #7320, but if all outstanding PR's could please rebase this would save everyone a lot of effort.