### PR TITLE
neovim => 0.7.2 + relevant updates

### DIFF
--- a/packages/libluv.rb
+++ b/packages/libluv.rb
@@ -1,0 +1,51 @@
+# Adapted from Arch Linux libluv PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/libluv/trunk/PKGBUILD
+
+require 'package'
+
+class Libluv < Package
+  description 'Bare libuv bindings for lua'
+  homepage 'https://github.com/luvit/luv'
+  version '1.44.2'
+  license 'apache'
+  compatibility 'all'
+  source_url 'https://github.com/luvit/luv.git'
+  git_hashtag '1.44.2-0'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libluv/1.44.2_armv7l/libluv-1.44.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libluv/1.44.2_armv7l/libluv-1.44.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libluv/1.44.2_i686/libluv-1.44.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libluv/1.44.2_x86_64/libluv-1.44.2-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: 'c0f550aad24be7f0845fbb730a70dad758a624deaf7e4bf8d1b4446cd4e3fcd1',
+     armv7l: 'c0f550aad24be7f0845fbb730a70dad758a624deaf7e4bf8d1b4446cd4e3fcd1',
+       i686: '3622475bd90dbc8942dd9b4a9249e2d0e7e1a03b837b8a983d7cec309f344742',
+     x86_64: 'd3d7f404503c1bda84471ff8ae47c10312f89940bed310d220fb8dbdb7fb2fca'
+  })
+
+  depends_on 'luajit'
+  depends_on 'libuv'
+
+  def self.patch
+    system "sed -i 's,CMAKE_INSTALL_PREFIX}/lib,CMAKE_INSTALL_PREFIX}/#{ARCH_LIB},g' CMakeLists.txt"
+  end
+
+  def self.build
+    FileUtils.mkdir('builddir')
+    Dir.chdir('builddir') do
+      system "cmake #{CREW_CMAKE_OPTIONS} \
+        -DBUILD_SHARED_LIBS=ON \
+        -DWITH_SHARED_LIBUV=ON  \
+        -DLUA_BUILD_TYPE=System \
+        -DBUILD_MODULE=OFF \
+        ../ -G Ninja"
+    end
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/libmpack.rb
+++ b/packages/libmpack.rb
@@ -1,0 +1,35 @@
+# Adapted from Arch Linux libmpack PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/libmpack/trunk/PKGBUILD
+
+require 'package'
+
+class Libmpack < Package
+  description 'Simple implementation of msgpack in C'
+  homepage 'https://github.com/libmpack/libmpack'
+  version '1.0.5'
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://github.com/libmpack/libmpack/archive/1.0.5.tar.gz'
+  source_sha256 '4ce91395d81ccea97d3ad4cb962f8540d166e59d3e2ddce8a22979b49f108956'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libmpack/1.0.5_armv7l/libmpack-1.0.5-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libmpack/1.0.5_armv7l/libmpack-1.0.5-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libmpack/1.0.5_i686/libmpack-1.0.5-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libmpack/1.0.5_x86_64/libmpack-1.0.5-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '9b657165f886604233c07ce4c441c3d10cf6452ae736de3bb9d137c39fda5526',
+     armv7l: '9b657165f886604233c07ce4c441c3d10cf6452ae736de3bb9d137c39fda5526',
+       i686: '2e56cc0bb40917c96f0458535e3c91d41e03f2495359e8549593fd5385c22de6',
+     x86_64: '03342ec096b7cd7c2d3651b0f0f339f2f254ca3b06c8f3b2336968087dcb3ecd'
+  })
+
+  def self.build
+    system "#{CREW_ENV_OPTIONS} make PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX}"
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} make install PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX}"
+  end
+end

--- a/packages/libtermkey.rb
+++ b/packages/libtermkey.rb
@@ -1,0 +1,37 @@
+# Adapted from Arch Linux libtermkey PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/libtermkey/trunk/PKGBUILD
+
+require 'package'
+
+class Libtermkey < Package
+  description 'Library for easy processing of keyboard entry from terminal-based programs'
+  homepage 'http://www.leonerd.org.uk/code/libtermkey'
+  version '0.22'
+  license 'MIT'
+  compatibility 'all'
+  source_url 'http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.22.tar.gz'
+  source_sha256 '6945bd3c4aaa83da83d80a045c5563da4edd7d0374c62c0d35aec09eb3014600'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtermkey/0.22_armv7l/libtermkey-0.22-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtermkey/0.22_armv7l/libtermkey-0.22-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtermkey/0.22_i686/libtermkey-0.22-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtermkey/0.22_x86_64/libtermkey-0.22-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: 'a6b1aa10ee1938f39b622256fe7afc6676efd607910df87ac19270caf88919a7',
+     armv7l: 'a6b1aa10ee1938f39b622256fe7afc6676efd607910df87ac19270caf88919a7',
+       i686: '81e147cc8748cf399b9db7fd5aafffd1e1d3040222157773d6d78c753329e551',
+     x86_64: '60bc1246305e3d00fbf172b1d062aefcc5bc40ea54859d360fa0faee587c6cd4'
+  })
+
+  depends_on 'unibilium'
+
+  def self.build
+    system "make PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX}"
+  end
+
+  def self.install
+    system "make PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX} DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end

--- a/packages/libuv.rb
+++ b/packages/libuv.rb
@@ -3,24 +3,24 @@ require 'package'
 class Libuv < Package
   description 'libuv is a multi-platform support library with a focus on asynchronous I/O.'
   homepage 'https://libuv.org/'
-  @_ver = '1.42.0'
+  @_ver = '1.44.2'
   version @_ver
   license 'BSD, BSD-2, ISC and MIT'
   compatibility 'all'
   source_url "https://dist.libuv.org/dist/v#{@_ver}/libuv-v#{@_ver}.tar.gz"
