### PR TITLE
glibc: don't use ChromeOS's plain text library files

### DIFF
--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -606,11 +606,12 @@ class Glibc < Package
           end
         end
         # Reject entries which aren't libraries ending in .so, and which aren't files.
-        # Reject libc.so because it points to libc_nonshared.a, which isn't provided by ChromeOS
+        # Reject text files such as libc.so because they points to files like
+        # libc_nonshared.a, which are not provided by ChromeOS
         Dir["/usr/#{ARCH_LIB}/#{lib}.so*"].reject { |f| File.directory?(f) }.each do |f|
           if `file #{f} | grep "shared object"`
             g = File.basename(f)
-            FileUtils.ln_sf f.to_s, g.to_s unless g == 'libc.so'
+            FileUtils.ln_sf f.to_s, g.to_s unless `file #{g} | grep "ASCII text"`
           end
         end
       end


### PR DESCRIPTION
- This is the general solution to the problem.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=glibc_fix4 CREW_TESTING=1 crew update
```
