### PR TITLE
Run preflight check on dependencies also, remove `autoremove` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ Where available commands are:
 
 | Command | Description |
 |:---|:---|
-| autoremove | remove unused dependencies installed by removed packages |
 | build | build package(s) from source and store the archive and checksum in the current working directory |
 | const | display constant(s) |
 | deps | display dependencies of package(s) |

--- a/bin/crew
+++ b/bin/crew
@@ -1318,7 +1318,7 @@ def resolve_dependencies
   puts 'The following packages also need to be installed: '
 
   @dependencies.each do |dep|
-    abort "Dependency #{dep} was not found.".lightred unless File.exist?("#{CREW_PACKAGES_PATH}/#{dep}.rb")
+    abort "Dependency #{dep} was not found.".lightred unless File.exist?( File.join(CREW_PACKAGES_PATH, "#{dep}.rb") )
   end
 
   puts @dependencies.join(' ')

--- a/bin/crew
+++ b/bin/crew
@@ -1317,7 +1317,7 @@ def resolve_dependencies
 
   # run preflight check for dependencies
   @dependencies.each do |depName|
-    dep_pkgPath = File.join(CREW_PACKAGES_PATH, depName)
+    dep_pkgPath = File.join(CREW_PACKAGES_PATH, "#{depName}.rb")
     Package.load_package(dep_pkgPath, depName).preflight
   end
 

--- a/bin/crew
+++ b/bin/crew
@@ -154,13 +154,6 @@ end
   end
 end
 
-def is_compatible?(pkgName)
-  pkgPath = File.join(CREW_PACKAGES_PATH, "#{pkgName}.rb")
-  pkg     = Package.load_package(pkgPath, pkgName)
-
-  return pkg.compatible?
-end
-
 def print_package(pkgPath, extra = false)
   pkgName = File.basename pkgPath, '.rb'
   begin

--- a/bin/crew
+++ b/bin/crew
@@ -1340,7 +1340,7 @@ def resolve_dependencies
     print_current_package
     install
   end
-  if @resolve_dependencies_and_install.eql?(1) or @resolve_dependencies_and_build.eql?(1)
+  if @resolve_dependencies_and_install.eql?(1) || @resolve_dependencies_and_build.eql?(1)
     @to_postinstall = @dependencies
   else
     @dependencies.each do |dep|

--- a/bin/crew
+++ b/bin/crew
@@ -154,7 +154,7 @@ end
   end
 end
 
-def is_compatible? (pkgName)
+def is_compatible?(pkgName)
   pkgPath = File.join(CREW_PACKAGES_PATH, "#{pkgName}.rb")
   pkg     = Package.load_package(pkgPath, pkgName)
 
@@ -172,10 +172,9 @@ def print_package(pkgPath, extra = false)
 end
 
 def print_current_package(extra = false)
-  status = case
-           when @device[:installed_packages].any? { |elem| elem[:name] == @pkg.name }
+  status = if @device[:installed_packages].any? { |elem| elem[:name] == @pkg.name }
              :installed
-           when !@pkg.compatible?
+           elsif !@pkg.compatible?
              :incompatible
            else
              :available

--- a/bin/crew
+++ b/bin/crew
@@ -23,7 +23,6 @@ DOC = <<~DOCOPT
   Chromebrew - Package manager for Chrome OS https://chromebrew.github.io
 
   Usage:
-    crew autoremove [options]
     crew build [options] [-k|--keep] <name> ...
     crew const [options] [<name> ...]
     crew deps [options] [-t|--tree] [-b|--include-build-deps] [--exclude-buildessential] <name> ...
