### PR TITLE
Add to buildessential, add concurrent-ruby

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -244,7 +244,7 @@ function extract_install () {
     ;;
     esac
     echo_intra "Installing ${1} ..."
-    tar cpf - ./*/* | (cd /; tar xp --keep-directory-symlink -f -)
+    tar cpf - ./*/* | (cd /; tar xp --keep-directory-symlink -m -f -)
     mv ./dlist "${CREW_CONFIG_PATH}/meta/${1}.directorylist"
     mv ./filelist "${CREW_CONFIG_PATH}/meta/${1}.filelist"
 }

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -95,6 +95,9 @@ class Buildessential < Package
   # for setting library paths in packages
   depends_on 'patchelf'
 
+  # Add pax_utils (gives us lddtree)
+  depends_on 'pax_utils'
+
   # Perl
   depends_on 'perl'
   depends_on 'pcre'
@@ -113,6 +116,8 @@ class Buildessential < Package
   depends_on 'py3_installer'
   depends_on 'py3_flit_core'
   depends_on 'py3_setuptools'
+  # Pax_utils needs this.
+  depends_on 'py3_pyelftools'
 
   # Qt
   # depends_on 'qtcreator'
@@ -123,6 +128,9 @@ class Buildessential < Package
 
   # Samurai
   # depends_on 'samurai'
+
+  # Add Gnu_time to get time binary
+  depends_on 'gnu_time'
 
   # xorg protocol headers
   # depends_on 'xorg_proto'
@@ -135,9 +143,12 @@ class Buildessential < Package
   # Packages needed for compressing archives
   depends_on 'zstd'
 
+  # Ruby gems
   # Add rubocop for linting packages. (This also installs the
   # rubocop config file.)
   depends_on 'ruby_rubocop'
   # Add ruby_debug
   depends_on 'ruby_debug'
+  # Add ruby_concurrent_ruby
+  depends_on 'ruby_concurrent_ruby'
 end

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -3,7 +3,7 @@ require 'package'
 class Buildessential < Package
   description 'A collection of tools essential to compile and build software.'
   homepage ''
-  version '1.21'
+  version '1.22'
   license 'GPL-3+'
   compatibility 'all'
 

--- a/packages/ruby_concurrent_ruby.rb
+++ b/packages/ruby_concurrent_ruby.rb
@@ -1,0 +1,56 @@
+require 'package'
+
+class Ruby_concurrent_ruby < Package
+  description 'Modern concurrency tools for Ruby. Inspired by Erlang, Clojure, Scala, Haskell, F#, C#, Java, and classic concurrency patterns.'
+  homepage 'https://github.com/ruby-concurrency/concurrent-ruby'
+  version '1.1.10'
+  compatibility 'all'
+  source_url 'SKIP'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby_concurrent_ruby/1.1.10_armv7l/ruby_concurrent_ruby-1.1.10-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby_concurrent_ruby/1.1.10_armv7l/ruby_concurrent_ruby-1.1.10-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby_concurrent_ruby/1.1.10_i686/ruby_concurrent_ruby-1.1.10-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby_concurrent_ruby/1.1.10_x86_64/ruby_concurrent_ruby-1.1.10-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '77ce10258eadf962da6da2e99e4646eceb68d4ead5e423640cf0f26dbbfac74e',
+     armv7l: '77ce10258eadf962da6da2e99e4646eceb68d4ead5e423640cf0f26dbbfac74e',
+       i686: 'f699799facdd54b2618a36f92a3f5a4423fe474a545b2e63d535bf5ae16672d9',
+     x86_64: 'aa8c2a94be76cad7e060216efe3a8b4433822e8b7a6567807801565f78f5e69a'
+  })
+
+  no_fhs
+
+  depends_on 'libyaml'
+  depends_on 'ruby'
+  # depends_on 'xdg_base'
+
+  # @xdg_config_home = ENV.fetch('XDG_CONFIG_HOME', nil)
+  # @xdg_config_home = "#{CREW_PREFIX}/.config" if @xdg_config_home.to_s.empty?
+
+  def self.build; end
+
+  def self.install
+    FileUtils.mkdir_p CREW_DEST_PREFIX
+  end
+
+  def self.postinstall
+    @gem_name = name.sub('ruby_', '').sub('_', '-')
+    system "gem uninstall -Dx --force --abort-on-dependent #{@gem_name}", exception: false
+    system "gem install -N #{@gem_name} --conservative", exception: false
+  end
+
+  def self.remove
+    @gem_name = name.sub('ruby_', '').sub('_', '-')
+    @gems_deps = `gem dependency ^#{@gem_name}\$`.scan(/^([^\s]+?)/).flatten
+    # Delete the first line and convert to an array.
+    @gems = @gems_deps.split("\n").drop(1).append(@gem_name)
+    # bundler never gets uninstalled, though gem dependency lists it for
+    # every package, so delete it from the list.
+    @gems.delete('bundler')
+    @gems.each do |gem|
+      system "gem uninstall -Dx --force --abort-on-dependent #{gem}", exception: false
+    end
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -6679,9 +6679,24 @@ url: http://www.ruby-lang.org/en/downloads/
 activity: medium
 ---
 kind: url
+name: ruby_concurrent_ruby
+url: https://github.com/ruby-concurrency/concurrent-ruby/releases
+activity: medium
+---
+kind: url
+name: ruby_debug
+url: https://github.com/ruby/debug/releases
+activity: medium
+---
+kind: url
 name: ruby_docopt
 url: https://github.com/docopt/docopt/releases
 activity: none
+---
+kind: url
+name: ruby_rubocop
+url: https://github.com/rubocop/rubocop/releases
+activity: medium
 ---
 kind: url
 name: ruby_webrick


### PR DESCRIPTION
Supersedes https://github.com/chromebrew/chromebrew/pull/7504
- Adds package for `concurrent-ruby` gem, which crew uses during builds.
- Adds other important packages for building and debugging building to `build_essential`.
- Fix issue with `install.sh` erroring out on timestamp difference when extracting. (This is an issue for extracting `.gemrc` to the home dir.)

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=fixup CREW_TESTING=1 crew update
```