-  source_sha256 '43129625155a8aed796ebe90b8d4c990a73985ec717de2b2d5d3a23cfe4deb72'
+  source_sha256 'ccfcdc968c55673c6526d8270a9c8655a806ea92468afcbcabc2b16040f03cb4'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libuv/1.42.0_armv7l/libuv-1.42.0-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libuv/1.42.0_armv7l/libuv-1.42.0-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libuv/1.42.0_i686/libuv-1.42.0-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libuv/1.42.0_x86_64/libuv-1.42.0-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libuv/1.44.2_armv7l/libuv-1.44.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libuv/1.44.2_armv7l/libuv-1.44.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libuv/1.44.2_i686/libuv-1.44.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libuv/1.44.2_x86_64/libuv-1.44.2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '2d9e73560c0285b089bca9c16285a54d550427ed63beeccc67b8e342298af8b6',
-     armv7l: '2d9e73560c0285b089bca9c16285a54d550427ed63beeccc67b8e342298af8b6',
-       i686: 'f050af38e8f6a434b062126afc279c74f83b91f553cc631c9712fbc3275d0847',
-     x86_64: '2e7162ae796316fac9bb5f2fe1cbcb0e13f4da6d35d5b89cc2f7f402aa17fbfd'
+    aarch64: 'b323b1255d8f8bb03b218cf3c271b16f0e70e2e9d8d7eb350ad7a099785b3552',
+     armv7l: 'b323b1255d8f8bb03b218cf3c271b16f0e70e2e9d8d7eb350ad7a099785b3552',
+       i686: '7735507974c9e44dd4d92285e62de13917bd8fedaeb4ea3eede2880e25328e75',
+     x86_64: '5e2a57c818451af267468a254de305595c86003f1f9160fd13205282cc1ab400'
   })
 
   def self.build
@@ -35,9 +35,9 @@ class Libuv < Package
   end
 
   # udp_multicast_join and udp_multicast_join6 tests fail
-  # def self.check
-  #   system "samu -C builddir test"
-  # end
+  def self.check
+    system 'samu -C builddir test || true'
+  end
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"

--- a/packages/libvterm.rb
+++ b/packages/libvterm.rb
@@ -1,0 +1,38 @@
+# Adapted from Arch Linux libvterm PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/libvterm/trunk/PKGBUILD
+
+require 'package'
+
+class Libvterm < Package
+  description 'Abstract library implementation of a VT220/xterm/ECMA-48 terminal emulator'
+  homepage 'https://www.leonerd.org.uk/code/libvterm/'
+  version '0.2'
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://www.leonerd.org.uk/code/libvterm/libvterm-0.2.tar.gz'
+  source_sha256 '4c5150655438cfb8c57e7bd133041140857eb04defd0e544521c0e469258e105'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libvterm/0.2_armv7l/libvterm-0.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libvterm/0.2_armv7l/libvterm-0.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libvterm/0.2_i686/libvterm-0.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libvterm/0.2_x86_64/libvterm-0.2-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: 'd6657b597dcd4cbe25c765ac04acdaa3962809921bcdb1d439f794481d112374',
+     armv7l: 'd6657b597dcd4cbe25c765ac04acdaa3962809921bcdb1d439f794481d112374',
+       i686: '043f3366932dff21028fc1042b6d3f0506160645413a311079284df9356939ec',
+     x86_64: '51a0aa91d1c4ca302c621afae3b379d40a2c66fd82ad9b64327177af9e016956'
+  })
+
+  depends_on 'glibc'
+  depends_on 'git' => :build
+
+  def self.build
+    system "make PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX}"
+  end
+
+  def self.install
+    system "make PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX} DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end

--- a/packages/lua.rb
+++ b/packages/lua.rb
@@ -3,23 +3,23 @@ require 'package'
 class Lua < Package
   description 'Lua is a powerful, efficient, lightweight, embeddable scripting language.'
   homepage 'https://www.lua.org/'
-  version '5.4.3'
+  version '5.4.4'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://www.lua.org/ftp/lua-5.4.3.tar.gz'
-  source_sha256 'f8612276169e3bfcbcfb8f226195bfc6e466fe13042f1076cbde92b7ec96bbfb'
+  source_url 'https://www.lua.org/ftp/lua-5.4.4.tar.gz'
+  source_sha256 '164c7849653b80ae67bec4b7473b884bf5cc8d2dca05653475ec2ed27b9ebf61'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lua/5.4.3_armv7l/lua-5.4.3-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lua/5.4.3_armv7l/lua-5.4.3-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lua/5.4.3_i686/lua-5.4.3-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lua/5.4.3_x86_64/lua-5.4.3-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lua/5.4.4_armv7l/lua-5.4.4-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lua/5.4.4_armv7l/lua-5.4.4-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lua/5.4.4_i686/lua-5.4.4-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lua/5.4.4_x86_64/lua-5.4.4-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '2cbf9670bd0a9388537d70d5559ff0505d31b6be36e85ccec0077ddb4f3fd3e3',
-     armv7l: '2cbf9670bd0a9388537d70d5559ff0505d31b6be36e85ccec0077ddb4f3fd3e3',
-       i686: '828d08293bb955aa2daa222fb6295a3c8f002c6ddd147d4d067129bed6b6e706',
-     x86_64: 'a1e7d87857e5ea2be3988975750e4af3cb881643bd751beb316b19f9305f5b88'
+    aarch64: 'dbf346d9ed69edd4e33914a98eae83badbdf2c6c3470b24118844d76154426bf',
+     armv7l: 'dbf346d9ed69edd4e33914a98eae83badbdf2c6c3470b24118844d76154426bf',
+       i686: 'a45a506c23fc52d59a6e888dddaffa9089668d080cc5d274963ecd634db3aa09',
+     x86_64: '88a629ca4d1efb18452ff8481bb1113e6d53115a713faebc508586a1f6f09b59'
   })
 
   def self.build
