### PR TITLE
Remove python 2 from core & buildessential, update doxygen -> 1.9.5

### DIFF
--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -108,7 +108,6 @@ class Buildessential < Package
   # depends_on 'composer'
 
   # Python
-  depends_on 'python2'
   depends_on 'python3'
   depends_on 'py3_build'
   depends_on 'py3_installer'

--- a/packages/core.rb
+++ b/packages/core.rb
@@ -70,7 +70,6 @@ class Core < Package
   depends_on 'py3_pip'
   depends_on 'py3_setuptools'
   depends_on 'py3_wheel'
-  depends_on 'python2'
   depends_on 'python3'
   depends_on 'readline'
   depends_on 'rsync'

--- a/packages/doxygen.rb
+++ b/packages/doxygen.rb
@@ -3,41 +3,38 @@ require 'package'
 class Doxygen < Package
   description 'Doxygen is the de facto standard tool for generating documentation from annotated C++ sources, but it also supports other popular programming languages such as C, Objective-C, C#, PHP, Java, Python, IDL (Corba, Microsoft, and UNO/OpenOffice flavors), Fortran, VHDL, Tcl, and to some extent D.'
   homepage 'http://www.doxygen.nl/'
-  version '1.8.17'
+  version '1.9.5'
   license 'GPL-2'
   compatibility 'all'
-  source_url 'https://github.com/doxygen/doxygen/archive/Release_1_8_17.tar.gz'
-  source_sha256 '1b5d337e4b73ef1357a88cbd06fc4c301f08f279dac0adb99e876f4d72361f4f'
+  source_url 'https://github.com/doxygen/doxygen/archive/Release_1_9_5.tar.gz'
+  source_sha256 '1c5c9cd4445f694e43f089c17529caae6fe889b732fb0b145211025a1fcda1bb'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/doxygen/1.8.17_armv7l/doxygen-1.8.17-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/doxygen/1.8.17_armv7l/doxygen-1.8.17-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/doxygen/1.8.17_i686/doxygen-1.8.17-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/doxygen/1.8.17_x86_64/doxygen-1.8.17-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/doxygen/1.9.5_armv7l/doxygen-1.9.5-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/doxygen/1.9.5_armv7l/doxygen-1.9.5-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/doxygen/1.9.5_i686/doxygen-1.9.5-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/doxygen/1.9.5_x86_64/doxygen-1.9.5-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'f775a0bd1f0ac17e216d5be7667e605bb8b819426dcd87ccb79547978883e79f',
-     armv7l: 'f775a0bd1f0ac17e216d5be7667e605bb8b819426dcd87ccb79547978883e79f',
-       i686: 'f6a9e88ac424e38e19df517723af86c2b3296d6119d24073ff411bd3988d1603',
-     x86_64: 'ff5909d7d941b2a9e29ffc2c1d54613f65c57ff5ac4bae186264f63614ee6be3'
+    aarch64: '29e7040a1a35caf72ed743594a2f4f41e9e20ca240865be676d1c3b6a25368da',
+     armv7l: '29e7040a1a35caf72ed743594a2f4f41e9e20ca240865be676d1c3b6a25368da',
+       i686: '3ed03d545754891a70844fc88b6cbcb74123262dd065d4e8d04ed9ba78d2d4cf',
+     x86_64: 'f4552b1b37b871beed3c94659a72da80ceb20e802e1afc1c78eeab6bab29b7e0'
   })
 
-  depends_on 'python2' => :build
+  depends_on 'python3' => :build
 
   def self.build
-    Dir.mkdir 'build'
-    Dir.chdir 'build' do
-      system 'cmake',
-             "-DCMAKE_INSTALL_PREFIX:PATH=#{CREW_PREFIX}",
-             "-DCMAKE_LIBRARY_PATH=#{CREW_LIB_PREFIX}",
-             '..'
-      system 'make'
+    FileUtils.mkdir('builddir')
+    Dir.chdir('builddir') do
+      system "cmake -G Ninja \
+            #{CREW_CMAKE_OPTIONS} \
+            .."
     end
+    system 'ninja -C builddir'
   end
 
   def self.install
-    Dir.chdir 'build' do
-      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    end
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/glmark2.rb
+++ b/packages/glmark2.rb
@@ -29,6 +29,7 @@ class Glmark2 < Package
   depends_on 'libpng'
   depends_on 'libx11'
   depends_on 'libxcb'
+  depends_on 'python2'
 
   def self.build
     system "python2 ./waf configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX} --with-flavors x11-gl,x11-glesv2"

--- a/packages/komodo.rb
+++ b/packages/komodo.rb
@@ -10,6 +10,7 @@ class Komodo < Package
   source_sha256 '5c2735e9a323ffe290425e5066dd6f72f11e5d58d732411e6648a685725e055a'
 
   depends_on 'gtk2'
+  depends_on 'python2'
   depends_on 'sommelier'
 
   def self.build

--- a/packages/libewf.rb
+++ b/packages/libewf.rb
@@ -31,7 +31,6 @@ class Libewf < Package
            "--prefix=#{CREW_PREFIX}",
            "--libdir=#{CREW_LIB_PREFIX}",
            '--enable-python',
-           '--enable-python2',
            '--enable-python3',
            '--enable-wide-character-type'
     system 'make'

--- a/packages/py2_six.rb
+++ b/packages/py2_six.rb
@@ -23,6 +23,7 @@ class Py2_six < Package
      x86_64: '360cfb9534fe9c0e4efe450c2267519b60acecac2429a90b7b2fabbe7da77c24'
   })
 
+  depends_on 'python2'
   depends_on 'py2_setuptools' => :build
 
   def self.build

--- a/packages/q.rb
+++ b/packages/q.rb
@@ -22,7 +22,7 @@ class Q < Package
      x86_64: 'd1c9c44e976208687c4f0a52e631cce825fefa737b5aedf19c252db9bd99019c'
   })
 
-  depends_on 'python27'
+  depends_on 'python2'
   depends_on 'sqlite'
 
   def self.install

--- a/packages/ranger.rb
+++ b/packages/ranger.rb
@@ -24,7 +24,7 @@ class Ranger < Package
 
   depends_on 'less'
   depends_on 'ncurses'
-  depends_on 'python27'
+  depends_on 'python2'
 
   def self.build
     system 'make'

--- a/packages/scons.rb
+++ b/packages/scons.rb
@@ -22,7 +22,7 @@ class Scons < Package
      x86_64: 'f4cff9a4f35e2feeff5aac3dc49605b645a8362f53a335f37dd49b1dd6f8092c'
   })
 
-  depends_on 'python27'
+  depends_on 'python2'
 
   def self.build
     nil

--- a/packages/smem.rb
+++ b/packages/smem.rb
@@ -23,7 +23,7 @@ class Smem < Package
   })
 
   depends_on 'buildessential' => :build
-  depends_on 'python27'
+  depends_on 'python2'
 
   def self.build
     system 'make smemcap'

--- a/packages/weechat.rb
+++ b/packages/weechat.rb
@@ -26,6 +26,7 @@ class Weechat < Package
   depends_on 'aspell' => :build
   depends_on 'libcurl' => :build
   depends_on 'lua' => :build
+  depends_on 'python2'
   depends_on 'tcl' => :build
 
   def self.build


### PR DESCRIPTION
- Python 2 is deprecated, so remove it from core, buildessential.
- Remove python2 dependency from `doxygen` and update it.
- Add `python2` dep to packages as needed.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmanduchromebrew.git CREW_TESTING_BRANCH=exit_python_2  CREW_TESTING=1 crew update
```
