### PR TITLE
libnotify -> 0.8.1

### DIFF
--- a/packages/libnotify.rb
+++ b/packages/libnotify.rb
@@ -3,29 +3,28 @@ require 'package'
 class Libnotify < Package
   description 'A library for sending desktop notifications.'
   homepage 'https://git.gnome.org/browse/libnotify'
-  @_ver = '0.7.9'
+  @_ver = '0.8.1'
   version @_ver
   license 'LGPL-2.1+'
   compatibility 'all'
   source_url "https://github.com/GNOME/libnotify/archive/#{@_ver}.tar.gz"
-  source_sha256 '9bd4f5fa911d27567e7cc2d2d09d69356c16703c4e8d22c0b49a5c45651f3af0'
+  source_sha256 '7c0b252edecbf08db50d775f9e720ecc03c742fb97c25f3966a8b7a4bedf8133'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnotify/0.7.9_armv7l/libnotify-0.7.9-chromeos-armv7l.tar.xz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnotify/0.7.9_armv7l/libnotify-0.7.9-chromeos-armv7l.tar.xz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnotify/0.7.9_i686/libnotify-0.7.9-chromeos-i686.tar.xz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnotify/0.7.9_x86_64/libnotify-0.7.9-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnotify/0.8.1_armv7l/libnotify-0.8.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnotify/0.8.1_armv7l/libnotify-0.8.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnotify/0.8.1_i686/libnotify-0.8.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnotify/0.8.1_x86_64/libnotify-0.8.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '06d8ab2630fbfae249c5bfb1e9dbd51cc57a7e1fe7c9b5297926cff9a9e4592b',
-      armv7l: '06d8ab2630fbfae249c5bfb1e9dbd51cc57a7e1fe7c9b5297926cff9a9e4592b',
-        i686: 'a12e7df177e5621731b8de4cdc714e6cc57a734e631445e4a501e7a81b90162b',
-      x86_64: '23b869cb69ff53a1eee4d2b6cd6f622400f10030404a882471f5ecdb354b38ee'
+    aarch64: 'bff49fc3b4241e28454b3b2de0a5fc0a63eeda9d7b33211e14e6edf1d4ee81e4',
+     armv7l: 'bff49fc3b4241e28454b3b2de0a5fc0a63eeda9d7b33211e14e6edf1d4ee81e4',
+       i686: 'b2d008a6f2953b66605d75b55c688b0c80bab3c53f89fab8cc64f35fa8866153',
+     x86_64: '87df4130086c957b893d67dc6833efdb37d8b8c7470dc0e26c3f70657d2e37b4'
   })
 
-  depends_on 'gtk_doc'
-  depends_on 'gtk3'
-  depends_on 'gnome_common'
+  depends_on 'gdk_pixbuf' # R
+  depends_on 'glib' # R
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \
@@ -35,7 +34,7 @@ class Libnotify < Package
     -Dgtk_doc=false \
     builddir"
     system 'meson configure builddir'
-    system 'ninja -C builddir'
+    system 'mold -run samu -C builddir'
   end
 
   def self.install


### PR DESCRIPTION
- updates to the Gnome 43 version.
- eliminate unnecessary deps

Builds properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` 

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=libnotify CREW_TESTING=1 crew update
```
