### PR TITLE
Update libcurl with dependencies

### DIFF
--- a/packages/libcurl.rb
+++ b/packages/libcurl.rb
@@ -3,23 +3,24 @@ require 'package'
 class Libcurl < Package
   description 'Command line tool and library for transferring data with URLs.'
   homepage 'https://curl.se/'
-  version '7.85.0'
+  @_ver = '7.85.0'
+  version "#{@_ver}-1"
   license 'curl'
   compatibility 'all'
-  source_url "https://curl.se/download/curl-#{version}.tar.xz"
+  source_url "https://curl.se/download/curl-#{@_ver}.tar.xz"
   source_sha256 '88b54a6d4b9a48cb4d873c7056dcba997ddd5b7be5a2d537a4acb55c20b04be6'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.85.0_armv7l/libcurl-7.85.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.85.0_armv7l/libcurl-7.85.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.85.0_i686/libcurl-7.85.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.85.0_x86_64/libcurl-7.85.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.85.0-1_armv7l/libcurl-7.85.0-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.85.0-1_armv7l/libcurl-7.85.0-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.85.0-1_i686/libcurl-7.85.0-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcurl/7.85.0-1_x86_64/libcurl-7.85.0-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'de7bc349114fa62ec50ddd14d72da7958947945277d3160f574be585843e15ac',
-     armv7l: 'de7bc349114fa62ec50ddd14d72da7958947945277d3160f574be585843e15ac',
-       i686: '0480804129d701ac23e881b72ee2eb2773080dab5271d8728277c082feab4470',
-     x86_64: '5c0680f92f85482e3ce4b9f03703e679289e8256afb7d0d9ef35aa116c731bb6'
+    aarch64: 'c6ca70a9231cd47ade098c3df35562f022279829154cf47eaf03784a738d8f82',
+     armv7l: 'c6ca70a9231cd47ade098c3df35562f022279829154cf47eaf03784a738d8f82',
+       i686: '02da81f62fea5a9d04634a71ce5b1915ed8c87facdf63651481ff3237d00a9fa',
+     x86_64: 'ff40e40bac00768c989d1193459fd512d46401a0427b095fe9b21d6892402a28'
   })
 
   depends_on 'brotli' # R
@@ -31,7 +32,6 @@ class Libcurl < Package
   depends_on 'libnghttp2' # R
   depends_on 'libpsl' # R
   depends_on 'libssh' # R
-  depends_on 'libunbound' # ?
   depends_on 'openldap' # R
   depends_on 'openssl' # R
   depends_on 'py3_pip' => :build
@@ -39,17 +39,12 @@ class Libcurl < Package
   depends_on 'valgrind' => :build
   depends_on 'zlibpkg' # R
   depends_on 'zstd' # R
+  no_patchelf
 
   def self.build
-    @libssh = '--with-libssh'
-    case ARCH
-    when 'i686'
-      @libssh = '--without-libssh'
-    end
-
     system '[ -x configure ] || autoreconf -fvi'
     system 'filefix'
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
+    system "mold -run ./configure #{CREW_OPTIONS} \
       --disable-maintainer-mode \
       --enable-ares \
       --enable-ipv6 \
@@ -58,11 +53,11 @@ class Libcurl < Package
       --with-ca-bundle=#{CREW_PREFIX}/etc/ssl/certs/ca-certificates.crt \
       --with-ca-fallback \
       --with-ca-path=#{CREW_PREFIX}/etc/ssl/certs \
-      #{@libssh} \
+      --with-libssh \
       --with-openssl \
       --without-gnutls \
       --without-librtmp"
-    system 'make'
+    system 'mold -run make'
   end
 
   def self.install

--- a/packages/libidn2.rb
+++ b/packages/libidn2.rb
@@ -3,29 +3,29 @@ require 'package'
 class Libidn2 < Package
   description 'GNU Libidn is a fully documented implementation of the Stringprep, Punycode and IDNA 2003 specifications.'
   homepage 'https://www.gnu.org/software/libidn/'
