### PR TITLE
glibc: keep postinstall failures from breaking install

### DIFF
--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -612,7 +612,7 @@ class Glibc < Package
     end
     if @libc_version.to_f >= 2.32
       puts 'Paring locales to a minimal set.'.lightblue
-      system 'localedef --list-archive | grep -v -i -e ^en -e ^cs -e ^de -e ^es -e ^fa -e ^fe -e ^it -e ^ja -e ^ru -e ^tr -e ^zh -e ^C| xargs localedef --delete-from-archive'
+      system 'localedef --list-archive | grep -v -i -e ^en -e ^cs -e ^de -e ^es -e ^fa -e ^fe -e ^it -e ^ja -e ^ru -e ^tr -e ^zh -e ^C| xargs localedef --delete-from-archive || true'
       FileUtils.mv "#{CREW_LIB_PREFIX}/locale/locale-archive", "#{CREW_LIB_PREFIX}/locale/locale-archive.tmpl"
       if @opt_verbose
         system 'build-locale-archive'


### PR DESCRIPTION
Fixes #7445 

- Hopefully this fixes this.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=glibc_233_fix  CREW_TESTING=1 crew update
```

