### PR TITLE
Re-enable And/Or cop, lint tree

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -124,9 +124,6 @@ Layout/FirstHashElementIndentation:
 Layout/IndentationStyle:
   EnforcedStyle: spaces
 
-Style/AndOr:
-  Enabled: false
-
 Style/RedundantReturn:
   Enabled: false
 

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -57,7 +57,7 @@ class ProgressBar
         return false
       end
     end
- 
+
     if @start_time
       @elapsed_time = (Time.now - @start_time).to_i
     else

--- a/packages/autossh.rb
+++ b/packages/autossh.rb
@@ -23,13 +23,13 @@ class Autossh < Package
   })
 
   depends_on 'openssh'
-  
+
   def self.build
     system "./configure #{CREW_OPTIONS} \
             --with-ssh=$(which ssh)"
     system 'make'
   end
-  
+
   def self.install
     system "mkdir -p #{CREW_DEST_PREFIX}/bin"
     system "mkdir -p #{CREW_DEST_PREFIX}/share/doc/autossh"

--- a/packages/caja.rb
+++ b/packages/caja.rb
@@ -25,17 +25,17 @@ class Caja < Package
     system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto' \
                 LDFLAGS='-flto=auto' \
             ./configure #{CREW_OPTIONS}"
-    
+
     # https://bugzilla.gnome.org/show_bug.cgi?id=656231
     system "sed -i 's/ -shared / -Wl,-O1,--as-needed\\0/g' libtool"
-    
+
     system 'make'
   end
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
-    
+
   def self.postinstall
     system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
   end

--- a/packages/crew_launcher.rb
+++ b/packages/crew_launcher.rb
@@ -8,7 +8,7 @@ class Crew_launcher < Package
   compatibility 'all'
   source_url 'https://github.com/chromebrew/crew-launcher.git'
   git_hashtag '1.1'
-  
+
   depends_on 'llvm'
   depends_on 'graphicsmagick'
 
@@ -26,7 +26,7 @@ class Crew_launcher < Package
       FileUtils.ln_s '../../../lib/crew/lib/color.rb', 'color.rb'
     end
     FileUtils.ln_s '../share/crew-launcher/main.rb', "#{CREW_DEST_PREFIX}/bin/crew-launcher"
-    
+
     system "curl -L https://github.com/chromebrew/chromebrew/raw/gh-pages/images/brew-title.png -o #{CREW_DEST_PREFIX}/share/crew-launcher/icon/brew.png"
 
     File.write "#{CREW_DEST_PREFIX}/etc/env.d/crew_launcher", <<~EOF

--- a/packages/dconf_editor.rb
+++ b/packages/dconf_editor.rb
@@ -40,7 +40,7 @@ class Dconf_editor < Package
   def self.check
     system 'ninja -C builddir test'
   end
-  
+
   def self.postinstall
     system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
   end

--- a/packages/desktop_file_utilities.rb
+++ b/packages/desktop_file_utilities.rb
@@ -6,7 +6,7 @@ class Desktop_file_utilities < Package
   version '1.0'
   license 'GPL-3+'
   compatibility 'all'
-  
+
   is_fake
 
   depends_on 'desktop_file_utils'

--- a/packages/djvulibre.rb
+++ b/packages/djvulibre.rb
@@ -24,7 +24,7 @@ class Djvulibre < Package
        i686: 'a0cf591f8e04fc89a0c2f45f0ad67c7c907971dcf85371a2184c3ea54e605da4',
      x86_64: 'd17ec121e01aea869ea74b421aebcf4b8f019e8b32268859256aadd32019aab5'
   })
- 
+
   depends_on 'libjpeg'
   depends_on 'libtiff'
   depends_on 'librsvg' => :build

--- a/packages/funny_manpages.rb
+++ b/packages/funny_manpages.rb
@@ -9,7 +9,7 @@ class Funny_manpages < Package
   compatibility 'all'
   source_url 'https:///github.com/ltworf/funny-manpages.git'
   git_hashtag @_ver
-  
+
   depends_on 'mandb'
 
   def self.install