@@ -28,7 +28,8 @@ class Lua < Package
 
   def self.install
     system "make PREFIX=#{CREW_PREFIX} \
-            LIBDIR=#{CREW_LIB_PREFIX} \
+            INSTALL_LIB=#{CREW_DEST_LIB_PREFIX} \
+            INSTALL_MAN=#{CREW_DEST_MAN_PREFIX}/man1 \
             INSTALL_TOP=#{CREW_DEST_PREFIX} \
             install"
   end

--- a/packages/luajit.rb
+++ b/packages/luajit.rb
@@ -7,6 +7,7 @@ class Luajit < Package
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/openresty/luajit2.git'
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luajit/2.1-20220411_armv7l/luajit-2.1-20220411-chromeos-armv7l.tar.zst',
@@ -20,8 +21,6 @@ class Luajit < Package
        i686: '747299199b1011f83b77c0e142052811bb0f4736a1ec834062ff6f1c36338951',
      x86_64: 'ad76e59f1079539a74159d81563ed7d23f5e333661d63a46cc3f6508d8fd8c5e'
   })
-
-  git_hashtag "v#{version}"
 
   def self.build
     system 'make', "PREFIX=#{CREW_PREFIX}", "MULTILIB=#{ARCH_LIB}"

--- a/packages/luajit.rb
+++ b/packages/luajit.rb
@@ -2,25 +2,26 @@ require 'package'
 
 class Luajit < Package
   description 'LuaJIT is a Just-In-Time Compiler (JIT) for the Lua programming language.'
-  homepage 'http://luajit.org/'
-  version '2.0.5-2'
+  homepage 'https://github.com/openresty/luajit2'
+  version '2.1-20220411'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://luajit.org/download/LuaJIT-2.0.5.tar.gz'
-  source_sha256 '874b1f8297c697821f561f9b73b57ffd419ed8f4278c82e05b48806d30c1e979'
+  source_url 'https://github.com/openresty/luajit2.git'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luajit/2.0.5-2_armv7l/luajit-2.0.5-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luajit/2.0.5-2_armv7l/luajit-2.0.5-2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luajit/2.0.5-2_i686/luajit-2.0.5-2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luajit/2.0.5-2_x86_64/luajit-2.0.5-2-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luajit/2.1-20220411_armv7l/luajit-2.1-20220411-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luajit/2.1-20220411_armv7l/luajit-2.1-20220411-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luajit/2.1-20220411_i686/luajit-2.1-20220411-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luajit/2.1-20220411_x86_64/luajit-2.1-20220411-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '0518de335a3dc8ac04d9bcbe476d3cf2f053c058737d57f6d723c31c6eb59c99',
-     armv7l: '0518de335a3dc8ac04d9bcbe476d3cf2f053c058737d57f6d723c31c6eb59c99',
-       i686: '4942a96c905bdbc35026f9737cf55e7ca9879f06bfe9923229aeeb51039fe96b',
-     x86_64: 'd95af6ff12ca102dfad963a0606b5e2181f9e3fd68788b470f21de580f52142b'
+    aarch64: '18fbd6916f9f75db3b5939997af0ef447102f49439941852c044e079d82bb611',
+     armv7l: '18fbd6916f9f75db3b5939997af0ef447102f49439941852c044e079d82bb611',
+       i686: '747299199b1011f83b77c0e142052811bb0f4736a1ec834062ff6f1c36338951',
+     x86_64: 'ad76e59f1079539a74159d81563ed7d23f5e333661d63a46cc3f6508d8fd8c5e'
   })
+
+  git_hashtag "v#{version}"
 
   def self.build
     system 'make', "PREFIX=#{CREW_PREFIX}", "MULTILIB=#{ARCH_LIB}"
@@ -28,7 +29,5 @@ class Luajit < Package
 
   def self.install
     system 'make', "PREFIX=#{CREW_PREFIX}", "MULTILIB=#{ARCH_LIB}", "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    system "ln -sf #{CREW_LIB_PREFIX}/libluajit-5.1.so.2.0.5 #{CREW_DEST_LIB_PREFIX}/libluajit-5.1.so.2"
-    system "ln -sf #{CREW_LIB_PREFIX}/libluajit-5.1.so.2.0.5 #{CREW_DEST_LIB_PREFIX}/libluajit-5.1.so"
   end
 end

--- a/packages/luajit_bitop.rb
+++ b/packages/luajit_bitop.rb
@@ -13,10 +13,16 @@ class Luajit_bitop < Package
   source_sha256 '1207c9293dcd52eb9dca6538d1b87352bd510f4e760938f5048433f7f272ce99'
 
   binary_url({
-    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luajit_bitop/1.0.2_x86_64/luajit_bitop-1.0.2-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luajit_bitop/1.0.2_armv7l/luajit_bitop-1.0.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luajit_bitop/1.0.2_armv7l/luajit_bitop-1.0.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luajit_bitop/1.0.2_i686/luajit_bitop-1.0.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luajit_bitop/1.0.2_x86_64/luajit_bitop-1.0.2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    x86_64: '1a28bc3fee7fe66bc29ac30f9a2d124e9955a5cd13d316a62aba5faa442969f8'
+    aarch64: '63df810db9bf29d11a124d7b7097c41602009a79be424ac1aa7bc435d0332eee',
+     armv7l: '63df810db9bf29d11a124d7b7097c41602009a79be424ac1aa7bc435d0332eee',
+       i686: '537c01093f1ae3389d732123af0dd75fe2e41d46bcaa2707afe1fc9dabc89526',
+     x86_64: '381bc79e24437a48a253e5227ab757775fcc18b36d591955a5b4d867e6b60bea'
   })
 
   depends_on 'luajit'
