### PR TITLE
rubocop: Disable some cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -128,7 +128,13 @@ Layout/FirstHashElementIndentation:
 Layout/IndentationStyle:
   EnforcedStyle: spaces
 
+Layout/SpaceInsideBlockBraces:
+  Enabled: false
+
 Layout/SpaceInsideParens:
+  Enabled: false
+
+Layout/TrailingEmptyLines:
   Enabled: false
 
 Style/RedundantReturn:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
   Exclude:
   - 'lib/docopt.rb'
 
@@ -118,8 +118,12 @@ Layout/HashAlignment:
 
 # End temporarily disabled cops
 
+Layout/CommentIndentation:
+  Enabled: false
+
 Layout/FirstHashElementIndentation:
-  EnforcedStyle: consistent
+  Enabled: false
+# EnforcedStyle: consistent
 
 Layout/IndentationStyle:
   EnforcedStyle: spaces


### PR DESCRIPTION
### Re: `rubocop` checks in my PR
For me, the `rubocop` check result is more like a suggestion, and I may ignore some of them when I think the current one is better.

For example:
```ruby
# trying to align a hash table to make it looks better

# first try
example = {
      a: 1,
    bcd: 2,
   asdf: 3
}

# rubocop doesn't like it, however
# C: [Correctable] Layout/FirstHashElementIndentation: Use 2 spaces for indentation in a hash, ...
# second try, and this time I followed rubocop's suggestion
example = {
  :a    => 1,
  :bcd  => 2,
  :asdf => 3
}

# rubocop doesn't like it either
# [Correctable] Style/HashSyntax: Use the new Ruby 1.9 hash syntax.
```

What I want to say is to compare the current version and `rubocop`'s one first, and if you think the `rubocop` one is better, tell me and I will change it :)

### Disabled cops
#### `Layout/CommentIndentation, Layout/FirstHashElementIndentation`
- It stops me from aligning the hash tables...
#### `Layout/TrailingEmptyLines`
- Github will do it for us when the PR merge