--- a/packages/gdb.rb
+++ b/packages/gdb.rb
@@ -62,7 +62,7 @@ class Gdb < Package
       system "make -C gdbserver DESTDIR=#{CREW_DEST_DIR} install"
     end
     # Remove files conflicting with binutils
-    FileUtils.rm_f "#{CREW_DEST_PREFIX}/share/info/bfd.info" 
+    FileUtils.rm_f "#{CREW_DEST_PREFIX}/share/info/bfd.info"
     conflict_packages = %w[binutils]
     conflict_packages.each do |package|
       file = File.read("#{CREW_META_PATH}#{package}.filelist")
@@ -73,6 +73,6 @@ class Gdb < Package
         end
       end
     end
-    FileUtils.rm_f "#{CREW_DEST_LIB_PREFIX}/libinproctrace.so" 
+    FileUtils.rm_f "#{CREW_DEST_LIB_PREFIX}/libinproctrace.so"
   end
 end

--- a/packages/gvim.rb
+++ b/packages/gvim.rb
@@ -80,7 +80,7 @@ class Gvim < Package
     # these are provided by 'xxd_standalone'
     @deletefiles = %W[#{CREW_DEST_PREFIX}/bin/xxd #{CREW_DEST_MAN_PREFIX}/man1/xxd.1]
     @deletefiles.each do |f|
-      FileUtils.rm_f f 
+      FileUtils.rm_f f
     end
   end
 

--- a/packages/hashpipe.rb
+++ b/packages/hashpipe.rb
@@ -33,7 +33,7 @@ class Hashpipe < Package
         * Copyright (C) 2018 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
       + * Code also imported from https://gitlab.gnome.org/GNOME/gtk/-/blob/master/gdk/wayland/cursor/os-compatibility.c
         */
-       
+
        #define _GNU_SOURCE
       @@ -10,12 +11,59 @@
        #include <stdbool.h>
@@ -47,7 +47,7 @@ class Hashpipe < Package
        #include <sys/sendfile.h>
        #include <fcntl.h>
        #include <openssl/evp.h>
-       
+
       +#ifndef HAVE_MKOSTEMP
       +static int
       +set_cloexec_or_close(int fd)
@@ -96,7 +96,7 @@ class Hashpipe < Package
        static bool hex2bin(unsigned char *bin, const char *hex, size_t hexlen)
        {
       @@ -51,11 +99,14 @@ static bool hex2bin(unsigned char *bin,
-       
+
        int main(int argc, char *argv[])
        {
       +	char *name;
@@ -114,7 +114,7 @@ class Hashpipe < Package
       @@ -65,12 +116,57 @@ int main(int argc, char *argv[])
        		return 1;
        	}
-       
+
       -	home = getenv("HOME");
       -	fd = open(home ? home : "/", O_TMPFILE | O_EXCL | O_RDWR, S_IRUSR | S_IWUSR);
       -	if (fd < 0) {
@@ -171,7 +171,7 @@ class Hashpipe < Package
       +		return -1;
        	}
       +#endif
-       
+
        	algo = argv[1];
        	hex = argv[2];
       @@ -99,7 +195,7 @@ int main(int argc, char *argv[])
@@ -188,12 +188,12 @@ class Hashpipe < Package
       +++ new/Makefile	2021-04-08 14:59:00.199269017 -0400
       @@ -4,7 +4,7 @@ BINDIR ?= $(PREFIX)/bin
        MANDIR ?= $(PREFIX)/share/man
-       
+
        LDLIBS := -lcrypto
       -CFLAGS ?= -O3 -march=native
       +CFLAGS ?= -O3
        CFLAGS += -std=gnu11 -Wall -pedantic
-       
+
        all: hashpipe
     HASHPIPE_PATCHEOF
     File.write('hashpipe.patch', @hashpipe_patch, perm: 0o644)

--- a/packages/jp2a.rb
+++ b/packages/jp2a.rb
@@ -21,11 +21,11 @@ class Jp2a < Package
        i686: '7ce07d9769cfe508d021f1fb17d7969c8f986c577a1f903de764890165824f18',
      x86_64: '981baefcffa4d9cc67758003cd068235b074b7200e1ffed05d0f5ce76116f089'
   })
-  
+
   depends_on 'libjpeg'
   depends_on 'libpng'
   depends_on 'termcap'
-  
+
   def self.build
     system "./configure #{CREW_OPTIONS} \
             --enable-curl"
@@ -35,7 +35,7 @@ class Jp2a < Package
   def self.check
     system 'make check || true'
   end
-  
+
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end

--- a/packages/libbytesize.rb
+++ b/packages/libbytesize.rb
@@ -3,7 +3,7 @@ require 'package'
 class Libbytesize < Package
   description 'A tiny library providing a C "class" for working with arbitrary big sizes in bytes'
   homepage 'https://github.com/storaged-project/libbytesize'
-  version '2.6'    
+  version '2.6'
   license 'LGPL-2.1+'
   compatibility 'all'
   source_url 'https://github.com/storaged-project/libbytesize/releases/download/2.6/libbytesize-2.6.tar.gz'
@@ -23,7 +23,7 @@ class Libbytesize < Package
   })
 
   depends_on 'gawk' => :build