-  @_ver = '2.3.2'
+  @_ver = '2.3.3'
   version @_ver
   license 'GPL-2+ and LGPL-3+'
   compatibility 'all'
   source_url "https://ftpmirror.gnu.org/libidn/libidn2-#{@_ver}.tar.gz"
-  source_sha256 '76940cd4e778e8093579a9d195b25fff5e936e9dc6242068528b437a76764f91'
+  source_sha256 'f3ac987522c00d33d44b323cae424e2cffcb4c63c6aa6cd1376edacbf1c36eb0'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libidn2/2.3.2_armv7l/libidn2-2.3.2-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libidn2/2.3.2_armv7l/libidn2-2.3.2-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libidn2/2.3.2_i686/libidn2-2.3.2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libidn2/2.3.2_x86_64/libidn2-2.3.2-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libidn2/2.3.3_armv7l/libidn2-2.3.3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libidn2/2.3.3_armv7l/libidn2-2.3.3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libidn2/2.3.3_i686/libidn2-2.3.3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libidn2/2.3.3_x86_64/libidn2-2.3.3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '6c335d7c611cc1d054c22d2b658aaa060a7bfd682528bac46dc404ffff14c818',
-     armv7l: '6c335d7c611cc1d054c22d2b658aaa060a7bfd682528bac46dc404ffff14c818',
-       i686: '7ce581270eeba81b5f3ec0d7f0e7826b95248a54e960608cc72777beb9f31098',
-     x86_64: '740ae2266e95b4d1974b80165967ec15efd0a7810a649fd7408bdb2964f06de7'
+    aarch64: '506044ffa75da19775112ad71b62c1531b9b272304ece0d250891b7df73dd298',
+     armv7l: '506044ffa75da19775112ad71b62c1531b9b272304ece0d250891b7df73dd298',
+       i686: 'f8b784f50e9cb56f73f78520a0712e6dceba66316a86571f3aa4165daab02a4f',
+     x86_64: '7c5c25b5028ec8c1a4e8ae7b525959b1130e4118e10233238ce96adf51938809'
   })
 
   def self.build
-    system "env #{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
-    system 'make'
+    system "mold -run ./configure #{CREW_OPTIONS}"
+    system 'mold -run make'
   end
 
   def self.install

--- a/packages/libnghttp2.rb
+++ b/packages/libnghttp2.rb
@@ -3,7 +3,7 @@ require 'package'
 class Libnghttp2 < Package
   description 'library implementing HTTP/2 protocol'
   homepage 'https://nghttp2.org/'
-  @_ver = '1.45.1'
+  @_ver = '1.50.0'
   version @_ver
   license 'MIT'
   compatibility 'all'
@@ -11,16 +11,16 @@ class Libnghttp2 < Package
   git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.45.1_armv7l/libnghttp2-1.45.1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.45.1_armv7l/libnghttp2-1.45.1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.45.1_i686/libnghttp2-1.45.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.45.1_x86_64/libnghttp2-1.45.1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.50.0_armv7l/libnghttp2-1.50.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.50.0_armv7l/libnghttp2-1.50.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.50.0_i686/libnghttp2-1.50.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.50.0_x86_64/libnghttp2-1.50.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'a53af4ca732b343d976f729e809dff883159482b6338dfcb1541e9d20da469db',
