### PR TITLE
rubocop: Disable `Layout/SpaceInsideParens` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -127,6 +127,9 @@ Layout/FirstHashElementIndentation:
 Layout/IndentationStyle:
   EnforcedStyle: spaces
 
+Layout/SpaceInsideParens:
+  Enabled: false
+
 Style/RedundantReturn:
   Enabled: false
 


### PR DESCRIPTION
See #7455 for more info