### PR TITLE
libcap -> 2.66

### DIFF
--- a/packages/libcap.rb
+++ b/packages/libcap.rb
@@ -4,28 +4,27 @@ class Libcap < Package
   description 'Libcap implements the user-space interfaces to the POSIX 1003.1e capabilities available in Linux kernels.'
   homepage 'https://directory.fsf.org/wiki/Libcap/'
   version '2.66'
-  compatibility 'all'
   license 'GPL-2 or BSD'
+  compatibility 'all'
   source_url 'https://git.kernel.org/pub/scm/libs/libcap/libcap.git'
   git_hashtag "libcap-#{version}"
 
   binary_url({
-    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.65_x86_64/libcap-2.65-chromeos-x86_64.tar.xz',
-   aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.66_armv7l/libcap-2.66-chromeos-armv7l.tar.xz',
-    armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.66_armv7l/libcap-2.66-chromeos-armv7l.tar.xz',
-      i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.66_i686/libcap-2.66-chromeos-i686.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.66_armv7l/libcap-2.66-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.66_armv7l/libcap-2.66-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.66_i686/libcap-2.66-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.66_x86_64/libcap-2.66-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    x86_64: '29070edba9fce8f5dfa9175296316e3978341065f314d10b394c2f7476da50ca',
-   aarch64: 'bf9b9bbb856551554fe1ebc873ebab47cc68cc6adc9cb07225d212d7801baf72',
-    armv7l: 'bf9b9bbb856551554fe1ebc873ebab47cc68cc6adc9cb07225d212d7801baf72',
-      i686: '177ac781b737599778f9a11c09607369e0b3e18ccd03e7664360fcb002028191'
+    aarch64: '066b33b52470c318c3e9f63fb3f493ab3dc3eb56bd500e4c431adbca76c585a7',
+     armv7l: '066b33b52470c318c3e9f63fb3f493ab3dc3eb56bd500e4c431adbca76c585a7',
+       i686: 'da159f192e4f081214a3972c1d47313733687a5a5b9eb5f97d6c6a1b72da84d2',
+     x86_64: '8f5459a6d5976be34b32e98802487e04571ef9e6d9a142b3efc1b4e350794883'
   })
 
   depends_on 'glibc' # R
   depends_on 'gperf' => :build
   depends_on 'linux_pam'
-  no_zstd
 
   def self.patch
     # add includes option to make it work with gperf-3.1
@@ -36,6 +35,10 @@ class Libcap < Package
     system "sed -i 's,prefix=/usr,prefix=#{CREW_PREFIX},g' Make.Rules"
     # set exec_prefix
     system "sed -i 's,^exec_prefix=,exec_prefix=\$(prefix),g' Make.Rules"
+    if ARCH == 'x86_64'
+      # use system libdir
+      system "sed -i 's,^lib_prefix=\$(exec_prefix),lib_prefix=#{CREW_LIB_PREFIX},g' Make.Rules"
+    end
     # http://git.yoctoproject.org/cgit.cgi/poky/plain/meta/recipes-support/libcap/files/0001-ensure-the-XATTR_NAME_CAPS-is-defined-when-it-is-use.patch
     system 'sed -i "s,^\#ifdef VFS_CAP_U32,\#if defined (VFS_CAP_U32) \&\& defined (XATTR_NAME_CAPS),g" libcap/cap_file.c'
   end

--- a/packages/libcap.rb
+++ b/packages/libcap.rb
@@ -3,23 +3,23 @@ require 'package'
 class Libcap < Package
   description 'Libcap implements the user-space interfaces to the POSIX 1003.1e capabilities available in Linux kernels.'
   homepage 'https://directory.fsf.org/wiki/Libcap/'
-  version '2.65'
-  license 'GPL-2 or BSD'
+  version '2.66'
   compatibility 'all'
+  license 'GPL-2 or BSD'
   source_url 'https://git.kernel.org/pub/scm/libs/libcap/libcap.git'
   git_hashtag "libcap-#{version}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.65_armv7l/libcap-2.65-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.65_armv7l/libcap-2.65-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.65_i686/libcap-2.65-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.65_x86_64/libcap-2.65-chromeos-x86_64.tar.xz'
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.65_x86_64/libcap-2.65-chromeos-x86_64.tar.xz',
+   aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.66_armv7l/libcap-2.66-chromeos-armv7l.tar.xz',
+    armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.66_armv7l/libcap-2.66-chromeos-armv7l.tar.xz',
+      i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcap/2.66_i686/libcap-2.66-chromeos-i686.tar.xz'
   })
   binary_sha256({
-    aarch64: '85f64941fe9c6854f2e96fd6b8cda6f9ffdf0340d3c36bfdc0aa705b85af8193',
-     armv7l: '85f64941fe9c6854f2e96fd6b8cda6f9ffdf0340d3c36bfdc0aa705b85af8193',
-       i686: '8bb0641494740536c12ae91e0c91a3aaec3051116ff916dba8ba258f3ac543e4',
-     x86_64: '29070edba9fce8f5dfa9175296316e3978341065f314d10b394c2f7476da50ca'
+    x86_64: '29070edba9fce8f5dfa9175296316e3978341065f314d10b394c2f7476da50ca',
+   aarch64: 'bf9b9bbb856551554fe1ebc873ebab47cc68cc6adc9cb07225d212d7801baf72',
+    armv7l: 'bf9b9bbb856551554fe1ebc873ebab47cc68cc6adc9cb07225d212d7801baf72',
+      i686: '177ac781b737599778f9a11c09607369e0b3e18ccd03e7664360fcb002028191'
   })
 
   depends_on 'glibc' # R
@@ -36,8 +36,6 @@ class Libcap < Package
     system "sed -i 's,prefix=/usr,prefix=#{CREW_PREFIX},g' Make.Rules"
     # set exec_prefix
     system "sed -i 's,^exec_prefix=,exec_prefix=\$(prefix),g' Make.Rules"
-    # use system libdir
-    system "sed -i 's,^lib_prefix=\$(exec_prefix),lib_prefix=#{CREW_LIB_PREFIX},g' Make.Rules"
     # http://git.yoctoproject.org/cgit.cgi/poky/plain/meta/recipes-support/libcap/files/0001-ensure-the-XATTR_NAME_CAPS-is-defined-when-it-is-use.patch
     system 'sed -i "s,^\#ifdef VFS_CAP_U32,\#if defined (VFS_CAP_U32) \&\& defined (XATTR_NAME_CAPS),g" libcap/cap_file.c'
   end


### PR DESCRIPTION
- Fixes pkg-config files being put in the wrong location.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=libcap266  CREW_TESTING=1 crew update
```
