### PR TITLE
Fix glibc symlinks not being made properly

### DIFF
--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -599,14 +599,14 @@ class Glibc < Package
       puts 'Creating symlinks to system glibc version to prevent breakage.'.lightblue
       @libraries.each do |lib|
         # Reject entries which aren't libraries ending in .so, and which aren't files.
-        Dir.glob("/#{ARCH_LIB}/#{lib}.so*").reject { |f| File.directory?(f) }.each do |f|
+        Dir["/#{ARCH_LIB}/#{lib}.so*"].reject { |f| File.directory?(f) }.each do |f|
           if `file #{f} | grep "shared object"`
             g = File.basename(f)
             FileUtils.ln_sf f.to_s, g.to_s
           end
         end
         # Reject entries which aren't libraries ending in .so, and which aren't files.
-        Dir.glob("/usr/#{ARCH_LIB}/#{lib}.so*").reject { |f| File.directory?(f) }.each do |f|
+        Dir["/usr/#{ARCH_LIB}/#{lib}.so*"].reject { |f| File.directory?(f) }.each do |f|
           if `file #{f} | grep "shared object"`
             g = File.basename(f)
             FileUtils.ln_sf f.to_s, g.to_s

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -20,7 +20,7 @@ class Glibc < Package
   # from the one ChromeOS ships with.
   # @libc_version = '2.33'
   if @libc_version == '2.23'.freeze
-    version '2.23-3'
+    version '2.23-4'
     source_url 'https://ftpmirror.gnu.org/glibc/glibc-2.23.tar.xz'
     source_sha256 '94efeb00e4603c8546209cefb3e1a50a5315c86fa9b078b6fad758e187ce13e9'
 
@@ -31,7 +31,7 @@ class Glibc < Package
       i686: '3ee19cbb907eb219a2c1b02df6de1ca13b09b0d375101657d54a2485aacdc445'
     })
   elsif @libc_version == '2.27'
-    version '2.27'
+    version '2.27-1'
     source_url 'https://ftpmirror.gnu.org/glibc/glibc-2.27.tar.xz'
     source_sha256 '5172de54318ec0b7f2735e5a91d908afe1c9ca291fec16b5374d9faadfc1fc72'
 
@@ -46,7 +46,7 @@ class Glibc < Package
        x86_64: '5fe94642dbbf900d22b715021c73ac1a601b81517f0da1e7413f0af8fbea7997'
     })
   elsif @libc_version == '2.32'.freeze # All architectures with updates past M92.
-    version '2.32-2'
+    version '2.32-3'
     source_url 'https://ftpmirror.gnu.org/glibc/glibc-2.32.tar.xz'
     source_sha256 '1627ea54f5a1a8467032563393e0901077626dc66f37f10ee6363bb722222836'
 
@@ -61,7 +61,7 @@ class Glibc < Package
        x86_64: '3e3eaa6551492ef0f1bc28600102503b721b19d0ee7396c4301771df402ea355'
     })
   elsif @libc_version.to_f >= 2.33 # All architectures with updates past M97.
-    version '2.33'
+    version '2.33-1'
     source_url 'https://ftpmirror.gnu.org/glibc/glibc-2.33.tar.xz'
     source_sha256 '2e2556000e105dbd57f0b6b2a32ff2cf173bde4f0d85dffccfd8b7e51a0677ff'
 
@@ -598,7 +598,15 @@ class Glibc < Package
       puts "System glibc version is #{LIBC_VERSION}.".lightblue
       puts 'Creating symlinks to system glibc version to prevent breakage.'.lightblue
       @libraries.each do |lib|
-        Dir.glob("/#{ARCH_LIB}/#{lib}*").each do |f|
+        # Reject entries which aren't libraries ending in .so, and which aren't files.
+        Dir.glob("/#{ARCH_LIB}/#{lib}.so*").reject { |f| File.directory?(f) }.each do |f|
+          if `file #{f} | grep "shared object"`
+            g = File.basename(f)
+            FileUtils.ln_sf f.to_s, g.to_s
+          end
+        end
+        # Reject entries which aren't libraries ending in .so, and which aren't files.
+        Dir.glob("/usr/#{ARCH_LIB}/#{lib}.so*").reject { |f| File.directory?(f) }.each do |f|
           if `file #{f} | grep "shared object"`
             g = File.basename(f)
             FileUtils.ln_sf f.to_s, g.to_s


### PR DESCRIPTION
Fixes #7328

- Previously the glibc postinstall was making symlinks for the system provided libraries in here:
```
@libraries = %w[ld libBrokenLocale libSegFault libanl libc libcrypt
                    libdl libm libmemusage libmvec libnsl libnss_compat libnss_db
                    libnss_dns libnss_files libnss_hesiod libpcprofile libpthread
                    libresolv librlv librt libthread_db-1.0 libutil]
```
exclusively from `/#{ARCH_LIB}/` but many of these files are actually in `/usr/#{ARCH_LIB}/`, so we need to symlink from there.
BUT we also have to make sure we select only the libraries we want and don't wildcard glob onto everything... AND we need to avoid selecting folders.

- Upon crew upgrade this should force glibc to reinstall, which will generate the symlinks properly.

Works properly:
- [x] `x86_64` 
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=glibc_fix2 CREW_TESTING=1 crew update
```
