### PR TITLE
lib/color: Refactor `color.rb`, add more colors

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -127,7 +127,13 @@ rescue Docopt::Exit => e
   exit 1
 end
 
-String.use_color = args['--color'] || !args['--no-color']
+# override default color options if specified
+if args.has_key?('--color')
+  String.use_color = true
+elsif args.has_key?('--no-color')
+  String.use_color = false
+end
+
 @opt_keep = args['--keep']
 @opt_verbose = args['--verbose']
 

--- a/bin/crew
+++ b/bin/crew
@@ -128,9 +128,9 @@ rescue Docopt::Exit => e
 end
 
 # override default color options if specified
-if args.has_key?('--color')
+if args['--color']
   String.use_color = true
-elsif args.has_key?('--no-color')
+elsif args['--no-color']
   String.use_color = false
 end
 

--- a/lib/color.rb
+++ b/lib/color.rb
@@ -4,24 +4,24 @@ class String
 
   # ANSI color codes
   @@color_codes = {
-    :black     => 30,
-    :red       => 31,
-    :green     => 32,
-    :orange    => 33,
-    :blue      => 34,
-    :purple    => 35,
-    :cyan      => 36,
-    :lightgray => 37,
+        black: 30,
+          red: 31,
+        green: 32,
+       orange: 33,
+         blue: 34,
+       purple: 35,
+         cyan: 36,
+    lightgray: 37,
 
     # colors with bold varient available
-    :gray        => { normal: 90, bold: 30 },
-    :lightred    => { normal: 91, bold: 31 },
-    :lightgreen  => { normal: 92, bold: 32 },
-    :yellow      => { normal: 93, bold: 33 },
-    :lightblue   => { normal: 94, bold: 34 },
-    :lightpurple => { normal: 95, bold: 35 },
-    :lightcyan   => { normal: 96, bold: 36 },
-    :white       => { normal: 97, bold: 37 }
+           gray: { normal: 90, bold: 30 },
+       lightred: { normal: 91, bold: 31 },
+     lightgreen: { normal: 92, bold: 32 },
+         yellow: { normal: 93, bold: 33 },
+      lightblue: { normal: 94, bold: 34 },
+    lightpurple: { normal: 95, bold: 35 },
+      lightcyan: { normal: 96, bold: 36 },
+          white: { normal: 97, bold: 37 }
   }
 
   class << self

--- a/lib/color.rb
+++ b/lib/color.rb
@@ -1,80 +1,61 @@
 # Colorization for strings
 class String
-  @use_color = $stdout.isatty
+  @@use_color = $stdout.isatty
+
+  # ANSI color codes
+  @@color_codes = {
+    :black     => 30,
+    :red       => 31,
+    :green     => 32,
+    :orange    => 33,
+    :blue      => 34,
+    :purple    => 35,
+    :cyan      => 36,
+    :lightgray => 37,
+
+    # colors with bold form available
+    :gray        => { normal: 90, bold: 30 },
+    :lightred    => { normal: 91, bold: 31 },
+    :lightgreen  => { normal: 92, bold: 32 },
+    :yellow      => { normal: 93, bold: 33 },
+    :lightblue   => { normal: 94, bold: 34 },
+    :lightpurple => { normal: 95, bold: 35 },
+    :lightcyan   => { normal: 96, bold: 36 },
+    :white       => { normal: 97, bold: 37 }
+  }
 
   class << self
-    attr_accessor :use_color
-  end
+    # create a getter/setter method for @@use_color
+    # like attr_accessor, but attr_accessor works on instance variables only
+    def use_color=(use_color)
+      @@use_color = use_color
+    end
 
-  def colorize(color_code, shade)
-    if self.class.use_color
-      return "\e[#{shade};#{color_code}m#{self}\e[0m"
-    else
-      return self
+    def use_color
+      return @@use_color
     end
   end
 
-  def black
-    colorize(30, 0)
+  def colorize(color_code, shade)
+    return @@use_color ? "\e[#{shade};#{color_code}m#{self}\e[0m" : self
   end
 
-  def red
-    colorize(31, 0)
-  end
+  # create function for each color
+  @@color_codes.each_pair do |name, code|
+    define_method(name) do |*opts|
+      bold_avail = code.is_a?(Hash)
 
-  def green
-    colorize(32, 0)
-  end
+      if bold_avail
+        # use bold form by default (if available),
+        # specify :no_bold to use normal form
+        use_bold   = !opts.include?(:no_bold)
+        color_code = code[use_bold ? :bold : :normal]
+      else
+        use_bold   = false
+        color_code = code
+      end
 
-  def orange
-    colorize(33, 0)
-  end
-
-  def blue
-    colorize(34, 0)
-  end
-
-  def purple
-    colorize(35, 0)
-  end
-
-  def cyan
-    colorize(36, 0)
-  end
-
-  def lightgray
-    colorize(37, 0)
-  end
-
-  def gray
-    colorize(30, 1)
-  end
-
-  def lightred
-    colorize(31, 1)
-  end
-
-  def lightgreen
-    colorize(32, 1)
-  end
-
-  def yellow
-    colorize(33, 1)
-  end
-
-  def lightblue
-    colorize(34, 1)
-  end
-
-  def lightpurple
-    colorize(35, 1)
-  end
-
-  def lightcyan
-    colorize(36, 1)
-  end
-
-  def white
-    colorize(37, 1)
+      return colorize(color_code, use_bold ? 1 : 0)
+    end
   end
 end

--- a/lib/color.rb
+++ b/lib/color.rb
@@ -40,7 +40,7 @@ class String
     return @@use_color ? "\e[#{shade};#{color_code}m#{self}\e[0m" : self
   end
 
-  # create function for each color
+  # create method for each color
   @@color_codes.each_pair do |name, code|
     define_method(name) do |*opts|
       bold_avail = code.is_a?(Hash)

--- a/lib/color.rb
+++ b/lib/color.rb
@@ -13,7 +13,7 @@ class String
     :cyan      => 36,
     :lightgray => 37,
 
-    # colors with bold form available
+    # colors with bold varient available
     :gray        => { normal: 90, bold: 30 },
     :lightred    => { normal: 91, bold: 31 },
     :lightgreen  => { normal: 92, bold: 32 },
@@ -46,8 +46,8 @@ class String
       bold_avail = code.is_a?(Hash)
 
       if bold_avail
-        # use bold form by default (if available),
-        # specify :no_bold to use normal form
+        # use bold varient by default (if available),
+        # specify :no_bold to use normal varient
         use_bold   = !opts.include?(:no_bold)
         color_code = code[use_bold ? :bold : :normal]
       else

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.26.0'
+CREW_VERSION = '1.26.1'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.26.1'
+CREW_VERSION = '1.26.2'
 
 ARCH_ACTUAL = `uname -m`.chomp
 # This helps with virtualized builds on aarch64 machines


### PR DESCRIPTION
### New changes
- Fix color detection on interactive terminals
- All color codes are listed on one hash table instead of each separated function
- Add new colors: lighter version of `black-lightgray` but without bold, can be used with:
```shell
# existing `lightgreen` function (with bold words)
puts "hello".lightgreen # => same as current

# existing `lightgreen` function with :no_bold option specified (without bold words)
puts "hello".lightgreen(:no_bold) # => identical color with the bold varient but without bold
```

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/supechicken/chromebrew.git CREW_TESTING_BRANCH=new_color CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
