### PR TITLE
Add ruby_rubocop to build_essential

### DIFF
--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -134,4 +134,8 @@ class Buildessential < Package
 
   # Packages needed for compressing archives
   depends_on 'zstd'
+
+  # Add rubocop for linting packages. (This also installs the
+  # rubocop config file.)
+  depends_on 'ruby_rubocop'
 end

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -3,7 +3,7 @@ require 'package'
 class Buildessential < Package
   description 'A collection of tools essential to compile and build software.'
   homepage ''
-  version '1.19'
+  version '1.20'
   license 'GPL-3+'
   compatibility 'all'
 


### PR DESCRIPTION
- We need this enough let's add it to `build_essential`.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=rubocop_buildessential  CREW_TESTING=1 crew update
```
