### PR TITLE
Add binutils dependency to gcc.rb

### DIFF
--- a/packages/gcc.rb
+++ b/packages/gcc.rb
@@ -22,6 +22,7 @@ class Gcc < Package
      x86_64: '01efdcdab6bebc32fd5608f6a061c7ceebd69e9f96084293a903f5af9c3576f3'
   })
 
+  depends_on 'binutils'
   depends_on 'ccache' => :build
   depends_on 'dejagnu' => :build # for test
   depends_on 'glibc' => :build


### PR DESCRIPTION
Needed for `as`, which gcc will fail a sanity check without.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=fix1 CREW_TESTING=1 crew update
```
