### PR TITLE
Add php_malware_finder package and yara dependency

### DIFF
--- a/packages/php_malware_finder.rb
+++ b/packages/php_malware_finder.rb
@@ -1,0 +1,33 @@
+require 'package'
+
+class Php_malware_finder < Package
+  description 'Detect potentially malicious PHP files.'
+  homepage 'https://github.com/nbs-system/php-malware-finder/'
+  version 'b8698eb'
+  license 'LGPL-3.0'
+  compatibility 'all'
+  source_url 'https://github.com/nbs-system/php-malware-finder.git'
+  git_hashtag 'b8698eb605cc06bc0585902d7fb7f4943113cc5d'
+
+  depends_on 'yara'
+
+  def self.build
+    system 'make || true' # || true is needed to bypass the debian release check.
+    system "sed -i 's,/etc/phpmalwarefinder,#{CREW_PREFIX}/share/php-malware-finder,' php-malware-finder/phpmalwarefinder"
+  end
+
+  def self.check
+    system 'make', 'tests'
+  end
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share"
+    FileUtils.mv 'php-malware-finder', "#{CREW_DEST_PREFIX}/share"
+    FileUtils.ln_s "#{CREW_PREFIX}/share/php-malware-finder/phpmalwarefinder", "#{CREW_DEST_PREFIX}/bin/pmf"
+  end
+
+  def self.postinstall
+    puts "\nType 'pmf -h' to get started.\n".lightblue
+  end
+end

--- a/packages/yara.rb
+++ b/packages/yara.rb
@@ -1,0 +1,38 @@
+require 'package'
+
+class Yara < Package
+  description 'The pattern matching swiss knife for malware researchers (and everyone else).'
+  homepage 'https://virustotal.github.io/yara/'
+  version '4.2.3'
+  license 'BSD-3 Clause'
+  compatibility 'all'
+  source_url 'https://github.com/VirusTotal/yara/archive/v4.2.3.tar.gz'
+  source_sha256 '1cd84fc2db606e83084a648152eb35103c3e30350825cb7553448d5ccde02a0d'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/yara/4.2.3_armv7l/yara-4.2.3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/yara/4.2.3_armv7l/yara-4.2.3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/yara/4.2.3_i686/yara-4.2.3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/yara/4.2.3_x86_64/yara-4.2.3-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: 'ddbebdd46dbe4d0da19fde9596b1e4c0c33a6a2a25abe88c07e4f7d41d1d05fb',
+     armv7l: 'ddbebdd46dbe4d0da19fde9596b1e4c0c33a6a2a25abe88c07e4f7d41d1d05fb',
+       i686: '0bdee5b010c9765aa14c0fea82866914c087814e0ca540e460e17176020cf404',
+     x86_64: 'd63b0bcb7feb4eef29d8271dd008d9c4cf9825eecc9e12cddde8b875d2457e8a'
+  })
+
+  def self.build
+    system './bootstrap.sh'
+    system "YACC=bison ./configure #{CREW_OPTIONS}"
+    system 'make'
+  end
+
+  def self.check
+    system 'make', 'check'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -6104,6 +6104,11 @@ url: https://php.net/distributions
 activity: high
 ---
 kind: url
+name: php_malware_finder
+url: https://github.com/nbs-system/php-malware-finder
+activity: low
+---
+kind: url
 name: phpsysinfo
 url: https://sourceforge.net/projects/phpsysinfo/files/phpsysinfo/
 activity: low
@@ -8302,6 +8307,11 @@ kind: url
 name: yajl
 url: https://github.com/lloyd/yajl/releases
 activity: none
+---
+kind: url
+name: yara
+url: https://github.com/VirusTotal/yara/releases
+activity: medium
 ---
 kind: url
 name: yarn


### PR DESCRIPTION
PHP-malware-finder does its very best to detect obfuscated/dodgy code as well as files using PHP functions often used in malwares/webshells.

YARA is a tool aimed at (but not limited to) helping malware researchers to identify and classify malware samples. With YARA you can create descriptions of malware families (or whatever you want to describe) based on textual or binary patterns.

Tested on all architectures.