### PR TITLE
hunspell: automatic selection of language if no input

### DIFF
--- a/packages/hunspell.rb
+++ b/packages/hunspell.rb
@@ -23,7 +23,7 @@ class Hunspell < Package
         puts '2 = Français'
         puts '3 = Español'
         puts '0 = Cancel'
-        $stdin.gets.chomp
+        $stdin.getc.chomp.to_i
       end
     rescue Timeout::Error
       @user_input = 1

--- a/packages/hunspell.rb
+++ b/packages/hunspell.rb
@@ -24,9 +24,9 @@ class Hunspell < Package
 
     EOT
 
-    if STDIN.isatty # check if stdin is a terminal
+    if $stdin.isatty # check if stdin is a terminal
       @stdin_thread = Thread.new do
-        @user_input = STDIN.getc.to_i
+        @user_input = $stdin.getc.to_i
 
         Thread.kill(@countdown_thread) # stop countdown when user input
       end

--- a/packages/hunspell.rb
+++ b/packages/hunspell.rb
@@ -31,6 +31,6 @@ class Hunspell < Package
     depends_on 'hunspell_en_us' if @user_input == 1
     depends_on 'hunspell_fr_fr' if @user_input == 2
     depends_on 'hunspell_es_any' if @user_input == 3
-    abort if @user_input == 0
+    abort if @user_input.zero?
   end
 end

--- a/packages/hunspell.rb
+++ b/packages/hunspell.rb
@@ -15,7 +15,7 @@ class Hunspell < Package
     puts <<~EOT
 
       Enter your preferred language:
