### PR TITLE
meson -> 0.63.2

### DIFF
--- a/packages/meson.rb
+++ b/packages/meson.rb
@@ -3,7 +3,7 @@ require 'package'
 class Meson < Package
   description 'Meson is an open source build system meant to be both extremely fast and user friendly.'
   homepage 'https://mesonbuild.com/'
-  @_ver = '0.63.1'
+  @_ver = '0.63.2'
   version @_ver
   license 'Apache-2.0'
   compatibility 'all'
@@ -11,16 +11,16 @@ class Meson < Package
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.63.1_armv7l/meson-0.63.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.63.1_armv7l/meson-0.63.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.63.1_i686/meson-0.63.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.63.1_x86_64/meson-0.63.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.63.2_armv7l/meson-0.63.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.63.2_armv7l/meson-0.63.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.63.2_i686/meson-0.63.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.63.2_x86_64/meson-0.63.2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '66d12e7c85e9dc3f901ecf020181649144a1f219d0f3b7d4ff8832587ecf50b3',
-     armv7l: '66d12e7c85e9dc3f901ecf020181649144a1f219d0f3b7d4ff8832587ecf50b3',
-       i686: 'e5c1e65482854b5f31e1f36e7e92711eedc2b0fe7b10cf6145910691e223eac5',
-     x86_64: '9df15c32f27a89dd68aab89c395f09198ed831c6a8db62ed3ac59f02fb6d5b78'
+    aarch64: 'f12540afa039e6d33a0567aa8d05f11e41118311c61d94fd27e9fc57e92a1e8f',
+     armv7l: 'f12540afa039e6d33a0567aa8d05f11e41118311c61d94fd27e9fc57e92a1e8f',
+       i686: '3de10a2ef8ce12c2e0f9b2e931ef38313252fac2544f48cd1c2a81d9779fa0ce',
+     x86_64: 'c60693ebee824f77a60ae0485a97b1381c85877b56c758babfbe50552e9afd95'
   })
 
   depends_on 'ninja'


### PR DESCRIPTION


Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=meson632 CREW_TESTING=1 crew update
```