@@ -109,6 +115,9 @@ class Luajit_bitop < Package
     PATCH_EOF
     File.write('lua53.patch', @lua53patch)
     system 'patch -p 1 -i lua53.patch'
+    system "sed -i 's,LUA= lua,LUA= luajit,g' Makefile"
+    @lua_cflags = `pkg-config --cflags luajit`.chomp
+    system "sed -i 's,-I/usr/local/include,#{@lua_cflags},g' Makefile"
   end
 
   def self.build

--- a/packages/luajit_bitop.rb
+++ b/packages/luajit_bitop.rb
@@ -1,0 +1,123 @@
+# Adapted from Arch Linux lua-bitop PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/lua-bitop/trunk/PKGBUILD
+
+require 'package'
+
+class Luajit_bitop < Package
+  description 'Bitwise operations on numbers'
+  homepage 'https://bitop.luajit.org/'
+  version '1.0.2'
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://bitop.luajit.org/download/LuaBitOp-1.0.2.tar.gz'
+  source_sha256 '1207c9293dcd52eb9dca6538d1b87352bd510f4e760938f5048433f7f272ce99'
+
+  binary_url({
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luajit_bitop/1.0.2_x86_64/luajit_bitop-1.0.2-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    x86_64: '1a28bc3fee7fe66bc29ac30f9a2d124e9955a5cd13d316a62aba5faa442969f8'
+  })
+
+  depends_on 'luajit'
+
+  def self.patch
+    # Patch from https://github.com/LuaJIT/LuaJIT/issues/384#issue-290243677
+    @lua53patch = <<~'PATCH_EOF'
+      diff -ur LuaBitOp-1.0.2/bit.c LuaBitOp-1.0.3/bit.c
+      --- LuaBitOp-1.0.2/bit.c	2012-05-08 15:15:00.000000000 -0400
+      +++ LuaBitOp-1.0.3/bit.c	2018-01-20 21:41:00.037749052 -0500
+      @@ -26,7 +26,7 @@
+       ** [ MIT license: http://www.opensource.org/licenses/mit-license.php ]
+       */
+
+      -#define LUA_BITOP_VERSION	"1.0.2"
+      +#define LUA_BITOP_VERSION	"1.0.3"
+
+       #define LUA_LIB
+       #include "lua.h"
+      @@ -46,7 +46,7 @@
+
+       typedef union {
+         lua_Number n;
+      -#ifdef LUA_NUMBER_DOUBLE
+      +#if defined(LUA_NUMBER_DOUBLE) || defined(LUA_FLOAT_DOUBLE)
+         uint64_t b;
+       #else
+         UBits b;
+      @@ -63,24 +63,25 @@
+       #else
+         bn.n = luaL_checknumber(L, idx);
+       #endif
+      -#if defined(LUA_NUMBER_DOUBLE)
+      +#if defined(LUA_NUMBER_DOUBLE) || defined(LUA_FLOAT_DOUBLE)
+         bn.n += 6755399441055744.0;  /* 2^52+2^51 */
+       #ifdef SWAPPED_DOUBLE
+         b = (UBits)(bn.b >> 32);
+       #else
+         b = (UBits)bn.b;
+       #endif
+      -#elif defined(LUA_NUMBER_INT) || defined(LUA_NUMBER_LONG) || \
+      -      defined(LUA_NUMBER_LONGLONG) || defined(LUA_NUMBER_LONG_LONG) || \
+      -      defined(LUA_NUMBER_LLONG)
+      +#elif defined(LUA_NUMBER_INT)       || defined(LUA_INT_INT) || \
+      +      defined(LUA_NUMBER_LONG)      || defined(LUA_INT_LONG) || \
+      +      defined(LUA_NUMBER_LONGLONG)  || defined(LUA_INT_LONGLONG) || \
+      +      defined(LUA_NUMBER_LONG_LONG) || defined(LUA_NUMBER_LLONG)
+         if (sizeof(UBits) == sizeof(lua_Number))
+           b = bn.b;
+         else
+           b = (UBits)(SBits)bn.n;
+      -#elif defined(LUA_NUMBER_FLOAT)
+      +#elif defined(LUA_NUMBER_FLOAT) || defined(LUA_FLOAT_FLOAT)
+       #error "A 'float' lua_Number type is incompatible with this library"
+       #else
+      -#error "Unknown number type, check LUA_NUMBER_* in luaconf.h"
+      +#error "Unknown number type, check LUA_NUMBER_*, LUA_FLOAT_*, LUA_INT_* in luaconf.h"
+       #endif
+       #if LUA_VERSION_NUM < 502
+         if (b == 0 && !lua_isnumber(L, idx)) {
+      @@ -91,7 +92,11 @@
+       }
+
+       /* Return bit type. */
+      +#if LUA_VERSION_NUM < 503
+       #define BRET(b)  lua_pushnumber(L, (lua_Number)(SBits)(b)); return 1;
+      +#else
+      +#define BRET(b)  lua_pushinteger(L, (lua_Integer)(SBits)(b)); return 1;
+      +#endif
+
+       static int bit_tobit(lua_State *L) { BRET(barg(L, 1)) }
+       static int bit_bnot(lua_State *L) { BRET(~barg(L, 1)) }
+      @@ -163,11 +168,15 @@
+       LUALIB_API int luaopen_bit(lua_State *L)
+       {
+         UBits b;
+      +#if LUA_VERSION_NUM < 503
+         lua_pushnumber(L, (lua_Number)1437217655L);
+      +#else
+      +  lua_pushinteger(L, (lua_Integer)1437217655L);
+      +#endif
+         b = barg(L, -1);
+         if (b != (UBits)1437217655L || BAD_SAR) {  /* Perform a simple self-test. */
+           const char *msg = "compiled with incompatible luaconf.h";
+      -#ifdef LUA_NUMBER_DOUBLE
+      +#if defined(LUA_NUMBER_DOUBLE) || defined(LUA_FLOAT_DOUBLE)
+       #ifdef _WIN32
+           if (b == (UBits)1610612736L)
+             msg = "use D3DCREATE_FPU_PRESERVE with DirectX";
+    PATCH_EOF
+    File.write('lua53.patch', @lua53patch)
+    system 'patch -p 1 -i lua53.patch'
+  end
+
+  def self.build
+    system "#{CREW_ENV_OPTIONS} make PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX} LUA=#{CREW_PREFIX}/bin/luajit"
+  end
+
+  def self.install
+    @lua_version = `luajit -e "print(_VERSION)" | awk '{print $2}'`.chomp
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/lib/lua/#{@lua_version}"
+    FileUtils.install 'bit.so', "#{CREW_DEST_PREFIX}/lib/lua/#{@lua_version}/bit.so", mode: 0o755
+  end
+end

--- a/packages/luajit_lpeg.rb
+++ b/packages/luajit_lpeg.rb
@@ -1,0 +1,46 @@
+# Adapted from Arch Linux lpeg PKGBUILD at:
+# https://github.com/archlinux/svntogit-packages/raw/packages/lpeg/trunk/PKGBUILD
+
+require 'package'
+
+class Luajit_lpeg < Package
+  description 'Pattern-matching library for Lua 5.1'
+  homepage 'http://www.inf.puc-rio.br/~roberto/lpeg'
+  version '1.0.2'
+  license 'MIT'
+  compatibility 'all'
+  source_url 'http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-1.0.2.tar.gz'
+  source_sha256 '48d66576051b6c78388faad09b70493093264588fcd0f258ddaab1cdd4a15ffe'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luajit_lpeg/1.0.2_armv7l/luajit_lpeg-1.0.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luajit_lpeg/1.0.2_armv7l/luajit_lpeg-1.0.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luajit_lpeg/1.0.2_i686/luajit_lpeg-1.0.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luajit_lpeg/1.0.2_x86_64/luajit_lpeg-1.0.2-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: 'd8e6f79a92c8d8c5bc189088bda5de3816d25bfde61538a7189ff8b90ba72363',
+     armv7l: 'd8e6f79a92c8d8c5bc189088bda5de3816d25bfde61538a7189ff8b90ba72363',
+       i686: '64ee5bb516995be8456dd8795eda03093d13317f391bb4dfe8682fb2a2520daa',
+     x86_64: '26842c281045e696a7476cc2f659a38e5e25db3ce5606ce05e27c2bd95934594'
+  })
+
+  depends_on 'luajit'
+
+  def self.patch
+    @lua_cflags = `pkg-config --cflags luajit`.chomp
+    system "sed -i 's,-I\$(LUADIR),#{@lua_cflags},g' makefile"
+  end
+
+  def self.build
+    system "#{CREW_ENV_OPTIONS} make PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX} LUA=#{CREW_PREFIX}/bin/luajit"
+  end
+
+  def self.install
+    @lua_version = `luajit -e "print(_VERSION)" | awk '{print $2}'`.chomp
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/lib/lua/#{@lua_version}"
+    FileUtils.install 'lpeg.so', "#{CREW_DEST_PREFIX}/lib/lua/#{@lua_version}/lpeg.so", mode: 0o755
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/lua/#{@lua_version}"
+    FileUtils.install 're.lua', "#{CREW_DEST_PREFIX}/share/lua/#{@lua_version}", mode: 0o644
+  end
+end

--- a/packages/luajit_mpack.rb
+++ b/packages/luajit_mpack.rb
@@ -26,7 +26,7 @@ class Luajit_mpack < Package
   })
 
   depends_on 'libmpack'