@@ -79,7 +78,6 @@ LICENSESTRING
 
 # All available crew commands.
 @cmds = %w[
-  autoremove
   build
   const
   deps
@@ -156,6 +154,13 @@ end
   end
 end
 
+def is_compatible? (pkgName)
+  pkgPath = File.join(CREW_PACKAGES_PATH, "#{pkgName}.rb")
+  pkg     = Package.load_package(pkgPath, pkgName)
+
+  return pkg.compatible?
+end
+
 def print_package(pkgPath, extra = false)
   pkgName = File.basename pkgPath, '.rb'
   begin
@@ -167,17 +172,24 @@ def print_package(pkgPath, extra = false)
 end
 
 def print_current_package(extra = false)
-  status = ''
-  status = 'installed' if @device[:installed_packages].any? { |elem| elem[:name] == @pkg.name }
-  status = 'incompatible' unless @device[:compatible_packages].any? { |elem| elem[:name] == @pkg.name }
+  status = case
+           when @device[:installed_packages].any? { |elem| elem[:name] == @pkg.name }
+             :installed
+           when !@pkg.compatible?
+             :incompatible
+           else
+             :available
+           end
+
   case status
-  when 'installed'
+  when :installed
     print @pkg.name.lightgreen
-  when 'incompatible'
+  when :incompatible
     print @pkg.name.lightred
-  else
+  when :available
     print @pkg.name.lightblue
   end
+
   print ": #{@pkg.description}".lightblue if @pkg.description
   if extra
     puts ''
@@ -216,7 +228,7 @@ def list_available
     rescue StandardError => e
       puts "Error with #{pkgName}.rb: #{e}".red unless e.to_s.include?('uninitialized constant')
     end
-    puts pkgName if (@pkg.compatibility&.include? 'all') || (@pkg.compatibility&.include? ARCH)
+    puts pkgName if @pkg.compatible?
   end
 end
 
@@ -286,7 +298,7 @@ def generate_compatible
         puts "#{pkgName} compatibility is #{@compatibility}" if @opt_verbose
       end
     end
-    if ((@pkg.compatibility&.include? 'all') || (@pkg.compatibility&.include? ARCH) || @pkg.compatibility.nil?) && @compatibility
+    if @pkg.compatible? && @compatibility
       # add to compatible packages
       puts "Adding #{pkgName} to compatible packages.".lightgreen if @opt_verbose
       @device[:compatible_packages].push(name: @pkg.name)
@@ -339,11 +351,6 @@ end
 
 def help(pkgName)
   case pkgName
-  when 'autoremove'
-    puts <<~EOT
-      Remove unused dependencies installed by removed packages
-      Usage: crew autoremove
-    EOT
   when 'build'
     puts <<~EOT
       Build package(s).
@@ -1264,12 +1271,13 @@ end
 
 def resolve_dependencies_and_install
   @resolve_dependencies_and_install = 1
-  preflight_fake_packages = %w[hunspell imagemagick jdk php]
-  unless @pkg.is_fake? && !preflight_fake_packages.include?(@pkg.name)
-    # Process preflight block to see if package should even
-    # be downloaded or installed.
-    pre_flight
-  end
+
+  abort "Package #{@pkg.name} is not compatible with your device architecture (#{ARCH}) :/".lightred unless @pkg.compatible?
+
+  # Process preflight block to see if package should even
+  # be downloaded or installed.
+  pre_flight
+
   begin
     origin = @pkg.name
 
@@ -1301,16 +1309,16 @@ def expand_dependencies
 end
 
 def resolve_dependencies
-  abort "Package #{@pkg.name} is not compatible with your device architecture (#{ARCH}) :/".lightred unless @device[:compatible_packages].any? { |elem| elem[:name] == @pkg.name }
-
   @dependencies = []
   expand_dependencies
 
   # leave only not installed packages in dependencies
-  @dependencies.select! { |name| @device[:installed_packages].none? { |pkg| pkg[:name] == name } }
-  %w[jdk11 jdk15 jdk16 jdk17 jdk18].each do |jdk|
-    @dependencies.delete('jdk8') if @dependencies.include?(jdk)
-    @dependencies.delete('jdk8') if @pkg.name == jdk
+  @dependencies.reject! { |name| @device[:installed_packages].any? { |pkg| pkg[:name] == name } }
+
+  # run preflight check for dependencies
+  @dependencies.each do |depName|
+    dep_pkgPath = File.join(CREW_PACKAGES_PATH, depName)
+    Package.load_package(dep_pkgPath, depName).preflight
   end
 
   return if @dependencies.empty?
@@ -1318,7 +1326,7 @@ def resolve_dependencies
   puts 'The following packages also need to be installed: '
 
   @dependencies.each do |dep|
-    abort "Dependency #{dep} was not found.".lightred unless File.exist?("#{CREW_PACKAGES_PATH}#{dep}.rb")
+    abort "Dependency #{dep} was not found.".lightred unless File.exist?("#{CREW_PACKAGES_PATH}/#{dep}.rb")
   end
 
   puts @dependencies.join(' ')
@@ -1330,26 +1338,22 @@ def resolve_dependencies
     abort 'No changes made.'
   when "\n", 'y', 'Y'
     puts 'Proceeding...'
-    proceed = true
   else
     puts "I don't understand `#{response}`. :(".lightred
     abort 'No changes made.'
   end
 
-  if proceed
+  @dependencies.each do |dep|
+    search dep
+    print_current_package
+    install
+  end
+  if @resolve_dependencies_and_install.eql?(1) or @resolve_dependencies_and_build.eql?(1)
+    @to_postinstall = @dependencies
+  else
     @dependencies.each do |dep|
       search dep
-      print_current_package
-      @pkg.is_dep = true
-      install
-    end
-    if (@resolve_dependencies_and_install == 1) || (@resolve_dependencies_and_build == 1)
-      @to_postinstall = @dependencies
-    else
-      @dependencies.each do |dep|
-        search dep
-        post_install
-      end
+      post_install
     end
   end
 end
@@ -1406,7 +1410,7 @@ def install
   end
 
   # add to installed packages
-  @device[:installed_packages].push(name: @pkg.name, version: @pkg.version, is_dep: @pkg.is_dep)
+  @device[:installed_packages].push(name: @pkg.name, version: @pkg.version)
   File.open("#{CREW_CONFIG_PATH}device.json.tmp", 'w') do |file|
     output = JSON.parse @device.to_json
     file.write JSON.pretty_generate(output)
@@ -1647,41 +1651,6 @@ def print_deps_tree(args)
   end
 
   puts treeView
-end
-
-def autoremove_command(_args)
-  deps_of_installed_pkgs = @device[:installed_packages].map do |pkg|
-    # ignore deleted/non-exist package recipes
-    next unless File.exist?("#{CREW_PACKAGES_PATH}/#{pkg[:name]}.rb")
-
-    set_package pkg[:name], "#{CREW_PACKAGES_PATH}/#{pkg[:name]}.rb"
-    next @pkg.dependencies
-  end.flatten
-
-  remove_pkg = @device[:installed_packages].select do |pkg|
-    pkg[:is_dep] and !deps_of_installed_pkgs.include?(pkg[:name])
-  end.map { |pkg| pkg[:name] }
-
-  return if remove_pkg.empty?
-
-  puts 'The following packages also need to be REMOVED: '
-  remove_pkg.each do |pkg|
-    print "#{pkg} "
-  end
-  print "\nDo you agree? [Y/n] "
-
-  response = $stdin.getc
-  case response
-  when 'n'
-    abort 'No changes made.'
-  when "\n", 'y', 'Y'
-    puts 'Proceeding...'
-  else
-    puts "I don't understand `#{response}`. :(".lightred
-    abort 'No changes made.'
-  end
-
-  remove_pkg.each { |pkg| remove(pkg) }
 end
 
 def build_command(args)

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.25.4'
+CREW_VERSION = '1.26.0'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -1,4 +1,5 @@
 require 'English'
+require_relative 'const'
 require_relative 'package_helpers'
 
 class Package
@@ -23,7 +24,7 @@ class Package
                      :remove       # Function to perform after package removal.
 
   class << self
-    attr_accessor :name, :is_dep, :in_build, :build_from_source, :in_upgrade
+    attr_accessor :name, :in_build, :build_from_source, :in_upgrade
   end
 
   def self.load_package(pkgFile, pkgName = File.basename(pkgFile, '.rb'))
@@ -155,6 +156,10 @@ exclude_buildessential: exclude_buildessential,
       @prop = instance_variable_get("@#{prop}")
       !!@prop
     end
+  end
+
+  def compatible?
+    return (@compatibility.casecmp?('all') or @compatibility.include?(ARCH))
   end
 
   def self.depends_on(dependency = nil)

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -159,7 +159,12 @@ exclude_buildessential: exclude_buildessential,
   end
 
   def self.compatible?
-    return (@compatibility.casecmp?('all') or @compatibility.include?(ARCH))
+    if @compatibility
+      return (@compatibility.casecmp?('all') or @compatibility.include?(ARCH))
+    else
+      warn "#{name}: Missing `compatibility` field.".yellow
+      return true
+    end
   end
 
   def self.depends_on(dependency = nil)

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -161,9 +161,10 @@ exclude_buildessential: exclude_buildessential,
 
   def self.compatible?
     if @compatibility
-      return (@compatibility.casecmp?('all') or @compatibility.include?(ARCH))
+      return (@compatibility.casecmp?('all') || @compatibility.include?(ARCH))
     else
-      abort "#{name}: Missing `compatibility` field.".lightred
+      warn "#{name}: Missing `compatibility` field.".lightred
+      return false
     end
   end
 

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -163,8 +163,7 @@ exclude_buildessential: exclude_buildessential,
     if @compatibility
       return (@compatibility.casecmp?('all') or @compatibility.include?(ARCH))
     else
-      warn "#{name}: Missing `compatibility` field.".yellow
-      return true
+      abort "#{name}: Missing `compatibility` field.".lightred
     end
   end
 

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -1,5 +1,6 @@
 require 'English'
 require_relative 'const'
+require_relative 'color'
 require_relative 'package_helpers'
 
 class Package

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -158,7 +158,7 @@ exclude_buildessential: exclude_buildessential,
     end
   end
 
-  def compatible?
+  def self.compatible?
     return (@compatibility.casecmp?('all') or @compatibility.include?(ARCH))
   end
 

--- a/packages/gzip.rb
+++ b/packages/gzip.rb
@@ -3,28 +3,61 @@ require 'package'
 class Gzip < Package
   description 'GNU Gzip is a popular data compression program originally written by Jean-loup Gailly for the GNU project.'
   homepage 'https://www.gnu.org/software/gzip/'
-  version '1.11'
-  license 'GPL-3'
+  version '1.12'
   compatibility 'all'
-  source_url 'https://ftpmirror.gnu.org/gzip/gzip-1.11.tar.xz'
-  source_sha256 '9b9a95d68fdcb936849a4d6fada8bf8686cddf58b9b26c9c4289ed0c92a77907'
+  license 'GPL-3'
+  source_url 'https://ftpmirror.gnu.org/gzip/gzip-1.12.tar.xz'
+  source_sha256 'ce5e03e519f637e1f814011ace35c4f87b33c0bbabeec35baf5fbd3479e91956'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gzip/1.11_armv7l/gzip-1.11-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gzip/1.11_armv7l/gzip-1.11-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gzip/1.11_i686/gzip-1.11-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gzip/1.11_x86_64/gzip-1.11-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gzip/1.12_armv7l/gzip-1.12-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gzip/1.12_armv7l/gzip-1.12-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gzip/1.12_x86_64/gzip-1.12-chromeos-x86_64.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gzip/1.12_i686/gzip-1.12-chromeos-i686.tar.zst'
   })
   binary_sha256({
-    aarch64: 'c9350be0932de35f6988748842ea5bb939b133add7f194f3b0d37f6ff55816bc',
-     armv7l: 'c9350be0932de35f6988748842ea5bb939b133add7f194f3b0d37f6ff55816bc',
-       i686: 'dd638a8e748003937fb955f97c2112affe77ba7c4a041b89778abce0ccd81794',
-     x86_64: '605605a9eb7f26b799b07b8246f80a82b7ab8a16a3749a393763a4401497bfda'
+    aarch64: '2a699b3eba6ff714a780e8c2c32131c842f2960d2eb04de280268c54d111aed1',
+     armv7l: '2a699b3eba6ff714a780e8c2c32131c842f2960d2eb04de280268c54d111aed1',
+     x86_64: 'bd27a2c304c111cd4983416745ff83c210f15773f2dc5fd864369d7617ef904a',
+       i686: '9beef9bcb1bbd34f2c476e1412854a72181104b4d7db79ffec815818b93a8e81'
   })
 
