### PR TITLE
jdk*: Make prompt more clearly + add openjdk detection

### DIFF
--- a/packages/jdk11.rb
+++ b/packages/jdk11.rb
@@ -26,7 +26,7 @@ class Jdk11 < Package
       pkg_branding = is_openjdk ? 'OpenJDK' : 'Oracle JDK'
         pkg_prefix = is_openjdk ? 'openjdk' : 'jdk'
 
-      abort <<~EOT.yellow unless jdk_major_ver == '11'
+      abort <<~EOT.yellow unless jdk_major_ver == name.delete_prefix('jdk')
 
         #{pkg_branding} #{jdk_ver} installed.
 

--- a/packages/jdk11.rb
+++ b/packages/jdk11.rb
@@ -4,11 +4,11 @@ require 'uri'
 class Jdk11 < Package
   description 'The Oracle JDK is a development environment for building applications, applets, and components using the Java programming language.'
   homepage 'https://www.oracle.com/java'
-  version '11.0.16.1'
+  version "#{@_ver = '11.0.16.1'}-1"
   license 'Oracle-BCLA-JavaSE'
   compatibility 'x86_64'
 
-  source_url File.join('file://', HOME, 'Downloads', "jdk-#{version}_linux-x64_bin.tar.gz")
+  source_url File.join('file://', HOME, 'Downloads', "jdk-#{@_ver}_linux-x64_bin.tar.gz")
   source_sha256 '4edc62ebb4359b276ea33abfd9a54bacb218b8f972603c20be9e415b8a59012c'
 
   no_compile_needed
@@ -20,7 +20,7 @@ class Jdk11 < Package
     if File.exist?(jdk_exec)
       jdk_ver_str   = `#{jdk_exec} -version 2>&1`
       jdk_ver       = jdk_ver_str[/version "(.+?)"/, 1]
-      jdk_major_ver = (jdk_ver =~ /^1.8/) ? '8' : jdk_ver.partition('.')[0]
+      jdk_major_ver = jdk_ver.match?(/^1.8/) ? '8' : jdk_ver.partition('.')[0]
 
       is_openjdk   = jdk_ver_str.include?('openjdk')
       pkg_branding = is_openjdk ? 'OpenJDK' : 'Oracle JDK'
@@ -35,7 +35,7 @@ class Jdk11 < Package
     end
 
     unless File.exist?( URI(source_url).path )
-      # check if we should prompt user to the archive page or download page based on #{version}
+      # check if we should prompt user to the archive page or download page based on #{@_ver}
       # download page only contains latest version while archive page only contains older versions
 
       # get latest available version
@@ -55,7 +55,7 @@ class Jdk11 < Package
         You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
         #{jdk_download_url}
 
-        Download "jdk-#{version}_linux-x64_bin.tar.gz" (Linux x64 Compressed Archive) to Chrome OS download folder to continue.
+        Download "jdk-#{@_ver}_linux-x64_bin.tar.gz" (Linux x64 Compressed Archive) to Chrome OS download folder to continue.
       EOT
     end
   end

--- a/packages/jdk11.rb
+++ b/packages/jdk11.rb
@@ -1,46 +1,96 @@
 require 'package'
+require 'uri'
 
 class Jdk11 < Package
-  description 'The JDK is a development environment for building applications, applets, and components using the Java programming language.'
-  homepage 'https://www.oracle.com/java/technologies/javase-jdk11-downloads.html'
+  description 'The Oracle JDK is a development environment for building applications, applets, and components using the Java programming language.'
+  homepage 'https://www.oracle.com/java/technologies/downloads/#java11'
   version '11.0.16.1'
   license 'Oracle-BCLA-JavaSE'
   compatibility 'x86_64'
-  source_url 'SKIP'
+
+  @jdk_arch = {
+     armv7l: 'arm32-vfp-hflt',
+       i686: 'i586',
+     x86_64: 'x64'
+  }
+
+  source_url({
+     x86_64: File.join('file://', HOME, 'Downloads', "jdk-#{version}_linux-#{@jdk_arch[:x86_64]}_bin.tar.gz")
+  })
+
+  source_sha256({
+     x86_64: '4edc62ebb4359b276ea33abfd9a54bacb218b8f972603c20be9e415b8a59012c'
+  })
 
   no_compile_needed
   no_patchelf
 
   def self.preflight
-    %w[jdk8 jdk15 jdk16 jdk17 jdk18].each do |jdk|
-      abort "#{jdk} installed.".lightgreen if Dir.exist? "#{CREW_PREFIX}/share/#{jdk}"
+    jdk_exec = File.join(CREW_PREFIX, 'bin', 'java')
+
+    if File.exist?(jdk_exec)
+        jdk_ver_str = `#{jdk_exec} -version 2>&1`
+            jdk_ver = jdk_ver_str[/version "(.+?)"/, 1]
+      jdk_major_ver = (jdk_ver =~ /^1.8/) ? '8' : jdk_ver.partition('.')[0]
+
+        is_openjdk = jdk_ver_str.include?('openjdk')
+      pkg_branding = is_openjdk ? 'OpenJDK' : 'Oracle JDK'
+        pkg_prefix = is_openjdk ? 'openjdk' : 'jdk'
+
+      abort <<~EOT.yellow unless jdk_major_ver == '11'
+
+        #{pkg_branding} #{jdk_ver} installed.
+
+        Run "crew remove #{pkg_prefix}#{jdk_major_ver}; crew install #{name}" to install this version of JDK
+      EOT
+    end
+
+    unless File.exist?( URI( get_source_url(ARCH.to_sym) ).path )
+      # check if we should prompt user to the archive page or download page based on #{version}
+      # download page only contains latest version while archive page only contains older versions
+
+      # get latest available version
+      latest_jdk_page = 'https://www.oracle.com/java/technologies/downloads/#java11'
+        is_latest_jdk = `curl -LSs '#{latest_jdk_page}'`.include?(version)
+
+      if is_latest_jdk
+        jdk_download_url = latest_jdk_page
+      else
+        jdk_download_url = 'https://www.oracle.com/java/technologies/javase/jdk11-archive-downloads.html'
+      end
+
+      abort <<~EOT.orange
+
+        Oracle now requires an account to download the JDK.
+
+        You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
+        #{jdk_download_url}
+
+        Download "jdk-#{version}_linux-#{@jdk_arch[ARCH.to_sym]}_bin.tar.gz" to Chrome OS download folder to continue.
+      EOT
     end
   end
 
   def self.install
-    jdk_bin = "#{HOME}/Downloads/jdk-#{version}_linux-x64_bin.tar.gz"
-    jdk_sha256 = 'da9297fa500517e82e575c88886ca2311018d86cf374177a8e12b8ea8c49e79e'
-    unless File.exist? jdk_bin
-      puts "\nOracle now requires an account to download the JDK.\n".orange
-      puts 'You must login at https://login.oracle.com/mysso/signon.jsp and then visit:'.orange
-      puts 'https://www.oracle.com/java/technologies/downloads/#java11'.orange
-      puts "\nDownload the JDK version #{version} for your architecture to #{HOME}/Downloads to continue.\n".orange
-      abort
+    jdk_dir = File.join(CREW_DEST_PREFIX, 'share', name)
+    FileUtils.mkdir_p [jdk_dir, File.join(CREW_DEST_PREFIX, 'bin'), CREW_DEST_MAN_PREFIX]
+
+    FileUtils.rm_f 'lib/src.zip'
+    FileUtils.cp_r Dir['*'], jdk_dir
+
+    Dir[ File.join(jdk_dir, 'bin', '*') ].each do |path|
+      filename = File.basename(path)
+       symlink = File.join(CREW_DEST_PREFIX, 'bin', filename)
+
+      FileUtils.ln_s path.sub(CREW_DEST_PREFIX, CREW_PREFIX), symlink
     end
-    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest(File.read(jdk_bin)) == jdk_sha256
-    system "tar xvf #{jdk_bin}"
-    jdk11_dir = "#{CREW_DEST_PREFIX}/share/jdk11"
-    FileUtils.mkdir_p jdk11_dir.to_s
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
-    FileUtils.cd "jdk-#{version}" do
-      FileUtils.rm_f 'lib/src.zip'
-      FileUtils.mv Dir['*'], "#{jdk11_dir}/"
-    end
-    Dir["#{jdk11_dir}/bin/*"].each do |filename|
-      binary = File.basename(filename)
-      FileUtils.ln_s "#{CREW_PREFIX}/share/jdk11/bin/#{binary}", "#{CREW_DEST_PREFIX}/bin/#{binary}"
-    end
-    FileUtils.rm ["#{jdk11_dir}/man/man1/kinit.1", "#{jdk11_dir}/man/man1/klist.1"] # conflicts with krb5 package
-    FileUtils.mv "#{jdk11_dir}/man/", "#{CREW_DEST_PREFIX}/share/"
+
+    FileUtils.rm Dir[ File.join(jdk_dir, 'man/man1/k{init,list}.1') ] # conflicts with krb5 package
+    FileUtils.mv Dir[ File.join(jdk_dir, 'man', '*') ], CREW_DEST_MAN_PREFIX
+  end
+
+  def self.postinstall
+    # remove jdk archive after installed
+    FileUtils.rm_f URI( get_source_url(ARCH.to_sym) ).path
   end
 end

--- a/packages/jdk11.rb
+++ b/packages/jdk11.rb
@@ -26,7 +26,7 @@ class Jdk11 < Package
       pkg_branding = is_openjdk ? 'OpenJDK' : 'Oracle JDK'
       pkg_prefix   = is_openjdk ? 'openjdk' : 'jdk'
 
