### PR TITLE
Git w/o musl, install.sh modified to work w/o git in bootstrap.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -215,11 +215,11 @@ function extract_install () {
     echo_intra "Extracting ${1} ..."
     if [[ "$2" == *".zst" ]];then
       if [[ -e /usr/bin/zstd ]]; then
-        PATH=/usr/bin:$PATH tar -Izstd -xpf ../"${2}"
+        tar -I /usr/bin/zstd -xpf ../"${2}"
       elif (LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} "${CREW_PREFIX}"/bin/zstd --version &> /dev/null); then
-        LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} tar -Izstd -xpf ../"${2}"
+        LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} tar -I "${CREW_PREFIX}"/bin/zstd -xpf ../"${2}"
       else
-        echo "Zstd is broken or nonfunctional, and packages can not be extracted properly."
+        echo_error "Zstd is broken or nonfunctional, and packages can not be extracted properly."
         exit 1
       fi
     elif [[ "$2" == *".tpxz" ]];then
@@ -298,7 +298,7 @@ echo -e "${RESET}"
 echo_info "Updating crew package information...\n"
 # Without setting LD_LIBRARY_PATH, the mandb postinstall fails
 # from not being able to find the gdbm library.
-export LD_LIBRARY_PATH=$(LD_LIBRARY_PATH=/usr/local/lib$LIB_SUFFIX:/usr/lib$LIB_SUFFIX:/lib$LIB_SUFFIX crew const CREW_LIB_PREFIX | sed -e 's:CREW_LIB_PREFIX=::g')
+export LD_LIBRARY_PATH=$(LD_LIBRARY_PATH=/usr/local/lib${LIB_SUFFIX}:/usr/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} crew const CREW_LIB_PREFIX | sed -e 's:CREW_LIB_PREFIX=::g')
 # Since we just ran git, just update package compatibility information.
 crew update compatible
 

--- a/install.sh
+++ b/install.sh
@@ -37,24 +37,24 @@ GRAY='\e[0;37m';   # Use Gray for program output.
 MAGENTA='\e[1;35m';
 RESET='\e[0m'
 
-# simplify colors and print errors to stderr (2)
+# Simplify colors and print errors to stderr (2).
 echo_error() { echo -e "${RED}${*}${RESET}" >&2; }
 echo_info() { echo -e "${YELLOW}${*}${RESET}" >&1; }
 echo_success() { echo -e "${GREEN}${*}${RESET}" >&1; }
 echo_intra() { echo -e "${BLUE}${*}${RESET}" >&1; }
 echo_out() { echo -e "${GRAY}${*}${RESET}" >&1; }
 
-# skip all checks if running on a docker container
+# Skip all checks if running on a docker container.
 [[ -f "/.dockerenv" ]] && CREW_FORCE_INSTALL=1
 
-# reject crostini
+# Reject crostini.
 if [[ -d /opt/google/cros-containers && "${CREW_FORCE_INSTALL}" != '1' ]]; then
   echo_error "Crostini containers are not supported by Chromebrew :/"
   echo_info "Run 'curl -Ls git.io/vddgY | CREW_FORCE_INSTALL=1 bash' to perform install anyway"
   exit 1
 fi
 
-# disallow non-stable channels Chrome OS
+# Disallow non-stable channels Chrome OS.
 if [ -f /etc/lsb-release ]; then
   if [[ ! "$(< /etc/lsb-release)" =~ CHROMEOS_RELEASE_TRACK=stable-channel$'\n' && "${CREW_FORCE_INSTALL}" != '1' ]]; then
     echo_error "The beta, dev, and canary channel are unsupported by Chromebrew"
@@ -72,26 +72,27 @@ fi
 
 echo_success "Welcome to Chromebrew!"
 
