### PR TITLE
fix typo in gnucobol

### DIFF
--- a/packages/gnucobol.rb
+++ b/packages/gnucobol.rb
@@ -25,7 +25,7 @@ class Gnucobol < Package
   depends_on 'glibc' # R
   depends_on 'gmp' # R
   depends_on 'libdb'
-  epends_on 'ncurses' # R
+  depends_on 'ncurses' # R
 
   def self.build
     system './configure',


### PR DESCRIPTION

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=fix_gnucobol CREW_TESTING=1 crew update
```
