### PR TITLE
vulkan_{headers,icd_loader,tools} -> 1.3.230 (and add vulkan_tools)

### DIFF
--- a/packages/vulkan_headers.rb
+++ b/packages/vulkan_headers.rb
@@ -3,25 +3,26 @@ require 'package'
 class Vulkan_headers < Package
   description 'Vulkan header files'
   homepage 'https://github.com/KhronosGroup/Vulkan-Headers'
-  @_ver = '1.3.224'
+  @_ver = '1.3.230'
   version @_ver
   license 'Apache-2.0'
   compatibility 'all'
   source_url 'https://github.com/KhronosGroup/Vulkan-Headers.git'
-  git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.224_armv7l/vulkan_headers-1.3.224-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.224_armv7l/vulkan_headers-1.3.224-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.224_i686/vulkan_headers-1.3.224-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.224_x86_64/vulkan_headers-1.3.224-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.230_armv7l/vulkan_headers-1.3.230-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.230_armv7l/vulkan_headers-1.3.230-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.230_i686/vulkan_headers-1.3.230-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.230_x86_64/vulkan_headers-1.3.230-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '07d06412605ad77da5eb584ff0004ca8bd375facdec7f208cc8507d87574770a',
-     armv7l: '07d06412605ad77da5eb584ff0004ca8bd375facdec7f208cc8507d87574770a',
-       i686: '09b838eacafe97c1471f3da15a82fef46bbd895b443f50f0cefb080b4e513595',
-     x86_64: '20e3b90d93447e620d730bfe3f0f55d97cfd19134ed275b5672f5d962863118a'
+    aarch64: 'd36b9887edca21f8092ed048bdce3b097312e1074c34a801088ac8eeadb9981b',
+     armv7l: 'd36b9887edca21f8092ed048bdce3b097312e1074c34a801088ac8eeadb9981b',
+       i686: 'de184f007aad9a8b937c769e9cbd37a4257e7d7bde3e39eaa947f0b7ee1d5369',
+     x86_64: 'db133f28b049375d584831c05020bb25778a7728d12d5f27198ee3d3f1c56d87'
   })
+
+  git_hashtag "v#{@_ver}"
 
   def self.build
     Dir.mkdir 'builddir'
@@ -31,10 +32,10 @@ class Vulkan_headers < Package
         #{CREW_CMAKE_OPTIONS} \
         .."
     end
-    system 'ninja -C builddir'
+    system 'mold -run samu -C builddir'
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
   end
 end

--- a/packages/vulkan_icd_loader.rb
+++ b/packages/vulkan_icd_loader.rb
@@ -3,25 +3,26 @@ require 'package'
 class Vulkan_icd_loader < Package
   description 'Vulkan Installable Client Driver ICD Loader'
   homepage 'https://github.com/KhronosGroup/Vulkan-Loader'
-  @_ver = '1.3.224'
+  @_ver = '1.3.230'
   version @_ver
   license 'Apache-2.0'
   compatibility 'all'
   source_url 'https://github.com/KhronosGroup/Vulkan-Loader.git'
-  git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.224_armv7l/vulkan_icd_loader-1.3.224-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.224_armv7l/vulkan_icd_loader-1.3.224-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.224_i686/vulkan_icd_loader-1.3.224-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.224_x86_64/vulkan_icd_loader-1.3.224-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.230_armv7l/vulkan_icd_loader-1.3.230-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.230_armv7l/vulkan_icd_loader-1.3.230-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.230_i686/vulkan_icd_loader-1.3.230-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.230_x86_64/vulkan_icd_loader-1.3.230-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '15b9c5272c0a2a8adcafd5984da16738a3a7032479b38f9ce77a3b4ddaf187e5',
-     armv7l: '15b9c5272c0a2a8adcafd5984da16738a3a7032479b38f9ce77a3b4ddaf187e5',
-       i686: 'c0c0c5a6fed09d2515de58c8f2af31081133fe8bc292d445b7bf5ce8676a4239',
-     x86_64: '53fdaa92fb1e31410c6ebd50f1661f8b99b3a62a2f1bc33be123b2fff7a3f2da'
+    aarch64: '15f8878ef502ebe90ed22535d2e99e6da804e02aae41f0a4c7403c4ae512b26f',
+     armv7l: '15f8878ef502ebe90ed22535d2e99e6da804e02aae41f0a4c7403c4ae512b26f',
+       i686: 'f36cd322d98a6c6874e9c450cf5bbde693b297cd8315f6e01d7cc94f6ff2d982',
+     x86_64: 'fdfb0631b3069712a4aa0095cd0055d5425d842a76bfa5e979fdba04a6a49f7e'
   })
+
+  git_hashtag "v#{@_ver}"
 
   depends_on 'libx11'
   depends_on 'libxrandr'

