### PR TITLE
Update vulkan_ packages to 1.3.231

### DIFF
--- a/packages/vulkan_headers.rb
+++ b/packages/vulkan_headers.rb
@@ -17,8 +17,8 @@ class Vulkan_headers < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.231_x86_64/vulkan_headers-1.3.231-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '8800391b595397138093b962f096ba4e85669325c8307338039417949425ad58',
-     armv7l: '8800391b595397138093b962f096ba4e85669325c8307338039417949425ad58',
+    aarch64: 'b19c5a426f01cf251c5660abccae19f6ab5082bdd12c7b6470856579664e0897',
+     armv7l: 'b19c5a426f01cf251c5660abccae19f6ab5082bdd12c7b6470856579664e0897',
        i686: '12f2ae15bff517cbefbbe61e59b408431235f60b78d6adef55740d5eb3ca83b2',
      x86_64: 'b627b23a35c7f934e7eed6227091dd897e8c4554102cc387fbf75379dd3de1d5'
   })

--- a/packages/vulkan_headers.rb
+++ b/packages/vulkan_headers.rb
@@ -3,26 +3,25 @@ require 'package'
 class Vulkan_headers < Package
   description 'Vulkan header files'
   homepage 'https://github.com/KhronosGroup/Vulkan-Headers'
-  @_ver = '1.3.230'
+  @_ver = '1.3.231'
   version @_ver
   license 'Apache-2.0'
   compatibility 'all'
   source_url 'https://github.com/KhronosGroup/Vulkan-Headers.git'
+  git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.230_armv7l/vulkan_headers-1.3.230-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.230_armv7l/vulkan_headers-1.3.230-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.230_i686/vulkan_headers-1.3.230-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.230_x86_64/vulkan_headers-1.3.230-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.231_armv7l/vulkan_headers-1.3.231-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.231_armv7l/vulkan_headers-1.3.231-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.231_i686/vulkan_headers-1.3.231-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.231_x86_64/vulkan_headers-1.3.231-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'd36b9887edca21f8092ed048bdce3b097312e1074c34a801088ac8eeadb9981b',
-     armv7l: 'd36b9887edca21f8092ed048bdce3b097312e1074c34a801088ac8eeadb9981b',
-       i686: 'de184f007aad9a8b937c769e9cbd37a4257e7d7bde3e39eaa947f0b7ee1d5369',
-     x86_64: 'db133f28b049375d584831c05020bb25778a7728d12d5f27198ee3d3f1c56d87'
+    aarch64: '8800391b595397138093b962f096ba4e85669325c8307338039417949425ad58',
+     armv7l: '8800391b595397138093b962f096ba4e85669325c8307338039417949425ad58',
+       i686: '12f2ae15bff517cbefbbe61e59b408431235f60b78d6adef55740d5eb3ca83b2',
+     x86_64: 'b627b23a35c7f934e7eed6227091dd897e8c4554102cc387fbf75379dd3de1d5'
   })
-
-  git_hashtag "v#{@_ver}"
 
   def self.build
     Dir.mkdir 'builddir'

--- a/packages/vulkan_icd_loader.rb
+++ b/packages/vulkan_icd_loader.rb
@@ -3,26 +3,25 @@ require 'package'
 class Vulkan_icd_loader < Package
   description 'Vulkan Installable Client Driver ICD Loader'
   homepage 'https://github.com/KhronosGroup/Vulkan-Loader'
-  @_ver = '1.3.230'
+  @_ver = '1.3.231'
   version @_ver
   license 'Apache-2.0'
   compatibility 'all'
   source_url 'https://github.com/KhronosGroup/Vulkan-Loader.git'