-      (The default, American English, will be selected in #{@timeout} seconds if there is no input.)
+      (The default, American English, will be selected if there is no input.)
 
         1 = American English
         2 = Français

--- a/packages/hunspell.rb
+++ b/packages/hunspell.rb
@@ -14,10 +14,7 @@ class Hunspell < Package
 
     puts <<~EOT
 
-      Enter your preferred language:
-      (The default, American English, will be selected if there is no input.)
-
-        1 = American English
+        1 = American English (default)
         2 = Français
         3 = Español
         0 = Cancel
@@ -26,7 +23,8 @@ class Hunspell < Package
 
     if $stdin.isatty # check if stdin is a terminal
       @stdin_thread = Thread.new do
-        @user_input = $stdin.getc.to_i
+        @user_input = $stdin.getc
+        @user_input = 1 if @user_input == "\n"
 
         Thread.kill(@countdown_thread) # stop countdown when user input
       end
@@ -34,7 +32,7 @@ class Hunspell < Package
       @countdown_thread = Thread.new do
         (0..@timeout).each do |i|
           remaining_time = @timeout - i
-          print "\r#{remaining_time} second(s) left: "
+          print "\rDefault selected in #{remaining_time} second(s).  Enter your preferred language [1 = American English]: "
 
           if remaining_time.zero?
             Thread.kill(@stdin_thread) # stop reading from terminal if timeout
@@ -49,17 +47,15 @@ class Hunspell < Package
     end
 
     case @user_input
-    when 0
+    when '0'
       abort "\nCancelled.".lightred
-    when 1
+    when '1'
       depends_on 'hunspell_en_us'
-    when 2
+    when '2'
       depends_on 'hunspell_fr_fr'
-    when 3
+    when '3'
       depends_on 'hunspell_es_any'
     else
       warn "\nSelected 'American English' by default.".yellow
       depends_on 'hunspell_en_us'
     end
-  end
-end

--- a/packages/hunspell.rb
+++ b/packages/hunspell.rb
@@ -14,10 +14,10 @@ class Hunspell < Package
 
     puts <<~EOT
 
-        1 = American English (default)
-        2 = Français
-        3 = Español
-        0 = Cancel
+      1 = American English (default)
+      2 = Français
+      3 = Español
+      0 = Cancel
 
     EOT
 
@@ -59,3 +59,5 @@ class Hunspell < Package
       warn "\nSelected 'American English' by default.".yellow
       depends_on 'hunspell_en_us'
     end
+  end
+end

--- a/packages/hunspell.rb
+++ b/packages/hunspell.rb
@@ -1,4 +1,5 @@
 require 'package'
+require 'timeout'
 
 class Hunspell < Package
   description 'Hunspell is a spell checker and morphological analyzer library'
@@ -12,27 +13,24 @@ class Hunspell < Package
   is_fake
 
   if ARGV[0] == 'install'
-    puts
-    puts 'Enter your preferred language:'
-    puts '1 = American English'
-    puts '2 = Français'
-    puts '3 = Español'
-    puts '0 = Cancel'
-
-    while version = $stdin.gets.chomp
-      case version
-      when '1'
-        depends_on 'hunspell_en_us'
-        break
-      when '2'
-        depends_on 'hunspell_fr_fr'
-        break
-      when '3'
-        depends_on 'hunspell_es_any'
-        break
-      when '0'
-        abort
+    begin
+      @timeout = 10
+      @user_input = Timeout.timeout(@timeout) do
+        puts
+        puts 'Enter your preferred language:'
+        puts "(The default, American English, will be selected in #{@timeout} seconds if there is no input.)"
+        puts '1 = American English'
+        puts '2 = Français'
+        puts '3 = Español'
+        puts '0 = Cancel'
+        $stdin.gets.chomp
       end
+    rescue Timeout::Error
+      @user_input = 1
     end
+    depends_on 'hunspell_en_us' if @user_input == 1
+    depends_on 'hunspell_fr_fr' if @user_input == 2
+    depends_on 'hunspell_es_any' if @user_input == 3
+    abort if @user_input == 0
   end
 end

--- a/packages/hunspell.rb
+++ b/packages/hunspell.rb
@@ -1,36 +1,65 @@
 require 'package'
-require 'timeout'
 
 class Hunspell < Package
   description 'Hunspell is a spell checker and morphological analyzer library'
-  homepage 'http://hunspell.github.io/'
+  homepage 'https://hunspell.github.io'
   version '1.7.0'
   license 'MPL-1.1, GPL-2 and LGPL-2.1'
   compatibility 'all'
-  source_url 'https://github.com/hunspell/hunspell/archive/v1.7.0.tar.gz'
-  source_sha256 'bb27b86eb910a8285407cf3ca33b62643a02798cf2eef468c0a74f6c3ee6bc8a'
 
   is_fake
 
-  if ARGV[0] == 'install'
-    begin
-      @timeout = 10
-      @user_input = Timeout.timeout(@timeout) do
-        puts
-        puts 'Enter your preferred language:'
-        puts "(The default, American English, will be selected in #{@timeout} seconds if there is no input.)"
-        puts '1 = American English'
-        puts '2 = Français'
-        puts '3 = Español'
-        puts '0 = Cancel'
-        $stdin.getc.chomp.to_i
+  if ARGV.include?('install') # fix when 'install' isn't in ARGV[0] (like `crew -k install`)
+    @timeout = 10
+
+    puts <<~EOT
+
+      Enter your preferred language:
+      (The default, American English, will be selected in #{@timeout} seconds if there is no input.)
+
+        1 = American English
+        2 = Français
+        3 = Español
+        0 = Cancel
+
+    EOT
+
+    if STDIN.isatty # check if stdin is a terminal
+      @stdin_thread = Thread.new do
+        @user_input = STDIN.getc.to_i
+
+        Thread.kill(@countdown_thread) # stop countdown when user input
       end
-    rescue Timeout::Error
-      @user_input = 1
+
+      @countdown_thread = Thread.new do
+        (0..@timeout).each do |i|
+          remaining_time = @timeout - i
+          print "\r#{remaining_time} second(s) left: "
+
+          if remaining_time.zero?
+            Thread.kill(@stdin_thread) # stop reading from terminal if timeout
+          else
+            sleep 1
+          end
+        end
+      end
+
+      @stdin_thread.join
+      @countdown_thread.join
     end
-    depends_on 'hunspell_en_us' if @user_input == 1
-    depends_on 'hunspell_fr_fr' if @user_input == 2
-    depends_on 'hunspell_es_any' if @user_input == 3
-    abort if @user_input.zero?
+
+    case @user_input
+    when 0
+      abort "\nCancelled.".lightred
+    when 1
+      depends_on 'hunspell_en_us'
+    when 2
+      depends_on 'hunspell_fr_fr'
+    when 3
+      depends_on 'hunspell_es_any'
+    else
+      warn "\nSelected 'American English' by default.".yellow
+      depends_on 'hunspell_en_us'
+    end
   end
 end


### PR DESCRIPTION

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=hunspell  CREW_TESTING=1 crew update
```