-  depends_on 'luajit' => ':build'
+  depends_on 'luajit' => :build
 
   def self.build
     system "#{CREW_ENV_OPTIONS} make PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX} LUA=#{CREW_PREFIX}/bin/luajit USE_SYSTEM_LUA=yes LUA_INCLUDE=`pkg-config --cflags luajit`"

--- a/packages/luajit_mpack.rb
+++ b/packages/luajit_mpack.rb
@@ -1,0 +1,40 @@
+# Adapted from Arch Linux lua-mpack PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/lua-mpack/trunk/PKGBUILD
+
+require 'package'
+
+class Luajit_mpack < Package
+  description 'libmpack lua binding'
+  homepage 'https://github.com/libmpack/libmpack-lua'
+  version '1.0.9'
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://github.com/libmpack/libmpack-lua/archive/1.0.9.tar.gz'
+  source_sha256 'e94d5cf95d7479dca00ff23755fe05a440f11f9d203635e862ad8842de95f40a'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luajit_mpack/1.0.9_armv7l/luajit_mpack-1.0.9-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luajit_mpack/1.0.9_armv7l/luajit_mpack-1.0.9-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luajit_mpack/1.0.9_i686/luajit_mpack-1.0.9-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luajit_mpack/1.0.9_x86_64/luajit_mpack-1.0.9-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '1be27ef45bfaf01f91a0be5ff9a4515224176a0c480bc1b475b4ab9e2519f46b',
+     armv7l: '1be27ef45bfaf01f91a0be5ff9a4515224176a0c480bc1b475b4ab9e2519f46b',
+       i686: '86fb45f1d5eb2ed5edb9bd291bf05f4d58730007e6adb067d544a26feb01bf3e',
+     x86_64: '4f23373e477afd0e99dc27cce8bbb8340478f98b1a96b30cdc43740523d11422'
+  })
+
+  depends_on 'libmpack'
+  depends_on 'luajit' => ':build'
+
+  def self.build
+    system "#{CREW_ENV_OPTIONS} make PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX} LUA=#{CREW_PREFIX}/bin/luajit USE_SYSTEM_LUA=yes LUA_INCLUDE=`pkg-config --cflags luajit`"
+  end
+
+  def self.install
+    @lua_version = `luajit -e "print(_VERSION)" | awk '{print $2}'`.chomp
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/lib/lua/#{@lua_version}"
+    FileUtils.install 'mpack.so', "#{CREW_DEST_PREFIX}/lib/lua/#{@lua_version}/mpack.so", mode: 0o755
+  end
+end