-     armv7l: 'a53af4ca732b343d976f729e809dff883159482b6338dfcb1541e9d20da469db',
-       i686: '209c4b802cc37ceb4e508e54a403fea7ab23a84c9ec317d8bf497723e32969c4',
-     x86_64: 'f1d7369aee4be665d89a1cc582802fa1cc9d0b7803bd5df91cf2eb8b62a79241'
+    aarch64: '6a791dffcb9fe605f95f2e822b7aa3b111009895b6bc5280c871243c2ef9a93f',
+     armv7l: '6a791dffcb9fe605f95f2e822b7aa3b111009895b6bc5280c871243c2ef9a93f',
+       i686: 'e07cd661c9896e5397124e826e2f6aae4f422e8ffc9a7c4080f80533d66fdc15',
+     x86_64: '0c28ae576d708afd41c95df79283b7b26f1eecd022acd3ee4143e52a230b6bd6'
   })
 
   depends_on 'jansson'
@@ -31,10 +31,10 @@ class Libnghttp2 < Package
   def self.build
     FileUtils.mkdir 'builddir'
     Dir.chdir 'builddir' do
-      system "cmake -G Ninja #{CREW_CMAKE_OPTIONS} \
+      system "mold -run cmake -G Ninja #{CREW_CMAKE_OPTIONS} \
         -DENABLE_SHARED_LIB=ON \
         -DENABLE_STATIC_LIB=ON .."
-      system 'samu'
+      system 'mold -run samu'
     end
   end
 

--- a/packages/libpsl.rb
+++ b/packages/libpsl.rb
@@ -4,32 +4,33 @@ class Libpsl < Package
   description 'C library for the Public Suffix List'
   homepage 'https://github.com/rockdaboot/libpsl'
   @_ver = '0.21.1'
-  version "#{@_ver}-1"
+  version "#{@_ver}-2"
   license 'MIT'
   compatibility 'all'
   source_url "https://github.com/rockdaboot/libpsl/releases/download/#{@_ver}/libpsl-#{@_ver}.tar.lz"
   source_sha256 '644375d557bb3b84c485df2dae98ee388fe1e11fb75230004e4b8623b3b833a9'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpsl/0.21.1-1_armv7l/libpsl-0.21.1-1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpsl/0.21.1-1_armv7l/libpsl-0.21.1-1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpsl/0.21.1-1_i686/libpsl-0.21.1-1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpsl/0.21.1-1_x86_64/libpsl-0.21.1-1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpsl/0.21.1-2_armv7l/libpsl-0.21.1-2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpsl/0.21.1-2_armv7l/libpsl-0.21.1-2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpsl/0.21.1-2_i686/libpsl-0.21.1-2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libpsl/0.21.1-2_x86_64/libpsl-0.21.1-2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '820d6bd20a1981c33a9d3a998d6d10660dda64124405ea0ca04f3cc485d35e00',
-     armv7l: '820d6bd20a1981c33a9d3a998d6d10660dda64124405ea0ca04f3cc485d35e00',
-       i686: '38032e35bd8c942a88ee0f911627b41b2e13f5cbc349827127582830fe4d21c8',
-     x86_64: 'e0e147b462d7a1d8a585ca205d6386263fdf7aa59b3b36aaaa3ee528fabf99c2'
+    aarch64: 'd3ceed9e1804466bc69c4850385353b2cc149c3c2e391726afef1791af4934ef',
+     armv7l: 'd3ceed9e1804466bc69c4850385353b2cc149c3c2e391726afef1791af4934ef',
+       i686: '8d06b3c1b028b6abab13f0c77d1e36903781d20e68b80709b09f2fd0fa0ac945',
+     x86_64: '36a20069519346782dad64a36cdb1628de2dcbf01320399ee6c088c18fd86b3f'
   })
 
   def self.build
-    system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_ENV_OPTIONS} #{CREW_OPTIONS}"
-    system 'make'
+    system "meson #{CREW_MESON_OPTIONS} \
+    builddir"
+    system 'meson configure builddir'
+    system 'mold -run samu -C builddir'
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
   end
 end

--- a/packages/libssh.rb
+++ b/packages/libssh.rb
@@ -3,25 +3,25 @@ require 'package'
 class Libssh < Package
   description 'libssh is a multiplatform C library implementing the SSHv2 and SSHv1 protocol on client and server side.'
   homepage 'https://www.libssh.org/'