+  git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.230_armv7l/vulkan_icd_loader-1.3.230-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.230_armv7l/vulkan_icd_loader-1.3.230-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.230_i686/vulkan_icd_loader-1.3.230-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.230_x86_64/vulkan_icd_loader-1.3.230-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.231_armv7l/vulkan_icd_loader-1.3.231-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.231_armv7l/vulkan_icd_loader-1.3.231-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.231_i686/vulkan_icd_loader-1.3.231-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.231_x86_64/vulkan_icd_loader-1.3.231-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '15f8878ef502ebe90ed22535d2e99e6da804e02aae41f0a4c7403c4ae512b26f',
-     armv7l: '15f8878ef502ebe90ed22535d2e99e6da804e02aae41f0a4c7403c4ae512b26f',
-       i686: 'f36cd322d98a6c6874e9c450cf5bbde693b297cd8315f6e01d7cc94f6ff2d982',
-     x86_64: 'fdfb0631b3069712a4aa0095cd0055d5425d842a76bfa5e979fdba04a6a49f7e'
+    aarch64: '704fdad903debb631c5039a433c335d61664d5e181f2bb0e3c2b4bbb8c1f8e1b',
+     armv7l: '704fdad903debb631c5039a433c335d61664d5e181f2bb0e3c2b4bbb8c1f8e1b',
+       i686: '9d546f058735fc9ae488e8cbc7adf064a2b5ff4649cc732ad066dc359475d662',
+     x86_64: 'bb1c74e5a6dc3ecde467665561d59992b22a577e8fa3b03613d2b32ef162f1d9'
   })
-
-  git_hashtag "v#{@_ver}"
 
   depends_on 'libx11'
   depends_on 'libxrandr'
@@ -31,8 +30,10 @@ class Vulkan_icd_loader < Package
   depends_on 'libxrandr' => :build
   depends_on 'wayland' => :build
   depends_on 'vulkan_headers' => :build
+  depends_on 'glibc' # R
 
   def self.build
+    system 'scripts/update_deps.py'
     Dir.mkdir 'builddir'
     Dir.chdir 'builddir' do
       system "env #{CREW_ENV_OPTIONS} \

--- a/packages/vulkan_icd_loader.rb
+++ b/packages/vulkan_icd_loader.rb
@@ -17,8 +17,8 @@ class Vulkan_icd_loader < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.231_x86_64/vulkan_icd_loader-1.3.231-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '704fdad903debb631c5039a433c335d61664d5e181f2bb0e3c2b4bbb8c1f8e1b',
-     armv7l: '704fdad903debb631c5039a433c335d61664d5e181f2bb0e3c2b4bbb8c1f8e1b',
+    aarch64: 'd48edf42f7c448182905ddeeb9651f2db0dfdbb331b19f3b67ac1f97d3e34b0a',
+     armv7l: 'd48edf42f7c448182905ddeeb9651f2db0dfdbb331b19f3b67ac1f97d3e34b0a',
        i686: '9d546f058735fc9ae488e8cbc7adf064a2b5ff4649cc732ad066dc359475d662',
      x86_64: 'bb1c74e5a6dc3ecde467665561d59992b22a577e8fa3b03613d2b32ef162f1d9'
   })

--- a/packages/vulkan_tools.rb
+++ b/packages/vulkan_tools.rb
@@ -6,23 +6,23 @@ require 'package'
 class Vulkan_tools < Package
   description 'Vulkan Utilities and Tools'
   homepage 'https://www.khronos.org/vulkan/'
-  version '1.3.230'
+  version '1.3.231'
   license 'custom'
   compatibility 'all'
-  source_url "https://github.com/KhronosGroup/Vulkan-Tools/archive/v#{version}.tar.gz"
-  source_sha256 '5bb190d20ee8ae4e8dd157b686bd2d3162dc3a814b3d0625d90b1d84dd177dbb'
+  source_url 'https://github.com/KhronosGroup/Vulkan-Tools.git'
+  git_hashtag "v#{version}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_tools/1.3.230_armv7l/vulkan_tools-1.3.230-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_tools/1.3.230_armv7l/vulkan_tools-1.3.230-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_tools/1.3.230_i686/vulkan_tools-1.3.230-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_tools/1.3.230_x86_64/vulkan_tools-1.3.230-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_tools/1.3.231_armv7l/vulkan_tools-1.3.231-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_tools/1.3.231_armv7l/vulkan_tools-1.3.231-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_tools/1.3.231_i686/vulkan_tools-1.3.231-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_tools/1.3.231_x86_64/vulkan_tools-1.3.231-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'be40fe9684ff980a1e4624ec112eba844b6a58e219cf71bb6bb4f1a75667693e',
-     armv7l: 'be40fe9684ff980a1e4624ec112eba844b6a58e219cf71bb6bb4f1a75667693e',
-       i686: '428aadff66735013c5dfc3b392cf54055b6d9dba0f710492fe4efd1c077e3674',
-     x86_64: 'fbe30a5c9296eaaaab392540792bbf729166979cc5313b2d306923fe3ec3c437'
+    aarch64: '13f37edccb74c776e39097bfb9bf67793a47a0c2c930c8ff5528d45100e84c6f',
+     armv7l: '13f37edccb74c776e39097bfb9bf67793a47a0c2c930c8ff5528d45100e84c6f',
+       i686: 'd2421e5c49e7fe100dba833ee308d3be28cad42a9be06cf4dca6beb7dbc47f99',
+     x86_64: '1578cd4a950863964659b1935232fc46ca98ab17b8559cfb4cd4488991f6cb86'
   })
 
   depends_on 'libx11'
