### PR TITLE
Add meld to packages

### DIFF
--- a/packages/meld.rb
+++ b/packages/meld.rb
@@ -9,12 +9,31 @@ class Meld < Package
   source_url 'https://gitlab.gnome.org/GNOME/meld/-/archive/3.22.0/meld-3.22.0.tar.gz'
   source_sha256 '6332dda01925a2ee367b4b2c50da9a89e040b6656f6643c4aae037c20690a8a2'
 
-  def self.install
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share"
-    FileUtils.cp_r ".", "#{CREW_DEST_PREFIX}/share/meld"
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meld/3.22.0_armv7l/meld-3.22.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meld/3.22.0_armv7l/meld-3.22.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meld/3.22.0_i686/meld-3.22.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meld/3.22.0_x86_64/meld-3.22.0-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '41addb40a83c9994b929eb2279f4a2ba1a9daca533ffb716a7e0e78010397061',
+     armv7l: '41addb40a83c9994b929eb2279f4a2ba1a9daca533ffb716a7e0e78010397061',
+       i686: '738c8fe2c1df886e38587f69dddaecb928d615e19233ccc5c4fdb83f8c552478',
+     x86_64: 'f3c5aa6aab0cde154c79bc8d9d860b1851ea760cb54d0ff31a1df9f91d9ed1a9'
+  })
 
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
-    FileUtils.ln_s "#{CREW_PREFIX}/share/meld/bin/meld", "#{CREW_DEST_PREFIX}/bin", force: true
+  depends_on 'gtk3'
+  depends_on 'gtksourceview_4'
+  gnome
+
+  def self.build
+    system "meson #{CREW_MESON_OPTIONS} \
+    builddir"
+    system 'meson configure builddir'
+    system 'mold -run samu -C builddir'
   end
 
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
+  end
 end

--- a/packages/meld.rb
+++ b/packages/meld.rb
@@ -1,0 +1,20 @@
+require 'package'
+
+class Meld < Package
+  description 'Meld is a visual diff and merge tool targeted at developers.'
+  homepage 'https://meldmerge.org/'
+  version '3.22.0'
+  license 'GPL-2'
+  compatibility 'all'
+  source_url 'https://gitlab.gnome.org/GNOME/meld/-/archive/3.22.0/meld-3.22.0.tar.gz'
+  source_sha256 '6332dda01925a2ee367b4b2c50da9a89e040b6656f6643c4aae037c20690a8a2'
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share"
+    FileUtils.cp_r ".", "#{CREW_DEST_PREFIX}/share/meld"
+
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    FileUtils.ln_s "#{CREW_PREFIX}/share/meld/bin/meld", "#{CREW_DEST_PREFIX}/bin", force: true
+  end
+
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -5024,6 +5024,11 @@ url: https://megatools.megous.com/builds
 activity: low
 ---
 kind: url
+name: meld
+url: https://gitlab.gnome.org/GNOME/meld/-/tags
+activity: medium
+---
+kind: url
 name: memcached
 url: https://memcached.org/downloads
 activity: high


### PR DESCRIPTION
## Description

This PR adds GNOME's [Meld](https://meldmerge.org) to Chromebrew's list of packages. Meld is my generic diff viewer of choice and it'd be great to be able to easily install it via `crew`!

## Additional information

Works properly:
- [x] `x86_64`
- [ ] `i686`
- [ ] `armv7l` <!-- (reasons why it doesn't) -->
(I can dig up my old ARM Chromebook to test on if necessary, but given the simplicity of this package's install, I wouldn't expect any issues)

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/SteveDesmond-ca/chromebrew.git CREW_TESTING_BRANCH=master CREW_TESTING=1 crew update
```