--- a/packages/msgpack_c.rb
+++ b/packages/msgpack_c.rb
@@ -1,0 +1,55 @@
+# Adapted from Arch Linux msgpack-c PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/msgpack-c/trunk/PKGBUILD
+
+require 'package'
+
+class Msgpack_c < Package
+  description 'An efficient object serialization library'
+  homepage 'https://msgpack.org/'
+  version '4.0.0'
+  license 'custom:Boost'
+  compatibility 'all'
+  source_url 'https://github.com/msgpack/msgpack-c/releases/download/c-4.0.0/msgpack-c-4.0.0.tar.gz'
+  source_sha256 '420fe35e7572f2a168d17e660ef981a589c9cbe77faa25eb34a520e1fcc032c8'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/msgpack_c/4.0.0_armv7l/msgpack_c-4.0.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/msgpack_c/4.0.0_armv7l/msgpack_c-4.0.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/msgpack_c/4.0.0_i686/msgpack_c-4.0.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/msgpack_c/4.0.0_x86_64/msgpack_c-4.0.0-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '6f135003a98c4c33e936257a416166187753d66618c8663176e60950314bbffd',
+     armv7l: '6f135003a98c4c33e936257a416166187753d66618c8663176e60950314bbffd',
+       i686: '54e7a62e5a889d34046131de43601a41762ce54fdc90751043e4b8bb4a3e8fdf',
+     x86_64: 'c4ce44f936fa4f393446b3193aca6cf911d23fc95c409a5d02ba500afe36706c'
+  })
+
+  depends_on 'cmake' => ':build'
+  depends_on 'doxygen' => ':build'
+  depends_on 'graphviz' => ':build'
+
+  def self.patch
+    system "sed -i 's,exec_prefix}/lib,exec_prefix}/#{ARCH_LIB},g' CMakeLists.txt"
+    system "sed -i 's,CMAKE_INSTALL_PREFIX}/lib,CMAKE_INSTALL_PREFIX}/#{ARCH_LIB},g' CMakeLists.txt"
+    system "sed -i 's,CMAKE_INSTALL_LIBDIR lib,CMAKE_INSTALL_LIBDIR #{ARCH_LIB},g' CMakeLists.txt"
+  end
+
+  def self.build
+    FileUtils.mkdir('builddir')
+    Dir.chdir('builddir') do
+      system "cmake #{CREW_CMAKE_OPTIONS} \
+      -DCMAKE_C_STANDARD='17' \
+      -DBUILD_SHARED_LIBS=ON \
+      -DMSGPACK_ENABLE_STATIC=OFF \
+      -DMSGPACK_BUILD_EXAMPLES=OFF \
+      -DMSGPACK_BUILD_TESTS=OFF \
+      ../ -G Ninja"
+    end
+    system 'samu -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
+  end
+end

--- a/packages/msgpack_c.rb
+++ b/packages/msgpack_c.rb
@@ -25,9 +25,9 @@ class Msgpack_c < Package
      x86_64: 'c4ce44f936fa4f393446b3193aca6cf911d23fc95c409a5d02ba500afe36706c'
   })
 
-  depends_on 'cmake' => ':build'
-  depends_on 'doxygen' => ':build'
-  depends_on 'graphviz' => ':build'
+  depends_on 'cmake' => :build
+  depends_on 'doxygen' => :build
+  depends_on 'graphviz' => :build
 
   def self.patch
     system "sed -i 's,exec_prefix}/lib,exec_prefix}/#{ARCH_LIB},g' CMakeLists.txt"

--- a/packages/neovim.rb
+++ b/packages/neovim.rb
@@ -16,10 +16,10 @@ class Neovim < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/neovim/0.7.2_x86_64/neovim-0.7.2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'ad6d1e50831c384c0095da78f856c9e12e9afc7b19207a81a43f6fd77603cbdb',
-     armv7l: 'ad6d1e50831c384c0095da78f856c9e12e9afc7b19207a81a43f6fd77603cbdb',
-       i686: '65ee63d50c1a3be1ba44b16e688cec5189f2da3667322040521ca7b0f6a870c5',
-     x86_64: 'eca57df7d7ae7376b17d783edd4a1e3bc21ad567263acee44710f3e98c9d4e1b'
+    aarch64: 'e0667ab9931ffeac77dd85ebacdf6075a69dd5c13ff553826f0d028ffb6e69bd',
+     armv7l: 'e0667ab9931ffeac77dd85ebacdf6075a69dd5c13ff553826f0d028ffb6e69bd',
+       i686: 'fd140ef5fdfbb6a7253acadf7d43ff659c70e92edf4bc8c66029dea1533399db',
+     x86_64: '28c53fa96db6ad95782cb0c75f36e7ef2ae34e934d9ed5d10e73363487764b3f'
   })
 
   depends_on 'msgpack_c'

--- a/packages/neovim.rb
+++ b/packages/neovim.rb
@@ -3,35 +3,68 @@ require 'package'
 class Neovim < Package
   description 'Neovim is a refactor, and sometimes redactor, in the tradition of Vim (which itself derives from Stevie).'
   homepage 'https://neovim.io/'
-  version '0.4.4'
+  version '0.7.2'
   license 'Apache-2.0 and vim'
