### PR TITLE
crew install: more workarounds to avoid git if necessary

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -304,8 +304,10 @@ echo_info "\nRunning Bootstrap package postinstall scripts...\n"
 crew postinstall $BOOTSTRAP_PACKAGES
 
 if ! "${CREW_PREFIX}"/bin/git version &> /dev/null; then
-  echo_other "\nGit is broken on your system. Please report this here:"
+  echo_other "\nGit is broken on your system, and crew update will not work properly."
+  echo_other "Please report this here:"
   echo_other "https://github.com/chromebrew/chromebrew/issues\n"
+  echo
 else
   echo_info "Synchronizng local package repo..."
   # First clear out temporary package repo so we can replace it with the 

--- a/install.sh
+++ b/install.sh
@@ -43,6 +43,7 @@ echo_info() { echo -e "${YELLOW}${*}${RESET}" >&1; }
 echo_success() { echo -e "${GREEN}${*}${RESET}" >&1; }
 echo_intra() { echo -e "${BLUE}${*}${RESET}" >&1; }
 echo_out() { echo -e "${GRAY}${*}${RESET}" >&1; }
+echo_other() { echo -e "${MAGENTA}${*}${RESET}" >&2; }
 
 # Skip all checks if running on a docker container.
 [[ -f "/.dockerenv" ]] && CREW_FORCE_INSTALL=1
@@ -302,27 +303,32 @@ yes | crew install core
 echo_info "\nRunning Bootstrap package postinstall scripts...\n"
 crew postinstall $BOOTSTRAP_PACKAGES
 
-echo_info "Synchronizng local package repo..."
-# First clear out temporary package repo so we can replace it with the 
-# repo downloaded via git.
-find "${CREW_LIB_PATH}" -mindepth 1 -delete
+if ! "${CREW_PREFIX}"/bin/git version &> /dev/null; then
+  echo_other "\nGit is broken on your system. Please report this here:"
+  echo_other "https://github.com/chromebrew/chromebrew/issues\n"
+else
+  echo_info "Synchronizng local package repo..."
+  # First clear out temporary package repo so we can replace it with the 
+  # repo downloaded via git.
+  find "${CREW_LIB_PATH}" -mindepth 1 -delete
 
-# Do a minimal clone, which also sets origin to the master/main branch
-# by default. For more on why this setup might be useful see:
-# https://github.blog/2020-01-17-bring-your-monorepo-down-to-size-with-sparse-checkout/
-# If using alternate branch don't use depth=1 .
-[[ "$BRANCH" == "master" ]] && GIT_DEPTH="--depth=1" || GIT_DEPTH=
-git clone $GIT_DEPTH --filter=blob:none --no-checkout "https://github.com/${OWNER}/${REPO}.git" "${CREW_LIB_PATH}"
+  # Do a minimal clone, which also sets origin to the master/main branch
+  # by default. For more on why this setup might be useful see:
+  # https://github.blog/2020-01-17-bring-your-monorepo-down-to-size-with-sparse-checkout/
+  # If using alternate branch don't use depth=1 .
+  [[ "$BRANCH" == "master" ]] && GIT_DEPTH="--depth=1" || GIT_DEPTH=
+  git clone $GIT_DEPTH --filter=blob:none --no-checkout "https://github.com/${OWNER}/${REPO}.git" "${CREW_LIB_PATH}"
 
-cd "${CREW_LIB_PATH}"
+  cd "${CREW_LIB_PATH}"
 
-# Checkout, overwriting local files.
-[[ "$BRANCH" != "master" ]] && git fetch --all
-git checkout "${BRANCH}"
+  # Checkout, overwriting local files.
+  [[ "$BRANCH" != "master" ]] && git fetch --all
+  git checkout "${BRANCH}"
 
-# Set sparse-checkout folders.
-git sparse-checkout set packages lib bin crew tools
-git reset --hard origin/"${BRANCH}"
+  # Set sparse-checkout folders.
+  git sparse-checkout set packages lib bin crew tools
+  git reset --hard origin/"${BRANCH}"
+fi
 echo -e "${RESET}"
 
 echo "                       . .

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -7,11 +7,9 @@ class Crew_profile_base < Package
   version @_ver
   license 'GPL-3+'
   compatibility 'all'
+  source_url "https://github.com/chromebrew/crew-profile-base/archive/refs/tags/#{@_ver}.tar.gz"
+  source_sha256 '93dc200df351a1f6e1faf458108bee87fff65f45e044d2b08b6c20ea8e064ab9'
 
-  source_url 'https://github.com/chromebrew/crew-profile-base.git'
-  git_hashtag @_ver
-
-  depends_on 'git'
   no_compile_needed
   no_patchelf
 


### PR DESCRIPTION
- hopefully this helps with debugging the AMD systems.
- crew_profile_base is adjusted to just download with curl.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmanu/chromebrew.git CREW_TESTING_BRANCH=no_git_install CREW_TESTING=1 crew update
```