-  
+
   def self.build
     system "./configure #{CREW_OPTIONS} --with-gtk-doc=no"
     system 'make'

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -134,7 +134,7 @@ class Mesa < Package
       @@ -391,16 +391,10 @@ lp_build_comp(struct lp_build_context *b
                 return LLVMBuildNot(builder, a, "");
           }
-       
+
       -   if(LLVMIsConstant(a))
       -      if (type.floating)
       -          return LLVMConstFSub(bld->one, a);
@@ -149,12 +149,12 @@ class Mesa < Package
       -         return LLVMBuildSub(builder, bld->one, a, "");
       +      return LLVMBuildSub(builder, bld->one, a, "");
        }
-       
-       
+
+
       @@ -479,16 +473,10 @@ lp_build_add(struct lp_build_context *bl
              }
           }
-       
+
       -   if(LLVMIsConstant(a) && LLVMIsConstant(b))
       -      if (type.floating)
       -         res = LLVMConstFAdd(a, b);
@@ -168,13 +168,13 @@ class Mesa < Package
       -      else
       -         res = LLVMBuildAdd(builder, a, b, "");
       +      res = LLVMBuildAdd(builder, a, b, "");
-       
+
           /* clamp to ceiling of 1.0 */
           if(bld->type.norm && (bld->type.floating || bld->type.fixed))
       @@ -815,16 +803,10 @@ lp_build_sub(struct lp_build_context *bl
              }
           }
-       
+
       -   if(LLVMIsConstant(a) && LLVMIsConstant(b))
       -      if (type.floating)
       -         res = LLVMConstFSub(a, b);
@@ -188,13 +188,13 @@ class Mesa < Package
       -      else
       -         res = LLVMBuildSub(builder, a, b, "");
       +      res = LLVMBuildSub(builder, a, b, "");
-       
+
           if(bld->type.norm && (bld->type.floating || bld->type.fixed))
              res = lp_build_max_simple(bld, res, bld->zero, GALLIVM_NAN_RETURN_OTHER_SECOND_NONNAN);
       @@ -980,29 +962,15 @@ lp_build_mul(struct lp_build_context *bl
           else
              shift = NULL;
-       
+
       -   if(LLVMIsConstant(a) && LLVMIsConstant(b)) {
       -      if (type.floating)
       -         res = LLVMConstFMul(a, b);
@@ -227,12 +227,12 @@ class Mesa < Package
       -      }
       +          res = LLVMBuildLShr(builder, res, shift, "");
           }