-# prompt user to enter the sudo password if it set
-# if the PASSWD_FILE specified by chromeos-setdevpasswd exist, that means a sudo password is set
+# Prompt user to enter the sudo password if it set.
+# If the PASSWD_FILE specified by chromeos-setdevpasswd exist, that means a sudo password is set.
 if [[ "$(< /usr/sbin/chromeos-setdevpasswd)" =~ PASSWD_FILE=\'([^\']+) ]] && [ -f "${BASH_REMATCH[1]}" ]; then
   echo_intra "Please enter the developer mode password"
-  # reset sudo timeout
+  # Reset sudo timeout.
   sudo -k
   sudo /bin/true
 fi
 
-# force curl to use system libraries
+# Force curl to use system libraries.
 function curl () {
-  # retry if download failed
-  # the --retry/--retry-all-errors parameter in curl will not work with the 'curl: (7) Couldn't connect to server'
-  # error, a for loop is used here
+  # Retry if download failed.
+  # The --retry/--retry-all-errors parameter in curl will not work with 
+  # the 'curl: (7) Couldn't connect to server' error, a for loop is used
+  # here.
   for (( i = 0; i < 4; i++ )); do
     env LD_LIBRARY_PATH='' ${CURL} --ssl -C - "${@}" && \
       return 0 || \
       echo_info "Retrying, $((3-$i)) retries left."
   done
-  # the download failed if we're still here
+  # The download failed if we're still here.
   echo_error "Download failed :/ Please check your network settings."
   return 1
 }
@@ -109,7 +110,7 @@ esac
 echo_info "\n\nDoing initial setup for install in ${CREW_PREFIX}."
 echo_info "This may take a while if there are preexisting files in ${CREW_PREFIX}...\n"
 
-# This will allow things to work without sudo
+# This will allow things to work without sudo.
 crew_folders="bin cache doc docbook etc include lib lib$LIB_SUFFIX libexec man sbin share tmp var"
 for folder in $crew_folders
 do
@@ -120,11 +121,12 @@ do
 done
 sudo chown "$(id -u)":"$(id -g)" "${CREW_PREFIX}"
 
-# Delete ${CREW_PREFIX}/{var,local} symlink on some Chromium OS distro if exist
+# Delete ${CREW_PREFIX}/{var,local} symlinks on some Chromium OS distro 
+# if they exist.
 [ -L ${CREW_PREFIX}/var ] && sudo rm -f "${CREW_PREFIX}/var"
 [ -L ${CREW_PREFIX}/local ] && sudo rm -f "${CREW_PREFIX}/local"
 
-# prepare directories
+# Prepare directories.
 for dir in "${CREW_CONFIG_PATH}/meta" "${CREW_DEST_DIR}" "${CREW_PACKAGES_PATH}" "${CREW_CACHE_DIR}" ; do
   if [ ! -d "${dir}" ]; then
     mkdir -p "${dir}"
@@ -133,7 +135,7 @@ done
 
 echo_info "\nDownloading information for Bootstrap packages..."
 echo -en "${GRAY}"
-# use parallel mode if available
+# Use parallel mode if available.
 if [[ "$(curl --help curl)" =~ --parallel ]]; then
   (cd "${CREW_LIB_PATH}"/packages && curl -OLZ "${URL}"/packages/{"${BOOTSTRAP_PACKAGES// /,}"}.rb)
 else
@@ -141,7 +143,7 @@ else
 fi
 echo -e "${RESET}"
 
-# prepare url and sha256
+# Prepare url and sha256.
 urls=()
 sha256s=()
 
@@ -154,7 +156,7 @@ case "${ARCH}" in
   ;;
 esac
 
-# create the device.json file if it doesn't exist
+# Create the device.json file if it doesn't exist.
 cd "${CREW_CONFIG_PATH}"
 if [ ! -f device.json ]; then
   echo_info "\nCreating new device.json."
@@ -173,10 +175,10 @@ for package in $BOOTSTRAP_PACKAGES; do
     urls+=("${BASH_REMATCH[1]}")
 done
 
-# functions to maintain packages
+# These functions are for handling packages.
 function download_check () {
     cd "$CREW_BREW_DIR"
-    # use cached file if available and caching enabled
+    # Use cached file if available and caching enabled.
     if [ -n "$CREW_CACHE_ENABLED" ] && [[ -f "$CREW_CACHE_DIR/${3}" ]] ; then
       echo_intra "Verifying cached ${1}..."
       echo_success "$(echo "${4}" "$CREW_CACHE_DIR/${3}" | sha256sum -c -)"
@@ -210,14 +212,15 @@ function download_check () {
 }
 
 function extract_install () {
-    # Start with a clean slate
+    # Start with a clean slate.
     rm -rf "${CREW_DEST_DIR}"
     mkdir "${CREW_DEST_DIR}"
     cd "${CREW_DEST_DIR}"
 
-    #extract and install
+    #Extract and install.
     echo_intra "Extracting ${1} ..."
-    if [[ "$2" == *".zst" ]];then
+    case "${2}" in
+    *.zst)
       if [[ -e /usr/bin/zstd ]]; then
         tar -I /usr/bin/zstd -xpf ../"${2}"
       elif ("${CREW_PREFIX}"/bin/zstd --version &> /dev/null); then
@@ -226,16 +229,19 @@ function extract_install () {
         echo "Zstd is broken or nonfunctional, and some packages can not be extracted properly."
         exit 1
       fi
-    elif [[ "$2" == *".tpxz" ]];then
+    ;;
+    *.tpxz)
       if "${CREW_PREFIX}"/bin/pixz -h &> /dev/null; then
         tar -I "${CREW_PREFIX}"/bin/pixz -xpf ../"${2}"
       else
         echo "Pixz is broken or nonfunctional, and some packages can not be extracted properly."
         exit 1
       fi
-    else
+    ;;
+    *)
       tar xpf ../"${2}"
-    fi
+    ;;
+    esac
     echo_intra "Installing ${1} ..."
     tar cpf - ./*/* | (cd /; tar xp --keep-directory-symlink -f -)
     mv ./dlist "${CREW_CONFIG_PATH}/meta/${1}.directorylist"
@@ -254,7 +260,7 @@ function update_device_json () {
   fi
 }
 echo_info "Downloading Bootstrap packages...\n"
-# extract, install and register packages
+# Extract, install and register packages.
 for i in $(seq 0 $((${#urls[@]} - 1))); do
   url="${urls["${i}"]}"
   sha256="${sha256s["${i}"]}"
@@ -269,8 +275,9 @@ for i in $(seq 0 $((${#urls[@]} - 1))); do
   update_device_json "${name}" "${version}"
 done
 
-## workaround https://github.com/chromebrew/chromebrew/issues/3305
-sudo ldconfig &> /dev/null || true
+## Workaround https://github.com/chromebrew/chromebrew/issues/3305
+# Maybe this isn't needed.
+# sudo ldconfig &> /dev/null || true
 echo_info "\nCreating symlink to 'crew' in ${CREW_PREFIX}/bin/"
 echo -e "${GRAY}"
 ln -sfv "../lib/crew/bin/crew" "${CREW_PREFIX}/bin/"
@@ -279,16 +286,17 @@ echo -e "${RESET}"
 echo_info "Setup and synchronize local package repo..."
 echo -e "${GRAY}"
 
-# Remove old git config directories if they exist
-rm -rf "${CREW_LIB_PATH}" && mkdir "${CREW_LIB_PATH}"
+# Remove old git config directories if they exist.
+find "${CREW_LIB_PATH}" -mindepth 1 -delete
 
-cd "${CREW_LIB_PATH}" && curl -L https://github.com/"${OWNER}"/"${REPO}"/tarball/"${BRANCH}" | tar -xz --strip-components=1
+curl -L --progress-bar https://github.com/"${OWNER}"/"${REPO}"/tarball/"${BRANCH}" | tar -xz --strip-components=1 -C "${CREW_LIB_PATH}"
 
 # Set LD_LIBRARY_PATH so crew doesn't break on i686 and
-# the mandb install doesn't fail
+# the mandb install doesn't fail.
 export LD_LIBRARY_PATH="${CREW_PREFIX}/lib${LIB_SUFFIX}"
 
-# Since we just downloaded the package repo, just update package compatibility information.
+# Since we just downloaded the package repo, just update package 
+# compatibility information.
 crew update compatible
 
 echo_info "Installing core Chromebrew packages...\n"
@@ -298,13 +306,14 @@ echo_info "\nRunning Bootstrap package postinstall scripts...\n"
 crew postinstall $BOOTSTRAP_PACKAGES
 
 echo_info "Synchronizng local package repo..."
-cd "${CREW_LIB_PATH}"/..
-rm -rf "${CREW_LIB_PATH}"
+# First clear out temporary package repo so we can replace it with the 
+# repo downloaded via git.
+find "${CREW_LIB_PATH}" -mindepth 1 -delete
 
 # Do a minimal clone, which also sets origin to the master/main branch
 # by default. For more on why this setup might be useful see:
 # https://github.blog/2020-01-17-bring-your-monorepo-down-to-size-with-sparse-checkout/
-# If using alternate branch don't use depth=1
+# If using alternate branch don't use depth=1 .
 [[ "$BRANCH" == "master" ]] && GIT_DEPTH="--depth=1" || GIT_DEPTH=
 git clone $GIT_DEPTH --filter=blob:none --no-checkout "https://github.com/${OWNER}/${REPO}.git" "${CREW_LIB_PATH}"
 
@@ -314,7 +323,7 @@ cd "${CREW_LIB_PATH}"
 [[ "$BRANCH" != "master" ]] && git fetch --all
 git checkout "${BRANCH}"
 
-# Set sparse-checkout folders
+# Set sparse-checkout folders.
 git sparse-checkout set packages lib bin crew tools
 git reset --hard origin/"${BRANCH}"
 echo -e "${RESET}"

--- a/install.sh
+++ b/install.sh
@@ -298,7 +298,7 @@ echo -e "${RESET}"
 echo_info "Updating crew package information...\n"
 # Without setting LD_LIBRARY_PATH, the mandb postinstall fails
 # from not being able to find the gdbm library.
-export LD_LIBRARY_PATH=$(crew const CREW_LIB_PREFIX | sed -e 's:CREW_LIB_PREFIX=::g')
+export LD_LIBRARY_PATH=$(LD_LIBRARY_PATH=/usr/local/lib$LIB_SUFFIX:/usr/lib$LIB_SUFFIX:/lib$LIB_SUFFIX crew const CREW_LIB_PREFIX | sed -e 's:CREW_LIB_PREFIX=::g')
 # Since we just ran git, just update package compatibility information.
 crew update compatible
 

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ CREW_PACKAGES_PATH="${CREW_LIB_PATH}/packages"
 ARCH="${ARCH/armv8l/armv7l}"
 
 # BOOTSTRAP_PACKAGES cannot depend on crew_profile_base for their core operations (completion scripts are fine)
-BOOTSTRAP_PACKAGES="zstd pixz ca_certificates git gmp ncurses xxhash lz4 popt libyaml openssl gcc rsync ruby c_ares libnghttp2 libidn2 libssh libpsl openldap brotli zlibpkg krb5 e2fsprogs libunistring pcre2 libcyrussasl libcurl"
+BOOTSTRAP_PACKAGES="zstd pixz ca_certificates git gmp ncurses xxhash lz4 popt libyaml openssl gcc rsync ruby c_ares libnghttp2 libidn2 libssh libpsl openldap brotli zlibpkg krb5 e2fsprogs libunistring pcre2 libcyrussasl libcurl glibc"
 RED='\e[1;91m';    # Use Light Red for errors.
 YELLOW='\e[1;33m'; # Use Yellow for informational messages.
 GREEN='\e[1;32m';  # Use Green for success messages.

--- a/install.sh
+++ b/install.sh
@@ -275,9 +275,6 @@ for i in $(seq 0 $((${#urls[@]} - 1))); do
   update_device_json "${name}" "${version}"
 done
 
-## Workaround https://github.com/chromebrew/chromebrew/issues/3305
-# Maybe this isn't needed.
-# sudo ldconfig &> /dev/null || true
 echo_info "\nCreating symlink to 'crew' in ${CREW_PREFIX}/bin/"
 echo -e "${GRAY}"
 ln -sfv "../lib/crew/bin/crew" "${CREW_PREFIX}/bin/"

--- a/install.sh
+++ b/install.sh
@@ -298,7 +298,7 @@ echo -e "${RESET}"
 echo_info "Updating crew package information...\n"
 # Without setting LD_LIBRARY_PATH, the mandb postinstall fails
 # from not being able to find the gdbm library.
-export LD_LIBRARY_PATH=$(LD_LIBRARY_PATH=/usr/local/lib${LIB_SUFFIX}:/usr/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} crew const CREW_LIB_PREFIX | sed -e 's:CREW_LIB_PREFIX=::g')
+export LD_LIBRARY_PATH=$(LD_LIBRARY_PATH=/usr/local/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX}:/usr/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX}:/lib:/usr/lib:/usr/local/lib crew const CREW_LIB_PREFIX | sed -e 's:CREW_LIB_PREFIX=::g')
 # Since we just ran git, just update package compatibility information.
 crew update compatible
 

--- a/install.sh
+++ b/install.sh
@@ -24,10 +24,7 @@ CREW_PACKAGES_PATH="${CREW_LIB_PATH}/packages"
 ARCH="${ARCH/armv8l/armv7l}"
 
 # BOOTSTRAP_PACKAGES cannot depend on crew_profile_base for their core operations (completion scripts are fine)
-BOOTSTRAP_PACKAGES="musl_zstd pixz ca_certificates git gmp ncurses xxhash lz4 popt libyaml openssl zstd gcc rsync ruby libcurl c_ares libnghttp2 libidn2 libssh libpsl openldap brotli zlibpkg krb5 e2fsprogs libunistring pcre2 libcyrussasl"
-
-# Add musl bin to path
-PATH=/usr/local/share/musl/bin:$PATH
+BOOTSTRAP_PACKAGES="pixz ca_certificates git gmp ncurses xxhash lz4 popt libyaml openssl zstd gcc rsync ruby libcurl c_ares libnghttp2 libidn2 libssh libpsl openldap brotli zlibpkg krb5 e2fsprogs libunistring pcre2 libcyrussasl"
 
 RED='\e[1;91m';    # Use Light Red for errors.
 YELLOW='\e[1;33m'; # Use Yellow for informational messages.
@@ -219,9 +216,8 @@ function extract_install () {
     echo_intra "Extracting ${1} ..."
     if [[ "$2" == *".zst" ]];then
       if [[ -e /usr/bin/zstd ]]; then
-        PATH=/usr/bin:/usr/local/share/musl/bin:$PATH tar -Izstd -xpf ../"${2}"
-      elif (LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} "${CREW_PREFIX}"/bin/zstd --version &> /dev/null) || \
-           (LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} "${CREW_PREFIX}"/share/musl/bin/zstd --version &> /dev/null); then
+        PATH=/usr/bin:$PATH tar -Izstd -xpf ../"${2}"
+      elif (LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} "${CREW_PREFIX}"/bin/zstd --version &> /dev/null); then
         LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} tar -Izstd -xpf ../"${2}"
       else
         echo "Zstd is broken or nonfunctional, and packages can not be extracted properly."

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ CREW_PACKAGES_PATH="${CREW_LIB_PATH}/packages"
 ARCH="${ARCH/armv8l/armv7l}"
 
 # BOOTSTRAP_PACKAGES cannot depend on crew_profile_base for their core operations (completion scripts are fine)
-BOOTSTRAP_PACKAGES="pixz ca_certificates git gmp ncurses xxhash lz4 popt libyaml openssl zstd gcc rsync ruby libcurl c_ares libnghttp2 libidn2 libssh libpsl openldap brotli zlibpkg krb5 e2fsprogs libunistring pcre2 libcyrussasl"
+BOOTSTRAP_PACKAGES="pixz ca_certificates git gmp ncurses xxhash lz4 popt libyaml openssl zstd gcc rsync ruby c_ares libnghttp2 libidn2 libssh libpsl openldap brotli zlibpkg krb5 e2fsprogs libunistring pcre2 libcyrussasl libcurl"
 
 RED='\e[1;91m';    # Use Light Red for errors.
 YELLOW='\e[1;33m'; # Use Yellow for informational messages.

--- a/install.sh
+++ b/install.sh
@@ -298,7 +298,7 @@ echo -e "${RESET}"
 echo_info "Updating crew package information...\n"
 # Without setting LD_LIBRARY_PATH, the mandb postinstall fails
 # from not being able to find the gdbm library.
-export LD_LIBRARY_PATH=$(LD_LIBRARY_PATH=/usr/local/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX}:/usr/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX}:/lib:/usr/lib:/usr/local/lib crew const CREW_LIB_PREFIX | sed -e 's:CREW_LIB_PREFIX=::g')
+export LD_LIBRARY_PATH=$(LD_LIBRARY_PATH=/usr/local/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX}:/usr/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX}:/lib:/usr/lib:/usr/local/lib crew const CREW_LIB_PREFIX | sed -e 's:CREW_LIB_PREFIX=::g'):$LD_LIBRARY_PATH
 # Since we just ran git, just update package compatibility information.
 crew update compatible
 

--- a/install.sh
+++ b/install.sh
@@ -24,8 +24,7 @@ CREW_PACKAGES_PATH="${CREW_LIB_PATH}/packages"
 ARCH="${ARCH/armv8l/armv7l}"
 
 # BOOTSTRAP_PACKAGES cannot depend on crew_profile_base for their core operations (completion scripts are fine)
-BOOTSTRAP_PACKAGES="pixz ca_certificates git gmp ncurses xxhash lz4 popt libyaml openssl zstd gcc rsync ruby c_ares libnghttp2 libidn2 libssh libpsl openldap brotli zlibpkg krb5 e2fsprogs libunistring pcre2 libcyrussasl libcurl"
-
+BOOTSTRAP_PACKAGES="zstd pixz ca_certificates git gmp ncurses xxhash lz4 popt libyaml openssl gcc rsync ruby c_ares libnghttp2 libidn2 libssh libpsl openldap brotli zlibpkg krb5 e2fsprogs libunistring pcre2 libcyrussasl libcurl"
 RED='\e[1;91m';    # Use Light Red for errors.
 YELLOW='\e[1;33m'; # Use Yellow for informational messages.
 GREEN='\e[1;32m';  # Use Green for success messages.

--- a/install.sh
+++ b/install.sh
@@ -216,17 +216,18 @@ function extract_install () {
     if [[ "$2" == *".zst" ]];then
       if [[ -e /usr/bin/zstd ]]; then
         tar -I /usr/bin/zstd -xpf ../"${2}"
-      elif (LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} "${CREW_PREFIX}"/bin/zstd --version &> /dev/null); then
-        LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} tar -I "${CREW_PREFIX}"/bin/zstd -xpf ../"${2}"
+      elif ("${CREW_PREFIX}"/bin/zstd --version &> /dev/null); then
+        tar -I "${CREW_PREFIX}"/bin/zstd -xpf ../"${2}"
       else
-        echo_error "Zstd is broken or nonfunctional, and packages can not be extracted properly."
+        echo "Zstd is broken or nonfunctional, and some packages can not be extracted properly."
         exit 1
       fi
     elif [[ "$2" == *".tpxz" ]];then
-      if ! LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} pixz -h &> /dev/null; then
-        tar xpf ../"${2}"
+      if "${CREW_PREFIX}"/bin/pixz -h &> /dev/null; then
+        tar -I "${CREW_PREFIX}"/bin/pixz -xpf ../"${2}"
       else
-        LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX} tar -Ipixz -xpf ../"${2}"
+        echo "Pixz is broken or nonfunctional, and some packages can not be extracted properly."
+        exit 1
       fi
     else
       tar xpf ../"${2}"

--- a/install.sh
+++ b/install.sh
@@ -296,9 +296,10 @@ git reset --hard origin/"${BRANCH}"
 echo -e "${RESET}"
 
 echo_info "Updating crew package information...\n"
-# Without setting LD_LIBRARY_PATH, the mandb postinstall fails
-# from not being able to find the gdbm library.
-export LD_LIBRARY_PATH=$(LD_LIBRARY_PATH=/usr/local/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX}:/usr/lib${LIB_SUFFIX}:/lib${LIB_SUFFIX}:/lib:/usr/lib:/usr/local/lib crew const CREW_LIB_PREFIX | sed -e 's:CREW_LIB_PREFIX=::g'):$LD_LIBRARY_PATH
+# set LD_LIBRARY_PATH so crew doesn't break on i686 and the mandb 
+# install doesn't fail
+export LD_LIBRARY_PATH="${CREW_PREFIX}/lib${LIB_SUFFIX}"
+
 # Since we just ran git, just update package compatibility information.
 crew update compatible
 

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -11,6 +11,7 @@ class Crew_profile_base < Package
   source_url 'https://github.com/chromebrew/crew-profile-base.git'
   git_hashtag @_ver
 
+  depends_on 'git'
   no_compile_needed
   no_patchelf
 

--- a/packages/git.rb
+++ b/packages/git.rb
@@ -25,6 +25,7 @@ class Git < Package
 
   depends_on 'ca_certificates' => :build
   depends_on 'libcurl'
+  depends_on 'libunistring'
   depends_on 'zlibpkg'
 
   no_patchelf

--- a/packages/git.rb
+++ b/packages/git.rb
@@ -25,7 +25,7 @@ class Git < Package
 
   depends_on 'ca_certificates' => :build
   depends_on 'libcurl'
-  depends_on 'libpcre2'
+  depends_on 'pcre2'
   depends_on 'libunistring'
   depends_on 'zlibpkg'
 

--- a/packages/git.rb
+++ b/packages/git.rb
@@ -3,23 +3,24 @@ require 'package'
 class Git < Package
   description 'Git is a free and open source distributed version control system designed to handle everything from small to very large projects with speed and efficiency.'
   homepage 'https://git-scm.com/'
-  version '2.37.3'
+  @_ver = '2.37.3'
+  version "#{@_ver}-1"
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.37.3.tar.xz'
   source_sha256 '814641d7f61659cfbc17825d0462499ca1403e39ff53d76a8512050e6483e87a'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.37.3_armv7l/git-2.37.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.37.3_armv7l/git-2.37.3-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.37.3_i686/git-2.37.3-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.37.3_x86_64/git-2.37.3-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.37.3-1_armv7l/git-2.37.3-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.37.3-1_armv7l/git-2.37.3-1-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.37.3-1_i686/git-2.37.3-1-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.37.3-1_x86_64/git-2.37.3-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'be6fb72e5cf642a53189c5b6e5824a1b385d15fce7e24e0912453ea2c943a294',
-     armv7l: 'be6fb72e5cf642a53189c5b6e5824a1b385d15fce7e24e0912453ea2c943a294',
-       i686: 'cf8e7975671265971ab7ae85fce53bcbe75db40928818e0d2c22579d01211b17',
-     x86_64: '520dea35d982722854f7674b44c1054363c6a7a3d295534597bbb210b9109b9b'
+    aarch64: '1073a00bb8d4394cf27e8f3d3afb14820af8893c27cb42d6977147a5f0e03f83',
+     armv7l: '1073a00bb8d4394cf27e8f3d3afb14820af8893c27cb42d6977147a5f0e03f83',
+       i686: 'e58fad11a7df3ed569a5adef9ed9971fd94d8c5b9caa347fa6f90423b49af94d',
+     x86_64: '1d2d944493da0243891a65713e6f838f7a0fb0f228b9ed0a12905a904f1b7761'
   })
 
   depends_on 'ca_certificates' => :build

--- a/packages/git.rb
+++ b/packages/git.rb
@@ -3,41 +3,29 @@ require 'package'
 class Git < Package
   description 'Git is a free and open source distributed version control system designed to handle everything from small to very large projects with speed and efficiency.'
   homepage 'https://git-scm.com/'
-  version '2.37.2'
+  version '2.37.3'
   license 'GPL-2'
   compatibility 'all'
-  source_url 'https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.37.2.tar.xz'
-  source_sha256 '1c3d9c821c4538e7a6dac30a4af8bd8dcfe4f651f95474c526b52f83406db003'
+  source_url 'https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.37.3.tar.xz'
+  source_sha256 '814641d7f61659cfbc17825d0462499ca1403e39ff53d76a8512050e6483e87a'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.37.2_armv7l/git-2.37.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.37.2_armv7l/git-2.37.2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.37.2_i686/git-2.37.2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.37.2_x86_64/git-2.37.2-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.37.3_armv7l/git-2.37.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.37.3_armv7l/git-2.37.3-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.37.3_i686/git-2.37.3-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.37.3_x86_64/git-2.37.3-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '70220afef4ed6b3a3d1efefce28ab02a118e09e206c1e6f7411959855839085e',
-     armv7l: '70220afef4ed6b3a3d1efefce28ab02a118e09e206c1e6f7411959855839085e',
-       i686: 'f1d49a1f9cab20818b67a654af0ce6f073c68bf972643426fbd122ecd58293ef',
-     x86_64: '1c683f85c63ab3eb205b3f023c85b3422b940da4e958c7445928d0e9c94b5903'
+    aarch64: 'be6fb72e5cf642a53189c5b6e5824a1b385d15fce7e24e0912453ea2c943a294',
+     armv7l: 'be6fb72e5cf642a53189c5b6e5824a1b385d15fce7e24e0912453ea2c943a294',
+       i686: 'cf8e7975671265971ab7ae85fce53bcbe75db40928818e0d2c22579d01211b17',
+     x86_64: '520dea35d982722854f7674b44c1054363c6a7a3d295534597bbb210b9109b9b'
   })
 
   depends_on 'ca_certificates' => :build
-  depends_on 'musl_curl' => :build
-  depends_on 'rust' => :build
-  depends_on 'musl_brotli' => :build
-  depends_on 'musl_libidn2' => :build
-  depends_on 'musl_libunbound' => :build
-  depends_on 'musl_libunistring' => :build
-  depends_on 'musl_native_toolchain' => :build
-  depends_on 'musl_ncurses' => :build
-  depends_on 'musl_openssl' => :build
-  depends_on 'musl_zlib' => :build
-  depends_on 'musl_zstd' => :build
-  depends_on 'musl_expat' => :build
+  depends_on 'libcurl'
+  depends_on 'zlibpkg'
 
-  is_musl
-  is_static
   no_patchelf
   no_zstd
 
@@ -65,42 +53,15 @@ class Git < Package
   end
 
   def self.build
-    # This build is dependent upon the musl curl package
-    @curl_static_libs = `#{CREW_MUSL_PREFIX}/bin/curl-config --static-libs`.chomp.gsub('=auto', '')
-    @git_libs = "#{@curl_static_libs} \
-        -l:libresolv.a \
-        -l:libm.a \
-        -l:libbrotlidec-static.a \
-        -l:libbrotlicommon-static.a \
-        -l:libzstd.a \
-        -l:libz.a \
-        -l:libssl.a \
-        -l:libcrypto.a \
-        -l:libpthread.a \
-        -l:libncursesw.a \
-        -l:libtinfow.a \
-        -l:libcurl.a \
-        -l:libidn2.a \
-        -l:libexpat.a"
-
     Dir.mkdir 'contrib/buildsystems/builddir'
     Dir.chdir 'contrib/buildsystems/builddir' do
-      # This is needed for git's cmake compiler check, which assumes glibc sysctl.h
-      FileUtils.mkdir_p 'sys'
-      FileUtils.ln_s "#{CREW_MUSL_PREFIX}/#{ARCH}-linux-musl#{MUSL_ABI}/include/linux/sysctl.h", 'sys/sysctl.h'
-
-      system "#{MUSL_CMAKE_OPTIONS.gsub('LDFLAGS=\'',
-                                        "LDFLAGS=\' #{@git_libs} -L#{CREW_MUSL_PREFIX}/lib \
-         -Wl,-rpath=#{CREW_MUSL_PREFIX}/lib").gsub('-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=TRUE',
-                                                   '-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF')} \
-          -DCMAKE_C_STANDARD_LIBRARIES='#{@git_libs}' \
-          -DCMAKE_CXX_STANDARD_LIBRARIES='#{@git_libs}' \
-          -DNO_VCPKG=TRUE \
+      system "mold -run cmake \
+          #{CREW_CMAKE_OPTIONS} \
           -DUSE_VCPKG=FALSE \
           -Wdev \
           -G Ninja \
           .."
-      system 'samu'
+      system 'mold -run samu'
     end
   end
 
@@ -115,18 +76,13 @@ class Git < Package
       source #{CREW_PREFIX}/share/git-completion/git-completion.bash
     GIT_BASHD_EOF
     File.write("#{CREW_DEST_PREFIX}/etc/bash.d/git", @git_bashd_env)
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
-    # Simplying the following block leads to the symlink not being created properly.
-    Dir.chdir "#{CREW_DEST_PREFIX}/bin" do
-      FileUtils.ln_s '../share/musl/bin/git', 'git'
-    end
   end
 
   def self.check
     # Check to see if linking libcurl worked, which means
     # git-remote-https should exist
-    unless File.symlink?("#{CREW_DEST_MUSL_PREFIX}/libexec/git-core/git-remote-https") ||
-           File.exist?("#{CREW_DEST_MUSL_PREFIX}/libexec/git-core/git-remote-https")
+    unless File.symlink?("#{CREW_DEST_PREFIX}/libexec/git-core/git-remote-https") ||
+           File.exist?("#{CREW_DEST_PREFIX}/libexec/git-core/git-remote-https")
       abort 'git-remote-https is broken'.lightred
     end
   end

--- a/packages/git.rb
+++ b/packages/git.rb
@@ -3,30 +3,30 @@ require 'package'
 class Git < Package
   description 'Git is a free and open source distributed version control system designed to handle everything from small to very large projects with speed and efficiency.'
   homepage 'https://git-scm.com/'
-  @_ver = '2.37.3'
-  version "#{@_ver}-1"
+  @_ver = '2.38.0'
+  version @_ver
   license 'GPL-2'
   compatibility 'all'
-  source_url 'https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.37.3.tar.xz'
-  source_sha256 '814641d7f61659cfbc17825d0462499ca1403e39ff53d76a8512050e6483e87a'
+  source_url 'https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.38.0.tar.xz'
+  source_sha256 '923eade26b1814de78d06bda8e0a9f5da8b7c4b304b3f9050ffb464f0310320a'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.37.3-1_armv7l/git-2.37.3-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.37.3-1_armv7l/git-2.37.3-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.37.3-1_i686/git-2.37.3-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.37.3-1_x86_64/git-2.37.3-1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.38.0_armv7l/git-2.38.0-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.38.0_armv7l/git-2.38.0-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.38.0_i686/git-2.38.0-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.38.0_x86_64/git-2.38.0-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '1073a00bb8d4394cf27e8f3d3afb14820af8893c27cb42d6977147a5f0e03f83',
-     armv7l: '1073a00bb8d4394cf27e8f3d3afb14820af8893c27cb42d6977147a5f0e03f83',
-       i686: 'e58fad11a7df3ed569a5adef9ed9971fd94d8c5b9caa347fa6f90423b49af94d',
-     x86_64: '1d2d944493da0243891a65713e6f838f7a0fb0f228b9ed0a12905a904f1b7761'
+    aarch64: '14c5aa369d3bbea0122c17228cc2123d8fcd055c2f4e03c3bf164fd177380f00',
+     armv7l: '14c5aa369d3bbea0122c17228cc2123d8fcd055c2f4e03c3bf164fd177380f00',
+       i686: '98eb7a1935c8d3af328be87ccc023fc4e08fbf7ddbfdafb3957c529d1b2c5be1',
+     x86_64: '5292a96fbd2c230395535311b696a9f87a3f337f104927b1ce39a31713da0653'
   })
 
   depends_on 'ca_certificates' => :build
   depends_on 'libcurl'
-  depends_on 'pcre2'
   depends_on 'libunistring'
+  depends_on 'pcre2'
   depends_on 'zlibpkg'
 
   no_patchelf

--- a/packages/git.rb
+++ b/packages/git.rb
@@ -25,6 +25,7 @@ class Git < Package
 
   depends_on 'ca_certificates' => :build
   depends_on 'libcurl'
+  depends_on 'libpcre2'
   depends_on 'libunistring'
   depends_on 'zlibpkg'
 

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -612,7 +612,7 @@ class Glibc < Package
     end
     if @libc_version.to_f >= 2.32
       puts 'Paring locales to a minimal set.'.lightblue
-      system 'localedef --list-archive | grep -v -i -e ^en -e ^cs -e ^de -e ^es -e ^fa -e ^fe -e ^it -e ^ja -e ^ru -e ^tr -e ^zh -e ^C| xargs localedef --delete-from-archive || true'
+      system 'localedef --list-archive | grep -v -i -e ^en -e ^cs -e ^de -e ^es -e ^fa -e ^fe -e ^it -e ^ja -e ^ru -e ^tr -e ^zh -e ^C| xargs localedef --delete-from-archive', exception: false
       FileUtils.mv "#{CREW_LIB_PREFIX}/locale/locale-archive", "#{CREW_LIB_PREFIX}/locale/locale-archive.tmpl"
       if @opt_verbose
         system 'build-locale-archive'

--- a/packages/libcurl.rb
+++ b/packages/libcurl.rb
@@ -32,6 +32,7 @@ class Libcurl < Package
   depends_on 'libnghttp2' # R
   depends_on 'libpsl' # R
   depends_on 'libssh' # R
+  depends_on 'libunistring' # R
   depends_on 'openldap' # R
   depends_on 'openssl' # R
   depends_on 'py3_pip' => :build

--- a/packages/libidn2.rb
+++ b/packages/libidn2.rb
@@ -23,6 +23,8 @@ class Libidn2 < Package
      x86_64: 'ea4b9348c401c8655f0a77fc92149887b26fb7cad7f6ce5628488fa72d8223d6'
   })
 
+  depends_on 'libunistring'
+
   def self.build
     system "mold -run ./configure #{CREW_OPTIONS}"
     system 'mold -run make'

--- a/packages/libpsl.rb
+++ b/packages/libpsl.rb
@@ -23,6 +23,8 @@ class Libpsl < Package
      x86_64: '65be38748baca2f4bf9cf689b9894ce62dc37d909e2545a27a9612ec9fb8d419'
   })
 
+  depends_on 'libidn2'
+
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \
     builddir"

--- a/packages/libssh.rb
+++ b/packages/libssh.rb
@@ -24,8 +24,11 @@ class Libssh < Package
      x86_64: 'e30f47fa94fd694f0d6947f597c9195923d7509096f3a9a51ce099970501c913'
   })
 
+  depends_on 'e2fsprogs'
+  depends_on 'krb5'
   depends_on 'libgcrypt'
   depends_on 'py3_abimap' => :build
+  depends_on 'zlibpkg'
 
   def self.build
     FileUtils.mkdir('builddir')

--- a/packages/libxml2.rb
+++ b/packages/libxml2.rb
@@ -24,6 +24,7 @@ class Libxml2 < Package
 
   depends_on 'gcc'
   depends_on 'icu4c'
+  depends_on 'ncurses'
   depends_on 'readline'
   depends_on 'zlibpkg'
   no_patchelf


### PR DESCRIPTION
 - Dependencies have been added to core packages to make sure the order at installation doesn't cause problems.
 - Also includes the glibc fix from #7449 in case that was causing your problem.
- waiting for @uberhacker to test the installer with: 
```
cd /usr/local
curl -OLf https://github.com/satmandu/chromebrew/raw/git_no_musl/install.sh
chmod +x install.sh
OWNER=satmandu BRANCH=git_no_musl ./install.sh
```
 
Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=git_no_musl  CREW_TESTING=1 crew update
```

