### PR TITLE
ninja -> 1.11.1, re2c -> 3.0

### DIFF
--- a/packages/ninja.rb
+++ b/packages/ninja.rb
@@ -3,39 +3,50 @@ require 'package'
 class Ninja < Package
   description 'a small build system with a focus on speed'
   homepage 'https://ninja-build.org'
-  version '1.10.2'
+  version '1.11.1'
   license 'GPL-2'
   compatibility 'all'
-  source_url 'https://github.com/ninja-build/ninja/archive/v1.10.2.tar.gz'
-  source_sha256 'ce35865411f0490368a8fc383f29071de6690cbadc27704734978221f25e2bed'
+  source_url 'https://github.com/ninja-build/ninja/archive/v1.11.1.tar.gz'
+  source_sha256 '31747ae633213f1eda3842686f83c2aa1412e0f5691d1c14dbbcc67fe7400cea'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.10.2_armv7l/ninja-1.10.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.10.2_armv7l/ninja-1.10.2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.10.2_i686/ninja-1.10.2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.10.2_x86_64/ninja-1.10.2-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.11.1_armv7l/ninja-1.11.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.11.1_armv7l/ninja-1.11.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.11.1_i686/ninja-1.11.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.11.1_x86_64/ninja-1.11.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'd6fe1cfab1c8c0c9a4865fcc1918ebe86a4effd17a28d9fc7b90401e550e2b90',
-     armv7l: 'd6fe1cfab1c8c0c9a4865fcc1918ebe86a4effd17a28d9fc7b90401e550e2b90',
-       i686: '36f809229fd7779f0783742a579043c9b8a69ec9454efcb1ff7655fd621d5e45',
-     x86_64: '40ee7476d70e15874acb59b43e4e379c67cc65793ead2af6fbd67331f06193ff'
+    aarch64: 'ff439c9f733c638cbfb37602ec31775ab8102f927e7c26b57b3bedd2a30c725d',
+     armv7l: 'ff439c9f733c638cbfb37602ec31775ab8102f927e7c26b57b3bedd2a30c725d',
+       i686: 'ffa46259484a0a86c92010b3cc62867fb2cff0862c9e2ce17723d8318b9ce635',
+     x86_64: '96cad814e005ffb14a47a01bb7bf61971cc1890439e879444f04bf88f5083886'
   })
 
   depends_on 're2c' => :build
-
-  def self.patch
-    system 'filefix'
-  end
+  depends_on 'samurai' => :build
 
   def self.build
-    system "env #{CREW_ENV_OPTIONS} \
-      AR=gcc-ar \
-      python3 configure.py --bootstrap"
+    Dir.mkdir 'builddir'
+    Dir.chdir 'builddir' do
+      # Handle issue with re2c: error: cannot rename or write temporary file
+      # ninja-1.11.1/builddir/lexer.cc to output file ninja-1.11.1/builddir/lexer.cc
+      # https://github.com/skvadrik/re2c/issues/417
+      if ARCH == 'x86_64'
+        @files = %w[lexer.cc depfile_parser.cc]
+        @files.each do |file|
+          FileUtils.touch file
+        end
+      end
+      system "mold -run cmake \
+          #{CREW_CMAKE_OPTIONS} \
+          -Wdev \
+          -G Ninja \
+          .."
+      system 'mold -run samu'
+    end
   end
 
   def self.install
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
-    FileUtils.install 'ninja', "#{CREW_DEST_PREFIX}/bin/ninja", mode: 0o755
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
   end
 end

--- a/packages/re2c.rb
+++ b/packages/re2c.rb
@@ -3,37 +3,38 @@ require 'package'
 class Re2c < Package
   description 're2c is a free and open-source lexer generator for C and C++.'
   homepage 'http://re2c.org/'
-  version '2.1.1'
+  version '3.0'
   license 'public-domain'
   compatibility 'all'
-  source_url 'https://github.com/skvadrik/re2c/releases/download/2.1.1/re2c-2.1.1.tar.lz'
-  source_sha256 '635860abc1c611dc5f7ab85581fa65bfa9b447946763b073d38e51620467539b'
+  source_url 'https://github.com/skvadrik/re2c/releases/download/3.0/re2c-3.0.tar.lz'
+  source_sha256 '39757db2defc21a6713560cdff75895fb30f02af22a3ac8066fd9ba84f16a1b3'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/re2c/2.1.1_armv7l/re2c-2.1.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/re2c/2.1.1_armv7l/re2c-2.1.1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/re2c/2.1.1_i686/re2c-2.1.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/re2c/2.1.1_x86_64/re2c-2.1.1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/re2c/3.0_armv7l/re2c-3.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/re2c/3.0_armv7l/re2c-3.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/re2c/3.0_i686/re2c-3.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/re2c/3.0_x86_64/re2c-3.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'f83c472ffa93b475b4fe715cbf05e131d8f9865d516af8d45a9ef3d5f029d1fd',
-     armv7l: 'f83c472ffa93b475b4fe715cbf05e131d8f9865d516af8d45a9ef3d5f029d1fd',
-       i686: '8f2ce53ecda3396e3fb199955a5803fd1ac695590a838a73f80cf1ce684680d5',
-     x86_64: '527b1e15f7c58f7725d04d0f025b630af76564ae42b14d979d6d958f221f92cd'
+    aarch64: '2d26bed05dd891ca9111f32fefb93e731ff075091e73780cac8978d87860185e',
+     armv7l: '2d26bed05dd891ca9111f32fefb93e731ff075091e73780cac8978d87860185e',
+       i686: '66382a147c0f35c6b66f80b1ff11191cd46a40f5134a0a740a1073c09b27242f',
+     x86_64: 'b84773fba0c9890b2128edc28925f3b4d827ed34f56f58204f6e2cba65d7bf3d'
   })
 
   def self.build
-    system "env #{CREW_ENV_OPTIONS} \
-      ./configure #{CREW_OPTIONS}"
-    system 'make'
-    system 'make bootstrap'
-  end
-
-  def self.check
-    system 'make check'
+    Dir.mkdir 'builddir'
+    Dir.chdir 'builddir' do
+      system "mold -run cmake \
+          #{CREW_CMAKE_OPTIONS} \
+          -Wdev \
+          -G Ninja \
+          .."
+      system 'mold -run samu'
+    end
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
   end
 end


### PR DESCRIPTION
- Updates ninja & re2c
- Converts both builds to use cmake.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=ninja  CREW_TESTING=1 crew update
```