-  @_ver = '0.9.6'
+  @_ver = '0.10.3'
   version @_ver
   @_ver_prelastdot = @_ver.rpartition('.')[0]
   license 'LGPL-2.1'
   compatibility 'all'
   source_url "https://www.libssh.org/files/#{@_ver_prelastdot}/libssh-#{@_ver}.tar.xz"
-  source_sha256 '86bcf885bd9b80466fe0e05453c58b877df61afa8ba947a58c356d7f0fab829b'
+  source_sha256 '6e889dbe4f3eecd13a452ca868ec85525ab9c39d778519a9c141b83da738c8aa'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.9.6_armv7l/libssh-0.9.6-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.9.6_armv7l/libssh-0.9.6-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.9.6_i686/libssh-0.9.6-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.9.6_x86_64/libssh-0.9.6-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.10.3_armv7l/libssh-0.10.3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.10.3_armv7l/libssh-0.10.3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.10.3_i686/libssh-0.10.3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.10.3_x86_64/libssh-0.10.3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '5c4a6da32f3b23488dd15e06a5eb77e191143e4d5b5a396331a429e9d5dd5cfd',
-     armv7l: '5c4a6da32f3b23488dd15e06a5eb77e191143e4d5b5a396331a429e9d5dd5cfd',
-       i686: '9a3d676f230262a5974fe05e7ea705c9062a5b27364655e29e2abf4158009389',
-     x86_64: 'a4a261a53541349d5c9564a74f7a5d5051d33a4cbdbc06885810eb948f0d01a8'
+    aarch64: '6d9677de1be1914cbfa478c80b25101304ead4f467d5e8970644a53be7e287d1',
+     armv7l: '6d9677de1be1914cbfa478c80b25101304ead4f467d5e8970644a53be7e287d1',
+       i686: 'fe25cd27845a0b9c1699ffc1c9cd118744d839801ab36152e492e074f58ee6e0',
+     x86_64: 'bfed4aeabbf90f40f8a369bba7a208e89c726f991af787d4c54ed51a593685e1'
   })
 
   depends_on 'libgcrypt'
@@ -29,26 +29,24 @@ class Libssh < Package
   def self.build
     FileUtils.mkdir('builddir')
     Dir.chdir('builddir') do
-      system "cmake #{CREW_CMAKE_OPTIONS} \
+      system "mold -run cmake #{CREW_CMAKE_OPTIONS} \
       -DWITH_EXAMPLES=OFF \
       -DBUILD_SHARED_LIBS=OFF \
-      -DWITH_STATIC_LIB=ON \
       ../ -G Ninja"
     end
-    system 'ninja -C builddir'
+    system 'mold -run samu -C builddir'
     Dir.chdir('builddir') do
       FileUtils.cp 'src/libssh.a', '../' if File.exist?('src/libssh.a')
-      system "cmake #{CREW_CMAKE_OPTIONS} \
+      system "mold -run cmake #{CREW_CMAKE_OPTIONS} \
       -DWITH_EXAMPLES=OFF \
       -DBUILD_SHARED_LIBS=ON \
-      -DWITH_STATIC_LIB=OFF \
       ../ -G Ninja"
     end
-    system 'ninja -C builddir'
+    system 'mold -run samu -C builddir'
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
     FileUtils.cp 'libssh.a', CREW_DEST_LIB_PREFIX if File.exist?('libssh.a')
   end
 end


### PR DESCRIPTION
- `libssh` -> 0.10.3
- `libidn2` -> 2.3.3
- `libnghttp2` -> 1.50.0
- `libpsl` rebuilt with meson
- `libcurl` rebuilt with libssh on `i686`
- This PR has all package updates from https://github.com/chromebrew/chromebrew/pull/7436 except for `git` and the `install.sh` changes.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=libcurl_rebuilds CREW_TESTING=1 crew update
```
