### PR TITLE
gnome_terminal -> 3.45.90

### DIFF
--- a/packages/gnome_terminal.rb
+++ b/packages/gnome_terminal.rb
@@ -6,20 +6,18 @@ class Gnome_terminal < Package
   @_ver = '3.45.90'
   version @_ver
   license 'GPL-3+'
-  compatibility 'all'
+  compatibility 'x86_64 armv7l aarch64'
   source_url 'https://gitlab.gnome.org/GNOME/gnome-terminal.git'
   git_hashtag @_ver
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_terminal/3.45.90_armv7l/gnome_terminal-3.45.90-chromeos-armv7l.tar.zst',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_terminal/3.45.90_armv7l/gnome_terminal-3.45.90-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_terminal/3.45.90_i686/gnome_terminal-3.45.90-chromeos-i686.tar.zst',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_terminal/3.45.90_x86_64/gnome_terminal-3.45.90-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
     aarch64: '88f445c929da22ee4ae71dae62c0ac1ee7fbe6ad226f4b29271612e6afbec5c2',
      armv7l: '88f445c929da22ee4ae71dae62c0ac1ee7fbe6ad226f4b29271612e6afbec5c2',
-       i686: '390c8cb3ba1a5b306320368f6dd45db21e6ad43b576cc9fe16c8cd7a28b82914',
      x86_64: 'a94bc8f5bf868dbb1134e02a9af01e1b188a97f786cfeeb656d00401e467552a'
   })
 
@@ -31,7 +29,6 @@ class Gnome_terminal < Package
   depends_on 'adobe_source_code_pro_fonts' # (Needed for monospace fonts)
   depends_on 'yelp_tools'
   depends_on 'gtk_doc'
-  depends_on 'sommelier' unless ARCH == 'i686'
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \

--- a/packages/gnome_terminal.rb
+++ b/packages/gnome_terminal.rb
@@ -3,22 +3,24 @@ require 'package'
 class Gnome_terminal < Package
   description 'The GNOME Terminal Emulator'
   homepage 'https://wiki.gnome.org/Apps/Terminal'
-  @_ver = '3.41.0'
+  @_ver = '3.45.90'
   version @_ver
   license 'GPL-3+'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/gnome-terminal.git'
-  git_hashtag '3.41.0'
+  git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_terminal/3.41.0_armv7l/gnome_terminal-3.41.0-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_terminal/3.41.0_armv7l/gnome_terminal-3.41.0-chromeos-armv7l.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_terminal/3.41.0_x86_64/gnome_terminal-3.41.0-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_terminal/3.45.90_armv7l/gnome_terminal-3.45.90-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_terminal/3.45.90_armv7l/gnome_terminal-3.45.90-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_terminal/3.45.90_i686/gnome_terminal-3.45.90-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_terminal/3.45.90_x86_64/gnome_terminal-3.45.90-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'a645989d30509d01be54ef794bf8c4f105cef48965c2beb0d05eded71faae724',
-     armv7l: 'a645989d30509d01be54ef794bf8c4f105cef48965c2beb0d05eded71faae724',
-     x86_64: 'ed42ef2ce74e24a414e978891802fc06cc8cc3c0bb4b9c9dfcd3e71b86b1c0ad'
+    aarch64: '88f445c929da22ee4ae71dae62c0ac1ee7fbe6ad226f4b29271612e6afbec5c2',
+     armv7l: '88f445c929da22ee4ae71dae62c0ac1ee7fbe6ad226f4b29271612e6afbec5c2',
+       i686: '390c8cb3ba1a5b306320368f6dd45db21e6ad43b576cc9fe16c8cd7a28b82914',
+     x86_64: 'a94bc8f5bf868dbb1134e02a9af01e1b188a97f786cfeeb656d00401e467552a'
   })
 
   depends_on 'gtk3'
@@ -29,6 +31,7 @@ class Gnome_terminal < Package
   depends_on 'adobe_source_code_pro_fonts' # (Needed for monospace fonts)
   depends_on 'yelp_tools'
   depends_on 'gtk_doc'
+  depends_on 'sommelier' unless ARCH == 'i686'
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \


### PR DESCRIPTION


Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=gnome_terminal CREW_TESTING=1 crew update
```