-  compatibility 'aarch64,armv7l,x86_64'
-  source_url 'https://github.com/neovim/neovim/archive/v0.4.4.tar.gz'
-  source_sha256 '2f76aac59363677f37592e853ab2c06151cca8830d4b3fe4675b4a52d41fc42c'
+  compatibility 'all'
+  source_url 'https://github.com/neovim/neovim.git'
+  git_hashtag "v#{version}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/neovim/0.4.4_armv7l/neovim-0.4.4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/neovim/0.4.4_armv7l/neovim-0.4.4-chromeos-armv7l.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/neovim/0.4.4_x86_64/neovim-0.4.4-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/neovim/0.7.2_armv7l/neovim-0.7.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/neovim/0.7.2_armv7l/neovim-0.7.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/neovim/0.7.2_i686/neovim-0.7.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/neovim/0.7.2_x86_64/neovim-0.7.2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '4f070268cb5386ad3cff2c3a5e7f332a79ce28335ec13f17763d2cb0c5a6083b',
-     armv7l: '4f070268cb5386ad3cff2c3a5e7f332a79ce28335ec13f17763d2cb0c5a6083b',
-     x86_64: '013241fb25fa27c2247ade5cffdc3694dcd58e4783c7b7a4bf339b92332804d5'
+    aarch64: 'ad6d1e50831c384c0095da78f856c9e12e9afc7b19207a81a43f6fd77603cbdb',
+     armv7l: 'ad6d1e50831c384c0095da78f856c9e12e9afc7b19207a81a43f6fd77603cbdb',
+       i686: '65ee63d50c1a3be1ba44b16e688cec5189f2da3667322040521ca7b0f6a870c5',
+     x86_64: 'eca57df7d7ae7376b17d783edd4a1e3bc21ad567263acee44710f3e98c9d4e1b'
   })
 
+  depends_on 'msgpack_c'
+  depends_on 'libluv'
+  depends_on 'libtermkey'
+  depends_on 'libuv'
+  depends_on 'libvterm'
+  depends_on 'luajit'
+  depends_on 'luajit_bitop'
+  depends_on 'luajit_lpeg'
+  depends_on 'luajit_mpack'
+  depends_on 'tree_sitter'
+  depends_on 'unibilium'
   depends_on 'xdg_base'
 
   def self.patch
-    system "sed -i 's,add_compile_options(-fstack-protector-strong),add_compile_options(-fstack-protector-strong)\\n    link_libraries(-fstack-protector-strong),g' CMakeLists.txt"
-    system "sed -i 's,add_compile_options(-fstack-protector --param ssp-buffer-size=4),add_compile_options(-fstack-protector --param ssp-buffer-size=4)\\n    link_libraries(-fstack-protector --param ssp-buffer-size=4),g' CMakeLists.txt"
+    # Patch from https://github.com/neovim/neovim/issues/16217#issuecomment-958641608
+    @neovimpatch = <<~'PATCH_EOF'
+      diff --git a/src/nvim/terminal.c b/src/nvim/terminal.c
+      index fb025265f..52d13fe4f 100644
+      --- a/src/nvim/terminal.c
+      +++ b/src/nvim/terminal.c
+      @@ -815,7 +815,7 @@ static int term_settermprop(VTermProp prop, VTermValue *val, void *data)
+
+         case VTERM_PROP_TITLE: {
+           buf_T *buf = handle_get_buffer(term->buf_handle);
+      -    buf_set_term_title(buf, val->string);
+      +    buf_set_term_title(buf, val->string.str);
+           break;
+         }
+    PATCH_EOF
+    File.write('neovim.patch', @neovimpatch)
+    system 'patch -p 1 -i neovim.patch'
   end
 
   def self.build
-    system 'make', 'CMAKE_BUILD_TYPE=RelWithDebInfo'
+    FileUtils.mkdir('builddir')
+    Dir.chdir('builddir') do
+      system "cmake #{CREW_CMAKE_OPTIONS} \
+        ../ -G Ninja"
+    end
+    system 'samu -C builddir'
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
   end
 end

--- a/packages/tree_sitter.rb
+++ b/packages/tree_sitter.rb
@@ -1,0 +1,48 @@
+# Adapted from Arch Linux tree-sitter PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/tree-sitter/trunk/PKGBUILD
+
+require 'package'
+
+class Tree_sitter < Package
+  description 'An incremental parsing system for programming tools'
+  homepage 'https://github.com/tree-sitter/tree-sitter'
+  version '0.20.7'
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://github.com/tree-sitter/tree-sitter.git'
+  git_hashtag "v#{version}"
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tree_sitter/0.20.7_armv7l/tree_sitter-0.20.7-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tree_sitter/0.20.7_armv7l/tree_sitter-0.20.7-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tree_sitter/0.20.7_i686/tree_sitter-0.20.7-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tree_sitter/0.20.7_x86_64/tree_sitter-0.20.7-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: 'e096d53784489397c39f249694d76e4a3f6a4b79d51a6f4b6e9a4be0d9615c5b',
+     armv7l: 'e096d53784489397c39f249694d76e4a3f6a4b79d51a6f4b6e9a4be0d9615c5b',
+       i686: '4d2c9d9708b9766c6033b4665fbee5fa87927118256acb65c2118fd0ad045bf7',
+     x86_64: '51fa29522e221124f3a6f2746b4d8bb88e2c9c110d7a31c068072c4d0c81c0fc'
+  })
+
+  depends_on 'git' => :build
+  depends_on 'rust' => :build
+
+  def self.patch
+    system "sed -i 's,PREFIX)/lib,PREFIX)/#{ARCH_LIB},' Makefile"
+  end
+
+  def self.build
+    system 'cargo fetch --locked'
+    system 'make'
+    Dir.chdir 'cli' do
+      system 'cargo build --release --locked --offline --all-features'
+    end
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} PREFIX=#{CREW_PREFIX} install"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    FileUtils.install 'target/release/tree-sitter', "#{CREW_DEST_PREFIX}/bin/tree-sitter", mode: 0o755
+  end
+end

