### PR TITLE
add missing runtime deps to ALL core packages, add getrealdeps script

### DIFF
--- a/packages/brotli.rb
+++ b/packages/brotli.rb
@@ -22,6 +22,8 @@ class Brotli < Package
     x86_64: '04cabaaf97a633c2ffe1de7ebc74dd4227f60e1dc1e69bd6094fe69e38020cb4'
   })
 
+  depends_on 'glibc' # R
+
   def self.build
     FileUtils.mkdir('builddir')
     Dir.chdir('builddir') do

--- a/packages/bz2.rb
+++ b/packages/bz2.rb
@@ -22,6 +22,8 @@ class Bz2 < Package
      x86_64: 'e5dee3da36d88d602496925888f966d47453d4a52e684c4bc6a982906b3b9f32'
   })
 
+  depends_on 'glibc' # R
+
   def self.patch
     system "sed -i 's,^LDFLAGS=,LDFLAGS=-flto,' Makefile"
     system "sed -i 's,^CFLAGS=-Wall,CFLAGS=-Wall -flto,' Makefile"

--- a/packages/c_ares.rb
+++ b/packages/c_ares.rb
@@ -22,6 +22,8 @@ class C_ares < Package
      x86_64: '9b7be17a55637cdcb7b956147b15269e0513ca954e298e679afd08ad8b4b17b3'
   })
 
+  depends_on 'glibc' # R
+
   def self.patch
     system "sed -i 's/1.18.0/#{version}/g' CMakeLists.txt"
   end

--- a/packages/cmake.rb
+++ b/packages/cmake.rb
@@ -24,6 +24,7 @@ class Cmake < Package
   })
 
   depends_on 'expat'
+  depends_on 'glibc' # R
   depends_on 'jsoncpp'
   depends_on 'zlibpkg'
   depends_on 'bz2'

--- a/packages/diffutils.rb
+++ b/packages/diffutils.rb
@@ -22,6 +22,7 @@ class Diffutils < Package
      x86_64: 'edddafc3090b7b146594d3b3d80c3c4cb8730c662b68eaaf2d90b42824368eb3'
   })
 
+  depends_on 'glibc' # R
   depends_on 'libsigsegv'
 
   def self.build

--- a/packages/e2fsprogs.rb
+++ b/packages/e2fsprogs.rb
@@ -23,9 +23,11 @@ class E2fsprogs < Package
      x86_64: 'aa77be21096e0f8f749cc4fc4f2e35d794ba70694a9e4d6b58c49353b5fe9138'
   })
 
+  depends_on 'glibc' # R
+  depends_on 'util_linux' # R
+
   def self.build
-    system "env #{CREW_ENV_OPTIONS} \
-      ./configure #{CREW_OPTIONS}\
+    system "./configure #{CREW_OPTIONS}\
       --enable-elf-shlibs \
       --enable-lto \
       --disable-libblkid \

--- a/packages/elfutils.rb
+++ b/packages/elfutils.rb
@@ -23,8 +23,16 @@ class Elfutils < Package
      x86_64: 'be351d1f3faacaf7fec9390486cf0b6cda2b96b9881470bc0c211a262c51717c'
   })
 
-  depends_on 'libcurl'
-  depends_on 'libmicrohttpd'
+  depends_on 'bz2' # R
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  depends_on 'libarchive' # R
+  depends_on 'libcurl' # R
+  depends_on 'libmicrohttpd' # R
+  depends_on 'sqlite' # R
+  depends_on 'xzutils' # R
+  depends_on 'zlibpkg' # R
+  depends_on 'zstd' # R
 
   def self.build
     # If debuginfod is disabled, gdb is broken.

--- a/packages/expat.rb
+++ b/packages/expat.rb
@@ -22,6 +22,8 @@ class Expat < Package
      x86_64: 'e5f8529e86f68486309d884676fdd72186a6ece1864d72ac97151a2d907690d4'
   })
 
+  depends_on 'glibc' # R
+
   def self.patch
     system 'filefix'
   end

--- a/packages/filecmd.rb
+++ b/packages/filecmd.rb
@@ -23,6 +23,11 @@ class Filecmd < Package
     x86_64: '4d0da2febbb0f5a9e5d08dfe2026a9816aa2b1fb603d2c9328082e740a96c8a2'
   })
 
+  depends_on 'bz2' # R
+  depends_on 'glibc' # R
+  depends_on 'xzutils' # R
+  depends_on 'zlibpkg' # R
+
   def self.build
     # The filefix command changes the full path of the file command in configure scripts.
     # Execute this command from your source code root directory.

--- a/packages/flex.rb
+++ b/packages/flex.rb
@@ -22,6 +22,7 @@ class Flex < Package
      x86_64: '805be1fdbf4d9d2ce81a652a064c6972eaf91824bb866867eb57c407dd9c2313'
   })
 
+  depends_on 'glibc' # R
   depends_on 'm4'
   depends_on 'bison' => :build
 

--- a/packages/gcc.rb
+++ b/packages/gcc.rb
@@ -22,17 +22,18 @@ class Gcc < Package
      x86_64: '01efdcdab6bebc32fd5608f6a061c7ceebd69e9f96084293a903f5af9c3576f3'
   })
 
-  depends_on 'binutils'
+  depends_on 'binutils' => :build
   depends_on 'ccache' => :build
   depends_on 'dejagnu' => :build # for test
-  depends_on 'glibc' => :build
+  depends_on 'glibc' # R
   depends_on 'gmp' # R
   depends_on 'isl' # R
+  depends_on 'libssp' # L
   depends_on 'mpc' # R
   depends_on 'mpfr' # R
-  depends_on 'libssp' # L
   depends_on 'zlibpkg' # R
   depends_on 'zstd' # R
+
 
   no_env_options
   no_patchelf

--- a/packages/gcc.rb
+++ b/packages/gcc.rb
@@ -31,6 +31,7 @@ class Gcc < Package
   depends_on 'mpc' # R
   depends_on 'mpfr' # R
   depends_on 'libssp' # L
+  depends_on 'zlibpkg' # R
   depends_on 'zstd' # R
 
   no_env_options

--- a/packages/gcc.rb
+++ b/packages/gcc.rb
@@ -34,7 +34,6 @@ class Gcc < Package
   depends_on 'zlibpkg' # R
   depends_on 'zstd' # R
 
-
   no_env_options
   no_patchelf
   no_zstd if ARCH == 'i686'

--- a/packages/gdbm.rb
+++ b/packages/gdbm.rb
@@ -23,10 +23,11 @@ class Gdbm < Package
      x86_64: '79ffa73dfefefdec13bfd9ccaac27f24e6bd6b86da4efd6b0544f45a6828ad51'
   })
 
+  depends_on 'glibc' # R
+  depends_on 'readline' # R
+
   def self.build
-    system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto' \
-      LDFLAGS='-flto=auto' \
-      ./configure \
+    system "./configure \
       #{CREW_OPTIONS}"
     system 'make'
   end

--- a/packages/gettext.rb
+++ b/packages/gettext.rb
@@ -31,7 +31,6 @@ class Gettext < Package
   depends_on 'libxml2' # R
   depends_on 'openmp'
 