--- a/packages/vulkan_tools.rb
+++ b/packages/vulkan_tools.rb
@@ -1,0 +1,81 @@
+# Adapted from Arch Linux vulkan-tools PKGBUILD at:
+# https://github.com/archlinux/svntogit-packages/raw/packages/vulkan-tools/trunk/PKGBUILD
+
+require 'package'
+
+class Vulkan_tools < Package
+  description 'Vulkan Utilities and Tools'
+  homepage 'https://www.khronos.org/vulkan/'
+  version '1.3.230'
+  license 'custom'
+  compatibility 'all'
+  source_url "https://github.com/KhronosGroup/Vulkan-Tools/archive/v#{version}.tar.gz"
+  source_sha256 '5bb190d20ee8ae4e8dd157b686bd2d3162dc3a814b3d0625d90b1d84dd177dbb'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_tools/1.3.230_armv7l/vulkan_tools-1.3.230-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_tools/1.3.230_armv7l/vulkan_tools-1.3.230-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_tools/1.3.230_i686/vulkan_tools-1.3.230-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_tools/1.3.230_x86_64/vulkan_tools-1.3.230-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: 'be40fe9684ff980a1e4624ec112eba844b6a58e219cf71bb6bb4f1a75667693e',
+     armv7l: 'be40fe9684ff980a1e4624ec112eba844b6a58e219cf71bb6bb4f1a75667693e',
+       i686: '428aadff66735013c5dfc3b392cf54055b6d9dba0f710492fe4efd1c077e3674',
+     x86_64: 'fbe30a5c9296eaaaab392540792bbf729166979cc5313b2d306923fe3ec3c437'
+  })
+
+  depends_on 'libx11'
+  depends_on 'wayland'
+  depends_on 'python3' => :build
+  depends_on 'vulkan_headers' => :build
+  depends_on 'vulkan_icd_loader' => :build
+  depends_on 'wayland_protocols' => :build
+  depends_on 'glslang' => :build
+  depends_on 'spirv_tools' => :build
+
+  def self.build
+    Dir.mkdir 'builddir'
+    Dir.chdir 'builddir' do
+      system "env #{CREW_ENV_OPTIONS} \
+        cmake -G Ninja \
+        #{CREW_CMAKE_OPTIONS} \
+        -DVULKAN_HEADERS_INSTALL_DIR=#{CREW_PREFIX} \
+        -DCMAKE_INSTALL_SYSCONFDIR=#{CREW_PREFIX}/etc \
+        -DCMAKE_INSTALL_DATADIR=#{CREW_PREFIX}/share \
+        -DCMAKE_SKIP_RPATH=True \
+        -DBUILD_WSI_XCB_SUPPORT=On \
+        -DBUILD_WSI_XLIB_SUPPORT=On \
+        -DBUILD_WSI_WAYLAND_SUPPORT=On \
+        -DBUILD_CUBE=ON \
+        -DBUILD_VULKANINFO=ON \
+        -DBUILD_ICD=OFF \
+        .."
+    end
+    Dir.mkdir 'builddir-wayland'
+    Dir.chdir 'builddir-wayland' do
+      system "env #{CREW_ENV_OPTIONS} \
+        cmake -G Ninja \
+        #{CREW_CMAKE_OPTIONS} \
+        -DVULKAN_HEADERS_INSTALL_DIR=#{CREW_PREFIX} \
+        -DCMAKE_INSTALL_SYSCONFDIR=#{CREW_PREFIX}/etc \
+        -DCMAKE_INSTALL_DATADIR=#{CREW_PREFIX}/share \
+        -DCMAKE_SKIP_RPATH=True \
+        -DBUILD_WSI_XCB_SUPPORT=OFF \
+        -DBUILD_WSI_XLIB_SUPPORT=OFF \
+        -DBUILD_WSI_WAYLAND_SUPPORT=On \
+        -DBUILD_CUBE=ON \
+        -DCUBE_WSI_SELECTION=WAYLAND \
+        -DBUILD_VULKANINFO=OFF \
+        -DBUILD_ICD=OFF \
+        .."
+    end
+    system 'samu -C builddir'
+    system 'samu -C builddir-wayland'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
+    FileUtils.install 'builddir-wayland/cube/vkcube-wayland', "#{CREW_DEST_PREFIX}/bin/vkcube-wayland", mode: 0o755
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -7750,12 +7750,17 @@ activity: medium
 ---
 kind: url
 name: vulkan_headers
-url: https://github.com/KhronosGroup/Vulkan-Headers/releases
+url: https://github.com/KhronosGroup/Vulkan-Headers/tags
 activity: high
 ---
 kind: url
 name: vulkan_icd_loader
-url: https://github.com/KhronosGroup/Vulkan-Loader/releases
+url: https://github.com/KhronosGroup/Vulkan-Loader/tags
+activity: high
+---
+kind: url
+name: vulkan_tools
+url: https://github.com/KhronosGroup/Vulkan-Tools/tags
 activity: high
 ---
 kind: url


### PR DESCRIPTION
Fixes #7463
- Also adds vulkan_tools

Builds properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` 
### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmanduchromebrew.git CREW_TESTING_BRANCH=vulkan_updates CREW_TESTING=1 crew update
```
