### PR TITLE
Add flex dependency to binutils.rb

### DIFF
--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -23,6 +23,8 @@ class Binutils < Package
      x86_64: '441b6efece778075bf55b36b70a42379d2bd3ae056bf8a6edef5ea6989cdc95d'
   })
 
+  depends_on 'flex'
+
   def self.prebuild
     FileUtils.rm_f "#{CREW_LIB_PREFIX}/libiberty.a"
   end


### PR DESCRIPTION
Fixes the following error:
```
/usr/local/bin/ar: error while loading shared libraries: /usr/local/lib64/libfl.so.2: cannot open shared object file: No such file or directory
```
### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=fix3 CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