-
   def self.build
     raise StandardError, 'Please remove libiconv before building.' if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
 

--- a/packages/gettext.rb
+++ b/packages/gettext.rb
@@ -23,15 +23,20 @@ class Gettext < Package
      x86_64: '4ada2428329f3fc4098b4fab8cc81d816028a7ac283c359c86fdc1d569a52af3'
   })
 
+  depends_on 'acl' # R
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
   depends_on 'jdk8' => :build
+  depends_on 'libunistring' # R
+  depends_on 'libxml2' # R
   depends_on 'openmp'
+
 
   def self.build
     raise StandardError, 'Please remove libiconv before building.' if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
 
     system 'filefix'
-    system "env #{CREW_ENV_OPTIONS} \
-    ./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_OPTIONS} \
       --disable-static \
       --enable-shared \
       --with-pic \

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -7,7 +7,6 @@ class Glibc < Package
   compatibility 'all'
 
   depends_on 'gawk' => :build
-  depends_on 'filecmd'
   depends_on 'libidn2' => :build
   depends_on 'texinfo' => :build
   depends_on 'hashpipe' => :build

--- a/packages/gmp.rb
+++ b/packages/gmp.rb
@@ -22,6 +22,8 @@ class Gmp < Package
      x86_64: '50847bd14c11de841c7c74696e2ff4503253bbaacd38e9ffb31814d6ccfb76f3'
   })
 
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
   no_patchelf
 
   def self.build

--- a/packages/gnucobol.rb
+++ b/packages/gnucobol.rb
@@ -22,7 +22,10 @@ class Gnucobol < Package
      x86_64: '00e04366fab756136bba0bcb07a285c1bda4d218b5f6555e0bc67583fb051963'
   })
 
+  depends_on 'glibc' # R
+  depends_on 'gmp' # R
   depends_on 'libdb'
+  epends_on 'ncurses' # R
 
   def self.build
     system './configure',

--- a/packages/gnutls.rb
+++ b/packages/gnutls.rb
@@ -22,16 +22,18 @@ class Gnutls < Package
      x86_64: '607851025aec31be1628da21af43c29307024cf5169bed7f34707504d0099824'
   })
 
-  depends_on 'zlibpkg'
-  depends_on 'libunistring'
-  depends_on 'gmp'
-  depends_on 'nettle'
-  depends_on 'libtasn1'
-  depends_on 'trousers'
-  depends_on 'p11kit' # This package cannot be built statically.
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  depends_on 'gmp' # R
   depends_on 'libffi'
-  depends_on 'libunbound'
-  depends_on 'libidn2'
+  depends_on 'libidn2' # R
+  depends_on 'libtasn1' # R
+  depends_on 'libunbound' # R
+  depends_on 'libunistring' # R
+  depends_on 'nettle' # R
+  depends_on 'p11kit' # R This package cannot be built statically.
+  depends_on 'trousers'
+  depends_on 'zlibpkg'
 
   def self.prebuild
     # Use IPv4 fallback if default connection fails.

--- a/packages/groff.rb
+++ b/packages/groff.rb
@@ -22,6 +22,14 @@ class Groff < Package
      x86_64: '3f3bf23656ec19567fab24646361569c2e42f8273e473b229eb5800ea53d1d30'
   })
 
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  # depends_on 'libice' # R (Not needed for groff binary)
+  # depends_on 'libsm' # R (Not needed for groff binary)
+  # depends_on 'libx11' # R (Not needed for groff binary)
+  # depends_on 'libxaw' # R (Not needed for groff binary)
+  # depends_on 'libxmu' # R (Not needed for groff binary)
+  # depends_on 'libxt' # R (Not needed for groff binary)
   depends_on 'uchardet'
 
   def self.build

--- a/packages/icu4c.rb
+++ b/packages/icu4c.rb
@@ -22,6 +22,9 @@ class Icu4c < Package
     x86_64: '868a783d335eb13ff06d29b5221448a50e68a728ee1c35f3dc4c16c816716d68'
   })
 
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+
   def self.build
     FileUtils.cd('source') do
       case ARCH

--- a/packages/isl.rb
+++ b/packages/isl.rb
@@ -22,6 +22,9 @@ class Isl < Package
      x86_64: '870574b61938cd278848864fd861a6d25ce27723375af17c3c3108fdc1197766'
   })
 
+  depends_on 'glibc' # R
+  depends_on 'gmp' # R
+
   def self.build
     system "./configure #{CREW_OPTIONS}"
     system 'make'

--- a/packages/krb5.rb
+++ b/packages/krb5.rb
@@ -23,7 +23,9 @@ class Krb5 < Package
   })
 
   depends_on 'ccache' => :build
-  depends_on 'e2fsprogs'
+  depends_on 'e2fsprogs' # R
+  depends_on 'glibc' # R
+  depends_on 'openssl' # R
 
   @k5libs = %w[libgssapi_krb5.a libgssrpc.a libk5crypto.a
                libkadm5clnt_mit.a libkadm5clnt.a libkadm5srv_mit.a libkadm5srv.a

--- a/packages/less.rb
+++ b/packages/less.rb
@@ -22,10 +22,11 @@ class Less < Package
      x86_64: 'fe15b66e0ad8e0be7c3695ad601019ac5abd610e8680ab5b07b7f289510b87c2'
   })
 
-  depends_on 'ncurses'
+  depends_on 'glibc' # R
+  depends_on 'ncurses' # R
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} --with-regex=posix"
+    system "./configure #{CREW_OPTIONS} --with-regex=posix"
     system 'make'
   end
 

--- a/packages/libarchive.rb
+++ b/packages/libarchive.rb
@@ -23,8 +23,14 @@ class Libarchive < Package
     x86_64: 'd21778e1bca3015e53dfe253eedae0b0f497c21554563d41eed6233b37a15762'
   })
 
-  depends_on 'lz4'
-  depends_on 'xzutils' => :build
+  depends_on 'acl' # R
+  depends_on 'bz2' # R
+  depends_on 'glibc' # R
+  depends_on 'libxml2' # R
+  depends_on 'lz4' # R
+  depends_on 'openssl' # R
+  depends_on 'xzutils' # R
+  depends_on 'zlibpkg' # R
 
   def self.build
     raise StandardError, 'Please remove libiconv before building.' if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")

--- a/packages/libcyrussasl.rb
+++ b/packages/libcyrussasl.rb
@@ -23,14 +23,20 @@ class Libcyrussasl < Package
   })
 
   depends_on 'diffutils' => :build
+  depends_on 'e2fsprogs' # R
+  depends_on 'glibc' # R
+  depends_on 'krb5' # R
+  depends_on 'libdb' # R
+  depends_on 'linux_pam' # R
+  depends_on 'openssl' # R
+
 
   def self.patch
     system 'filefix'
   end
 
   def self.build
-    system "env #{CREW_ENV_OPTIONS} \
-      ./configure \
+    system "./configure \
       #{CREW_OPTIONS} \
       --enable-static \
       --enable-shared \