--- a/packages/unibilium.rb
+++ b/packages/unibilium.rb
@@ -1,0 +1,42 @@
+# Adapted from Arch Linux unibilium PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/unibilium/trunk/PKGBUILD
+
+require 'package'
+
+class Unibilium < Package
+  description 'A terminfo parsing library'
+  homepage 'https://github.com/neovim/unibilium'
+  version '2.1.1'
+  license 'LGPL3'
+  compatibility 'all'
+  source_url 'https://github.com/neovim/unibilium/archive/v2.1.1.tar.gz'
+  source_sha256 '6f0ee21c8605340cfbb458cbd195b4d074e6d16dd0c0e12f2627ca773f3cabf1'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/unibilium/2.1.1_armv7l/unibilium-2.1.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/unibilium/2.1.1_armv7l/unibilium-2.1.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/unibilium/2.1.1_i686/unibilium-2.1.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/unibilium/2.1.1_x86_64/unibilium-2.1.1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '5ef4d9793a3679dc58bc75b493745d8821c10c0476f0f2734e2e2bdd60fd106d',
+     armv7l: '5ef4d9793a3679dc58bc75b493745d8821c10c0476f0f2734e2e2bdd60fd106d',
+       i686: 'ce3d2b5f614521d8b081720a9965564d19d3aca3d37fa41afaefc11452c2b17d',
+     x86_64: 'f6531c4268d66b85dabce905041344c4166612823436e48aeb395ddefe58b732'
+  })
+
+  depends_on 'glibc'
+
+  def self.build
+    FileUtils.mkdir('builddir')
+    Dir.chdir('builddir') do
+      system "cmake #{CREW_CMAKE_OPTIONS} \
+        ../ -G Ninja"
+    end
+    system 'samu -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -3880,7 +3880,7 @@ activity: none
 ---
 kind: url
 name: libluv
-url: https://github.com/luvit/luv
+url: https://github.com/luvit/luv/releases
 activity: low
 ---
 kind: url
@@ -3965,7 +3965,7 @@ activity: low
 ---
 kind: url
 name: libmpack
-url: https://github.com/libmpack/libmpack
+url: https://github.com/libmpack/libmpack/tags
 activity: low
 ---
 kind: url
@@ -4356,7 +4356,7 @@ activity: none
 kind: url
 name: libtermkey
 url: http://www.leonerd.org.uk/code/libtermkey
-activity: low
+activity: none
 ---
 kind: url
 name: libticables2
@@ -4505,7 +4505,7 @@ activity: low
 ---
 kind: url
 name: libvterm
-url: https://www.leonerd.org.uk/code/libvterm/
+url: https://bazaar.launchpad.net/~libvterm/libvterm/trunk/changes
 activity: low
 ---
 kind: url
@@ -4855,8 +4855,8 @@ activity: none
 ---
 kind: url
 namw: luajit_bitop
-url: https://bitop.luajit.org/
-activity: low
+url: https://bitop.luajit.org/download.html
+activity: none
 ---
 kind: url
 name: luajit_lpeg
@@ -4865,7 +4865,7 @@ activity: low
 ---
 kind: url
 name: luajit_mpack
-url: https://github.com/libmpack/libmpack-lua
+url: https://github.com/libmpack/libmpack-lua/releases
 activity: low
 ---
 kind: url

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -3879,6 +3879,11 @@ url: https://www.gnupg.org/ftp/gcrypt/libksba
 activity: none
 ---
 kind: url
+name: libluv
+url: https://github.com/luvit/luv
+activity: low
+---
+kind: url
 name: libmad
 url: ftp://ftp.mars.org/pub/mpeg/
 activity: none
@@ -3956,6 +3961,11 @@ activity: none
 kind: url
 name: libmp3lame
 url: https://sourceforge.net/projects/lame/files/lame/
+activity: low
+---
+kind: url
+name: libmpack
+url: https://github.com/libmpack/libmpack
 activity: low
 ---
 kind: url
@@ -4344,6 +4354,11 @@ url: https://ftpmirror.gnu.org/libtasn1
 activity: none
 ---
 kind: url
+name: libtermkey
+url: http://www.leonerd.org.uk/code/libtermkey
+activity: low
+---
+kind: url
 name: libticables2
 url: https://sourceforge.net/projects/tilp/files/tilp2-linux/
 activity: none
@@ -4486,6 +4501,11 @@ activity: low
 kind: url
 name: libvpx
 url: https://github.com/webmproject/libvpx/releases
+activity: low
+---
+kind: url
+name: libvterm
+url: https://www.leonerd.org.uk/code/libvterm/
 activity: low
 ---
 kind: url
@@ -4832,6 +4852,21 @@ kind: url
 name: luajit
 url: https://luajit.org/download.html
 activity: none
+---
+kind: url
+namw: luajit_bitop
+url: https://bitop.luajit.org/
+activity: low
+---
+kind: url
+name: luajit_lpeg
+url: http://www.inf.puc-rio.br/~roberto/lpeg
+activity: low
+---
+kind: url
+name: luajit_mpack
+url: https://github.com/libmpack/libmpack-lua
+activity: low
 ---
 kind: url
 name: lv2
@@ -5182,6 +5217,11 @@ kind: url
 name: mpv
 url: https://github.com/mpv-player/mpv/releases
 activity: high
+---
+kind: url
+name: msgpack_c
+url: https://msgpack.org/
+activity: low
 ---
 kind: url
 name: msttcorefonts


### PR DESCRIPTION
Fixes #7367

- update neovim to current
- update luajit to a repo which hasn't been abandoned
- fix lua library paths and update package
- add necessary dependencies for neovim, with relevant Lua packages built against luajit.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=neovim  CREW_TESTING=1 crew update
```
![image](https://user-images.githubusercontent.com/1096701/188517358-508a6fc5-fb41-4c7c-b21d-44ef226be550.png)

