### PR TITLE
Fix case bug in Linters.yml

### DIFF
--- a/.github/workflows/Linters.yml
+++ b/.github/workflows/Linters.yml
@@ -29,24 +29,32 @@ jobs:
             type="$(file -b $file | cut -d' ' -f1)"
             case $type in
               Bourne-Again)
-                ext="sh";;
+                ext="sh"
+                ;;
               HTML)
-                ext="md";;
+                ext="md"
+                ;;
               Ruby)
-                ext="rb";;
+                ext="rb"
+                ;;
             esac
             case $ext in
               md)
-                mdl $file;;
+                mdl $file
+                ;;
               rb)
                 ruby=true
-                ruby -wcWlevel=2 $file;;
+                ruby -wcWlevel=2 $file
+                ;;
               sh)
-                shellcheck $file;;
+                shellcheck $file
+                ;;
               yml|yaml)
-                yaml-lint $file;;
+                yaml-lint $file
+                ;;
               *)
-                echo "Unable to check syntax of $file.";;
+                echo "Unable to check syntax of $file."
+                ;;
             esac
             codespell $file
           done


### PR DESCRIPTION
The double semicolon (`;;`) at the end of the line in case statements only works with single line cases.  In order to be consistent, I changed all case statements to put the `;;` on the last line.