### PR TITLE
rubocop: allow CapitalW

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -173,6 +173,9 @@ Style/MultilineBlockChain:
 Style/NumericLiterals:
   Enabled: false
 
+Style/RedundantCapitalW:
+  Enabled: false
+
 Naming/AccessorMethodName:
   Enabled: false
 


### PR DESCRIPTION
- Multiple packages use something like`%W[ #{CREW_DEST_PREFIX}/file ... ]`, so do not let rubocop change that to a lowercase `%w[`, since that breaks such ruby code.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

This should automatically change what the CI rubocop does, right?