-      abort <<~EOT.yellow unless jdk_major_ver == name.delete_prefix('jdk')
+      abort <<~EOT.yellow unless jdk_major_ver == name.delete_prefix('jdk') and !is_openjdk
 
         #{pkg_branding} #{jdk_ver} installed.
 

--- a/packages/jdk11.rb
+++ b/packages/jdk11.rb
@@ -3,24 +3,13 @@ require 'uri'
 
 class Jdk11 < Package
   description 'The Oracle JDK is a development environment for building applications, applets, and components using the Java programming language.'
-  homepage 'https://www.oracle.com/java/technologies/downloads/#java11'
+  homepage 'https://www.oracle.com/java'
   version '11.0.16.1'
   license 'Oracle-BCLA-JavaSE'
   compatibility 'x86_64'
 
-  @jdk_arch = {
-     armv7l: 'arm32-vfp-hflt',
-       i686: 'i586',
-     x86_64: 'x64'
-  }
-
-  source_url({
-     x86_64: File.join('file://', HOME, 'Downloads', "jdk-#{version}_linux-#{@jdk_arch[:x86_64]}_bin.tar.gz")
-  })
-
-  source_sha256({
-     x86_64: '4edc62ebb4359b276ea33abfd9a54bacb218b8f972603c20be9e415b8a59012c'
-  })
+  source_url File.join('file://', HOME, 'Downloads', "jdk-#{version}_linux-x64_bin.tar.gz")
+  source_sha256 '4edc62ebb4359b276ea33abfd9a54bacb218b8f972603c20be9e415b8a59012c'
 
   no_compile_needed
   no_patchelf
@@ -45,7 +34,7 @@ class Jdk11 < Package
       EOT
     end
 
-    unless File.exist?( URI( get_source_url(ARCH.to_sym) ).path )
+    unless File.exist?( URI( get_source_url(:x86_64) ).path )
       # check if we should prompt user to the archive page or download page based on #{version}
       # download page only contains latest version while archive page only contains older versions
 
@@ -66,7 +55,7 @@ class Jdk11 < Package
         You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
         #{jdk_download_url}
 
-        Download "jdk-#{version}_linux-#{@jdk_arch[ARCH.to_sym]}_bin.tar.gz" to Chrome OS download folder to continue.
+        Download "jdk-#{version}_linux-x64_bin.tar.gz" (Linux x64 Compressed Archive) to Chrome OS download folder to continue.
       EOT
     end
   end
@@ -91,6 +80,6 @@ class Jdk11 < Package
 
   def self.postinstall
     # remove jdk archive after installed
-    FileUtils.rm_f URI( get_source_url(ARCH.to_sym) ).path
+    FileUtils.rm_f URI( get_source_url(:x86_64) ).path
   end
 end

--- a/packages/jdk11.rb
+++ b/packages/jdk11.rb
@@ -26,7 +26,7 @@ class Jdk11 < Package
       pkg_branding = is_openjdk ? 'OpenJDK' : 'Oracle JDK'
       pkg_prefix   = is_openjdk ? 'openjdk' : 'jdk'
 
-      abort <<~EOT.yellow unless jdk_major_ver == name.delete_prefix('jdk') and !is_openjdk
+      abort <<~EOT.yellow unless jdk_major_ver == name.delete_prefix('jdk') && !is_openjdk
 
         #{pkg_branding} #{jdk_ver} installed.
 

--- a/packages/jdk11.rb
+++ b/packages/jdk11.rb
@@ -34,7 +34,7 @@ class Jdk11 < Package
       EOT
     end
 
-    unless File.exist?( URI( get_source_url(:x86_64) ).path )
+    unless File.exist?( URI(source_url).path )
       # check if we should prompt user to the archive page or download page based on #{version}
       # download page only contains latest version while archive page only contains older versions
 
@@ -80,6 +80,6 @@ class Jdk11 < Package
 
   def self.postinstall
     # remove jdk archive after installed
-    FileUtils.rm_f URI( get_source_url(:x86_64) ).path
+    FileUtils.rm_f URI(source_url).path
   end
 end

--- a/packages/jdk11.rb
+++ b/packages/jdk11.rb
@@ -4,7 +4,8 @@ require 'uri'
 class Jdk11 < Package
   description 'The Oracle JDK is a development environment for building applications, applets, and components using the Java programming language.'
   homepage 'https://www.oracle.com/java'
-  version "#{@_ver = '11.0.16.1'}-1"
+  @_ver = '11.0.16.1'
+  version "#{@_ver}-1"
   license 'Oracle-BCLA-JavaSE'
   compatibility 'x86_64'
 
@@ -34,30 +35,30 @@ class Jdk11 < Package
       EOT
     end
 
-    unless File.exist?( URI(source_url).path )
-      # check if we should prompt user to the archive page or download page based on #{@_ver}
-      # download page only contains latest version while archive page only contains older versions
+    return if File.exist?( URI(source_url).path )
 
-      # get latest available version
-      latest_jdk_page = 'https://www.oracle.com/java/technologies/downloads/#java11'
-      is_latest_jdk   = `curl -LSs '#{latest_jdk_page}'`.include?(version)
+    # check if we should prompt user to the archive page or download page based on #{@_ver}
+    # download page only contains latest version while archive page only contains older versions
 
-      if is_latest_jdk
-        jdk_download_url = latest_jdk_page
-      else
-        jdk_download_url = 'https://www.oracle.com/java/technologies/javase/jdk11-archive-downloads.html'
-      end
+    # get latest available version
+    latest_jdk_page = 'https://www.oracle.com/java/technologies/downloads/#java11'
+    is_latest_jdk   = `curl -LSs '#{latest_jdk_page}'`.include?(version)
 
-      abort <<~EOT.orange
-
-        Oracle now requires an account to download the JDK.
-
-        You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
-        #{jdk_download_url}
-
-        Download "jdk-#{@_ver}_linux-x64_bin.tar.gz" (Linux x64 Compressed Archive) to Chrome OS download folder to continue.
-      EOT
+    if is_latest_jdk
+      jdk_download_url = latest_jdk_page
+    else
+      jdk_download_url = 'https://www.oracle.com/java/technologies/javase/jdk11-archive-downloads.html'
     end
+
+    abort <<~EOT.orange
+
+      Oracle now requires an account to download the JDK.
+
+      You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
+      #{jdk_download_url}
+
+      Download "jdk-#{@_ver}_linux-x64_bin.tar.gz" (Linux x64 Compressed Archive) to Chrome OS download folder to continue.
+    EOT
   end
 
   def self.install

--- a/packages/jdk11.rb
+++ b/packages/jdk11.rb
@@ -18,13 +18,13 @@ class Jdk11 < Package
     jdk_exec = File.join(CREW_PREFIX, 'bin', 'java')
 
     if File.exist?(jdk_exec)
-        jdk_ver_str = `#{jdk_exec} -version 2>&1`
-            jdk_ver = jdk_ver_str[/version "(.+?)"/, 1]
+      jdk_ver_str   = `#{jdk_exec} -version 2>&1`
+      jdk_ver       = jdk_ver_str[/version "(.+?)"/, 1]
       jdk_major_ver = (jdk_ver =~ /^1.8/) ? '8' : jdk_ver.partition('.')[0]
 
-        is_openjdk = jdk_ver_str.include?('openjdk')
+      is_openjdk   = jdk_ver_str.include?('openjdk')
       pkg_branding = is_openjdk ? 'OpenJDK' : 'Oracle JDK'
-        pkg_prefix = is_openjdk ? 'openjdk' : 'jdk'
+      pkg_prefix   = is_openjdk ? 'openjdk' : 'jdk'
 
       abort <<~EOT.yellow unless jdk_major_ver == name.delete_prefix('jdk')
 
@@ -40,7 +40,7 @@ class Jdk11 < Package
 
       # get latest available version
       latest_jdk_page = 'https://www.oracle.com/java/technologies/downloads/#java11'
-        is_latest_jdk = `curl -LSs '#{latest_jdk_page}'`.include?(version)
+      is_latest_jdk   = `curl -LSs '#{latest_jdk_page}'`.include?(version)
 
       if is_latest_jdk
         jdk_download_url = latest_jdk_page
@@ -67,15 +67,15 @@ class Jdk11 < Package
     FileUtils.rm_f 'lib/src.zip'
     FileUtils.cp_r Dir['*'], jdk_dir
 
-    Dir[ File.join(jdk_dir, 'bin', '*') ].each do |path|
+    Dir[File.join(jdk_dir, 'bin', '*')].each do |path|
       filename = File.basename(path)
-       symlink = File.join(CREW_DEST_PREFIX, 'bin', filename)
+      symlink  = File.join(CREW_DEST_PREFIX, 'bin', filename)
 
       FileUtils.ln_s path.sub(CREW_DEST_PREFIX, CREW_PREFIX), symlink
     end
 
-    FileUtils.rm Dir[ File.join(jdk_dir, 'man/man1/k{init,list}.1') ] # conflicts with krb5 package
-    FileUtils.mv Dir[ File.join(jdk_dir, 'man', '*') ], CREW_DEST_MAN_PREFIX
+    FileUtils.rm Dir[File.join(jdk_dir, 'man/man1/k{init,list}.1')] # conflicts with krb5 package
+    FileUtils.mv Dir[File.join(jdk_dir, 'man', '*')], CREW_DEST_MAN_PREFIX
   end
 
   def self.postinstall

