### PR TITLE
Fix 3:5 [comments] too few spaces before comment in Rubocop.yml

### DIFF
--- a/.github/workflows/Rubocop.yml
+++ b/.github/workflows/Rubocop.yml
@@ -1,6 +1,6 @@
 ---
 name: Rubocop
-on: # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
   pull_request:
     branches: [master]
 jobs:


### PR DESCRIPTION
Very petty warning.