### PR TITLE
Add ruby debug package, rebuild ruby from 3.1 stable branch

### DIFF
--- a/packages/core.rb
+++ b/packages/core.rb
@@ -3,7 +3,7 @@ require 'package'
 class Core < Package
   description 'Core Chromebrew Packages.'
   homepage 'https://github.com/chromebrew/chromebrew'
-  version '1.5'
+  version '1.6'
   license 'GPL-3+'
   compatibility 'all'
 

--- a/packages/core.rb
+++ b/packages/core.rb
@@ -75,6 +75,7 @@ class Core < Package
   depends_on 'rsync'
   depends_on 'rtmpdump'
   depends_on 'ruby'
+  depends_on 'ruby_debug'
   depends_on 'slang'
   depends_on 'sqlite'
   depends_on 'uchardet'

--- a/packages/ruby.rb
+++ b/packages/ruby.rb
@@ -64,11 +64,11 @@ class Ruby < Package
     puts 'Updating ruby gems. This may take a while...'
     unless Kernel.system("grep -q \"no-document\" #{HOME}/.gemrc")
       File.write("#{HOME}/.gemrc", "gem: --no-document\n",
-                   mode: 'a')
+                 mode: 'a')
     end
     unless Kernel.system("grep -q \"gempath\" #{HOME}/.gemrc")
       File.write("#{HOME}/.gemrc", "gempath: #{CREW_LIB_PREFIX}/ruby/gems/3.1.0\n",
-                   mode: 'a')
+                 mode: 'a')
     end
     silent = @opt_verbose ? '' : '--silent'
     system "gem update #{silent} -N --system"

--- a/packages/ruby.rb
+++ b/packages/ruby.rb
@@ -43,7 +43,7 @@ class Ruby < Package
     system '[ -x configure ] || autoreconf -fiv'
     system "RUBY_TRY_CFLAGS='stack_protector=no' \
       RUBY_TRY_LDFLAGS='stack_protector=no' \
-      optflags='-flto -fuse-ld=mold' \
+      optflags='-flto -fuse-ld=#{CREW_LINKER}' \
       ./configure #{CREW_OPTIONS} \
       --enable-shared \
       --disable-fortify-source"
@@ -62,9 +62,13 @@ class Ruby < Package
 
   def self.postinstall
     puts 'Updating ruby gems. This may take a while...'
-    if (File.exist?("#{HOME}/.gemrc") && !Kernel.system("grep -q \"gem: --no-document\" #{HOME}/.gemrc")) || !File.exist?("#{HOME}/.gemrc")
+    unless Kernel.system("grep -q \"--no-document\" #{HOME}/.gemrc")
       File.write("#{HOME}/.gemrc", "gem: --no-document\n",
-mode: 'a')
+                   mode: 'a')
+    end
+    unless Kernel.system("grep -q \"gempath\" #{HOME}/.gemrc")
+      File.write("#{HOME}/.gemrc", "gempath: #{CREW_LIB_PREFIX}/ruby/gems/3.1.0\n",
+                   mode: 'a')
     end
     silent = @opt_verbose ? '' : '--silent'
     system "gem update #{silent} -N --system"

--- a/packages/ruby.rb
+++ b/packages/ruby.rb
@@ -3,23 +3,23 @@ require 'package'
 class Ruby < Package
   description 'Ruby is a dynamic, open source programming language with a focus on simplicity and productivity.'
   homepage 'https://www.ruby-lang.org/en/'
-  version '3.1.2-4'
+  version '3.1-994b505'
   license 'Ruby-BSD and BSD-2'
   compatibility 'all'
