### PR TITLE
add binary of xorg_intel_driver and update libxvmc

### DIFF
--- a/packages/libxvmc.rb
+++ b/packages/libxvmc.rb
@@ -3,36 +3,36 @@ require 'package'
 class Libxvmc < Package
   description 'X.org X-Video Motion Compensation Library'
   homepage 'https://www.x.org'
-  version '1.0.12'
+  version '1.0.13'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://www.x.org/archive/individual/lib/libXvMC-1.0.12.tar.gz'
-  source_sha256 '024c9ec4f001f037eeca501ee724c7e51cf287eb69ced8c6126e16e7fa9864b5'
+  source_url "https://gitlab.freedesktop.org/xorg/lib/libxvmc/-/archive/libXvMC-#{version}/libxvmc-libXvMC-#{version}.tar.gz"
+  source_sha256 '58a1766176947ec41cf44c917d831db5d619fec11f99637d6deca45458e9829b'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxvmc/1.0.12_armv7l/libxvmc-1.0.12-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxvmc/1.0.12_armv7l/libxvmc-1.0.12-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxvmc/1.0.12_i686/libxvmc-1.0.12-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxvmc/1.0.12_x86_64/libxvmc-1.0.12-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxvmc/1.0.13_armv7l/libxvmc-1.0.13-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxvmc/1.0.13_armv7l/libxvmc-1.0.13-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxvmc/1.0.13_i686/libxvmc-1.0.13-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxvmc/1.0.13_x86_64/libxvmc-1.0.13-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'de7b0488e06370113a6fe8328f9bb7930a780d881a7532265378bc262b324c74',
-     armv7l: 'de7b0488e06370113a6fe8328f9bb7930a780d881a7532265378bc262b324c74',
-       i686: 'a7282ab86a3545c068795f719d1dec124fc10a9c61d8ce058e724c4c32f288e0',
-     x86_64: '1aa077674ba2b1c3ed3fc6397589ad2a16b4d29bcab9c20fafac64a2e19a673b'
+    aarch64: 'fd33a7a2d68eeb1526c3d7e69f57d003f8d94fd0ac4b48e8cf842ec65961e70c',
+     armv7l: 'fd33a7a2d68eeb1526c3d7e69f57d003f8d94fd0ac4b48e8cf842ec65961e70c',
+       i686: '4495ace012bc8611229c72ea0c0dbf49b7888cfecadd37dfbd7517cb12bf890f',
+     x86_64: '47ce9336e23acf5f44f06501a411a8e79a853b41c746f2fc368f55b0903130fc'
   })
 
   depends_on 'libxv'
   depends_on 'libx11'
 
   def self.build
-    system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto' \
-            LDFLAGS='-flto=auto' \
-            ./configure #{CREW_OPTIONS}"
-    system 'make'
+    system "meson #{CREW_MESON_OPTIONS} \
+            builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end

--- a/packages/xorg_intel_driver.rb
+++ b/packages/xorg_intel_driver.rb
@@ -5,39 +5,37 @@ require 'package'
 class Xorg_intel_driver < Package
   description 'The Xorg Intel Driver package contains the X.Org Video Driver for Intel integrated video chips including 8xx, 9xx, Gxx, Qxx, HD, Iris, and Iris Pro graphics processors.'
   homepage 'https://01.org/linuxgraphics/'
-  @_commit = '31486f40f8e8f8923ca0799aea84b58799754564'
-  version "2.99.917+916+g#{@_commit[0..8]}"
+  @_ver = '31486f40f8e8f8923ca0799aea84b58799754564'
+  version "2.99.917+916+g#{@_ver[0..7]}"
   license 'MIT and ISC'
   compatibility 'x86_64'
-
-  source_url "https://gitlab.freedesktop.org/xorg/driver/xf86-video-intel/-/archive/#{@_commit}/xf86-video-intel-#{@_commit}.tar.gz"
-  # source_url "https://xorg.freedesktop.org/archive/individual/driver/xf86-video-intel-2.21.15.tar.gz"
+  source_url "https://gitlab.freedesktop.org/xorg/driver/xf86-video-intel/-/archive/#{@_ver}/xf86-video-intel-#{@_ver}.tar.gz"
   source_sha256 '7936e8ddc2f09f272584cc9e9a2d265e9ab435f645ccd12085cd56291fa70653'
 
+  binary_url({
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_intel_driver/2.99.917+916+g31486f4_x86_64/xorg_intel_driver-2.99.917+916+g31486f4-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    x86_64: '54715305c2ddab79a838edbccf707c2e9153912b7b8f07f6cf5d0fc0123f8cdb'
+  })
+
   depends_on 'xorg_server'
-  depends_on 'libxvmc' => :build
+  # No longer builds against current versions of libxvmc
+  # See https://gitlab.freedesktop.org/xorg/driver/xf86-video-intel/-/issues/180#note_387356
+  # depends_on 'libxvmc' => :build
 
   def self.build
-    # don't try to use meson, it may make your system run out of memory and reboot
-    system './autogen.sh'
-    system "env CFLAGS='-flto=auto -lXv' CXXFLAGS='-flto=auto -lXv' \
-            LDFLAGS='-flto=auto -lXv' \
-            ./configure \
-            #{CREW_OPTIONS} \
-            --libexecdir=#{CREW_LIB_PREFIX} \
-            --with-default-dri=3"
-
-    # system "env LDFLAGS='-lXv' \
-    #        meson #{CREW_MESON_OPTIONS} \
-    #        -Dwith-default-dri=3 \
-    #        builddir"
-    #
-    # system 'meson configure builddir'
-    # system "ninja -l #{CREW_NPROC.to_i/2} -C builddir"
+    # LTO is broken with this build.
+    # See https://gitlab.freedesktop.org/xorg/driver/xf86-video-intel/-/issues/28
+    system "meson #{CREW_MESON_FNO_LTO_OPTIONS} \
+            -Ddefault-dri=3 \
+            -Dxvmc=false \
+            builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    # system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
 end


### PR DESCRIPTION
Fixes #7458 


Builds properly:
- [x] `x86_64`


### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=xorg CREW_TESTING=1 crew update
```
