### PR TITLE
rubocop: Disable `and/or` check, re-enable trailing space check

### DIFF
--- a/.github/workflows/Rubocop.yml
+++ b/.github/workflows/Rubocop.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: rubocop
+    - name: Rubocop
       uses: Freshly/Octocop@v0.0.2
       with:
         github_token: ${{ secrets.github_token }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,9 +62,6 @@ Metrics/BlockNesting:
 Metrics/ParameterLists:
   Enabled: false
 
-Layout/TrailingWhitespace:
-  Enabled: false
-
 Layout/LineContinuationLeadingSpace:
   Enabled: false
 
@@ -126,6 +123,9 @@ Layout/FirstHashElementIndentation:
 
 Layout/IndentationStyle:
   EnforcedStyle: spaces
+
+Style/AndOr:
+  Enabled: false
 
 Style/RedundantReturn:
   Enabled: false


### PR DESCRIPTION
Compared to `&&/||`, the `and/or` statement is more self-explained and beginner-friendly

Also re-enabled the trailing space check