-  source_url 'https://github.com/ruby/ruby.git'
-  git_hashtag 'v3_1_2'
+  source_url 'https://github.com/ruby/ruby/archive/994b505ffb0bf9eb795525199b47697412a98abb.zip'
+  source_sha256 '247155fd6978dffea5f1f25e7a77d1fe3c29c224ad24e15384c49e7e0aa71761'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.2-4_armv7l/ruby-3.1.2-4-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.2-4_armv7l/ruby-3.1.2-4-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.2-4_i686/ruby-3.1.2-4-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.2-4_x86_64/ruby-3.1.2-4-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1-994b505_armv7l/ruby-3.1-994b505-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1-994b505_armv7l/ruby-3.1-994b505-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1-994b505_i686/ruby-3.1-994b505-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1-994b505_x86_64/ruby-3.1-994b505-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'f4baac3cf547bedef9519071dcb0132b6869c2f9f2500b5bbca5cb8e5ac518bb',
-     armv7l: 'f4baac3cf547bedef9519071dcb0132b6869c2f9f2500b5bbca5cb8e5ac518bb',
-       i686: '8c61a756a2311f658bdbe024575e2f1c7fefee7e85479b21f2a24e4efedeba75',
-     x86_64: 'b6d98ba7d393e88ef14ddc48f45319b754b373c78ab592577f29fd92b1d932ea'
+    aarch64: 'ffa3f5aea7408599aab2d074876b30484bd845abf79dfffef8646fd8c38b7292',
+     armv7l: 'ffa3f5aea7408599aab2d074876b30484bd845abf79dfffef8646fd8c38b7292',
+       i686: '78180a2bbfbaadbbb0cfa8a6f3d9c3fe741da922dbf0242b53a4f6676d11e6d5',
+     x86_64: 'ae3cf478808d30321e87db6433f38d0886cf38adef123eba0e0a826b6c6367f1'
   })
 
   depends_on 'zlibpkg' # R

--- a/packages/ruby.rb
+++ b/packages/ruby.rb
@@ -62,7 +62,7 @@ class Ruby < Package
 
   def self.postinstall
     puts 'Updating ruby gems. This may take a while...'
-    unless Kernel.system("grep -q \"--no-document\" #{HOME}/.gemrc")
+    unless Kernel.system("grep -q \"no-document\" #{HOME}/.gemrc")
       File.write("#{HOME}/.gemrc", "gem: --no-document\n",
                    mode: 'a')
     end

--- a/packages/ruby.rb
+++ b/packages/ruby.rb
@@ -3,23 +3,23 @@ require 'package'
 class Ruby < Package
   description 'Ruby is a dynamic, open source programming language with a focus on simplicity and productivity.'
   homepage 'https://www.ruby-lang.org/en/'
-  version '3.1.2-3'
+  version '3.1.2-4'
   license 'Ruby-BSD and BSD-2'
   compatibility 'all'
   source_url 'https://github.com/ruby/ruby.git'
   git_hashtag 'v3_1_2'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.2-3_armv7l/ruby-3.1.2-3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.2-3_armv7l/ruby-3.1.2-3-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.2-3_i686/ruby-3.1.2-3-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.2-3_x86_64/ruby-3.1.2-3-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.2-4_armv7l/ruby-3.1.2-4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.2-4_armv7l/ruby-3.1.2-4-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.2-4_i686/ruby-3.1.2-4-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.2-4_x86_64/ruby-3.1.2-4-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'a466a4eed626562b831ece35d10502f3b0816ba81ac7ff3b4c7a04051aa17856',
-     armv7l: 'a466a4eed626562b831ece35d10502f3b0816ba81ac7ff3b4c7a04051aa17856',
-       i686: '52fb0865ecb00ce46a1f5e58bf39413aaa32683f4dd547d316ac83a1c54a7946',
-     x86_64: 'b18f6c4ad3165cc35f25d6089276a7680a4e34bd9dd1ff3fbcd150ba17a8ef7a'
+    aarch64: 'f4baac3cf547bedef9519071dcb0132b6869c2f9f2500b5bbca5cb8e5ac518bb',
+     armv7l: 'f4baac3cf547bedef9519071dcb0132b6869c2f9f2500b5bbca5cb8e5ac518bb',
+       i686: '8c61a756a2311f658bdbe024575e2f1c7fefee7e85479b21f2a24e4efedeba75',
+     x86_64: 'b6d98ba7d393e88ef14ddc48f45319b754b373c78ab592577f29fd92b1d932ea'
   })
 
   depends_on 'zlibpkg' # R
@@ -33,6 +33,7 @@ class Ruby < Package
   depends_on 'readline' # R
   depends_on 'ca_certificates'
   depends_on 'libyaml' # This is needed to install gems
+
   # at run-time, system's gmp, openssl, readline and zlibpkg can be used
 
   no_patchelf
@@ -61,7 +62,10 @@ class Ruby < Package
 
   def self.postinstall
     puts 'Updating ruby gems. This may take a while...'