@@ -33,8 +33,13 @@ class Vulkan_tools < Package
   depends_on 'wayland_protocols' => :build
   depends_on 'glslang' => :build
   depends_on 'spirv_tools' => :build
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  depends_on 'libxcb' # R
+  depends_on 'libxext' # R
 
   def self.build
+    system 'scripts/update_deps.py'
     Dir.mkdir 'builddir'
     Dir.chdir 'builddir' do
       system "env #{CREW_ENV_OPTIONS} \

--- a/packages/vulkan_tools.rb
+++ b/packages/vulkan_tools.rb
@@ -29,7 +29,7 @@ class Vulkan_tools < Package
   depends_on 'wayland'
   depends_on 'python3' => :build
   depends_on 'vulkan_headers' => :build
-  depends_on 'vulkan_icd_loader' => :build
+  depends_on 'vulkan_icd_loader'
   depends_on 'wayland_protocols' => :build
   depends_on 'glslang' => :build
   depends_on 'spirv_tools' => :build

--- a/packages/vulkan_tools.rb
+++ b/packages/vulkan_tools.rb
@@ -19,24 +19,25 @@ class Vulkan_tools < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_tools/1.3.231_x86_64/vulkan_tools-1.3.231-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '13f37edccb74c776e39097bfb9bf67793a47a0c2c930c8ff5528d45100e84c6f',
-     armv7l: '13f37edccb74c776e39097bfb9bf67793a47a0c2c930c8ff5528d45100e84c6f',
-       i686: 'd2421e5c49e7fe100dba833ee308d3be28cad42a9be06cf4dca6beb7dbc47f99',
-     x86_64: '1578cd4a950863964659b1935232fc46ca98ab17b8559cfb4cd4488991f6cb86'
+    aarch64: '51bb8acd2988d6b166d02aef12deca99f2043a9cfa14b7fc1d482c5423ff6e58',
+     armv7l: '51bb8acd2988d6b166d02aef12deca99f2043a9cfa14b7fc1d482c5423ff6e58',
+       i686: 'e6b5506c8a5e21c9d6acef7ef2fcd9044531d3e09a5c7e957d9c258bc2076ac2',
+     x86_64: 'aefe2651e6d31b6b1acd5e7604ffaad046e3a391e538ae4bbf79b6e9394cd236'
   })
 
-  depends_on 'libx11'
-  depends_on 'wayland'
-  depends_on 'python3' => :build
-  depends_on 'vulkan_headers' => :build
-  depends_on 'vulkan_icd_loader'
-  depends_on 'wayland_protocols' => :build
-  depends_on 'glslang' => :build
-  depends_on 'spirv_tools' => :build
   depends_on 'gcc' # R
   depends_on 'glibc' # R
+  depends_on 'glslang' => :build
+  depends_on 'libx11' # R
   depends_on 'libxcb' # R
   depends_on 'libxext' # R
+  depends_on 'libxrandr' => :build
+  depends_on 'python3' => :build
+  depends_on 'spirv_tools' => :build
+  depends_on 'vulkan_headers' => :build
+  depends_on 'vulkan_icd_loader' # R
+  depends_on 'wayland_protocols' => :build
+  depends_on 'wayland' # R
 
   def self.build
     system 'scripts/update_deps.py'


### PR DESCRIPTION
Fixes #7463 Maybe?

- Adjusts package build to try to fix issues with resultant binaries.

_Builds_ properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=vulkan_1.3.231  CREW_TESTING=1 crew update
```