-       
+
           return res;
       @@ -1288,15 +1256,6 @@ lp_build_div(struct lp_build_context *bl
           if(a == bld->undef || b == bld->undef)
              return bld->undef;
-       
+
       -   if(LLVMIsConstant(a) && LLVMIsConstant(b)) {
       -      if (type.floating)
       -         return LLVMConstFDiv(a, b);
@@ -247,11 +247,11 @@ class Mesa < Package
              ((util_get_cpu_caps()->has_sse && type.width == 32 && type.length == 4) ||
       @@ -2643,7 +2602,7 @@ lp_build_rcp(struct lp_build_context *bl
           assert(type.floating);
-       
+
           if(LLVMIsConstant(a))
       -      return LLVMConstFDiv(bld->one, a);
       +      return LLVMBuildFDiv(builder, bld->one, a, "");
-       
+
           /*
            * We don't use RCPPS because:
 

--- a/packages/nmap.rb
+++ b/packages/nmap.rb
@@ -32,7 +32,7 @@ class Nmap < Package
     # ensure we build devendored deps"
     @deps = %w[libpcap libpcre macosx mwin32 libssh2 libz]
     @deps.each do |dep|
-      FileUtils.rm_rf dep 
+      FileUtils.rm_rf dep
     end
     system 'autoreconf -fiv'
     system 'filefix'

--- a/packages/postgres.rb
+++ b/packages/postgres.rb
@@ -78,7 +78,7 @@ class Postgres < Package
       case $stdin.getc
       when 'y', 'Y'
         FileUtils.rm_rf PGDATA
-        FileUtils.rm_rf "#{CREW_PREFIX}/pgsql" 
+        FileUtils.rm_rf "#{CREW_PREFIX}/pgsql"
         puts "#{PGDATA} removed.".lightred
       else
         puts "#{PGDATA} saved.".lightgreen

--- a/packages/py2_pip.rb
+++ b/packages/py2_pip.rb
@@ -35,6 +35,6 @@ class Py2_pip < Package
     system "python2 setup.py install #{PY_SETUP_INSTALL_OPTIONS}"
 
     # Don't make pip2 the default pip
-    FileUtils.rm_f "#{CREW_DEST_PREFIX}/bin/pip" 
+    FileUtils.rm_f "#{CREW_DEST_PREFIX}/bin/pip"
   end
 end

--- a/packages/python2.rb
+++ b/packages/python2.rb
@@ -104,7 +104,7 @@ class Python2 < Package
     # system "find #{CREW_DEST_PREFIX} -name 'libpython*.a' -print | xargs -r rm"
 
     # move dynamic libraries to their correct places, so the dynamic loader can find them
-    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX 
+    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
     FileUtils.mv "#{CREW_DEST_PREFIX}/lib/libpython2.7.so", CREW_DEST_LIB_PREFIX unless CREW_LIB_SUFFIX.empty?
     FileUtils.mv "#{CREW_DEST_PREFIX}/lib/libpython2.7.so.1.0", CREW_DEST_LIB_PREFIX unless CREW_LIB_SUFFIX.empty?
 

--- a/packages/ticker.rb
+++ b/packages/ticker.rb
@@ -21,19 +21,19 @@ class Ticker < Package
        i686: '1319a716958c27c529e1427dd5789ca99a8d1e95200ca22451d3694b7e01cc93',
      x86_64: '42f30e5bab0f5f2d54046bf044cd27f09e72d5b91ba89a788cb5189edff63a75'
   })
-  
+
   depends_on 'slang'
-  
+
   def self.patch
     system "sed -i '12d' ticker.c"
     system "sed -i 's:#!/usr/bin/perl -w:#!#{CREW_PREFIX}/bin/perl -w:' sysinfo-ticker"
   end
-  
+
   def self.build
     system "./configure #{CREW_OPTIONS} || true" # Configure will fail
     system 'make'
   end
-  
+
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end

--- a/packages/unixodbc.rb
+++ b/packages/unixodbc.rb
@@ -21,7 +21,7 @@ class Unixodbc < Package
        i686: '590762ad9a2cd402ae52da0382c652d8e08a6b049f875ae99ec792f228331cd8',
      x86_64: '705488db5fc32fe2062da25e4650ac090983404525c9d06f32646058a76cfb2a'
   })
-  
+
   def self.build
     system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \

--- a/packages/usbutils.rb
+++ b/packages/usbutils.rb
@@ -39,7 +39,7 @@ class Usbutils < Package
   end
 
   def self.postinstall
-    FileUtils.mkdir_p "#{CREW_PREFIX}/share/hwdata/" 
+    FileUtils.mkdir_p "#{CREW_PREFIX}/share/hwdata/"
     system "curl -#LO http://www.linux-usb.org/usb.ids -o #{CREW_PREFIX}/share/hwdata/usb.ids"
     puts "It's recommended that you setup a cron job to update this file regularly.".lightblue
     puts 'You can install a cron package by executing `crew install cronie`'.lightblue

--- a/packages/vim.rb
+++ b/packages/vim.rb
@@ -80,7 +80,7 @@ class Vim < Package
     # these are provided by 'xxd_standalone'
     @deletefiles = %W[#{CREW_DEST_PREFIX}/bin/xxd #{CREW_DEST_MAN_PREFIX}/man1/xxd.1]
     @deletefiles.each do |f|
-      FileUtils.rm_f f 
+      FileUtils.rm_f f
     end
 
     # remove desktop and icon files for the terminal package

--- a/packages/vim_runtime.rb
+++ b/packages/vim_runtime.rb
@@ -80,7 +80,7 @@ class Vim_runtime < Package
     # these are provided by 'xxd_standalone'
     @deletefiles = %W[#{CREW_DEST_PREFIX}/bin/xxd #{CREW_DEST_MAN_PREFIX}/man1/xxd.1]
     @deletefiles.each do |f|
-      FileUtils.rm_f f 
+      FileUtils.rm_f f
     end
 
     # add sane defaults and simulate some XDG support

--- a/packages/wayland_proxy_virtwl.rb
+++ b/packages/wayland_proxy_virtwl.rb
@@ -36,7 +36,7 @@ class Wayland_proxy_virtwl < Package
       FileUtils.cp "#{CREW_PREFIX}/bin/ld.bfd", "#{CREW_DEST_PREFIX}/bin/ld"
     end
     system "PATH=#{CREW_DEST_PREFIX}/bin:$PATH OPAMROOT=#{@OPAMROOT} opam install . --root=#{@OPAMROOT} --destdir=#{CREW_DEST_DIR}#{@OPAMROOT} -y"
-    FileUtils.rm_f "#{CREW_DEST_PREFIX}/bin/ld" 
+    FileUtils.rm_f "#{CREW_DEST_PREFIX}/bin/ld"
     Dir.chdir "#{CREW_DEST_PREFIX}/bin" do
       FileUtils.ln_s '../share/opam/bin/wayland-proxy-virtwl', 'wayland-proxy-virtwl'
     end

--- a/packages/webkit2gtk.rb
+++ b/packages/webkit2gtk.rb
@@ -7,7 +7,7 @@ class Webkit2gtk < Package
   version @_ver
   license 'LGPL-2+ and BSD-2'
   compatibility 'all'
-  
+
   is_fake
 
   depends_on 'webkit2gtk_4'

--- a/packages/xfce4_panel.rb
+++ b/packages/xfce4_panel.rb
@@ -32,7 +32,7 @@ class Xfce4_panel < Package
   def self.patch
     system 'filefix'
   end
-  
+
   def self.build
     system <<~BUILD
       [ -x autogen.sh ] && env NOCONFIGURE='1' ./autogen.sh
@@ -47,7 +47,7 @@ class Xfce4_panel < Package
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
-  
+
   def self.postinstall
     system 'gtk-update-icon-cache', '-f', '-t', "#{CREW_PREFIX}/share/icons/hicolor"
   end

--- a/packages/zzuf.rb
+++ b/packages/zzuf.rb
@@ -21,7 +21,7 @@ class Zzuf < Package
        i686: 'fc620b537e809bfcd5a7c598ba25c60ab8ce5a8091d2ba0330cbce19ecd466dc',
      x86_64: '013eef3b0e2c088071352d6a29e60c9b1562db09a5371e427a6d9cc387ec1092'
   })
-  
+
   def self.build
     system "./configure #{CREW_OPTIONS}"
     system 'make'
@@ -30,7 +30,7 @@ class Zzuf < Package
   def self.check
     system 'make check'
   end
-  
+
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end


### PR DESCRIPTION
@supechicken, please actually lint the tree when you change the rubocop file, otherwise it will break all new prs made on it, and prs that rebase.

In regards to the And/Or cop, `&&` and `||` have been used as boolean operators since the dawn of time, and are very easy to find the meaning of if a beginner does not understand. Also, using `or` and `and` will only help English-speaking beginners. Furthermore, allowing `or` and `and` to be used alongside `&&` and `||` will make things even worse, as a beginner would presume they have a different meaning to the english variants.