--- a/packages/libdb.rb
+++ b/packages/libdb.rb
@@ -22,6 +22,8 @@ class Libdb < Package
      x86_64: '0e51467868c7ea8fdf9916bf2ee1b3500b8ea7f0f5cd8f9ec4c9f3a3aafc2213'
   })
 
+  depends_on 'glibc' # R
+
   def self.build
     Dir.chdir 'build_unix' do
       system "../dist/configure #{CREW_OPTIONS} --enable-dbm"

--- a/packages/libedit.rb
+++ b/packages/libedit.rb
@@ -22,6 +22,8 @@ class Libedit < Package
      x86_64: '41ec1b9f504bc593668bf88cde1eb85fcfd621397d7ec17c29ec686bc2238b5b'
   })
 
+  depends_on 'glibc' # R
+
   def self.build
     system "./configure #{CREW_OPTIONS} \
             CPPFLAGS=\"-I#{CREW_PREFIX}/include/ncursesw\""

--- a/packages/libffi.rb
+++ b/packages/libffi.rb
@@ -23,6 +23,8 @@ class Libffi < Package
      x86_64: 'fec954fcb51b1186ab2d084e29edf05773cf31b0543ad947bf9f325186022ab5'
   })
 
+  depends_on 'glibc' # R
+
   def self.build
     system 'autoreconf -fiv'
     system "./configure #{CREW_OPTIONS}"

--- a/packages/libidn2.rb
+++ b/packages/libidn2.rb
@@ -23,6 +23,7 @@ class Libidn2 < Package
      x86_64: 'ea4b9348c401c8655f0a77fc92149887b26fb7cad7f6ce5628488fa72d8223d6'
   })
 
+  depends_on 'glibc' # R
   depends_on 'libunistring'
 
   def self.build

--- a/packages/libmetalink.rb
+++ b/packages/libmetalink.rb
@@ -22,12 +22,15 @@ class Libmetalink < Package
      x86_64: '62986bd07f7fd2ade3114e8600e1a920b8614447acdd34164b77181ceb3a6687'
   })
 
-  depends_on 'hashpipe' => :build
+  depends_on 'glibc' # R
+  depends_on 'icu4c' # R
+  depends_on 'libxml2' # R
+  depends_on 'zlibpkg' # R
 
   def self.patch
-    system 'curl -Ls https://launchpadlibrarian.net/380798344/0001-fix-covscan-issues.patch | \
-      hashpipe sha256 d236dfa0d4a1938a40ff2ce4dd348c42b74ad68807df0f1b6ea69c11725fd9cf | \
-      patch -Np1 --binary'
+    downloader 'https://launchpadlibrarian.net/380798344/0001-fix-covscan-issues.patch',
+               'd236dfa0d4a1938a40ff2ce4dd348c42b74ad68807df0f1b6ea69c11725fd9cf'
+    system 'patch -Np1 -i 0001-fix-covscan-issues.patch'
     system 'filefix'
   end
 

--- a/packages/libnghttp2.rb
+++ b/packages/libnghttp2.rb
@@ -23,6 +23,7 @@ class Libnghttp2 < Package
      x86_64: '1c2011cfb262d79a8a280d6a914a37a362e119ea7c95efa3882063cd160babe2'
   })
 
+  depends_on 'glibc' # R
   depends_on 'jansson'
   depends_on 'jemalloc'
   depends_on 'libev' => :build

--- a/packages/libpipeline.rb
+++ b/packages/libpipeline.rb
@@ -23,10 +23,10 @@ class Libpipeline < Package
      x86_64: 'bcdc10711b7697fd61d50f996a5df4467702914d36823d7fbc62590b1f0a5ece'
   })
 
+  depends_on 'glibc' # R
+
   def self.build
-    system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
-      LDFLAGS='-flto=auto' \
-      ./configure \
+    system "./configure \
       #{CREW_OPTIONS} \
       --enable-shared \
       --with-pic"

--- a/packages/libpsl.rb
+++ b/packages/libpsl.rb
@@ -23,6 +23,7 @@ class Libpsl < Package
      x86_64: '65be38748baca2f4bf9cf689b9894ce62dc37d909e2545a27a9612ec9fb8d419'
   })
 
+  depends_on 'glibc' # R
   depends_on 'libidn2'
 
   def self.build

--- a/packages/libsigsegv.rb
+++ b/packages/libsigsegv.rb
@@ -22,11 +22,12 @@ class Libsigsegv < Package
      x86_64: 'efc24c18a85c611994d3e516994ab71a0a1f79780d47af8267940d68ae7f8716'
   })
 
+  depends_on 'glibc' # R
+  no_env_options
+
   def self.build
     system 'autoreconf -fiv'
     # libsigsegv fails to build with LTO.
-    ENV['CREW_DISABLE_ENV_OPTIONS'] = '1'
-    reload_constants
     system "#{CREW_ENV_FNO_LTO_OPTIONS} ./configure #{CREW_OPTIONS} \
     --enable-shared \
     --enable-static \

--- a/packages/libtasn1.rb
+++ b/packages/libtasn1.rb
@@ -25,6 +25,7 @@ class Libtasn1 < Package
   # bison, diff, cmp are required at compile-time
   depends_on 'bison' => :build
   depends_on 'diffutils' => :build
+  depends_on 'glibc' # R
 
   def self.build
     system "./configure #{CREW_OPTIONS} \

--- a/packages/libtirpc.rb
+++ b/packages/libtirpc.rb
@@ -23,7 +23,9 @@ class Libtirpc < Package
      x86_64: '8fffa00840f66ff4b6bb9c8d66a36d15208829fe2ff00dd0c46b435fcbc2201b'
   })
 
-  depends_on 'e2fsprogs'
+  depends_on 'e2fsprogs' # R
+  depends_on 'glibc' # R
+  depends_on 'krb5' # R
 
   def self.build
     system "./configure #{CREW_OPTIONS} #{CREW_ENV_OPTIONS}"

--- a/packages/libunbound.rb
+++ b/packages/libunbound.rb
@@ -23,7 +23,8 @@ class Libunbound < Package
      x86_64: '5c4125bce66bb83fc775a5fe236718dee958b9724d5b6adf55d3b682c2b05401'
   })
 
-  depends_on 'openssl' # On i686 openssl needs to be installed before libunbound.
+  depends_on 'glibc' # R
+  depends_on 'openssl' # R On i686 openssl needs to be installed before libunbound.
 
   def self.patch
     system 'filefix'

--- a/packages/libxml2.rb
+++ b/packages/libxml2.rb
@@ -22,11 +22,12 @@ class Libxml2 < Package
      x86_64: '0d463712429ba8c0d01f58ac772db9e5e1e88d47ae57f88c7e9a06e87dc8788b'
   })
 
-  depends_on 'gcc'
-  depends_on 'icu4c'
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  depends_on 'icu4c' # R
   depends_on 'ncurses'
-  depends_on 'readline'
-  depends_on 'zlibpkg'
+  depends_on 'readline' # R
+  depends_on 'zlibpkg' # R
   no_patchelf
 
   def self.patch

--- a/packages/libyaml.rb
+++ b/packages/libyaml.rb
@@ -22,6 +22,7 @@ class Libyaml < Package
      x86_64: '157e3e7c7dad0cea905a78944270b7b1fdd58bd363eeb167784a6d90a8c362b8'
   })
 