+  def self.patch
+    return unless ARCH == 'i686'
+
+    # Patch from https://git.savannah.gnu.org/cgit/gnulib.git/diff/?id=84863a1c4dc8cca8fb0f6f670f67779cdd2d543b
+    @gnulibpatch = <<~'PATCH_EOF'
+      diff --git a/lib/string.in.h b/lib/string.in.h
+      index b6840fa..33160b2 100644
+      --- a/lib/string.in.h
+      +++ b/lib/string.in.h
+      @@ -583,7 +583,7 @@ _GL_FUNCDECL_RPL (strndup, char *,
+                         _GL_ATTRIBUTE_MALLOC _GL_ATTRIBUTE_DEALLOC_FREE);
+       _GL_CXXALIAS_RPL (strndup, char *, (char const *__s, size_t __n));
+       # else
+      -#  if !@HAVE_DECL_STRNDUP@ || __GNUC__ >= 11
+      +#  if !@HAVE_DECL_STRNDUP@ || (__GNUC__ >= 11 && !defined strndup)
+       _GL_FUNCDECL_SYS (strndup, char *,
+                         (char const *__s, size_t __n)
+                         _GL_ARG_NONNULL ((1))
+      @@ -593,7 +593,7 @@ _GL_CXXALIAS_SYS (strndup, char *, (char const *__s, size_t __n));
+       # endif
+       _GL_CXXALIASWARN (strndup);
+       #else
+      -# if __GNUC__ >= 11
+      +# if __GNUC__ >= 11 && !defined strndup
+       /* For -Wmismatched-dealloc: Associate strndup with free or rpl_free.  */
+       _GL_FUNCDECL_SYS (strndup, char *,
+                         (char const *__s, size_t __n)
+    PATCH_EOF
+    File.write('gnulib.patch', @gnulibpatch)
+    system 'patch -p 1 -i gnulib.patch'
+  end
+
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
-    system 'make'
+    system "./configure #{CREW_OPTIONS} \
+            --enable-threads=posix"
+    system "mold -run make -j #{CREW_NPROC}"
   end
 
   def self.install


### PR DESCRIPTION
The `File.exist?` check of `jdk*.rb` will be moved to `self.preflight` in my next PR, and the current installation logic does not run preflight on dependencies, which breaks the `jdk` fake package.

Also removed the `autoremove` command since it is broken for a long while + cleanup

Tested on `x86_64`

### Changes
- Run compatibility check for `@pkg` earlier
- Run preflight check on dependencies
- Add a new function (`@pkg.compatible?`) for compatibility check (`lib/package.rb`)
- Remove `crew autoremove` command