--- a/packages/jdk11.rb
+++ b/packages/jdk11.rb
@@ -41,14 +41,9 @@ class Jdk11 < Package
     # download page only contains latest version while archive page only contains older versions
 
     # get latest available version
-    latest_jdk_page = 'https://www.oracle.com/java/technologies/downloads/#java11'
-    is_latest_jdk   = `curl -LSs '#{latest_jdk_page}'`.include?(version)
-
-    if is_latest_jdk
-      jdk_download_url = latest_jdk_page
-    else
-      jdk_download_url = 'https://www.oracle.com/java/technologies/javase/jdk11-archive-downloads.html'
-    end
+    latest_jdk_page  = 'https://www.oracle.com/java/technologies/downloads/#java11'
+    is_latest_jdk    = `curl -LSs '#{latest_jdk_page}'`.include?(version)
+    jdk_download_url = is_latest_jdk ? latest_jdk_page : 'https://www.oracle.com/java/technologies/javase/jdk11-archive-downloads.html'
 
     abort <<~EOT.orange
 

--- a/packages/jdk17.rb
+++ b/packages/jdk17.rb
@@ -1,46 +1,78 @@
 require 'package'
+require 'uri'
 
 class Jdk17 < Package
-  description 'The JDK is a development environment for building applications, applets, and components using the Java programming language.'
-  homepage 'https://www.oracle.com/java/technologies/downloads/#java17'
-  version '17.0.3.1'
+  description 'The Oracle JDK is a development environment for building applications, applets, and components using the Java programming language.'
+  homepage 'https://www.oracle.com/java'
+  version '17.0.4.1'
   license 'Oracle-BCLA-JavaSE'
   compatibility 'x86_64'
-  source_url 'SKIP'
+
+  @jdk_arch = {
+     armv7l: 'arm32-vfp-hflt',
+       i686: 'i586',
+     x86_64: 'x64'
+  }
+
+  source_url File.join('file://', HOME, 'Downloads', "jdk-#{version}_linux-x64_bin.tar.gz")
+  source_sha256 '2ac20cd72aa09c6577438e5ab5fd67e2dab606c724a84cfd289feecf6c22a1cf'
 
   no_compile_needed
   no_patchelf
 
   def self.preflight
-    %w[jdk8 jdk11 jdk15 jdk16 jdk18].each do |jdk|
-      abort "#{jdk} installed.".lightgreen if Dir.exist? "#{CREW_PREFIX}/share/#{jdk}"
+    jdk_exec = File.join(CREW_PREFIX, 'bin', 'java')
+
+    if File.exist?(jdk_exec)
+        jdk_ver_str = `#{jdk_exec} -version 2>&1`
+            jdk_ver = jdk_ver_str[/version "(.+?)"/, 1]
+      jdk_major_ver = (jdk_ver =~ /^1.8/) ? '8' : jdk_ver.partition('.')[0]
+
+        is_openjdk = jdk_ver_str.include?('openjdk')
+      pkg_branding = is_openjdk ? 'OpenJDK' : 'Oracle JDK'
+        pkg_prefix = is_openjdk ? 'openjdk' : 'jdk'
+
+      abort <<~EOT.yellow unless jdk_major_ver == '11'
+
+        #{pkg_branding} #{jdk_ver} installed.
+
+        Run "crew remove #{pkg_prefix}#{jdk_major_ver}; crew install #{name}" to install this version of JDK
+      EOT
+    end
+
+    unless File.exist?( URI( get_source_url(:x86_64) ).path )
+      abort <<~EOT.orange
+
+        Oracle now requires an account to download the JDK.
+
+        You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
+        https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html
+
+        Download "jdk-#{version}_linux-x64_bin.tar.gz" (Linux x64 Compressed Archive) to Chrome OS download folder to continue.
+      EOT
     end
   end
 
   def self.install
-    jdk_bin = "#{HOME}/Downloads/jdk-17_linux-x64_bin.tar.gz"
-    jdk_sha256 = '11b4465229b77fa84416a14b5e7023b6d2cf03cda5eb1557d57aea0247fff643'
-    unless File.exist? jdk_bin
-      puts "\nOracle now requires an account to download the JDK.\n".orange
-      puts 'You must login at https://login.oracle.com/mysso/signon.jsp and then visit:'.orange
-      puts 'https://www.oracle.com/java/technologies/downloads/#java17'.orange
-      puts "\nDownload the JDK for your architecture to #{HOME}/Downloads to continue.\n".orange
-      abort
+    jdk_dir = File.join(CREW_DEST_PREFIX, 'share', name)
+    FileUtils.mkdir_p [jdk_dir, File.join(CREW_DEST_PREFIX, 'bin'), CREW_DEST_MAN_PREFIX]
+
+    FileUtils.rm_f 'lib/src.zip'
+    FileUtils.cp_r Dir['*'], jdk_dir
+
+    Dir[ File.join(jdk_dir, 'bin', '*') ].each do |path|
+      filename = File.basename(path)
+       symlink = File.join(CREW_DEST_PREFIX, 'bin', filename)
+
+      FileUtils.ln_s path.sub(CREW_DEST_PREFIX, CREW_PREFIX), symlink
     end
-    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest(File.read(jdk_bin)) == jdk_sha256
-    system "tar xvf #{jdk_bin}"
-    jdk17_dir = "#{CREW_DEST_PREFIX}/share/jdk17"
-    FileUtils.mkdir_p jdk17_dir.to_s
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
-    FileUtils.cd "jdk-#{version}" do
-      FileUtils.rm_f 'lib/src.zip'
-      FileUtils.mv Dir['*'], "#{jdk17_dir}/"
-    end
-    Dir["#{jdk17_dir}/bin/*"].each do |filename|
-      binary = File.basename(filename)
-      FileUtils.ln_s "#{CREW_PREFIX}/share/jdk17/bin/#{binary}", "#{CREW_DEST_PREFIX}/bin/#{binary}"
-    end
-    FileUtils.rm ["#{jdk17_dir}/man/man1/kinit.1", "#{jdk17_dir}/man/man1/klist.1"] # conflicts with krb5 package
-    FileUtils.mv "#{jdk17_dir}/man/", "#{CREW_DEST_PREFIX}/share/"
+
+    FileUtils.rm Dir[ File.join(jdk_dir, 'man/man1/k{init,list}.1') ] # conflicts with krb5 package
+    FileUtils.mv Dir[ File.join(jdk_dir, 'man', '*') ], CREW_DEST_MAN_PREFIX
+  end
+
+  def self.postinstall
+    # remove jdk archive after installed
+    FileUtils.rm_f URI( get_source_url(:x86_64) ).path
   end
 end

--- a/packages/jdk17.rb
+++ b/packages/jdk17.rb
@@ -40,7 +40,7 @@ class Jdk17 < Package
       EOT
     end
 
-    unless File.exist?( URI( get_source_url(:x86_64) ).path )
+    unless File.exist?( URI(source_url).path )
       abort <<~EOT.orange
 
         Oracle now requires an account to download the JDK.
@@ -73,6 +73,6 @@ class Jdk17 < Package
 
   def self.postinstall
     # remove jdk archive after installed
-    FileUtils.rm_f URI( get_source_url(:x86_64) ).path
+    FileUtils.rm_f URI(source_url).path
   end
 end

--- a/packages/jdk17.rb
+++ b/packages/jdk17.rb
@@ -4,7 +4,8 @@ require 'uri'
 class Jdk17 < Package
   description 'The Oracle JDK is a development environment for building applications, applets, and components using the Java programming language.'
   homepage 'https://www.oracle.com/java'
-  version (@_ver = '17.0.4.1')
+  @_ver = '17.0.4.1'
+  version @_ver
   license 'Oracle-BCLA-JavaSE'
   compatibility 'x86_64'
 
@@ -40,17 +41,17 @@ class Jdk17 < Package
       EOT
     end
 
-    unless File.exist?( URI(source_url).path )
-      abort <<~EOT.orange
+    return if File.exist?( URI(source_url).path )
 
-        Oracle now requires an account to download the JDK.
+    abort <<~EOT.orange
 
-        You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
-        https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html
+      Oracle now requires an account to download the JDK.
 
-        Download "jdk-#{@_ver}_linux-x64_bin.tar.gz" (Linux x64 Compressed Archive) to Chrome OS download folder to continue.
-      EOT
-    end
+      You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
+      https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html
+
+      Download "jdk-#{@_ver}_linux-x64_bin.tar.gz" (Linux x64 Compressed Archive) to Chrome OS download folder to continue.
+    EOT
   end
 
   def self.install

--- a/packages/jdk17.rb
+++ b/packages/jdk17.rb
@@ -32,7 +32,7 @@ class Jdk17 < Package
       pkg_branding = is_openjdk ? 'OpenJDK' : 'Oracle JDK'
       pkg_prefix   = is_openjdk ? 'openjdk' : 'jdk'
 
-      abort <<~EOT.yellow unless jdk_major_ver == name.delete_prefix('jdk')
+      abort <<~EOT.yellow unless jdk_major_ver == name.delete_prefix('jdk') and !is_openjdk
 
         #{pkg_branding} #{jdk_ver} installed.
 

--- a/packages/jdk17.rb
+++ b/packages/jdk17.rb
@@ -4,7 +4,7 @@ require 'uri'
 class Jdk17 < Package
   description 'The Oracle JDK is a development environment for building applications, applets, and components using the Java programming language.'
   homepage 'https://www.oracle.com/java'
-  version '17.0.4.1'
+  version (@_ver = '17.0.4.1')
   license 'Oracle-BCLA-JavaSE'
   compatibility 'x86_64'
 