+  depends_on 'glibc' # R
   no_patchelf
 
   def self.build

--- a/packages/llvm.rb
+++ b/packages/llvm.rb
@@ -23,11 +23,19 @@ class Llvm < Package
      x86_64: 'e70d89a80486f4afa911df7624510f465a75658b40df8db21a0ef41770fdc83a'
   })
 
-  depends_on 'ocaml' => :build
-  depends_on 'py3_pygments' => :build
   depends_on 'ccache' => :build
   depends_on 'elfutils' # R
   depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  depends_on 'libedit' # R
+  depends_on 'libffi' # R
+  depends_on 'libxml2' # R
+  depends_on 'ncurses' # R
+  depends_on 'ocaml' => :build
+  depends_on 'py3_pygments' => :build
+  depends_on 'xzutils' # R
+  depends_on 'zlibpkg' # R
+  depends_on 'zstd' # R
   no_env_options
   no_patchelf
 

--- a/packages/lz4.rb
+++ b/packages/lz4.rb
@@ -22,6 +22,7 @@ class Lz4 < Package
      x86_64: '76a2f4eccf84e78f32bbd2f8e6042f3ed4cda506ca74706fbbc4d60488b54a2a'
   })
 
+  depends_on 'glibc' # R
   no_patchelf
 
   def self.build

--- a/packages/m4.rb
+++ b/packages/m4.rb
@@ -22,10 +22,11 @@ class M4 < Package
      x86_64: '6a5c76203b00d2058e27e4a65aafb737b30bf1d2225fa6be0c30738d19a1e782'
   })
 
+  depends_on 'glibc' # R
   depends_on 'libsigsegv'
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_OPTIONS}"
     system 'make'
   end
 

--- a/packages/make.rb
+++ b/packages/make.rb
@@ -22,6 +22,8 @@ class Make < Package
      x86_64: '26dee9755f910ebbc5e8742fc40937dc4b5900ded4a415b26aa282def3821d9d'
   })
 
+  depends_on 'glibc' # R
+
   def self.build
     system './configure',
            "--prefix=#{CREW_PREFIX}",

--- a/packages/mawk.rb
+++ b/packages/mawk.rb
@@ -22,11 +22,10 @@ class Mawk < Package
      x86_64: '5cfce5981ae0c1d388f6d716cc6205485877c593bee96ff44005ed0fba0c6fc3'
   })
 
+  depends_on 'glibc' # R
+
   def self.build
-    system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      ./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_OPTIONS}"
     system 'make'
   end
 

--- a/packages/most.rb
+++ b/packages/most.rb
@@ -22,7 +22,8 @@ class Most < Package
      x86_64: '3fcf532ef15440abe83413ae0c422e480096a6b4997890eca2825ef288ed13ed'
   })
 
-  depends_on 'slang'
+  depends_on 'glibc' # R
+  depends_on 'slang' # R
 
   def self.build
     system "./configure #{CREW_OPTIONS}"

--- a/packages/mpc.rb
+++ b/packages/mpc.rb
@@ -22,6 +22,7 @@ class Mpc < Package
      x86_64: '57276bec912dabfed4d65d5edb3e18788c168056727057ee0c91aa8484eebdba'
   })
 
+  depends_on 'glibc' # R
   depends_on 'gmp' # R
   depends_on 'mpfr' # R
 

--- a/packages/mpfr.rb
+++ b/packages/mpfr.rb
@@ -24,6 +24,7 @@ class Mpfr < Package
 
   depends_on 'autoconf_archive' => :build
   depends_on 'hashpipe' => :build
+  depends_on 'glibc' # R
   depends_on 'gmp' # R
 
   def self.patch

--- a/packages/ncurses.rb
+++ b/packages/ncurses.rb
@@ -22,13 +22,14 @@ class Ncurses < Package
      x86_64: '567cf7a40682009b0b817795e62e248374e87896ab76e5bd5fc69f98d252bf31'
   })
 
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
   no_patchelf
 
   def self.build
     # build libncurses
     Dir.mkdir 'ncurses_build'
     Dir.chdir 'ncurses_build' do
-      # system "env #{CREW_ENV_OPTIONS} \
       system "../configure #{CREW_OPTIONS} \
           --program-prefix='' \
           --program-suffix='' \
@@ -46,7 +47,6 @@ class Ncurses < Package
     # build libncursesw
     Dir.mkdir 'ncursesw_build'
     Dir.chdir 'ncursesw_build' do
-      # system "env #{CREW_ENV_OPTIONS} \
       system "../configure #{CREW_OPTIONS} \
           --program-prefix='' \
           --program-suffix='' \

--- a/packages/nettle.rb
+++ b/packages/nettle.rb
@@ -23,6 +23,8 @@ class Nettle < Package
      x86_64: '8f3f8f16263b2a1ccef1c078ee9443bcbe4f7a08fc9bb66ab1e5cf0715e7df0f'
   })
 
+  depends_on 'glibc' # R
+  depends_on 'gmp' # R
   depends_on 'm4'
   depends_on 'openssl'
 

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -24,6 +24,7 @@ class Openssl < Package
   })
 
   depends_on 'ccache' => :build
+  depends_on 'glibc' # R
   no_patchelf
   no_zstd
 

--- a/packages/p11kit.rb
+++ b/packages/p11kit.rb
@@ -22,8 +22,9 @@ class P11kit < Package
      x86_64: '8259e4144eea281d3da641b7973e807518f521db62c552691a2e8d65f879ee87'
   })
 
-  depends_on 'libffi'
-  depends_on 'libtasn1'
+  depends_on 'glibc' # R
+  depends_on 'libffi' # R
+  depends_on 'libtasn1' # R
 
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \

--- a/packages/patch.rb
+++ b/packages/patch.rb
@@ -22,6 +22,9 @@ class Patch < Package
      x86_64: '2c756988d1ed11102e6bc33146d43349e303bac645ec8d16ef7ec521f3d0b5d9'
   })
 
+  depends_on 'attr' # R
+  depends_on 'glibc' # R
+
   def self.build
     system './configure',
            "--prefix=#{CREW_PREFIX}",

--- a/packages/pcre.rb
+++ b/packages/pcre.rb
@@ -23,10 +23,12 @@ class Pcre < Package
      x86_64: '4c62ce6b8ae532c7b0885973b50363034c2a84b281baa5542149226a38016cbe'
   })
 
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  depends_on 'readline' # R
+
   def self.build
-    system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto' \
-      LDFLAGS='-flto=auto' \
-      ./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_OPTIONS} \
       --enable-shared \
       --with-pic \
       --enable-unicode-properties \

--- a/packages/pcre2.rb
+++ b/packages/pcre2.rb
@@ -23,10 +23,11 @@ class Pcre2 < Package
      x86_64: '17002f3ed5ebba3944dc1050a314e75b03a25a0bfc54ac1c12d1060178456199'
   })
 
+  depends_on 'glibc' # R
+  depends_on 'readline' # R
+
   def self.build
-    system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto' \
-      LDFLAGS='-flto=auto' \
-      ./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_OPTIONS} \
       --enable-shared \
       --with-pic \
       --enable-unicode-properties \

