### PR TITLE
fop -> 2.7, remove jdk8 dep

### DIFF
--- a/packages/fop.rb
+++ b/packages/fop.rb
@@ -3,26 +3,26 @@ require 'package'
 class Fop < Package
   description 'Apache FOP (Formatting Objects Processor) is a print formatter driven by XSL formatting objects (XSL-FO) and an output independent formatter.'
   homepage 'https://xmlgraphics.apache.org/fop/'
-  version '2.6-1'
+  version '2.7'
   license 'Apache-2.0'
   compatibility 'all'
-  source_url 'https://downloads.apache.org/xmlgraphics/fop/binaries/fop-2.6-bin.tar.gz'
-  source_sha256 'ccfd7a1d4e5a04e76723946efa1147ffa9a8715ce2b58d2a27085a8e744520f8'
+  source_url 'https://downloads.apache.org/xmlgraphics/fop/binaries/fop-2.7-bin.tar.gz'
+  source_sha256 'ec75d6135f55f57b275f8332e069f8817990fdc7f63b1f5c0cb9da5609aa3074'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fop/2.6-1_armv7l/fop-2.6-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fop/2.6-1_armv7l/fop-2.6-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fop/2.6-1_i686/fop-2.6-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fop/2.6-1_x86_64/fop-2.6-1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fop/2.7_armv7l/fop-2.7-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fop/2.7_armv7l/fop-2.7-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fop/2.7_i686/fop-2.7-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fop/2.7_x86_64/fop-2.7-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '5b7a73cd366557240852ea2ec1dc75d2f75d2b0b47c6d5634c2995aba1de79c0',
-     armv7l: '5b7a73cd366557240852ea2ec1dc75d2f75d2b0b47c6d5634c2995aba1de79c0',
-       i686: '6b830403f1596aba2a77856a892913b7b0776f2cb78cc62c1d867d8ad394db5a',
-     x86_64: '489c9c4000771c944e54a70e01015e0d5e62acbf1d32cea7c41eb481b506ed1c'
+    aarch64: '3b9f80cc072b9f23a54a06f8f83ded64d1c1a4c79ad1f887c79b0ecb5b25da74',
+     armv7l: '3b9f80cc072b9f23a54a06f8f83ded64d1c1a4c79ad1f887c79b0ecb5b25da74',
+       i686: '525ad8aea3c8c5512a85fb82c01a9569a3bbc858a9b1ca0369d9c430c814ccb4',
+     x86_64: '5e36714fdc3db30e7f9df579d47a19bdff8da481ac2665bf4449458f34344629'
   })
 
-  depends_on 'jdk8'
+  depends_on 'openjdk8'
 
   def self.install
     system "mkdir -p #{CREW_DEST_PREFIX}/bin"


### PR DESCRIPTION
- Update and replace `jdk8` dep with `openjdk8` dep.
- Did not break the `libxfont2` build, which depends upon it.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=fop CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