@@ -14,7 +14,7 @@ class Jdk17 < Package
      x86_64: 'x64'
   }
 
-  source_url File.join('file://', HOME, 'Downloads', "jdk-#{version}_linux-x64_bin.tar.gz")
+  source_url File.join('file://', HOME, 'Downloads', "jdk-#{@_ver}_linux-x64_bin.tar.gz")
   source_sha256 '2ac20cd72aa09c6577438e5ab5fd67e2dab606c724a84cfd289feecf6c22a1cf'
 
   no_compile_needed
@@ -26,7 +26,7 @@ class Jdk17 < Package
     if File.exist?(jdk_exec)
       jdk_ver_str   = `#{jdk_exec} -version 2>&1`
       jdk_ver       = jdk_ver_str[/version "(.+?)"/, 1]
-      jdk_major_ver = (jdk_ver =~ /^1.8/) ? '8' : jdk_ver.partition('.')[0]
+      jdk_major_ver = jdk_ver.match?(/^1.8/) ? '8' : jdk_ver.partition('.')[0]
 
       is_openjdk   = jdk_ver_str.include?('openjdk')
       pkg_branding = is_openjdk ? 'OpenJDK' : 'Oracle JDK'
@@ -48,7 +48,7 @@ class Jdk17 < Package
         You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
         https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html
 
-        Download "jdk-#{version}_linux-x64_bin.tar.gz" (Linux x64 Compressed Archive) to Chrome OS download folder to continue.
+        Download "jdk-#{@_ver}_linux-x64_bin.tar.gz" (Linux x64 Compressed Archive) to Chrome OS download folder to continue.
       EOT
     end
   end

--- a/packages/jdk17.rb
+++ b/packages/jdk17.rb
@@ -32,7 +32,7 @@ class Jdk17 < Package
       pkg_branding = is_openjdk ? 'OpenJDK' : 'Oracle JDK'
         pkg_prefix = is_openjdk ? 'openjdk' : 'jdk'
 
-      abort <<~EOT.yellow unless jdk_major_ver == '11'
+      abort <<~EOT.yellow unless jdk_major_ver == name.delete_prefix('jdk')
 
         #{pkg_branding} #{jdk_ver} installed.
 

--- a/packages/jdk17.rb
+++ b/packages/jdk17.rb
@@ -32,7 +32,7 @@ class Jdk17 < Package
       pkg_branding = is_openjdk ? 'OpenJDK' : 'Oracle JDK'
       pkg_prefix   = is_openjdk ? 'openjdk' : 'jdk'
 
-      abort <<~EOT.yellow unless jdk_major_ver == name.delete_prefix('jdk') and !is_openjdk
+      abort <<~EOT.yellow unless jdk_major_ver == name.delete_prefix('jdk') && !is_openjdk
 
         #{pkg_branding} #{jdk_ver} installed.
 

--- a/packages/jdk17.rb
+++ b/packages/jdk17.rb
@@ -24,13 +24,13 @@ class Jdk17 < Package
     jdk_exec = File.join(CREW_PREFIX, 'bin', 'java')
 
     if File.exist?(jdk_exec)
-        jdk_ver_str = `#{jdk_exec} -version 2>&1`
-            jdk_ver = jdk_ver_str[/version "(.+?)"/, 1]
+      jdk_ver_str   = `#{jdk_exec} -version 2>&1`
+      jdk_ver       = jdk_ver_str[/version "(.+?)"/, 1]
       jdk_major_ver = (jdk_ver =~ /^1.8/) ? '8' : jdk_ver.partition('.')[0]
 
-        is_openjdk = jdk_ver_str.include?('openjdk')
+      is_openjdk   = jdk_ver_str.include?('openjdk')
       pkg_branding = is_openjdk ? 'OpenJDK' : 'Oracle JDK'
-        pkg_prefix = is_openjdk ? 'openjdk' : 'jdk'
+      pkg_prefix   = is_openjdk ? 'openjdk' : 'jdk'
 
       abort <<~EOT.yellow unless jdk_major_ver == name.delete_prefix('jdk')
 
@@ -60,15 +60,15 @@ class Jdk17 < Package
     FileUtils.rm_f 'lib/src.zip'
     FileUtils.cp_r Dir['*'], jdk_dir
 
-    Dir[ File.join(jdk_dir, 'bin', '*') ].each do |path|
+    Dir[File.join(jdk_dir, 'bin', '*')].each do |path|
       filename = File.basename(path)
-       symlink = File.join(CREW_DEST_PREFIX, 'bin', filename)
+      symlink  = File.join(CREW_DEST_PREFIX, 'bin', filename)
 
       FileUtils.ln_s path.sub(CREW_DEST_PREFIX, CREW_PREFIX), symlink
     end
 
-    FileUtils.rm Dir[ File.join(jdk_dir, 'man/man1/k{init,list}.1') ] # conflicts with krb5 package
-    FileUtils.mv Dir[ File.join(jdk_dir, 'man', '*') ], CREW_DEST_MAN_PREFIX
+    FileUtils.rm Dir[File.join(jdk_dir, 'man/man1/k{init,list}.1')] # conflicts with krb5 package
+    FileUtils.mv Dir[File.join(jdk_dir, 'man', '*')], CREW_DEST_MAN_PREFIX
   end
 
   def self.postinstall

--- a/packages/jdk18.rb
+++ b/packages/jdk18.rb
@@ -1,46 +1,72 @@
 require 'package'
+require 'uri'
 
 class Jdk18 < Package
-  description 'The JDK is a development environment for building applications, applets, and components using the Java programming language.'
-  homepage 'https://www.oracle.com/java/technologies/downloads/#java18'
-  version '18.0.1.1'
+  description 'The Oracle JDK is a development environment for building applications, applets, and components using the Java programming language.'
+  homepage 'https://www.oracle.com/java'
+  version '18.0.2.1'
   license 'Oracle-BCLA-JavaSE'
   compatibility 'x86_64'
-  source_url 'SKIP'
+
+  source_url File.join('file://', HOME, 'Downloads', "jdk-#{version}_linux-x64_bin.tar.gz")
+  source_sha256 'cd905013facbb5c2b5354165cc372e327259de4991c28f31c7d4231dbf638934'
 
   no_compile_needed
   no_patchelf
 
   def self.preflight
-    %w[jdk8 jdk11 jdk15 jdk16 jdk17].each do |jdk|
-      abort "#{jdk} installed.".lightgreen if Dir.exist? "#{CREW_PREFIX}/share/#{jdk}"
+    jdk_exec = File.join(CREW_PREFIX, 'bin', 'java')
+
+    if File.exist?(jdk_exec)
+        jdk_ver_str = `#{jdk_exec} -version 2>&1`
+            jdk_ver = jdk_ver_str[/version "(.+?)"/, 1]
+      jdk_major_ver = (jdk_ver =~ /^1.8/) ? '8' : jdk_ver.partition('.')[0]
+
+        is_openjdk = jdk_ver_str.include?('openjdk')
+      pkg_branding = is_openjdk ? 'OpenJDK' : 'Oracle JDK'
+        pkg_prefix = is_openjdk ? 'openjdk' : 'jdk'
+
+      abort <<~EOT.yellow unless jdk_major_ver == '11'
+
+        #{pkg_branding} #{jdk_ver} installed.
+
+        Run "crew remove #{pkg_prefix}#{jdk_major_ver}; crew install #{name}" to install this version of JDK
+      EOT
+    end
+
+    unless File.exist?( URI( get_source_url(:x86_64) ).path )
+      abort <<~EOT.orange
+
+        Oracle now requires an account to download the JDK.
+
+        You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
+        https://www.oracle.com/java/technologies/javase/jdk18-archive-downloads.html
+
+        Download "jdk-#{version}_linux-x64_bin.tar.gz" (Linux x64 Compressed Archive) to Chrome OS download folder to continue.
+      EOT
     end
   end
 
   def self.install
-    jdk_bin = "#{HOME}/Downloads/jdk-18_linux-x64_bin.tar.gz"
-    jdk_sha256 = 'dbabd3f726775a63329254b001b4190c082206e38323950b2db478606f1d65fa'
-    unless File.exist? jdk_bin
-      puts "\nOracle now requires an account to download the JDK.\n".orange
-      puts 'You must login at https://login.oracle.com/mysso/signon.jsp and then visit:'.orange
-      puts 'https://www.oracle.com/java/technologies/downloads/#java18'.orange
-      puts "\nDownload the JDK for your architecture to #{HOME}/Downloads to continue.\n".orange
-      abort
+    jdk_dir = File.join(CREW_DEST_PREFIX, 'share', name)
+    FileUtils.mkdir_p [jdk_dir, File.join(CREW_DEST_PREFIX, 'bin'), CREW_DEST_MAN_PREFIX]
+
+    FileUtils.rm_f 'lib/src.zip'
+    FileUtils.cp_r Dir['*'], jdk_dir
+
+    Dir[ File.join(jdk_dir, 'bin', '*') ].each do |path|
+      filename = File.basename(path)
+       symlink = File.join(CREW_DEST_PREFIX, 'bin', filename)
+
+      FileUtils.ln_s path.sub(CREW_DEST_PREFIX, CREW_PREFIX), symlink
     end