-    File.write("#{HOME}/.gemrc", "gem: --no-document\n", mode: 'a') if (File.exist?("#{HOME}/.gemrc") && !Kernel.system("grep -q \"gem: --no-document\" #{HOME}/.gemrc")) || !File.exist?("#{HOME}/.gemrc")
+    if (File.exist?("#{HOME}/.gemrc") && !Kernel.system("grep -q \"gem: --no-document\" #{HOME}/.gemrc")) || !File.exist?("#{HOME}/.gemrc")
+      File.write("#{HOME}/.gemrc", "gem: --no-document\n",
+mode: 'a')
+    end
     silent = @opt_verbose ? '' : '--silent'
     system "gem update #{silent} -N --system"
   end

--- a/packages/ruby_debug.rb
+++ b/packages/ruby_debug.rb
@@ -38,7 +38,7 @@ class Ruby_debug < Package
 
   def self.postinstall
     @gem_name = name.delete('ruby_')
-    system "gem uninstall -Dx --force --abort-on-dependent #{gem}", exception: false
+    system "gem uninstall -Dx --force --abort-on-dependent #{@gem_name}", exception: false
     system "gem install -N #{@gem_name} --conservative"
   end
 

--- a/packages/ruby_debug.rb
+++ b/packages/ruby_debug.rb
@@ -1,10 +1,7 @@
-# Adapted from Arch Linux ruby-rubocop PKGBUILD at:
-# https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=ruby-rubocop
-
 require 'package'
 
 class Ruby_debug < Package
-  description 'Ruby debug.rb'
+  description 'Debugging functionality for Ruby. This is completely rewritten debug.rb which was contained by the ancient Ruby versions.'
   homepage 'https://github.com/ruby/debug'
   version '1.6.2'
   compatibility 'all'
@@ -33,31 +30,28 @@ class Ruby_debug < Package
   # @xdg_config_home = "#{CREW_PREFIX}/.config" if @xdg_config_home.to_s.empty?
 
   def self.build
-    # system 'bundle install'
-    # system 'rake build'
   end
 
   def self.install
-    # system "gem install --build=#{CREW_DEST_DIR} pkg/rubocop-#{version}.gem"
     FileUtils.mkdir_p CREW_DEST_PREFIX
   end
 
   def self.postinstall
-    @gem_name = name.sub('ruby_', '')
-    system "gem uninstall -Dx --force --abort-on-dependent #{@gem_name} || true"
+    @gem_name = name.delete('ruby_')
+    system "gem uninstall -Dx --force --abort-on-dependent #{gem}", exception: false
     system "gem install -N #{@gem_name} --conservative"
   end
 
   def self.remove
-    @gem_name = name.sub('ruby_', '')
-    @gems_deps = `gem dependency ^#{@gem_name}\$ | awk '{print \$1}'`.chomp
+    @gem_name = name.delete('ruby_')
+    @gems_deps = `gem dependency ^#{@gem_name}\$`.scan(/^([^\s]+?)/).flatten
     # Delete the first line and convert to an array.
     @gems = @gems_deps.split("\n").drop(1).append(@gem_name)
     # bundler never gets uninstalled, though gem dependency lists it for
     # every package, so delete it from the list.
     @gems.delete('bundler')
     @gems.each do |gem|
-      system "gem uninstall -Dx --force --abort-on-dependent #{gem} || true"
+      system "gem uninstall -Dx --force --abort-on-dependent #{gem}", exception: false
     end
   end
 end

