### PR TITLE
neovim -> 0.8.0

### DIFF
--- a/packages/libvterm.rb
+++ b/packages/libvterm.rb
@@ -6,30 +6,29 @@ require 'package'
 class Libvterm < Package
   description 'Abstract library implementation of a VT220/xterm/ECMA-48 terminal emulator'
   homepage 'https://www.leonerd.org.uk/code/libvterm/'
-  version '0.2'
+  version '0.3'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://www.leonerd.org.uk/code/libvterm/libvterm-0.2.tar.gz'
-  source_sha256 '4c5150655438cfb8c57e7bd133041140857eb04defd0e544521c0e469258e105'
+  source_url 'https://www.leonerd.org.uk/code/libvterm/libvterm-0.3.tar.gz'
+  source_sha256 '61eb0d6628c52bdf02900dfd4468aa86a1a7125228bab8a67328981887483358'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libvterm/0.2_armv7l/libvterm-0.2-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libvterm/0.2_armv7l/libvterm-0.2-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libvterm/0.2_i686/libvterm-0.2-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libvterm/0.2_x86_64/libvterm-0.2-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libvterm/0.3_armv7l/libvterm-0.3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libvterm/0.3_armv7l/libvterm-0.3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libvterm/0.3_i686/libvterm-0.3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libvterm/0.3_x86_64/libvterm-0.3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'd6657b597dcd4cbe25c765ac04acdaa3962809921bcdb1d439f794481d112374',
-     armv7l: 'd6657b597dcd4cbe25c765ac04acdaa3962809921bcdb1d439f794481d112374',
-       i686: '043f3366932dff21028fc1042b6d3f0506160645413a311079284df9356939ec',
-     x86_64: '51a0aa91d1c4ca302c621afae3b379d40a2c66fd82ad9b64327177af9e016956'
+    aarch64: '63bd50be7529cb4ae529474030be223abce26c0edc1c38f64f57adc7c9b0eacd',
+     armv7l: '63bd50be7529cb4ae529474030be223abce26c0edc1c38f64f57adc7c9b0eacd',
+       i686: '33de59b348d3bfe9b10980378daa205b604c49a07a39089beefa34ba909cea63',
+     x86_64: 'fb1046fabd96fb9f241b4ae4dc5e2b04e9aeb04efd0a873cdd0fff2e9601af24'
   })
 
   depends_on 'glibc'
-  depends_on 'git' => :build
 
   def self.build
-    system "make PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX}"
+    system "mold -run make PREFIX=#{CREW_PREFIX} LIBDIR=#{CREW_LIB_PREFIX}"
   end
 
   def self.install

--- a/packages/neovim.rb
+++ b/packages/neovim.rb
@@ -3,23 +3,23 @@ require 'package'
 class Neovim < Package
   description 'Neovim is a refactor, and sometimes redactor, in the tradition of Vim (which itself derives from Stevie).'
   homepage 'https://neovim.io/'
-  version '0.7.2'
+  version '0.8.0'
   license 'Apache-2.0 and vim'
   compatibility 'all'
   source_url 'https://github.com/neovim/neovim.git'
   git_hashtag "v#{version}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/neovim/0.7.2_armv7l/neovim-0.7.2-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/neovim/0.7.2_armv7l/neovim-0.7.2-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/neovim/0.7.2_i686/neovim-0.7.2-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/neovim/0.7.2_x86_64/neovim-0.7.2-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/neovim/0.8.0_armv7l/neovim-0.8.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/neovim/0.8.0_armv7l/neovim-0.8.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/neovim/0.8.0_i686/neovim-0.8.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/neovim/0.8.0_x86_64/neovim-0.8.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'e0667ab9931ffeac77dd85ebacdf6075a69dd5c13ff553826f0d028ffb6e69bd',
-     armv7l: 'e0667ab9931ffeac77dd85ebacdf6075a69dd5c13ff553826f0d028ffb6e69bd',
-       i686: 'fd140ef5fdfbb6a7253acadf7d43ff659c70e92edf4bc8c66029dea1533399db',
-     x86_64: '28c53fa96db6ad95782cb0c75f36e7ef2ae34e934d9ed5d10e73363487764b3f'
+    aarch64: 'de13d5f6f05c830f324a28dae940342e4e4664167a9aebc156a42ebe07d11171',
+     armv7l: 'de13d5f6f05c830f324a28dae940342e4e4664167a9aebc156a42ebe07d11171',
+       i686: '74aa26a81166856482eafe1feda1025e415735bd8314240c980df941ae444c4a',
+     x86_64: '9050b20d8d9d3ace8ffad7110cd7e61da1db94c5938ccfe48f983fa6a977cd01'
   })
 
   depends_on 'msgpack_c'
@@ -34,26 +34,6 @@ class Neovim < Package
   depends_on 'tree_sitter'
   depends_on 'unibilium'
   depends_on 'xdg_base'
-
-  def self.patch
-    # Patch from https://github.com/neovim/neovim/issues/16217#issuecomment-958641608
-    @neovimpatch = <<~'PATCH_EOF'
-      diff --git a/src/nvim/terminal.c b/src/nvim/terminal.c
-      index fb025265f..52d13fe4f 100644
-      --- a/src/nvim/terminal.c
-      +++ b/src/nvim/terminal.c
-      @@ -815,7 +815,7 @@ static int term_settermprop(VTermProp prop, VTermValue *val, void *data)
-
-         case VTERM_PROP_TITLE: {
-           buf_T *buf = handle_get_buffer(term->buf_handle);
-      -    buf_set_term_title(buf, val->string);
-      +    buf_set_term_title(buf, val->string.str);
-           break;
-         }
-    PATCH_EOF
-    File.write('neovim.patch', @neovimpatch)
-    system 'patch -p 1 -i neovim.patch'
-  end
 
   def self.build
     FileUtils.mkdir('builddir')


### PR DESCRIPTION
- Also updates required dependency libvterm -> 0.3

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` 

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=neovim8 CREW_TESTING=1 crew update
```
