### PR TITLE
Rebuild ruby from 3.1 branch w/o coreutils installed.

### DIFF
--- a/packages/ruby.rb
+++ b/packages/ruby.rb
@@ -3,23 +3,23 @@ require 'package'
 class Ruby < Package
   description 'Ruby is a dynamic, open source programming language with a focus on simplicity and productivity.'
   homepage 'https://www.ruby-lang.org/en/'
-  version '3.1-994b505'
+  version '3.1.3-9fc7df7'
   license 'Ruby-BSD and BSD-2'
   compatibility 'all'
-  source_url 'https://github.com/ruby/ruby/archive/994b505ffb0bf9eb795525199b47697412a98abb.zip'
-  source_sha256 '247155fd6978dffea5f1f25e7a77d1fe3c29c224ad24e15384c49e7e0aa71761'
+  source_url 'https://github.com/ruby/ruby/archive/9fc7df7504f41a7f370e62a004c3fc0abc439295.zip'
+  source_sha256 '2c8e6f1f8a6185629f7783e7a9a8c28f98b1ca41450f24fd0f98bf171a6de60a'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1-994b505_armv7l/ruby-3.1-994b505-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1-994b505_armv7l/ruby-3.1-994b505-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1-994b505_i686/ruby-3.1-994b505-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1-994b505_x86_64/ruby-3.1-994b505-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.3-9fc7df7_armv7l/ruby-3.1.3-9fc7df7-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.3-9fc7df7_armv7l/ruby-3.1.3-9fc7df7-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.3-9fc7df7_i686/ruby-3.1.3-9fc7df7-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.3-9fc7df7_x86_64/ruby-3.1.3-9fc7df7-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'ffa3f5aea7408599aab2d074876b30484bd845abf79dfffef8646fd8c38b7292',
-     armv7l: 'ffa3f5aea7408599aab2d074876b30484bd845abf79dfffef8646fd8c38b7292',
-       i686: '78180a2bbfbaadbbb0cfa8a6f3d9c3fe741da922dbf0242b53a4f6676d11e6d5',
-     x86_64: 'ae3cf478808d30321e87db6433f38d0886cf38adef123eba0e0a826b6c6367f1'
+    aarch64: 'e5c31e18f8771a1cbf641adb400cdfecdd05a44167ea5d353c0916f3fb2ab12b',
+     armv7l: 'e5c31e18f8771a1cbf641adb400cdfecdd05a44167ea5d353c0916f3fb2ab12b',
+       i686: 'ab2315e481abb83214b7321fc2274f861a6b9e0d8f07633b871d13c0f2912328',
+     x86_64: '596e3e7e81683a40ef470d6059b1cb679c90311af164a86e29f0008e0df2ee45'
   })
 
   depends_on 'zlibpkg' # R
@@ -58,18 +58,17 @@ class Ruby < Package
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    # Gems are stored in a ruby majorversion.minorversion.0 folder.
+    @gemrc = <<~GEMRCEOF
+      gem: --no-document
+      gempath: #{CREW_LIB_PREFIX}/ruby/gems/#{RUBY_VERSION.rpartition('.')[0]}.0
+    GEMRCEOF
+    FileUtils.mkdir_p CREW_DEST_HOME
+    File.write("#{CREW_DEST_HOME}/.gemrc", @gemrc)
   end
 
   def self.postinstall
     puts 'Updating ruby gems. This may take a while...'
-    unless Kernel.system("grep -q \"no-document\" #{HOME}/.gemrc")
-      File.write("#{HOME}/.gemrc", "gem: --no-document\n",
-                 mode: 'a')
-    end
-    unless Kernel.system("grep -q \"gempath\" #{HOME}/.gemrc")
-      File.write("#{HOME}/.gemrc", "gempath: #{CREW_LIB_PREFIX}/ruby/gems/3.1.0\n",
-                 mode: 'a')
-    end
     silent = @opt_verbose ? '' : '--silent'
     system "gem update #{silent} -N --system"
   end

--- a/packages/ruby.rb
+++ b/packages/ruby.rb
@@ -70,6 +70,6 @@ class Ruby < Package
   def self.postinstall
     puts 'Updating ruby gems. This may take a while...'
     silent = @opt_verbose ? '' : '--silent'
-    system "gem update #{silent} -N --system"
+    system "gem update #{silent} -N --system", exception: false
   end
 end


### PR DESCRIPTION
- This is built from containers without coreutils ever installed.
- `.gemrc` is now stored in the package instead of installed during postinstall

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=ruby_rebuild CREW_TESTING=1 crew update ; yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