--- a/packages/perl.rb
+++ b/packages/perl.rb
@@ -23,6 +23,9 @@ class Perl < Package
      x86_64: '4c0bc04df5a046bffe2e35b5fc6bfec8cfbe462c5cc4e9b2fb9e7e70c8373828'
   })
 
+  depends_on 'gdbm' # R
+  depends_on 'glibc' # R
+  depends_on 'libdb' # R
   depends_on 'patch' => :build
   no_patchelf
 

--- a/packages/pkgconfig.rb
+++ b/packages/pkgconfig.rb
@@ -22,6 +22,9 @@ class Pkgconfig < Package
      x86_64: 'f17babbbfcf112c2bff4844545e401fe0c705062c1f354ac446da5e8021b7f1b'
   })
 
+  depends_on 'glib' # R
+  depends_on 'glibc' # R
+
   def self.build
     raise StandardError, 'Please remove libiconv before building.' if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
 

--- a/packages/qb64.rb
+++ b/packages/qb64.rb
@@ -22,10 +22,14 @@ class Qb64 < Package
      x86_64: 'f93227d12bceb6248131ceecd2d542c995a4476185c6bb1f00095135879acf49'
   })
 
-  depends_on 'libglu'
-  depends_on 'freeglut'
   depends_on 'alsa_lib'
   depends_on 'alsa_plugins'
+  depends_on 'freeglut'
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  depends_on 'libglu'
+  depends_on 'libx11' # R
+  depends_on 'mesa' # R
   depends_on 'sommelier'
 
   def self.patch

--- a/packages/qttools.rb
+++ b/packages/qttools.rb
@@ -22,6 +22,9 @@ class Qttools < Package
      x86_64: '4fe6c1fcd3b4bdfbdface915f9c7d71b6c73deadbb5bb20cb5d89af8d6d9d2d2'
   })
 
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  depends_on 'mesa' # R
   depends_on 'qtbase'
   depends_on 'libtinfo'
 

--- a/packages/rdfind.rb
+++ b/packages/rdfind.rb
@@ -26,6 +26,9 @@ class Rdfind < Package
   })
 
   depends_on 'autoconf_archive' => :build
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  depends_on 'nettle' # R
 
   def self.patch
     system "sed -i '/<vector>/a #include <limits>' rdfind.cc"

--- a/packages/readline.rb
+++ b/packages/readline.rb
@@ -23,11 +23,11 @@ class Readline < Package
      x86_64: '3d60b7fd04b57c4b57b34d8af12ab7b7dbf368842fc8b19b09df7698e9623292'
   })
 
+  depends_on 'glibc' # R
+  depends_on 'ncurses' # R
+
   def self.build
-    system "env CFLAGS='-flto=auto -g0' \
-      CXXFLAGS='-flto=auto' \
-      LDFLAGS='-flto=auto' \
-      ./configure \
+    system "./configure \
       #{CREW_OPTIONS} \
       --with-curses \
       --enable-multibyte"

--- a/packages/rtmpdump.rb
+++ b/packages/rtmpdump.rb
@@ -22,6 +22,12 @@ class Rtmpdump < Package
      x86_64: '7e76a4f0a4f359f5ab8283ac175c4dc85f2d54aad1413840240627e810d5c6c0'
   })
 
+  depends_on 'glibc' # R
+  depends_on 'gmp' # R
+  depends_on 'gnutls' # R
+  depends_on 'nettle' # R
+  depends_on 'zlibpkg' # R
+
   @make_common_opts = ['SYS=posix', "prefix=#{CREW_PREFIX}", "libdir=#{CREW_LIB_PREFIX}",
                        "mandir=#{CREW_PREFIX}/share/man", 'CRYPTO=GNUTLS']
 

--- a/packages/ruby.rb
+++ b/packages/ruby.rb
@@ -24,6 +24,7 @@ class Ruby < Package
 
   depends_on 'zlibpkg' # R
   depends_on 'glibc' # R
+  depends_on 'filecmd' # L (This is to enable file command use in package files.)
   depends_on 'gmp' # R
   depends_on 'gcc' # R
   depends_on 'libffi' # R

--- a/packages/rust.rb
+++ b/packages/rust.rb
@@ -22,6 +22,10 @@ class Rust < Package
      x86_64: 'cc282c03048bc2b9204569f92beee2fb5242745a1d9b3c859e72990bf4a3b253'
   })
 
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  depends_on 'zlibpkg' # R
+
   def self.install
     ENV['RUST_BACKTRACE'] = 'full'
     ENV['CARGO_HOME'] = "#{CREW_DEST_PREFIX}/share/cargo"

--- a/packages/slang.rb
+++ b/packages/slang.rb
@@ -22,6 +22,11 @@ class Slang < Package
      x86_64: '6d7968b8a251a184c06d96e0466c9c7fabae9033c7be9ad9fc4b2b60816eaa37'
   })
 
+  depends_on 'glibc' # R
+  depends_on 'libpng' # R
+  depends_on 'pcre' # R
+  depends_on 'zlibpkg' # R
+
   def self.build
     system './configure',
            "--prefix=#{CREW_PREFIX}",

--- a/packages/sqlite.rb
+++ b/packages/sqlite.rb
@@ -22,12 +22,13 @@ class Sqlite < Package
      x86_64: '7ea92b093047843e47d9a383ecb05831774824913b562c245c9460875773cdb3'
   })
 
+  depends_on 'glibc' # R
   depends_on 'libedit'
   depends_on 'readline'
-  depends_on 'zlibpkg'
+  depends_on 'zlibpkg' # R
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_OPTIONS} \
       --enable-shared \
       --enable-editline \
       --enable-readline \

--- a/packages/symlinks.rb
+++ b/packages/symlinks.rb
@@ -23,6 +23,8 @@ class Symlinks < Package
      x86_64: '39fe5a53a1c557aa71cfd6d7760e069c0421931e3e5345c57696e1cf79bf8e39'
   })
 
+  depends_on 'glibc' # R
+
   def self.patch
     system('for i in `cat debian/patches/series`; do patch -p 1 < debian/patches/$i; done')
     system "sed -i 's,/usr/local,#{CREW_DEST_PREFIX},g' Makefile"

--- a/packages/texinfo.rb
+++ b/packages/texinfo.rb
@@ -22,6 +22,7 @@ class Texinfo < Package
      x86_64: '6a6c3c50dfbd0fbc32552308d45ba48cf44e55fd7c29563aabbaefa9b3726bfe'
   })
 
+  depends_on 'glibc' # R
   depends_on 'perl'
   depends_on 'perl_locale_messages'
   depends_on 'perl_text_unidecode'

--- a/packages/uchardet.rb
+++ b/packages/uchardet.rb
@@ -22,6 +22,9 @@ class Uchardet < Package
      x86_64: '75d94151c984a1b983e765fdfe33f767c84170c0b95724671665d4a8f80cb4be'
   })
 
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+
   def self.build
     system "cmake -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX} -DCMAKE_BUILD_TYPE=Release && make"
   end

