### PR TITLE
cmake -> 3.24.2

### DIFF
--- a/packages/cmake.rb
+++ b/packages/cmake.rb
@@ -3,7 +3,7 @@ require 'package'
 class Cmake < Package
   description 'CMake is an open-source, cross-platform family of tools designed to build, test and package software.'
   homepage 'https://cmake.org/'
-  @_ver = '3.24.1'
+  @_ver = '3.24.2'
   version @_ver
   license 'CMake'
   compatibility 'all'
@@ -11,16 +11,16 @@ class Cmake < Package
   git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.24.1_armv7l/cmake-3.24.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.24.1_armv7l/cmake-3.24.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.24.1_i686/cmake-3.24.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.24.1_x86_64/cmake-3.24.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.24.2_armv7l/cmake-3.24.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.24.2_armv7l/cmake-3.24.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.24.2_i686/cmake-3.24.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.24.2_x86_64/cmake-3.24.2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'da3d25ea366b19967544870b483c76f6a903ab9678ac844ef77c6d3302a5ea4b',
-     armv7l: 'da3d25ea366b19967544870b483c76f6a903ab9678ac844ef77c6d3302a5ea4b',
-       i686: 'e8cbc2ee57556d44bf6857bf2bf039a139563407e352843edcf83568abf2285d',
-     x86_64: '39c47fa7e44241983b3dc86e876abd5ae7c9d17cd46f1ce9fa7a4e277a0a191c'
+    aarch64: '14b515ebc3b2fdf607975d38e193d50b61a2a3163edff069bfa266346e09bfec',
+     armv7l: '14b515ebc3b2fdf607975d38e193d50b61a2a3163edff069bfa266346e09bfec',
+       i686: '7ba3147e7d93c10f59d71c510fd49742dd2574dd8cc794ac1aede4506942e758',
+     x86_64: '017673d3425483e0e33af04c6ecb59f1a6713047a1ef9a23cb98fbbb9019d6c8'
   })
 
   depends_on 'expat'
@@ -39,16 +39,14 @@ class Cmake < Package
   def self.build
     Dir.mkdir 'builddir'
     Dir.chdir 'builddir' do
-      # mold linker breaks the build on i686, so just disable for this
-      # build
-      system "cmake \
+      system "mold -run cmake \
           -G Ninja \
-          #{CREW_CMAKE_OPTIONS.gsub('mold', 'gold')} \
+          #{CREW_CMAKE_OPTIONS} \
           -DCMAKE_USE_SYSTEM_LIBRARIES=ON \
           -DBUILD_QtDialog=NO \
           .."
     end
-    system 'ninja -C builddir'
+    system 'mold -run ninja -C builddir'
   end
 
   # Failed tests:


### PR DESCRIPTION
- Fixes builds of webit2gtk breaking.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=cmake3242 CREW_TESTING=1 crew update
```
