### PR TITLE
Make debug & rubocop gem installs more robust

### DIFF
--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -3,7 +3,7 @@ require 'package'
 class Buildessential < Package
   description 'A collection of tools essential to compile and build software.'
   homepage ''
-  version '1.20'
+  version '1.21'
   license 'GPL-3+'
   compatibility 'all'
 
@@ -138,4 +138,6 @@ class Buildessential < Package
   # Add rubocop for linting packages. (This also installs the
   # rubocop config file.)
   depends_on 'ruby_rubocop'
+  # Add ruby_debug
+  depends_on 'ruby_debug'
 end

--- a/packages/core.rb
+++ b/packages/core.rb
@@ -3,7 +3,7 @@ require 'package'
 class Core < Package
   description 'Core Chromebrew Packages.'
   homepage 'https://github.com/chromebrew/chromebrew'
-  version '1.6'
+  version '1.7'
   license 'GPL-3+'
   compatibility 'all'
 
@@ -75,7 +75,6 @@ class Core < Package
   depends_on 'rsync'
   depends_on 'rtmpdump'
   depends_on 'ruby'
-  depends_on 'ruby_debug'
   depends_on 'slang'
   depends_on 'sqlite'
   depends_on 'uchardet'

--- a/packages/ruby_debug.rb
+++ b/packages/ruby_debug.rb
@@ -38,7 +38,7 @@ class Ruby_debug < Package
   def self.postinstall
     @gem_name = name.sub('ruby_', '')
     system "gem uninstall -Dx --force --abort-on-dependent #{@gem_name}", exception: false
-    system "gem install -N #{@gem_name} --conservative"
+    system "gem install -N #{@gem_name} --conservative", exception: false
   end
 
   def self.remove

--- a/packages/ruby_rubocop.rb
+++ b/packages/ruby_rubocop.rb
@@ -47,7 +47,7 @@ class Ruby_rubocop < Package
 
   def self.postinstall
     @gem_name = name.sub('ruby_', '')
-    system "gem install -N #{@gem_name} --conservative"
+    system "gem install -N #{@gem_name} --conservative", exception: false
 
     puts "Installing Chromebrew rubocop config file at #{@xdg_config_home}/rubocop/config.yml".lightblue
     puts 'This can be overridden by a ~/.rubocop.yml'.lightblue
@@ -64,7 +64,7 @@ class Ruby_rubocop < Package
     # every package, so delete it from the list.
     @gems.delete('bundler')
     @gems.each do |gem|
-      system "gem uninstall -Dx --force --abort-on-dependent #{gem} || true"
+      system "gem uninstall -Dx --force --abort-on-dependent #{gem}", exception: false
     end
 
     FileUtils.rm_f "#{@xdg_config_home}/rubocop/config.yml"


### PR DESCRIPTION

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=rejigger_ruby_gems  CREW_TESTING=1 crew update
```