--- a/packages/unzip.rb
+++ b/packages/unzip.rb
@@ -23,6 +23,7 @@ class Unzip < Package
   })
 
   depends_on 'compressdoc' => :build
+  depends_on 'glibc' # R
   depends_on 'patch' => :build
 
   # adapted from the homebrew recipe as seen at: https://github.com/Homebrew/homebrew-dupes/blob/master/unzip.rb

--- a/packages/valgrind.rb
+++ b/packages/valgrind.rb
@@ -22,6 +22,8 @@ class Valgrind < Package
      x86_64: 'ac13fa3ae34fdcd2284fbc866b2959c89e9287e60b6704e3dd8d73a165a54956'
   })
 
+  depends_on 'glibc' # R
+
   def self.build
     system 'autoreconf -fvi'
     system "env #{CREW_ENV_OPTIONS}

--- a/packages/xxhash.rb
+++ b/packages/xxhash.rb
@@ -22,6 +22,7 @@ class Xxhash < Package
      x86_64: 'c1f0005397d8433a33ab6195f82d7f17e6271530599ad52538c6550360b97afc'
   })
 
+  depends_on 'glibc' # R
   no_patchelf
   no_zstd
 

--- a/packages/xzutils.rb
+++ b/packages/xzutils.rb
@@ -23,6 +23,7 @@ class Xzutils < Package
   })
 
   depends_on 'autoconf_archive' => :build
+  depends_on 'glibc' # R
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh --no-po4a'

--- a/packages/yasm.rb
+++ b/packages/yasm.rb
@@ -22,6 +22,8 @@ class Yasm < Package
      x86_64: '8ec504db1d9c91adb6680f17e328daf6114758cbf2106fc4eb2e8028834b3737'
   })
 
+  depends_on 'glibc' # R
+
   def self.build
     system "env CFLAGS='-pipe -flto=auto' CPPFLAGS='-pipe -flto=auto' \
       LDFLAGS='-flto=auto' \

--- a/packages/zip.rb
+++ b/packages/zip.rb
@@ -22,6 +22,9 @@ class Zip < Package
      x86_64: 'c78a63d3630f3dbf637127e1a5a08942fd1da213cde296d33e77823e8547a56c'
   })
 
+  depends_on 'bz2' # R
+  depends_on 'glibc' # R
+
   # adapted from the homebrew recipe as seen at: https://github.com/Homebrew/homebrew-core/blob/master/Formula/zip.rb
   # Upstream is unmaintained so we use the Debian patchset:
   # https://packages.debian.org/sid/zip

--- a/packages/zlibpkg.rb
+++ b/packages/zlibpkg.rb
@@ -24,22 +24,25 @@ class Zlibpkg < Package
      x86_64: '8d7c564fa93fd091ac36d0923acc8802a8d46f82b593e9be56b0a9252ad45fbe'
   })
 
+  depends_on 'glibc' # R
+
   def self.patch
     system "sed -i 's,CMAKE_INSTALL_PREFIX}/lib,CMAKE_INSTALL_PREFIX}/#{ARCH_LIB},g' CMakeLists.txt"
     system "sed -i 's,CMAKE_INSTALL_PREFIX}/share/pkgconfig,CMAKE_INSTALL_PREFIX}/#{ARCH_LIB}/pkgconfig,g' CMakeLists.txt"
   end
 
   def self.build
-    # Build zlib proper
-    FileUtils.mkdir 'builddir'
+    Dir.mkdir 'builddir'
     Dir.chdir 'builddir' do
-      system "cmake -G Ninja #{CREW_CMAKE_OPTIONS} .."
+      system "cmake \
+        -G Ninja \
+        #{CREW_CMAKE_OPTIONS} \
+        -Wno-dev \
+        .."
     end
     system 'samu -C builddir'
   end
 
   def self.install
-    # Install zlib
     system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
   end
-end

--- a/packages/zlibpkg.rb
+++ b/packages/zlibpkg.rb
@@ -46,3 +46,4 @@ class Zlibpkg < Package
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
   end
+end

--- a/packages/zstd.rb
+++ b/packages/zstd.rb
@@ -23,6 +23,7 @@ class Zstd < Package
      x86_64: 'b04d97b3d328f8c0805e2fcee0526b1e955255ca21ceaed6f6e1fb8e6941b312'
   })
 
+  depends_on 'glibc' # R
   depends_on 'musl_zstd'
   no_patchelf
   no_zstd

--- a/tools/getrealdeps.sh
+++ b/tools/getrealdeps.sh
@@ -4,13 +4,23 @@
 # set -x
 pkg="${1}"
 
-RED='\e[1;91m';    # Use Light Red for errors.
-YELLOW='\e[1;33m'; # Use Yellow for informational messages.
-GREEN='\e[1;32m';  # Use Green for success messages.
-BLUE='\e[1;34m';   # Use Blue for intrafunction messages.
-GRAY='\e[0;37m';   # Use Gray for program output.
-MAGENTA='\e[1;35m';
-RESET='\e[0m'
+if [ -z "${NOCOLORS}" ]; then
+  RED='\e[1;91m';    # Use Light Red for errors.
+  YELLOW='\e[1;33m'; # Use Yellow for informational messages.
+  GREEN='\e[1;32m';  # Use Green for success messages.
+  BLUE='\e[1;34m';   # Use Blue for intrafunction messages.
+  GRAY='\e[0;37m';   # Use Gray for program output.
+  MAGENTA='\e[1;35m';
+  RESET='\e[0m'
+else
+  RED='';
+  YELLOW='';
+  GREEN='';
+  BLUE='';
+  GRAY='';
+  MAGENTA='';
+  RESET=''
+fi
 
 # Simplify colors and print errors to stderr (2).
 echo_error() { echo -e "${RED}${*}${RESET}" >&2; }

--- a/tools/getrealdeps.sh
+++ b/tools/getrealdeps.sh
@@ -115,7 +115,7 @@ do
   $GREP -q "depends_on '$i'" /usr/local/lib/crew/packages/"${pkg}".rb || echo "$i"
 done
 )
-echo_info "\nPackage ${pkg} has these runtime dependencies:"
+echo_info "\nPackage ${pkg} has runtime library dependencies on these packages:"
 echo -e "${RESET}"
 for i in $pkgdeps
 do
@@ -125,7 +125,7 @@ echo -e "${RESET}"
 
 # If there are no missing deps, no warning is needed.
 if [ -n "${missingpkgdeps}" ]; then
-  echo_error "\nPackage file ${pkg}.rb is missing these runtime dependencies:"
+  echo_error "\nPackage file ${pkg}.rb is missing these runtime library dependencies:"
   echo -e "${RESET}"
   for i in $missingpkgdeps
   do

--- a/tools/getrealdeps.sh
+++ b/tools/getrealdeps.sh
@@ -4,6 +4,9 @@
 # set -x
 pkg="${1}"
 
+# Exit quickly if an invalid package name is given.
+[[ ( -z "$pkg" ) || ( "$pkg" == *"#"* ) ]] && exit 1
+
 if [ -z "${NOCOLORS}" ]; then
   RED='\e[1;91m';    # Use Light Red for errors.
   YELLOW='\e[1;33m'; # Use Yellow for informational messages.
