### PR TITLE
libxml2 -> 2.10.2, disable patchelf

### DIFF
--- a/packages/libxml2.rb
+++ b/packages/libxml2.rb
@@ -3,29 +3,30 @@ require 'package'
 class Libxml2 < Package
   description 'Libxml2 is the XML C parser and toolkit developed for the Gnome project.'
   homepage 'http://xmlsoft.org/'
-  version '2.10.0'
+  version '2.10.2'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.10.0/libxml2-v2.10.0.tar.bz2'
-  source_sha256 'c44124d025162767a1d3fe35b556c5855e6be7240e3dc3159490e91d5cadbba3'
+  source_url 'https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.10.2/libxml2-v2.10.2.tar.bz2'
+  source_sha256 'd50e8a55b2797501929d3411b81d5d37ec44e9a4aa58eae9052572977c632d7a'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.10.0_armv7l/libxml2-2.10.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.10.0_armv7l/libxml2-2.10.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.10.0_i686/libxml2-2.10.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.10.0_x86_64/libxml2-2.10.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.10.2_armv7l/libxml2-2.10.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.10.2_armv7l/libxml2-2.10.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.10.2_i686/libxml2-2.10.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.10.2_x86_64/libxml2-2.10.2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'ef7e24bb4d42f795fe30b040bf4b9fb3e0edd1df7fe96f4bf34ce13c673bf178',
-     armv7l: 'ef7e24bb4d42f795fe30b040bf4b9fb3e0edd1df7fe96f4bf34ce13c673bf178',
-       i686: '0de66dfa80be15da9282743da640cea6d4f17c92b8d8eccaa1c119fe17fbc00b',
-     x86_64: '6e838bd7d320bc13666834eb97bd6f1532e1971a83609d0a0b522e3b78e00e7b'
+    aarch64: 'd71f1920d9c2db027f1dabf735038ef8bbcfca33d714773ae6d1049879ac9889',
+     armv7l: 'd71f1920d9c2db027f1dabf735038ef8bbcfca33d714773ae6d1049879ac9889',
+       i686: 'e1c1c121adb611590f66062919e5a15cfdd62a9da89b37105af5789660db416a',
+     x86_64: '0d463712429ba8c0d01f58ac772db9e5e1e88d47ae57f88c7e9a06e87dc8788b'
   })
 
   depends_on 'gcc'
   depends_on 'icu4c'
   depends_on 'readline'
   depends_on 'zlibpkg'
+  no_patchelf
 
   def self.patch
     # Fix encoding.c:1961:31: error: ‘TRUE’ undeclared (first use in this function)

--- a/packages/py3_libxml2.rb
+++ b/packages/py3_libxml2.rb
@@ -3,23 +3,23 @@ require 'package'
 class Py3_libxml2 < Package
   description 'Libxml2-python provides access to libxml2 and libxslt in Python.'
   homepage 'https://gitlab.gnome.org/GNOME/libxml2/'
-  version '2.10.0'
+  version '2.10.2'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.10.0/libxml2-v2.10.0.tar.bz2'
-  source_sha256 'c44124d025162767a1d3fe35b556c5855e6be7240e3dc3159490e91d5cadbba3'
+  source_url 'https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.10.2/libxml2-v2.10.2.tar.bz2'
+  source_sha256 'd50e8a55b2797501929d3411b81d5d37ec44e9a4aa58eae9052572977c632d7a'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_libxml2/2.10.0_armv7l/py3_libxml2-2.10.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_libxml2/2.10.0_armv7l/py3_libxml2-2.10.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_libxml2/2.10.0_i686/py3_libxml2-2.10.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_libxml2/2.10.0_x86_64/py3_libxml2-2.10.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_libxml2/2.10.2_armv7l/py3_libxml2-2.10.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_libxml2/2.10.2_armv7l/py3_libxml2-2.10.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_libxml2/2.10.2_i686/py3_libxml2-2.10.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_libxml2/2.10.2_x86_64/py3_libxml2-2.10.2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'f8a22b53605a67930373f64af313ffe448ccd6596f276b5af257057280f8b445',
-     armv7l: 'f8a22b53605a67930373f64af313ffe448ccd6596f276b5af257057280f8b445',
-       i686: 'de352c024364b3dc0ca187df68e6e2c397c1886aa13a886938aace1b1e7556ec',
-     x86_64: '34f173dbe2b29e9eb1e72e96b6629f92ae0d5cd5da795f3d9915054425f80dff'
+    aarch64: '198aec6c86c106f45a2d945032ec232a5650a7a5f2630da11ad9d11eb40a7592',
+     armv7l: '198aec6c86c106f45a2d945032ec232a5650a7a5f2630da11ad9d11eb40a7592',
+       i686: '16f08ba727a13268c8a0a4516a9c81f1bcc9291a81d8a4c1e5cdeb2aa6473a98',
+     x86_64: 'd5578c3e0aac30896b6f198e9b93988e055b5deca57dbaed7c9fda12b60aaa80'
   })
 
   depends_on 'libxml2'


### PR DESCRIPTION
- This is an update and a modification to help with `i686` installs.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` 

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=libxml2 CREW_TESTING=1 crew update
```
