### PR TITLE
Add linters to GitHub Actions workflow

### DIFF
--- a/.github/workflows/Linters.yml
+++ b/.github/workflows/Linters.yml
@@ -1,6 +1,6 @@
 ---
-name: Rubocop
-on:  # yamllint disable-line rule:truthy
+name: Linters
+on:
   pull_request:
     branches: [master]
 jobs:
@@ -14,9 +14,10 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.1
-      - name: Install yamllint
+      - name: Install linters
         run: |
-          sudo apt install yamllint -y
+          gem install mdl yaml-lint
+          sudo apt install codespell shellcheck -y
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v33
@@ -26,16 +27,28 @@ jobs:
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             ext="${file##*.}"
             type="$(file -b $file | cut -d' ' -f1)"
-            [[ "$type" == "Ruby" ]] && ext="rb"
+            case $type in
+              Bourne-Again)
+                ext="sh";;
+              HTML)
+                ext="md";;
+              Ruby)
+                ext="rb";;
+            esac
             case $ext in
-              yml|yaml)
-                yamllint $file;;
+              md)
+                mdl $file;;
               rb)
                 ruby=true
                 ruby -wcWlevel=2 $file;;
+              sh)
+                shellcheck $file;;
+              yml|yaml)
+                yaml-lint $file;;
               *)
                 echo "Unable to check syntax of $file.";;
             esac
+            codespell $file
           done
           echo "ruby=$ruby" >> $GITHUB_ENV
       - name: Rubocop


### PR DESCRIPTION
Adds codespell, shellcheck and markdown linters.  Also renamed Rubocop.yml to Linters.yml to better describe the workflow.