### PR TITLE
lib/downloader: Fix progress bar length on older CrOS terminals

### DIFF
--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -11,10 +11,9 @@ class ProgressBar
     # character used to fill the progress bar, one of the box-drawing character in unicode
     @bar_char = "\u2501"
 
-    # color scheme of progress bar, can be changed
-    # see color.rb for more available colors
-    @bar_front_color = :lightcyan
-    @bar_bg_color = :gray
+    # color scheme of progress bar (in ANSI color codes), can be changed
+    @bar_front_color = [ 96, 0 ]
+    @bar_bg_color = [ 90, 0 ]
 
     # all info blocks with space taken
     @info_before_bar = { downloaded_size_in_str: 20 }
@@ -94,8 +93,8 @@ class ProgressBar
         end
 
         # print progress bar with color code
-        print ( @bar_char * completed_length).send(@bar_front_color),
-              (@bar_char * uncompleted_length).send(@bar_bg_color)
+        print ( @bar_char * completed_length).send(:colorize, *@bar_front_color),
+              (@bar_char * uncompleted_length).send(:colorize, *@bar_bg_color)
 
         @info_after_bar.each_pair do |varName, width|
           printf '  %*.*s', width, width, instance_variable_get("@#{varName}")

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -13,7 +13,7 @@ class ProgressBar
 
     # color scheme of progress bar, can be changed
     # see color.rb for more available colors
-    @bar_front_color = %i[lightblue no_bold]
+    @bar_front_color = %i[lightcyan no_bold]
     @bar_bg_color    = %i[grey no_bold]
 
     # all info blocks with space taken

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -12,8 +12,8 @@ class ProgressBar
     @bar_char = "\u2501"
 
     # color scheme of progress bar (in ANSI color codes), can be changed
-    @bar_front_color = [96, 0]
-    @bar_bg_color = [90, 0]
+    @bar_front_color = [:lightblue, :no_bold]
+    @bar_bg_color = [:grey, :no_bold]
 
     # all info blocks with space taken
     @info_before_bar = { downloaded_size_in_str: 20 }
@@ -93,8 +93,8 @@ class ProgressBar
         end
 
         # print progress bar with color code
-        print ( @bar_char * completed_length).send(:colorize, *@bar_front_color),
-              (@bar_char * uncompleted_length).send(:colorize, *@bar_bg_color)
+        print ( @bar_char * completed_length).send(*@bar_front_color),
+              (@bar_char * uncompleted_length).send(*@bar_bg_color)
 
         @info_after_bar.each_pair do |varName, width|
           printf '  %*.*s', width, width, instance_variable_get("@#{varName}")

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -14,7 +14,7 @@ class ProgressBar
     # color scheme of progress bar, can be changed
     # see color.rb for more available colors
     @bar_front_color = %i[lightblue no_bold]
-    @bar_bg_color = %i[grey no_bold]
+    @bar_bg_color    = %i[grey no_bold]
 
     # all info blocks with space taken
     @info_before_bar = { downloaded_size_in_str: 20 }

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -14,7 +14,7 @@ class ProgressBar
     # color scheme of progress bar, can be changed
     # see color.rb for more available colors
     @bar_front_color = %i[lightcyan no_bold]
-    @bar_bg_color    = %i[grey no_bold]
+    @bar_bg_color    = %i[gray no_bold]
 
     # all info blocks with space taken
     @info_before_bar = { downloaded_size_in_str: 20 }

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -12,8 +12,8 @@ class ProgressBar
     @bar_char = "\u2501"
 
     # color scheme of progress bar (in ANSI color codes), can be changed
-    @bar_front_color = [ 96, 0 ]
-    @bar_bg_color = [ 90, 0 ]
+    @bar_front_color = [96, 0]
+    @bar_bg_color = [90, 0]
 
     # all info blocks with space taken
     @info_before_bar = { downloaded_size_in_str: 20 }

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -94,7 +94,7 @@ class ProgressBar
         end
 
         # print progress bar with color code
-        print ( @bar_char * completed_length).send(*@bar_front_color),
+        print (@bar_char * completed_length).send(*@bar_front_color),
               (@bar_char * uncompleted_length).send(*@bar_bg_color)
 
         @info_after_bar.each_pair do |varName, width|

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -11,9 +11,10 @@ class ProgressBar
     # character used to fill the progress bar, one of the box-drawing character in unicode
     @bar_char = "\u2501"
 
-    # color scheme of progress bar (in ANSI color codes), can be changed
-    @bar_front_color = [:lightblue, :no_bold]
-    @bar_bg_color = [:grey, :no_bold]
+    # color scheme of progress bar, can be changed
+    # see color.rb for more available colors
+    @bar_front_color = %i[lightblue no_bold]
+    @bar_bg_color = %i[grey no_bold]
 
     # all info blocks with space taken
     @info_before_bar = { downloaded_size_in_str: 20 }


### PR DESCRIPTION
On older CrOS terminals (mainly `i686`), the progress bar will overflow since a width bug will occur when using the box-drawing char with bold character color form (`1;36m`)

Changed the front/background color code to its non-bold equivalent in this PR

### Run the following to get this pull request's changes locally for testing.
```shell
CREW_TESTING=1 CREW_TESTING_REPO=https://github.com/supechicken/chromebrew CREW_TESTING_BRANCH=fix_progbar_color crew update
```