### PR TITLE
coreutils: add libcap dep

### DIFF
--- a/packages/coreutils.rb
+++ b/packages/coreutils.rb
@@ -23,6 +23,8 @@ class Coreutils < Package
      x86_64: '905824619128baca70687e6d998debca143b8cac871e2874490dfff8d3c4e127'
   })
 
+  depends_on 'libcap' #R
+
   def self.build
     system "env #{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
     system 'make'

--- a/packages/coreutils.rb
+++ b/packages/coreutils.rb
@@ -23,7 +23,7 @@ class Coreutils < Package
      x86_64: '905824619128baca70687e6d998debca143b8cac871e2874490dfff8d3c4e127'
   })
 
-  depends_on 'libcap' #R
+  depends_on 'libcap' # R
 
   def self.build
     system "env #{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"


### PR DESCRIPTION
- This fixes an issue on `i686` where programs like `ls` break when coreutils is installed.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=coreutils CREW_TESTING=1 crew update
```