--- a/packages/ruby_debug.rb
+++ b/packages/ruby_debug.rb
@@ -1,0 +1,63 @@
+# Adapted from Arch Linux ruby-rubocop PKGBUILD at:
+# https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=ruby-rubocop
+
+require 'package'
+
+class Ruby_debug < Package
+  description 'Ruby debug.rb'
+  homepage 'https://github.com/ruby/debug'
+  version '1.6.2'
+  compatibility 'all'
+  source_url 'SKIP'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby_debug/1.6.2_armv7l/ruby_debug-1.6.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby_debug/1.6.2_armv7l/ruby_debug-1.6.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby_debug/1.6.2_i686/ruby_debug-1.6.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby_debug/1.6.2_x86_64/ruby_debug-1.6.2-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '2bdb5f3152576c078f7375bf83cf87c19a620b91c80e6363d127e5aa68ec790c',
+     armv7l: '2bdb5f3152576c078f7375bf83cf87c19a620b91c80e6363d127e5aa68ec790c',
+       i686: '0046afda40659300d9237be3c45ea444f43c1ccadfbc82e787d4528fb55d98c3',
+     x86_64: '449811904d7d9b2969504f5930d3347a4e1590bda94dea9b43d5856935a7a93e'
+  })
+
+  no_fhs
+
+  depends_on 'libyaml'
+  depends_on 'ruby'
+  # depends_on 'xdg_base'
+
+  # @xdg_config_home = ENV.fetch('XDG_CONFIG_HOME', nil)
+  # @xdg_config_home = "#{CREW_PREFIX}/.config" if @xdg_config_home.to_s.empty?
+
+  def self.build
+    # system 'bundle install'
+    # system 'rake build'
+  end
+
+  def self.install
+    # system "gem install --build=#{CREW_DEST_DIR} pkg/rubocop-#{version}.gem"
+    FileUtils.mkdir_p CREW_DEST_PREFIX
+  end
+
+  def self.postinstall
+    @gem_name = name.sub('ruby_', '')
+    system "gem uninstall -Dx --force --abort-on-dependent #{@gem_name} || true"
+    system "gem install -N #{@gem_name} --conservative"
+  end
+
+  def self.remove
+    @gem_name = name.sub('ruby_', '')
+    @gems_deps = `gem dependency ^#{@gem_name}\$ | awk '{print \$1}'`.chomp
+    # Delete the first line and convert to an array.
+    @gems = @gems_deps.split("\n").drop(1).append(@gem_name)
+    # bundler never gets uninstalled, though gem dependency lists it for
+    # every package, so delete it from the list.
+    @gems.delete('bundler')
+    @gems.each do |gem|
+      system "gem uninstall -Dx --force --abort-on-dependent #{gem} || true"
+    end
+  end
+end

--- a/packages/ruby_debug.rb
+++ b/packages/ruby_debug.rb
@@ -37,13 +37,13 @@ class Ruby_debug < Package
   end
 
   def self.postinstall
-    @gem_name = name.delete('ruby_')
+    @gem_name = name.sub('ruby_','')
     system "gem uninstall -Dx --force --abort-on-dependent #{@gem_name}", exception: false
     system "gem install -N #{@gem_name} --conservative"
   end
 
   def self.remove
-    @gem_name = name.delete('ruby_')
+    @gem_name = name.sub('ruby_','')
     @gems_deps = `gem dependency ^#{@gem_name}\$`.scan(/^([^\s]+?)/).flatten
     # Delete the first line and convert to an array.
     @gems = @gems_deps.split("\n").drop(1).append(@gem_name)

--- a/packages/ruby_debug.rb
+++ b/packages/ruby_debug.rb
@@ -29,21 +29,20 @@ class Ruby_debug < Package
   # @xdg_config_home = ENV.fetch('XDG_CONFIG_HOME', nil)
   # @xdg_config_home = "#{CREW_PREFIX}/.config" if @xdg_config_home.to_s.empty?
 
-  def self.build
-  end
+  def self.build; end
 
   def self.install
     FileUtils.mkdir_p CREW_DEST_PREFIX
   end
 
   def self.postinstall
-    @gem_name = name.sub('ruby_','')
+    @gem_name = name.sub('ruby_', '')
     system "gem uninstall -Dx --force --abort-on-dependent #{@gem_name}", exception: false
     system "gem install -N #{@gem_name} --conservative"
   end
 
   def self.remove
-    @gem_name = name.sub('ruby_','')
+    @gem_name = name.sub('ruby_', '')
     @gems_deps = `gem dependency ^#{@gem_name}\$`.scan(/^([^\s]+?)/).flatten
     # Delete the first line and convert to an array.
     @gems = @gems_deps.split("\n").drop(1).append(@gem_name)


### PR DESCRIPTION
- Hopefully deal with the annoying ruby debug gem reinstall messages, e.g. `Ignoring debug-1.4.0 because its extensions are not built. Try: gem pristine debug --version 1.4.0`
- Ruby rebuilt from the ruby 3.1 git branch.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=ruby_debug CREW_TESTING=1 crew update ; crew upgrade
```