### PR TITLE
new package neo-matrix

### DIFF
--- a/packages/neo_matrix.rb
+++ b/packages/neo_matrix.rb
@@ -1,0 +1,39 @@
+require 'package'
+
+class Neo_matrix < Package
+  description 'Simulates the digital rain from "The Matrix" (A CMatrix clone with 32-bit color and Unicode support)'
+  homepage 'https://github.com/st3w/neo'
+  @_ver = '0.6.1'
+  version @_ver
+  license 'GPL-3'
+  compatibility 'all'
+  source_url 'https://github.com/st3w/neo.git'
+  git_hashtag "v#{@_ver}"
+
+  depends_on 'ttf_hanazono' # L
+  depends_on 'glibc' # R
+  depends_on 'ncurses' # R
+
+  def self.patch
+    # We like having a verbose autoreconf
+    system "sed -i 's:^autoreconf:autoreconf --verbose:' autogen.sh"
+  end
+
+  def self.build
+    system './autogen.sh'
+    # The program name is neo-matrix for us
+    # "neo" refers to different software that existed before this neo
+    system "./configure #{CREW_OPTIONS.sub '--program-suffix=\'\'', ''} \
+      --program-suffix='-matrix'"
+    system 'make'
+  end
+
+  def self.check
+    # At the time of writing (20 Oct 2022), neo has no checks
+    system 'make', 'check'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/ttf_hanazono.rb
+++ b/packages/ttf_hanazono.rb
@@ -1,0 +1,29 @@
+require 'package'
+
+class Ttf_hanazono < Package
+  description 'A free Japanese kanji font, which contains about 78,685 characters (and 2 SPACEs) defined in ISO/IEC 10646 standard / the Unicode standard.'
+  homepage 'http://fonts.jp/hanazono' # From ArchLinux PKGBUILD, could not actually resolve site
+  @_ver = 20170904
+  @_revision = 68253
+  version "#{@_ver}-r#{@_revision}"
+  license 'OFL and custom'
+  compatibility 'all'
+  source_url "http://sourceforge.jp/frs/redir.php?m=jaist&f=%2Fhanazono-font%2F#{@_revision}%2Fhanazono-#{@_ver}.zip"
+  source_sha256 '571cd4a09ae7da0c642d640fc2442c050aa450ebb0587a95cdd097d41a9c9572'
+
+  no_compile_needed
+
+  binary_url({
+  })
+
+  binary_sha256({
+  })
+
+  def self.install
+    @_ttf_fonts_dir = "#{CREW_DEST_PREFIX}/share/fonts/TTF"
+    FileUtils.mkdir_p @_ttf_fonts_dir
+    %w[HanaMinA HanaMinB].each fontfile do
+      FileUtils.install 'HanaMinA.ttf' "#{@_ttf_fonts_dir}/#{fontfile}.ttf"
+    end
+  end
+end

--- a/packages/ttf_hanazono.rb
+++ b/packages/ttf_hanazono.rb
@@ -13,12 +13,6 @@ class Ttf_hanazono < Package
 
   no_compile_needed
 
-  binary_url({
-  })
-
-  binary_sha256({
-  })
-
   def self.install
     @_ttf_fonts_dir = "#{CREW_DEST_PREFIX}/share/fonts/TTF"
     FileUtils.mkdir_p @_ttf_fonts_dir


### PR DESCRIPTION
<!-- (let GitHub automatically close an issue when this pull request gets merged) -->

<!--
## Before you submit a pull request

This template is not necessary when you do simple things like updating packages to the latest version. But in doubt, it's always better so provide some information.
-->

## Description
`neo-matrix` is a fun little terminal screensaver much like [cmatrix](https://github.com/chromebrew/chromebrew/blob/master/packages/cmatrix.rb) but with 32-bit color support and actual japanese font support.

<!--
Provide a description, what your changes do and why they are important

Please link issues and other pull requests connected to this one.
-->

## Additional information
<!-- Mention things we might need to know. Like: -->

Works properly (tested in containers):
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/saltedcoffii/chromebrew.git CREW_TESTING_BRANCH=neo_0.6.1 CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