-    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest(File.read(jdk_bin)) == jdk_sha256
-    system "tar xvf #{jdk_bin}"
-    jdk18_dir = "#{CREW_DEST_PREFIX}/share/jdk18"
-    FileUtils.mkdir_p jdk18_dir.to_s
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
-    FileUtils.cd "jdk-#{version}" do
-      FileUtils.rm_f 'lib/src.zip'
-      FileUtils.mv Dir['*'], "#{jdk18_dir}/"
-    end
-    Dir["#{jdk18_dir}/bin/*"].each do |filename|
-      binary = File.basename(filename)
-      FileUtils.ln_s "#{CREW_PREFIX}/share/jdk18/bin/#{binary}", "#{CREW_DEST_PREFIX}/bin/#{binary}"
-    end
-    FileUtils.rm ["#{jdk18_dir}/man/man1/kinit.1", "#{jdk18_dir}/man/man1/klist.1"] # conflicts with krb5 package
-    FileUtils.mv "#{jdk18_dir}/man/", "#{CREW_DEST_PREFIX}/share/"
+
+    FileUtils.rm Dir[ File.join(jdk_dir, 'man/man1/k{init,list}.1') ] # conflicts with krb5 package
+    FileUtils.mv Dir[ File.join(jdk_dir, 'man', '*') ], CREW_DEST_MAN_PREFIX
+  end
+
+  def self.postinstall
+    # remove jdk archive after installed
+    FileUtils.rm_f URI( get_source_url(:x86_64) ).path
   end
 end

--- a/packages/jdk18.rb
+++ b/packages/jdk18.rb
@@ -18,13 +18,13 @@ class Jdk18 < Package
     jdk_exec = File.join(CREW_PREFIX, 'bin', 'java')
 
     if File.exist?(jdk_exec)
-        jdk_ver_str = `#{jdk_exec} -version 2>&1`
-            jdk_ver = jdk_ver_str[/version "(.+?)"/, 1]
+      jdk_ver_str   = `#{jdk_exec} -version 2>&1`
+      jdk_ver       = jdk_ver_str[/version "(.+?)"/, 1]
       jdk_major_ver = (jdk_ver =~ /^1.8/) ? '8' : jdk_ver.partition('.')[0]
 
-        is_openjdk = jdk_ver_str.include?('openjdk')
+      is_openjdk   = jdk_ver_str.include?('openjdk')
       pkg_branding = is_openjdk ? 'OpenJDK' : 'Oracle JDK'
-        pkg_prefix = is_openjdk ? 'openjdk' : 'jdk'
+      pkg_prefix   = is_openjdk ? 'openjdk' : 'jdk'
 
       abort <<~EOT.yellow unless jdk_major_ver == name.delete_prefix('jdk')
 
@@ -54,15 +54,15 @@ class Jdk18 < Package
     FileUtils.rm_f 'lib/src.zip'
     FileUtils.cp_r Dir['*'], jdk_dir
 
-    Dir[ File.join(jdk_dir, 'bin', '*') ].each do |path|
+    Dir[File.join(jdk_dir, 'bin', '*')].each do |path|
       filename = File.basename(path)
-       symlink = File.join(CREW_DEST_PREFIX, 'bin', filename)
+      symlink  = File.join(CREW_DEST_PREFIX, 'bin', filename)
 
       FileUtils.ln_s path.sub(CREW_DEST_PREFIX, CREW_PREFIX), symlink
     end
 
-    FileUtils.rm Dir[ File.join(jdk_dir, 'man/man1/k{init,list}.1') ] # conflicts with krb5 package
-    FileUtils.mv Dir[ File.join(jdk_dir, 'man', '*') ], CREW_DEST_MAN_PREFIX
+    FileUtils.rm Dir[File.join(jdk_dir, 'man/man1/k{init,list}.1')] # conflicts with krb5 package
+    FileUtils.mv Dir[File.join(jdk_dir, 'man', '*')], CREW_DEST_MAN_PREFIX
   end
 
   def self.postinstall

--- a/packages/jdk18.rb
+++ b/packages/jdk18.rb
@@ -26,7 +26,7 @@ class Jdk18 < Package
       pkg_branding = is_openjdk ? 'OpenJDK' : 'Oracle JDK'
       pkg_prefix   = is_openjdk ? 'openjdk' : 'jdk'
 
-      abort <<~EOT.yellow unless jdk_major_ver == name.delete_prefix('jdk')
+      abort <<~EOT.yellow unless jdk_major_ver == name.delete_prefix('jdk') and !is_openjdk
 
         #{pkg_branding} #{jdk_ver} installed.
 

--- a/packages/jdk18.rb
+++ b/packages/jdk18.rb
@@ -26,7 +26,7 @@ class Jdk18 < Package
       pkg_branding = is_openjdk ? 'OpenJDK' : 'Oracle JDK'
         pkg_prefix = is_openjdk ? 'openjdk' : 'jdk'
 
-      abort <<~EOT.yellow unless jdk_major_ver == '11'
+      abort <<~EOT.yellow unless jdk_major_ver == name.delete_prefix('jdk')
 
         #{pkg_branding} #{jdk_ver} installed.
 

--- a/packages/jdk18.rb
+++ b/packages/jdk18.rb
@@ -34,7 +34,7 @@ class Jdk18 < Package
       EOT
     end
 
-    unless File.exist?( URI( get_source_url(:x86_64) ).path )
+    unless File.exist?( URI(source_url).path )
       abort <<~EOT.orange
 
         Oracle now requires an account to download the JDK.
@@ -67,6 +67,6 @@ class Jdk18 < Package
 
   def self.postinstall
     # remove jdk archive after installed
-    FileUtils.rm_f URI( get_source_url(:x86_64) ).path
+    FileUtils.rm_f URI(source_url).path
   end
 end

--- a/packages/jdk18.rb
+++ b/packages/jdk18.rb
@@ -4,7 +4,8 @@ require 'uri'
 class Jdk18 < Package
   description 'The Oracle JDK is a development environment for building applications, applets, and components using the Java programming language.'
   homepage 'https://www.oracle.com/java'
-  version (@_ver = '18.0.2.1')
+  @_ver = '18.0.2.1'
+  version @_ver
   license 'Oracle-BCLA-JavaSE'
   compatibility 'x86_64'
 
@@ -34,17 +35,17 @@ class Jdk18 < Package
       EOT
     end
 
-    unless File.exist?( URI(source_url).path )
-      abort <<~EOT.orange
+    return if File.exist?( URI(source_url).path )
 
-        Oracle now requires an account to download the JDK.
+    abort <<~EOT.orange
 
-        You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
-        https://www.oracle.com/java/technologies/javase/jdk18-archive-downloads.html
+      Oracle now requires an account to download the JDK.
 
-        Download "jdk-#{@_ver}_linux-x64_bin.tar.gz" (Linux x64 Compressed Archive) to Chrome OS download folder to continue.
-      EOT
-    end
+      You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
+      https://www.oracle.com/java/technologies/javase/jdk18-archive-downloads.html
+
+      Download "jdk-#{@_ver}_linux-x64_bin.tar.gz" (Linux x64 Compressed Archive) to Chrome OS download folder to continue.
+    EOT
   end
 
   def self.install

--- a/packages/jdk18.rb
+++ b/packages/jdk18.rb
@@ -4,11 +4,11 @@ require 'uri'
 class Jdk18 < Package
   description 'The Oracle JDK is a development environment for building applications, applets, and components using the Java programming language.'
   homepage 'https://www.oracle.com/java'
-  version '18.0.2.1'
+  version (@_ver = '18.0.2.1')
   license 'Oracle-BCLA-JavaSE'
   compatibility 'x86_64'
 
-  source_url File.join('file://', HOME, 'Downloads', "jdk-#{version}_linux-x64_bin.tar.gz")
+  source_url File.join('file://', HOME, 'Downloads', "jdk-#{@_ver}_linux-x64_bin.tar.gz")
   source_sha256 'cd905013facbb5c2b5354165cc372e327259de4991c28f31c7d4231dbf638934'
 
   no_compile_needed
@@ -20,7 +20,7 @@ class Jdk18 < Package
     if File.exist?(jdk_exec)
       jdk_ver_str   = `#{jdk_exec} -version 2>&1`
       jdk_ver       = jdk_ver_str[/version "(.+?)"/, 1]
-      jdk_major_ver = (jdk_ver =~ /^1.8/) ? '8' : jdk_ver.partition('.')[0]
+      jdk_major_ver = jdk_ver.match?(/^1.8/) ? '8' : jdk_ver.partition('.')[0]
 
       is_openjdk   = jdk_ver_str.include?('openjdk')
       pkg_branding = is_openjdk ? 'OpenJDK' : 'Oracle JDK'
@@ -42,7 +42,7 @@ class Jdk18 < Package
         You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
         https://www.oracle.com/java/technologies/javase/jdk18-archive-downloads.html
 
-        Download "jdk-#{version}_linux-x64_bin.tar.gz" (Linux x64 Compressed Archive) to Chrome OS download folder to continue.
+        Download "jdk-#{@_ver}_linux-x64_bin.tar.gz" (Linux x64 Compressed Archive) to Chrome OS download folder to continue.
       EOT
     end
   end

--- a/packages/jdk18.rb
+++ b/packages/jdk18.rb
@@ -26,7 +26,7 @@ class Jdk18 < Package
       pkg_branding = is_openjdk ? 'OpenJDK' : 'Oracle JDK'
       pkg_prefix   = is_openjdk ? 'openjdk' : 'jdk'
 
-      abort <<~EOT.yellow unless jdk_major_ver == name.delete_prefix('jdk') and !is_openjdk
+      abort <<~EOT.yellow unless jdk_major_ver == name.delete_prefix('jdk') && !is_openjdk
 
         #{pkg_branding} #{jdk_ver} installed.
 

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -50,7 +50,7 @@ class Jdk8 < Package
       pkg_branding = is_openjdk ? 'OpenJDK' : 'Oracle JDK'
         pkg_prefix = is_openjdk ? 'openjdk' : 'jdk'
 