@@ -31,7 +34,7 @@ echo_out() { echo -e "${GRAY}${*}${RESET}" >&1; }
 echo_other() { echo -e "${MAGENTA}${*}${RESET}" >&2; }
 
 if ! [[ -f "/usr/local/etc/crew/meta/${pkg}.filelist" ]]; then
-  echo_error "Package $pkg either does not exist or does not contain any files."
+  echo_error "Package $pkg either does not exist or does not contain any libraries."
   exit 1
 fi
 

--- a/tools/getrealdeps.sh
+++ b/tools/getrealdeps.sh
@@ -63,7 +63,9 @@ pkgfiles=$(crewfilesfxn "${pkg}")
 rm -rf /tmp/deps/"${pkg}"
 pkgdeps=$(unset lines ; for i in $pkgfiles ; \
 do \
-[[ "$(head -c 4 "${i}")" == $'\x7FELF' ]] || continue
+[[ -f "${i}" ]] || continue
+read -r -n 4 exec_header_bytes < "${i}"
+[[ "$exec_header_bytes" == $'\x7FELF' ]] || continue
 [[ $i = *_tkinter* ]] && continue # Carveout for Python3
 mkdir -p /tmp/deps/"${pkg}"/
 lines+=$(echo ; readelf -d "$i" 2>/dev/null | $GREP NEEDED | awk '{print $5}' \

--- a/tools/getrealdeps.sh
+++ b/tools/getrealdeps.sh
@@ -34,7 +34,7 @@ fi
 # This is a subset of what crew whatprovides gives
 whatprovidesfxn() {
   pkgdepslcl="${1}"
-  filelcl=$($GREP --exclude "${pkg}.filelist" "$pkgdepslcl" /usr/local/etc/crew/meta/*.filelist | $GREP "$CREW_LIB_PREFIX")
+  filelcl=$($GREP --exclude "${pkg}.filelist" "^${CREW_LIB_PREFIX}.*${pkgdepslcl}$" /usr/local/etc/crew/meta/*.filelist)
   packagelcl=$(echo "$filelcl" | \
   sed 's/.filelist.*//g' | sed 's:.*/::' | awk '!x[$0]++' | sed s/://g)
   echo "$packagelcl"
@@ -63,7 +63,7 @@ echo "$lines" | tr " " "\n" \
 | awk 'NF' | awk '!x[$0]++')
 
 # Remove duplicates.
-pkgdeps=$(echo "$pkgdeps" | tr " " "\n" |  awk '!x[$0]++')
+pkgdeps="$(awk 'NF' <<< "${pkgdeps}" | awk '!x[$0]++')"
 
 # Figure out which Chromebrew packages provide the relevant deps.
 pkgdeps=$(unset lines; for j in $pkgdeps ; \

--- a/tools/getrealdeps.sh
+++ b/tools/getrealdeps.sh
@@ -30,6 +30,11 @@ echo_intra() { echo -e "${BLUE}${*}${RESET}" >&1; }
 echo_out() { echo -e "${GRAY}${*}${RESET}" >&1; }
 echo_other() { echo -e "${MAGENTA}${*}${RESET}" >&2; }
 
+if ! [[ -f "/usr/local/etc/crew/meta/${pkg}.filelist" ]]; then
+  echo_error "Package $pkg either does not exist or does not contain any files."
+  exit 1
+fi
+
 # Install grep if a functional local copy does not exist.
 if grep --version &> /dev/null; then
   GREP=grep

--- a/tools/getrealdeps.sh
+++ b/tools/getrealdeps.sh
@@ -2,7 +2,7 @@
 # getrealdeps for Chromebrew
 # Author: Satadru Pramanik (satmandu) satadru at gmail dot com
 # set -x
-pkg="${1}"
+pkg="${1%.rb}"
 
 # Exit quickly if an invalid package name is given.
 [[ ( -z "$pkg" ) || ( "$pkg" == *"#"* ) ]] && exit 1
@@ -91,16 +91,16 @@ do lines+=$(echo ; whatprovidesfxn "$j"); done ; \
 echo "$lines" | tr " " "\n" | awk '!x[$0]++')
 
 # Remove original package from list.
-pkgdeps=$(tr " " "\n" <<< "$pkgdeps" | sed "/${1}/d" | sort -u )
+pkgdeps=$(tr " " "\n" <<< "$pkgdeps" | sed "/${pkg}/d" | sort -u )
 
 # Note which dependencies are missing.
 missingpkgdeps=$(
 for i in $pkgdeps
 do
-  $GREP -q "depends_on '$i'" /usr/local/lib/crew/packages/"${1}".rb || echo "$i"
+  $GREP -q "depends_on '$i'" /usr/local/lib/crew/packages/"${pkg}".rb || echo "$i"
 done
 )
-echo_info "\nPackage ${1} has these runtime dependencies:"
+echo_info "\nPackage ${pkg} has these runtime dependencies:"
 echo -e "${RESET}"
 for i in $pkgdeps
 do
@@ -110,7 +110,7 @@ echo -e "${RESET}"
 
 # If there are no missing deps, no warning is needed.
 if [ -n "${missingpkgdeps}" ]; then
-  echo_error "\nPackage file ${1}.rb is missing these runtime dependencies:"
+  echo_error "\nPackage file ${pkg}.rb is missing these runtime dependencies:"
   echo -e "${RESET}"
   for i in $missingpkgdeps
   do

--- a/tools/getrealdeps.sh
+++ b/tools/getrealdeps.sh
@@ -33,6 +33,16 @@ echo_intra() { echo -e "${BLUE}${*}${RESET}" >&1; }
 echo_out() { echo -e "${GRAY}${*}${RESET}" >&1; }
 echo_other() { echo -e "${MAGENTA}${*}${RESET}" >&2; }
 
+# Install jq if a functional local copy does not exist.
+if ! jq --version &> /dev/null; then
+  crew install jq
+fi
+
+# Package needs to be installed for package filelist to be populated.
+if ! [[ $(jq --arg key "${pkg}" -e '.installed_packages[] | select(.name == $key )' /usr/local/etc/crew/device.json) ]]; then
+  crew install "${pkg}"
+fi
+
 if ! [[ -f "/usr/local/etc/crew/meta/${pkg}.filelist" ]]; then
   echo_error "Package $pkg either does not exist or does not contain any libraries."
   exit 1
@@ -44,6 +54,11 @@ if grep --version &> /dev/null; then
 else
   crew install grep
   GREP=/usr/local/bin/grep
+fi
+
+# Install mawk if a functional local copy of awk does not exist.
+if ! awk -W version &> /dev/null; then
+  crew install mawk
 fi
 
 : "${CREW_LIB_PREFIX:=$(crew const | $GREP CREW_LIB_PREFIX | awk -F = '{print $2}')}"

--- a/tools/getrealdeps.sh
+++ b/tools/getrealdeps.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# getrealdeps for Chromebrew
+# Author: Satadru Pramanik (satmandu) satadru at gmail dot com
+# set -x
+pkg="${1}"
+[[ ! -e '/usr/local/bin/grep' ]] && crew install grep
+GREP=/usr/local/bin/grep
+CREW_LIB_PREFIX=$(crew const | $GREP CREW_LIB_PREFIX | awk -F = '{print $2}')
+
+# Which packages have a needed library in CREW_LIB_PREFIX
+# This is a subset of what crew whatprovides gives
+whatprovidesfxn() {
+  pkgdepslcl="${1}"
+  filelcl=$(cd /usr/local/etc/crew/meta/ ; $GREP --exclude "${pkg}.filelist" "$pkgdepslcl" *.filelist | $GREP "$CREW_LIB_PREFIX")
+  packagelcl=$(echo "$filelcl" | \
+  sed 's/.filelist.*//g' | sed 's:.*/::' | awk '!x[$0]++' | sed s/://g)
+  echo "$packagelcl"
+}
+
+# What files does a package provide
+crewfilesfxn() {
+ pkgname="${1}"
+ files=$(cat /usr/local/etc/crew/meta/"${pkgname}".filelist)
+ echo "$files"
+}
+
+pkgfiles=$(crewfilesfxn "${pkg}")
+# Use readelf to determine library dependencie, as
+# this doesn't almost run a program like using ldd would.
+rm -rf /tmp/deps/"${pkg}"
+pkgdeps=$(unset lines ; for i in $pkgfiles ; \
+do \
+[[ $i = *.c ]] && continue
+[[ $i = *.gz ]] && continue
+[[ $i = *.h ]] && continue
+[[ $i = *.json ]] && continue
+[[ $i = *.py* ]] && continue
+[[ $i = *_tkinter* ]] && continue # Carveout for Python3
+[[ $i = *.txt ]] && continue
+[[ $i = *.xml ]] && continue
+[[ $i = *.zip ]] && continue
+mkdir -p /tmp/deps/"${pkg}"/
+lines+=$(echo ; readelf -d "$i" 2>/dev/null | $GREP NEEDED | awk '{print $5}' \
+| sed 's/\[//g' | sed 's/\]//g' | awk '!x[$0]++' | tee /tmp/deps/"${pkg}"/$(basename "$i") ; echo ) ; \
+done ; \
+echo "$lines" | tr " " "\n" \
+| awk 'NF' | awk '!x[$0]++')
+
+# Remove duplicates.
+pkgdeps=$(echo "$pkgdeps" | tr " " "\n" |  awk '!x[$0]++')
+
+# Figure out which Chromebrew packages provide the relevant deps.
+pkgdeps=$(unset lines; for j in $pkgdeps ; \
+do lines+=$(echo ; whatprovidesfxn "$j"); done ; \
+echo "$lines" | tr " " "\n" | awk '!x[$0]++')
+
+# Remove original package from list.
+pkgdeps=$(echo "$pkgdeps" | tr " " "\n" | sed "/${1}/d" | sort -u )
+
+# Note which dependencies are missing.
+missingpkgdeps=$(
+for i in $pkgdeps
+do
+  $GREP -q "depends_on '$i'" /usr/local/lib/crew/packages/"${1}".rb || echo "$i"
+done
+)
+
+for i in $pkgdeps
+do
+echo "  depends_on '$i' # R"
+done
+
+# If there are no missing deps, no warning is needed.
+if [ -n "${missingpkgdeps}" ]; then
+  echo "There are missing dependencies in the package:"
+  for i in $missingpkgdeps
+  do
+    echo "  depends_on '$i' # R"
+  done
+fi

--- a/tools/getrealdeps.sh
+++ b/tools/getrealdeps.sh
@@ -90,7 +90,7 @@ echo -e "${RESET}"
 
 # If there are no missing deps, no warning is needed.
 if [ -n "${missingpkgdeps}" ]; then
-  echo_error "\nPackage file ${1}.rb is missing these dependencies:"
+  echo_error "\nPackage file ${1}.rb is missing these runtime dependencies:"
   echo -e "${RESET}"
   for i in $missingpkgdeps
   do

--- a/tools/getrealdeps.sh
+++ b/tools/getrealdeps.sh
@@ -3,6 +3,23 @@
 # Author: Satadru Pramanik (satmandu) satadru at gmail dot com
 # set -x
 pkg="${1}"
+
+RED='\e[1;91m';    # Use Light Red for errors.
+YELLOW='\e[1;33m'; # Use Yellow for informational messages.
+GREEN='\e[1;32m';  # Use Green for success messages.
+BLUE='\e[1;34m';   # Use Blue for intrafunction messages.
+GRAY='\e[0;37m';   # Use Gray for program output.
+MAGENTA='\e[1;35m';
+RESET='\e[0m'
+
+# Simplify colors and print errors to stderr (2).
+echo_error() { echo -e "${RED}${*}${RESET}" >&2; }
+echo_info() { echo -e "${YELLOW}${*}${RESET}" >&1; }
+echo_success() { echo -e "${GREEN}${*}${RESET}" >&1; }
+echo_intra() { echo -e "${BLUE}${*}${RESET}" >&1; }
+echo_out() { echo -e "${GRAY}${*}${RESET}" >&1; }
+echo_other() { echo -e "${MAGENTA}${*}${RESET}" >&2; }
+
 [[ ! -e '/usr/local/bin/grep' ]] && crew install grep
 GREP=/usr/local/bin/grep
 CREW_LIB_PREFIX=$(crew const | $GREP CREW_LIB_PREFIX | awk -F = '{print $2}')
@@ -64,17 +81,21 @@ do
   $GREP -q "depends_on '$i'" /usr/local/lib/crew/packages/"${1}".rb || echo "$i"
 done
 )
-
+echo_info "\nPackage ${1} has these runtime dependencies:"
+echo -e "${RESET}"
 for i in $pkgdeps
 do
-echo "  depends_on '$i' # R"
+echo_intra "  depends_on '$i' # R"
 done
+echo -e "${RESET}"
 
 # If there are no missing deps, no warning is needed.
 if [ -n "${missingpkgdeps}" ]; then
-  echo "There are missing dependencies in the package:"
+  echo_error "\nPackage file ${1}.rb is missing these dependencies:"
+  echo -e "${RESET}"
   for i in $missingpkgdeps
   do
-    echo "  depends_on '$i' # R"
+    echo_other "  depends_on '$i' # R"
   done
 fi
+echo -e "${RESET}"


### PR DESCRIPTION
- Also adds the `getrealdeps` script to tools.
- (I'd note that the script doesn't actually check to see what binaries are being run from the package script itself as those could themselves be considered install or build-time dependencies.)

![image](https://user-images.githubusercontent.com/1096701/194715991-4418814e-9de4-4ab8-8ff3-5d78a462e1ba.png)

```
chronos@cheekon-x86_64 /usr/local/lib/crew/packages $ crew deps -t uchardet
Walking through dependencies recursively, this may take a while...

 : satisfied dependency
 : build dependency
 : runtime dependency

└───┬─uchardet
    ├───┬─gcc
    │   ├─────glibc
    │   ├─────gmp
    │   ├─────isl
    │   ├─────libssp
    │   ├───┬─mpc
    │   │   └─────mpfr
    │   ├─────zlibpkg
    │   └───┬─zstd
    │       └─────musl_zstd
    └─────glibc
```

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=gcc_fix CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
