### PR TITLE
glibc: don't use ChromeOS version of libc.so

### DIFF
--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -606,10 +606,11 @@ class Glibc < Package
           end
         end
         # Reject entries which aren't libraries ending in .so, and which aren't files.
+        # Reject libc.so because it points to libc_nonshared.a, which isn't provided by ChromeOS
         Dir["/usr/#{ARCH_LIB}/#{lib}.so*"].reject { |f| File.directory?(f) }.each do |f|
           if `file #{f} | grep "shared object"`
             g = File.basename(f)
-            FileUtils.ln_sf f.to_s, g.to_s
+            FileUtils.ln_sf f.to_s, g.to_s unless g == 'libc.so'
           end
         end
       end


### PR DESCRIPTION
The ChromeOS libc.so contains this:
```
/* GNU ld script
   Use the shared library, but some functions are only in
   the static library, so try that secondarily.  */
OUTPUT_FORMAT(elf32-littlearm)
GROUP ( /lib/libc.so.6 /usr/lib/libc_nonshared.a  AS_NEEDED ( /lib/ld-linux-armhf.so.3 ) )
```
But `libc_nonshared.a` isn't provided by ChromeOS! So we have to use our own:
```
/* GNU ld script
   Use the shared library, but some functions are only in
   the static library, so try that secondarily.  */
OUTPUT_FORMAT(elf32-littlearm)
GROUP ( /usr/local/lib/libc.so.6 /usr/local/lib/libc_nonshared.a  AS_NEEDED ( /usr/local/lib/ld-linux-armhf.so.3 ) )
```

(Without this compiles don't work.)


Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=glibc_fix3 CREW_TESTING=1 crew update
```