-      abort <<~EOT.yellow unless jdk_major_ver == '8'
+      abort <<~EOT.yellow unless jdk_major_ver == name.delete_prefix('jdk')
 
         #{pkg_branding} #{jdk_ver} installed.
 

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -72,7 +72,7 @@ class Jdk8 < Package
         You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
         #{jdk_download_url}
 
-        Download JDK version #{version.cyan} for your architecture (#{@jdk_arch[ARCH.to_sym].cyan}) to Chrome OS download folder to continue.
+        Download JDK version #{version.cyan.delete_suffix("\e[0m")} for your architecture (#{@jdk_arch[ARCH.to_sym].cyan.delete_suffix("\e[0m")}) to Chrome OS download folder to continue.
       EOT
     end
   end

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -43,7 +43,7 @@ class Jdk8 < Package
       pkg_branding = is_openjdk ? 'OpenJDK' : 'Oracle JDK'
         pkg_prefix = is_openjdk ? 'openjdk' : 'jdk'
 
-      abort <<~EOT.yellow
+      abort <<~EOT.yellow unless jdk_major_ver == '8'
 
         #{pkg_branding} #{jdk_ver} installed.
 

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -3,15 +3,22 @@ require 'uri'
 
 class Jdk8 < Package
   description 'The Oracle JDK is a development environment for building applications, applets, and components using the Java programming language.'
