### PR TITLE
Fix gem install command line

### DIFF
--- a/packages/ruby_concurrent_ruby.rb
+++ b/packages/ruby_concurrent_ruby.rb
@@ -43,7 +43,7 @@ class Ruby_concurrent_ruby < Package
 
   def self.remove
     @gem_name = name.sub('ruby_', '').sub('_', '-')
-    @gems_deps = `gem dependency ^#{@gem_name}\$`.scan(/^([^\s]+?)/).flatten
+    @gems_deps = `gem dependency ^#{@gem_name}\$ | awk '{print \$1}'`.chomp
     # Delete the first line and convert to an array.
     @gems = @gems_deps.split("\n").drop(1).append(@gem_name)
     # bundler never gets uninstalled, though gem dependency lists it for

--- a/packages/ruby_concurrent_ruby.rb
+++ b/packages/ruby_concurrent_ruby.rb
@@ -3,7 +3,7 @@ require 'package'
 class Ruby_concurrent_ruby < Package
   description 'Modern concurrency tools for Ruby. Inspired by Erlang, Clojure, Scala, Haskell, F#, C#, Java, and classic concurrency patterns.'
   homepage 'https://github.com/ruby-concurrency/concurrent-ruby'
-  version '1.1.10'
+  version '1.1.10-1'
   compatibility 'all'
   source_url 'SKIP'
 
@@ -38,7 +38,7 @@ class Ruby_concurrent_ruby < Package
   def self.postinstall
     @gem_name = name.sub('ruby_', '').sub('_', '-')
     system "gem uninstall -Dx --force --abort-on-dependent #{@gem_name}", exception: false
-    system "gem install -N #{@gem_name} --conservative", exception: false
+    system "gem install -N #{@gem_name}", exception: false
   end
 
   def self.remove

--- a/packages/ruby_debug.rb
+++ b/packages/ruby_debug.rb
@@ -3,7 +3,7 @@ require 'package'
 class Ruby_debug < Package
   description 'Debugging functionality for Ruby. This is completely rewritten debug.rb which was contained by the ancient Ruby versions.'
   homepage 'https://github.com/ruby/debug'
-  version '1.6.2'
+  version '1.6.2-1'
   compatibility 'all'
   source_url 'SKIP'
 
@@ -38,7 +38,7 @@ class Ruby_debug < Package
   def self.postinstall
     @gem_name = name.sub('ruby_', '')
     system "gem uninstall -Dx --force --abort-on-dependent #{@gem_name}", exception: false
-    system "gem install -N #{@gem_name} --conservative", exception: false
+    system "gem install -N #{@gem_name}", exception: false
   end
 
   def self.remove

--- a/packages/ruby_debug.rb
+++ b/packages/ruby_debug.rb
@@ -43,7 +43,7 @@ class Ruby_debug < Package
 
   def self.remove
     @gem_name = name.sub('ruby_', '')
-    @gems_deps = `gem dependency ^#{@gem_name}\$`.scan(/^([^\s]+?)/).flatten
+    @gems_deps = `gem dependency ^#{@gem_name}\$ | awk '{print \$1}'`.chomp
     # Delete the first line and convert to an array.
     @gems = @gems_deps.split("\n").drop(1).append(@gem_name)
     # bundler never gets uninstalled, though gem dependency lists it for

--- a/packages/ruby_rubocop.rb
+++ b/packages/ruby_rubocop.rb
@@ -6,7 +6,7 @@ require 'package'
 class Ruby_rubocop < Package
   description 'A Ruby static code analyzer and formatter'
   homepage 'https://rubocop.org'
-  version '1.26.1'
+  version '1.36'
   compatibility 'all'
   source_url 'SKIP'
   # source_url 'https://github.com/rubocop/rubocop.git'
@@ -47,7 +47,7 @@ class Ruby_rubocop < Package
 
   def self.postinstall
     @gem_name = name.sub('ruby_', '')
-    system "gem install -N #{@gem_name} --conservative", exception: false
+    system "gem install -N #{@gem_name}", exception: false
 
     puts "Installing Chromebrew rubocop config file at #{@xdg_config_home}/rubocop/config.yml".lightblue
     puts 'This can be overridden by a ~/.rubocop.yml'.lightblue


### PR DESCRIPTION
- Removing `--conservative` from the gem install command line fixes the installs of dependencies.
- Replace postinstall regex usage in ruby gem packages which doesn't work.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=gem_noconservative CREW_TESTING=1 crew update ; crew upgrade
```