-  homepage 'https://www.oracle.com/java/technologies/downloads/#java8'
+  homepage 'https://www.oracle.com/java'
   version '8u341'
   license 'Oracle-BCLA-JavaSE'
   compatibility 'all'
 
   @jdk_arch = {
-     armv7l: 'arm32-vfp-hflt',
-       i686: 'i586',
-     x86_64: 'x64'
+    armv7l: 'arm32-vfp-hflt',
+      i686: 'i586',
+    x86_64: 'x64'
+  }
+
+  @jdk_description = {
+    aarch64: 'ARM 32 Hard Float ABI',
+     armv7l: 'ARM 32 Hard Float ABI',
+       i686: 'x86 Compressed Archive',
+     x86_64: 'x64 Compressed Archive'
   }
 
   source_url({
@@ -72,7 +79,7 @@ class Jdk8 < Package
         You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
         #{jdk_download_url}
 
-        Download "jdk-#{version}-linux-#{@jdk_arch[ARCH.to_sym]}.tar.gz" to Chrome OS download folder to continue.
+        Download "jdk-#{version}-linux-#{@jdk_arch[ARCH.to_sym]}.tar.gz" (#{@jdk_description[ARCH.to_sym]}) to Chrome OS download folder to continue.
       EOT
     end
   end

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -42,13 +42,13 @@ class Jdk8 < Package
     jdk_exec = File.join(CREW_PREFIX, 'bin', 'java')
 
     if File.exist?(jdk_exec)
-        jdk_ver_str = `#{jdk_exec} -version 2>&1`
-            jdk_ver = jdk_ver_str[/version "(.+?)"/, 1]
+      jdk_ver_str   = `#{jdk_exec} -version 2>&1`
+      jdk_ver       = jdk_ver_str[/version "(.+?)"/, 1]
       jdk_major_ver = (jdk_ver =~ /^1.8/) ? '8' : jdk_ver.partition('.')[0]
 
-        is_openjdk = jdk_ver_str.include?('openjdk')
+      is_openjdk   = jdk_ver_str.include?('openjdk')
       pkg_branding = is_openjdk ? 'OpenJDK' : 'Oracle JDK'
-        pkg_prefix = is_openjdk ? 'openjdk' : 'jdk'
+      pkg_prefix   = is_openjdk ? 'openjdk' : 'jdk'
 
       abort <<~EOT.yellow unless jdk_major_ver == name.delete_prefix('jdk')
 
@@ -64,7 +64,7 @@ class Jdk8 < Package
 
       # get latest available version
       latest_jdk_page = 'https://www.oracle.com/java/technologies/downloads/#java8'
-        is_latest_jdk = `curl -LSs '#{latest_jdk_page}'`.include?(version)
+      is_latest_jdk   = `curl -LSs '#{latest_jdk_page}'`.include?(version)
 
       if is_latest_jdk
         jdk_download_url = latest_jdk_page
@@ -91,14 +91,14 @@ class Jdk8 < Package
     FileUtils.rm_f ['src.zip', 'javafx-src.zip']
     FileUtils.cp_r Dir['*'], jdk_dir
 
-    Dir[ File.join(jdk_dir, 'bin', '*') ].each do |path|
+    Dir[File.join(jdk_dir, 'bin', '*')].each do |path|
       filename = File.basename(path)
-       symlink = File.join(CREW_DEST_PREFIX, 'bin', filename)
+      symlink  = File.join(CREW_DEST_PREFIX, 'bin', filename)
 
       FileUtils.ln_s path.sub(CREW_DEST_PREFIX, CREW_PREFIX), symlink
     end
 
-    FileUtils.mv Dir[ File.join(jdk_dir, 'man', '*') ], CREW_DEST_MAN_PREFIX
+    FileUtils.mv Dir[File.join(jdk_dir, 'man', '*')], CREW_DEST_MAN_PREFIX
   end
 
   def self.postinstall

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -50,7 +50,7 @@ class Jdk8 < Package
       pkg_branding = is_openjdk ? 'OpenJDK' : 'Oracle JDK'
       pkg_prefix   = is_openjdk ? 'openjdk' : 'jdk'
 
-      abort <<~EOT.yellow unless jdk_major_ver == name.delete_prefix('jdk')
+      abort <<~EOT.yellow unless jdk_major_ver == name.delete_prefix('jdk') and !is_openjdk
 
         #{pkg_branding} #{jdk_ver} installed.
 

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -93,4 +93,9 @@ class Jdk8 < Package
 
     FileUtils.mv Dir[ File.join(jdk_dir, 'man', '*') ], CREW_DEST_MAN_PREFIX
   end
+
+  def self.postinstall
+    # remove jdk archive after installed
+    FileUtils.rm_f URI( get_source_url(ARCH.to_sym) ).path
+  end
 end

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -1,4 +1,5 @@
 require 'package'
+require 'uri'
 
 class Jdk8 < Package
   description 'The JDK is a development environment for building applications, applets, and components using the Java programming language.'
@@ -43,13 +44,14 @@ class Jdk8 < Package
         pkg_prefix = is_openjdk ? 'openjdk' : 'jdk'
 
       abort <<~EOT.yellow
+
         #{pkg_branding} #{jdk_ver} installed.
 
         Run "crew remove #{pkg_prefix}#{jdk_major_ver}; crew install #{name}" to install this version of JDK
       EOT
     end
 
-    unless File.exist?(jdk_bin)
+    unless File.exist?( URI( get_source_url(ARCH.to_sym) ).path )
       # check if we should prompt user to the archive page or download page based on #{version}
       # download page only contains latest version while archive page only contains older versions
 
@@ -64,6 +66,7 @@ class Jdk8 < Package
       end
 
       abort <<~EOT.orange
+
         Oracle now requires an account to download the JDK.
 
         You must login at https://login.oracle.com/mysso/signon.jsp and then visit:

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -72,7 +72,7 @@ class Jdk8 < Package
         You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
         #{jdk_download_url}
 
-        Download JDK version >>>#{version}<<< for your architecture (#{@jdk_arch[ARCH.to_sym].cyan}) to Chrome OS download folder to continue.
+        Download JDK version **#{version}** for your architecture (#{@jdk_arch[ARCH.to_sym]}) to Chrome OS download folder to continue.
       EOT
     end
   end

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -34,7 +34,7 @@ class Jdk8 < Package
     jdk_exec = File.join(CREW_PREFIX, 'bin', 'java')
 
     if File.exist?(jdk_exec)
-        jdk_ver_str = `#{jdk_exec} -version`
+        jdk_ver_str = `#{jdk_exec} -version 2>&1`
             jdk_ver = jdk_ver_str[/version "(.+?)"/, 1]
       jdk_major_ver = (jdk_ver =~ /^1.8/) ? '8' : jdk_ver.partition('.')[0]
 

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -4,7 +4,7 @@ require 'uri'
 class Jdk8 < Package
   description 'The Oracle JDK is a development environment for building applications, applets, and components using the Java programming language.'
   homepage 'https://www.oracle.com/java'
-  version '8u341'
+  version (@_ver = '8u341')
   license 'Oracle-BCLA-JavaSE'
   compatibility 'all'
 
@@ -22,10 +22,10 @@ class Jdk8 < Package
   }
 
   source_url({
-    aarch64: File.join('file://', HOME, 'Downloads', "jdk-#{version}-linux-#{@jdk_arch[:armv7l]}.tar.gz"),
-     armv7l: File.join('file://', HOME, 'Downloads', "jdk-#{version}-linux-#{@jdk_arch[:armv7l]}.tar.gz"),
-       i686: File.join('file://', HOME, 'Downloads', "jdk-#{version}-linux-#{@jdk_arch[:i686]}.tar.gz"),
-     x86_64: File.join('file://', HOME, 'Downloads', "jdk-#{version}-linux-#{@jdk_arch[:x86_64]}.tar.gz")
+    aarch64: File.join('file://', HOME, 'Downloads', "jdk-#{@_ver}-linux-#{@jdk_arch[:armv7l]}.tar.gz"),
+     armv7l: File.join('file://', HOME, 'Downloads', "jdk-#{@_ver}-linux-#{@jdk_arch[:armv7l]}.tar.gz"),
+       i686: File.join('file://', HOME, 'Downloads', "jdk-#{@_ver}-linux-#{@jdk_arch[:i686]}.tar.gz"),
+     x86_64: File.join('file://', HOME, 'Downloads', "jdk-#{@_ver}-linux-#{@jdk_arch[:x86_64]}.tar.gz")
   })
 
   source_sha256({
@@ -44,7 +44,7 @@ class Jdk8 < Package
     if File.exist?(jdk_exec)
       jdk_ver_str   = `#{jdk_exec} -version 2>&1`
       jdk_ver       = jdk_ver_str[/version "(.+?)"/, 1]
-      jdk_major_ver = (jdk_ver =~ /^1.8/) ? '8' : jdk_ver.partition('.')[0]
+      jdk_major_ver = jdk_ver.match?(/^1.8/) ? '8' : jdk_ver.partition('.')[0]
 
       is_openjdk   = jdk_ver_str.include?('openjdk')
       pkg_branding = is_openjdk ? 'OpenJDK' : 'Oracle JDK'
@@ -59,7 +59,7 @@ class Jdk8 < Package
     end
 
     unless File.exist?( URI( get_source_url(ARCH.to_sym) ).path )
-      # check if we should prompt user to the archive page or download page based on #{version}
+      # check if we should prompt user to the archive page or download page based on #{@_ver}
       # download page only contains latest version while archive page only contains older versions
 
       # get latest available version
@@ -79,7 +79,7 @@ class Jdk8 < Package
         You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
         #{jdk_download_url}
 
-        Download "jdk-#{version}-linux-#{@jdk_arch[ARCH.to_sym]}.tar.gz" (#{@jdk_description[ARCH.to_sym]}) to Chrome OS download folder to continue.
+        Download "jdk-#{@_ver}-linux-#{@jdk_arch[ARCH.to_sym]}.tar.gz" (#{@jdk_description[ARCH.to_sym]}) to Chrome OS download folder to continue.
       EOT
     end
   end

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -4,7 +4,8 @@ require 'uri'
 class Jdk8 < Package
   description 'The Oracle JDK is a development environment for building applications, applets, and components using the Java programming language.'
   homepage 'https://www.oracle.com/java'
-  version (@_ver = '8u341')
+  @_ver = '8u341'
+  version @_ver
   license 'Oracle-BCLA-JavaSE'
   compatibility 'all'
 
@@ -58,30 +59,30 @@ class Jdk8 < Package
       EOT
     end
 
-    unless File.exist?( URI( get_source_url(ARCH.to_sym) ).path )
-      # check if we should prompt user to the archive page or download page based on #{@_ver}
-      # download page only contains latest version while archive page only contains older versions
+    return if File.exist?( URI( get_source_url(ARCH.to_sym) ).path )
 
-      # get latest available version
-      latest_jdk_page = 'https://www.oracle.com/java/technologies/downloads/#java8'
-      is_latest_jdk   = `curl -LSs '#{latest_jdk_page}'`.include?(version)
+    # check if we should prompt user to the archive page or download page based on #{@_ver}
+    # download page only contains latest version while archive page only contains older versions
 
-      if is_latest_jdk
-        jdk_download_url = latest_jdk_page
-      else
-        jdk_download_url = 'https://www.oracle.com/java/technologies/javase/javase8u211-later-archive-downloads.html#JDK'
-      end
+    # get latest available version
+    latest_jdk_page = 'https://www.oracle.com/java/technologies/downloads/#java8'
+    is_latest_jdk   = `curl -LSs '#{latest_jdk_page}'`.include?(version)
 
-      abort <<~EOT.orange
-
-        Oracle now requires an account to download the JDK.
-
-        You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
-        #{jdk_download_url}
-
-        Download "jdk-#{@_ver}-linux-#{@jdk_arch[ARCH.to_sym]}.tar.gz" (#{@jdk_description[ARCH.to_sym]}) to Chrome OS download folder to continue.
-      EOT
+    if is_latest_jdk
+      jdk_download_url = latest_jdk_page
+    else
+      jdk_download_url = 'https://www.oracle.com/java/technologies/javase/javase8u211-later-archive-downloads.html#JDK'
     end
+
+    abort <<~EOT.orange
+
+      Oracle now requires an account to download the JDK.
+
+      You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
+      #{jdk_download_url}
+
+      Download "jdk-#{@_ver}-linux-#{@jdk_arch[ARCH.to_sym]}.tar.gz" (#{@jdk_description[ARCH.to_sym]}) to Chrome OS download folder to continue.
+    EOT
   end
 
   def self.install

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -79,7 +79,7 @@ class Jdk8 < Package
 
   def self.install
     jdk_dir = File.join(CREW_DEST_PREFIX, 'share', name)
-    FileUtils.mkdir_p [jdk8_dir, File.join(CREW_DEST_PREFIX, 'bin'), CREW_DEST_MAN_PREFIX]
+    FileUtils.mkdir_p [jdk_dir, File.join(CREW_DEST_PREFIX, 'bin'), CREW_DEST_MAN_PREFIX]
 
     Dir.chdir( Dir['jdk1.8.0_*'][0] ) do
       FileUtils.rm_f ['src.zip', 'javafx-src.zip']

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -65,14 +65,9 @@ class Jdk8 < Package
     # download page only contains latest version while archive page only contains older versions
 
     # get latest available version
-    latest_jdk_page = 'https://www.oracle.com/java/technologies/downloads/#java8'
-    is_latest_jdk   = `curl -LSs '#{latest_jdk_page}'`.include?(version)
-
-    if is_latest_jdk
-      jdk_download_url = latest_jdk_page
-    else
-      jdk_download_url = 'https://www.oracle.com/java/technologies/javase/javase8u211-later-archive-downloads.html#JDK'
-    end
+    latest_jdk_page  = 'https://www.oracle.com/java/technologies/downloads/#java8'
+    is_latest_jdk    = `curl -LSs '#{latest_jdk_page}'`.include?(version)
+    jdk_download_url = is_latest_jdk ? latest_jdk_page : 'https://www.oracle.com/java/technologies/javase/javase8u211-later-archive-downloads.html#JDK'
 
     abort <<~EOT.orange
 

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -2,54 +2,94 @@ require 'package'
 
 class Jdk8 < Package
   description 'The JDK is a development environment for building applications, applets, and components using the Java programming language.'
-  homepage 'https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html'
-  version '8u333'
+  homepage 'https://www.oracle.com/java/technologies/downloads/#java8'
+  version '8u341'
   license 'Oracle-BCLA-JavaSE'
   compatibility 'all'
-  source_url 'SKIP'
+
+  @jdk_arch = {
+     armv7l: 'arm32-vfp-hflt',
+       i686: 'i586',
+     x86_64: 'x64'
+  }
+
+  source_url({
+    aarch64: File.join('file://', HOME, 'Downloads', "jdk-#{version}-linux-#{@jdk_arch[:armv7l]}.tar.gz"),
+     armv7l: File.join('file://', HOME, 'Downloads', "jdk-#{version}-linux-#{@jdk_arch[:armv7l]}.tar.gz"),
+       i686: File.join('file://', HOME, 'Downloads', "jdk-#{version}-linux-#{@jdk_arch[:i686]}.tar.gz"),
+     x86_64: File.join('file://', HOME, 'Downloads', "jdk-#{version}-linux-#{@jdk_arch[:x86_64]}.tar.gz")
+  })
+
+  source_sha256({
+    aarch64: '6dec09bd213bf97bcab99e54881af85f3911e771f8843470fe384520c0249c33',
+     armv7l: '6dec09bd213bf97bcab99e54881af85f3911e771f8843470fe384520c0249c33',
+       i686: '6beb8997121c771b9d69742f2be583f566736e517d8afa5d91b371c729e515da',
+     x86_64: 'c98e57cfc6ac9947d9aa9a31c5878d52e2bf764f8d90f20eec08f3c3fcaee0e7'
+  })
 
   no_compile_needed
   no_patchelf
 
   def self.preflight
-    %w[jdk11 jdk15 jdk16 jdk17 jdk18].each do |jdk|
-      abort "#{jdk} installed.".lightgreen if Dir.exist? "#{CREW_PREFIX}/share/#{jdk}"
+    jdk_exec = File.join(CREW_PREFIX, 'bin', 'java')
+
+    if File.exist?(jdk_exec)
+        jdk_ver_str = `#{jdk_exec} -version`
+            jdk_ver = jdk_ver_str[/version "(.+?)"/, 1]
+      jdk_major_ver = (jdk_ver =~ /^1.8/) ? '8' : jdk_ver.partition('.')[0]
+
+        is_openjdk = jdk_ver_str.include?('openjdk')
+      pkg_branding = is_openjdk ? 'OpenJDK' : 'Oracle JDK'
+        pkg_prefix = is_openjdk ? 'openjdk' : 'jdk'
+
+      abort <<~EOT.yellow
+        #{pkg_branding} #{jdk_ver} installed.
+
+        Run "crew remove #{pkg_prefix}#{jdk_major_ver}; crew install #{name}" to install this version of JDK
+      EOT
+    end
+
+    unless File.exist?(jdk_bin)
+      # check if we should prompt user to the archive page or download page based on #{version}
+      # download page only contains latest version while archive page only contains older versions
+
+      # get latest available version
+      latest_jdk_page = 'https://www.oracle.com/java/technologies/downloads/#java8'
+      latest_jdk_ver  = `curl -LSs '#{latest_jdk_page}'`[/8u\d{3}/]
+
+      if latest_jdk_ver == version
+        jdk_download_url = latest_jdk_page
+      else
+        jdk_download_url = 'https://www.oracle.com/java/technologies/javase/javase8u211-later-archive-downloads.html#JDK'
+      end
+
+      abort <<~EOT.orange
+        Oracle now requires an account to download the JDK.
+
+        You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
+        #{jdk_download_url}
+
+        Download JDK version #{version.lightcyan(:no_bold)} for your architecture (#{@jdk_arch.lightcyan(:no_bold)}) to Chrome OS download folder to continue.
+      EOT
     end
   end
 
   def self.install
-    case ARCH
-    when 'aarch64', 'armv7l'
-      jdk_bin = "#{HOME}/Downloads/jdk-#{version}-linux-arm32-vfp-hflt.tar.gz"
-      jdk_sha256 = '8e42b06b7db1196d771561e1167444e29f13e8bf41adfda3e70e55c0476d900f'
-    when 'i686'
-      jdk_bin = "#{HOME}/Downloads/jdk-#{version}-linux-i586.tar.gz"
-      jdk_sha256 = '9337ea438cf3aca880bfc9c1500fd15ce121cec1d601dd5f55baf1f7f475f0ce'
-    when 'x86_64'
-      jdk_bin = "#{HOME}/Downloads/jdk-#{version}-linux-x64.tar.gz"
-      jdk_sha256 = '5390619a722eaccabd3b496f462b7f87cf69f98d3662fdc8452562b7bcb17e09'
+    jdk_dir = File.join(CREW_DEST_PREFIX, 'share', name)
+    FileUtils.mkdir_p [jdk8_dir, File.join(CREW_DEST_PREFIX, 'bin'), CREW_DEST_MAN_PREFIX]
+
+    Dir.chdir( Dir['jdk1.8.0_*'][0] ) do
+      FileUtils.rm_f ['src.zip', 'javafx-src.zip']
+      FileUtils.cp_r Dir['*'], jdk_dir
     end
-    unless File.exist? jdk_bin
-      puts "\nOracle now requires an account to download the JDK.\n".orange
-      puts 'You must login at https://login.oracle.com/mysso/signon.jsp and then visit:'.orange
-      puts 'https://www.oracle.com/java/technologies/javase/javase-jdk8-downloads.html'.orange
-      puts "\nDownload the JDK for your architecture to #{HOME}/Downloads to continue.\n".orange
-      abort
+
+    Dir[ File.join(jdk_dir, 'bin', '*') ].each do |path|
+      filename = File.basename(path)
+       symlink = File.join(CREW_DEST_PREFIX, 'bin', filename)
+
+      FileUtils.ln_s path.sub(CREW_DEST_PREFIX, CREW_PREFIX), symlink
     end
-    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest(File.read(jdk_bin)) == jdk_sha256
-    system "tar xvf #{jdk_bin}"
-    jdk8_dir = "#{CREW_DEST_PREFIX}/share/jdk8"
-    FileUtils.mkdir_p jdk8_dir.to_s
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
-    FileUtils.cd 'jdk1.8.0_333' do
-      FileUtils.rm_f 'src.zip'
-      FileUtils.rm_f 'javafx-src.zip'
-      FileUtils.cp_r Dir['*'], "#{jdk8_dir}/"
-    end
-    Dir["#{jdk8_dir}/bin/*"].each do |filename|
-      binary = File.basename(filename)
-      FileUtils.ln_s "#{CREW_PREFIX}/share/jdk8/bin/#{binary}", "#{CREW_DEST_PREFIX}/bin/#{binary}"
-    end
-    FileUtils.mv "#{jdk8_dir}/man/", "#{CREW_DEST_PREFIX}/share/"
+
+    FileUtils.mv Dir[ File.join(jdk8_dir, 'man', '*') ], CREW_DEST_MAN_PREFIX
   end
 end

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -72,7 +72,7 @@ class Jdk8 < Package
         You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
         #{jdk_download_url}
 
-        Download the "jdk-#{version}-linux-#{@jdk_arch[ARCH.to_sym]}.tar.gz" archive to Chrome OS download folder to continue.
+        Download "jdk-#{version}-linux-#{@jdk_arch[ARCH.to_sym]}.tar.gz" to Chrome OS download folder to continue.
       EOT
     end
   end
@@ -81,10 +81,8 @@ class Jdk8 < Package
     jdk_dir = File.join(CREW_DEST_PREFIX, 'share', name)
     FileUtils.mkdir_p [jdk_dir, File.join(CREW_DEST_PREFIX, 'bin'), CREW_DEST_MAN_PREFIX]
 
-    Dir.chdir( Dir['jdk1.8.0_*'][0] ) do
-      FileUtils.rm_f ['src.zip', 'javafx-src.zip']
-      FileUtils.cp_r Dir['*'], jdk_dir
-    end
+    FileUtils.rm_f ['src.zip', 'javafx-src.zip']
+    FileUtils.cp_r Dir['*'], jdk_dir
 
     Dir[ File.join(jdk_dir, 'bin', '*') ].each do |path|
       filename = File.basename(path)
@@ -93,6 +91,6 @@ class Jdk8 < Package
       FileUtils.ln_s path.sub(CREW_DEST_PREFIX, CREW_PREFIX), symlink
     end
 
-    FileUtils.mv Dir[ File.join(jdk8_dir, 'man', '*') ], CREW_DEST_MAN_PREFIX
+    FileUtils.mv Dir[ File.join(jdk_dir, 'man', '*') ], CREW_DEST_MAN_PREFIX
   end
 end

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -2,7 +2,7 @@ require 'package'
 require 'uri'
 
 class Jdk8 < Package
-  description 'The JDK is a development environment for building applications, applets, and components using the Java programming language.'
+  description 'The Oracle JDK is a development environment for building applications, applets, and components using the Java programming language.'
   homepage 'https://www.oracle.com/java/technologies/downloads/#java8'
   version '8u341'
   license 'Oracle-BCLA-JavaSE'
@@ -57,9 +57,9 @@ class Jdk8 < Package
 
       # get latest available version
       latest_jdk_page = 'https://www.oracle.com/java/technologies/downloads/#java8'
-      latest_jdk_ver  = `curl -LSs '#{latest_jdk_page}'`[/8u\d{3}/]
+        is_latest_jdk = `curl -LSs '#{latest_jdk_page}'`.include?(version)
 
-      if latest_jdk_ver == version
+      if is_latest_jdk
         jdk_download_url = latest_jdk_page
       else
         jdk_download_url = 'https://www.oracle.com/java/technologies/javase/javase8u211-later-archive-downloads.html#JDK'

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -72,7 +72,7 @@ class Jdk8 < Package
         You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
         #{jdk_download_url}
 
-        Download JDK version #{version.lightcyan(:no_bold)} for your architecture (#{@jdk_arch.lightcyan(:no_bold)}) to Chrome OS download folder to continue.
+        Download JDK version #{version.cyan} for your architecture (#{@jdk_arch[ARCH.to_sym].cyan}) to Chrome OS download folder to continue.
       EOT
     end
   end

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -72,7 +72,7 @@ class Jdk8 < Package
         You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
         #{jdk_download_url}
 
-        Download JDK version **#{version}** for your architecture (#{@jdk_arch[ARCH.to_sym]}) to Chrome OS download folder to continue.
+        Download the "jdk-#{version}-linux-#{@jdk_arch[ARCH.to_sym]}.tar.gz" archive to Chrome OS download folder to continue.
       EOT
     end
   end

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -72,7 +72,7 @@ class Jdk8 < Package
         You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
         #{jdk_download_url}
 
-        Download JDK version #{version.cyan.delete_suffix("\e[0m")} for your architecture (#{@jdk_arch[ARCH.to_sym].cyan.delete_suffix("\e[0m")}) to Chrome OS download folder to continue.
+        Download JDK version >>>#{version}<<< for your architecture (#{@jdk_arch[ARCH.to_sym].cyan}) to Chrome OS download folder to continue.
       EOT
     end
   end

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -50,7 +50,7 @@ class Jdk8 < Package
       pkg_branding = is_openjdk ? 'OpenJDK' : 'Oracle JDK'
       pkg_prefix   = is_openjdk ? 'openjdk' : 'jdk'
 
-      abort <<~EOT.yellow unless jdk_major_ver == name.delete_prefix('jdk') and !is_openjdk
+      abort <<~EOT.yellow unless jdk_major_ver == name.delete_prefix('jdk') && !is_openjdk
 
         #{pkg_branding} #{jdk_ver} installed.
 


### PR DESCRIPTION
### Changes
- jdk8 => 8u341
- jdk17 => 17.0.4.1
- jdk18 => 18.0.2.1
- The jdk download prompt will tell you the version and exact filename of the archive now (to prevent misleading)
```
Oracle now requires an account to download the JDK.

You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
https://www.oracle.com/java/technologies/javase/jdk18-archive-downloads.html

Download "jdk-18.0.2.1_linux-x64_bin.tar.gz" (Linux x64 Compressed Archive) to Chrome OS download folder to continue.
```
- The preflight message is updated and able to detect `openjdk*` now
```
OpenJDK 17.0.4.1 installed.

Run "crew remove openjdk17; crew install jdk8" to install this version of JDK
```
- Added backup link in case the version is no longer exists on the main download page
- Refactor to use `source_url` over `downloader()`

Tested on `x86_64`