### PR TITLE
Fix bash errors

### DIFF
--- a/packages/bash.rb
+++ b/packages/bash.rb
@@ -59,14 +59,9 @@ class Bash < Package
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     FileUtils.ln_s "#{CREW_PREFIX}/bin/bash", "#{CREW_DEST_PREFIX}/bin/sh"
+  end
 
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/bash.d/"
-    @bashenv = <<~BASHEOF
-      # Make Chromebrew's version of bash start automatically
-      if [[ "$(coreutils --coreutils-prog=readlink "/proc/$$/exe")" != '#{CREW_PREFIX}/bin/bash' ]]; then
-        exec #{CREW_PREFIX}/bin/bash
-      fi
-    BASHEOF
-    File.write("#{CREW_DEST_PREFIX}/etc/bash.d/bash", @bashenv)
+  def self.postinstall
+    FileUtils.rm_f "#{CREW_PREFIX}/etc/bash.d/bash" if File.file?("#{CREW_PREFIX}/etc/bash.d/bash")
   end
 end

--- a/packages/bash.rb
+++ b/packages/bash.rb
@@ -3,24 +3,28 @@ require 'package'
 class Bash < Package
   description 'The GNU Bourne Again SHell is a Bourne-compatible shell with useful csh and ksh features.'
   homepage 'https://www.gnu.org/software/bash/'
-  version '5.2-1'
+  version '5.2-2'
   license 'GPL-3'
   compatibility 'all'
   source_url 'https://ftpmirror.gnu.org/bash/bash-5.2.tar.gz'
   source_sha256 'a139c166df7ff4471c5e0733051642ee5556c1cc8a4a78f145583c5c81ab32fb'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bash/5.2-1_armv7l/bash-5.2-1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bash/5.2-1_armv7l/bash-5.2-1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bash/5.2-1_i686/bash-5.2-1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bash/5.2-1_x86_64/bash-5.2-1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bash/5.2-2_armv7l/bash-5.2-2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bash/5.2-2_armv7l/bash-5.2-2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bash/5.2-2_i686/bash-5.2-2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bash/5.2-2_x86_64/bash-5.2-2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '06b11b54021d3aed9765959a7bb11d062c1fa5df454ce617dffdc0be9e9bab8f',
-     armv7l: '06b11b54021d3aed9765959a7bb11d062c1fa5df454ce617dffdc0be9e9bab8f',
-       i686: '30949988b5b75a3db5e0d33385a470e434b0b4cc584c837f9380cd5af4c489c8',
-     x86_64: '897db36a9bc15c296d519a77af77d0dee125f17a72dc923031a11910c3afd880'
+    aarch64: '5167feed4d0bfc86b1b13ea87eadf4167bdd879122ad1c113002fc367a5db57e',
+     armv7l: '5167feed4d0bfc86b1b13ea87eadf4167bdd879122ad1c113002fc367a5db57e',
+       i686: '9454bcfda1d88307a80c00f68e9a5294c29331ffdf3c6f951385faef3cd5ffb5',
+     x86_64: 'a777bad1a9ce382c07e73e192c48063baa481c53ef78bf5e74c32aeb60b9eefd'
   })
+
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  depends_on 'ncurses' # R
 
   def self.build
     system "./configure #{CREW_OPTIONS} \
@@ -59,9 +63,5 @@ class Bash < Package
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     FileUtils.ln_s "#{CREW_PREFIX}/bin/bash", "#{CREW_DEST_PREFIX}/bin/sh"
-  end
-
-  def self.postinstall
-    FileUtils.rm_f "#{CREW_PREFIX}/etc/bash.d/bash" if File.file?("#{CREW_PREFIX}/etc/bash.d/bash")
   end
 end

--- a/packages/bash_completion.rb
+++ b/packages/bash_completion.rb
@@ -3,23 +3,23 @@ require 'package'
 class Bash_completion < Package
   description 'Programmable completion functions for bash'
   homepage 'https://github.com/scop/bash-completion'
-  version '2.11'
+  version '2.11-1'
   license 'GPL-2+'
   compatibility 'all'
   source_url 'https://github.com/scop/bash-completion/archive/refs/tags/2.11.tar.gz'
   source_sha256 '16adefabf43ec8ffb473704f5724d775c2f47e9f750d7d608f0251ec21fe8813'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bash_completion/2.11_armv7l/bash_completion-2.11-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bash_completion/2.11_armv7l/bash_completion-2.11-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bash_completion/2.11_i686/bash_completion-2.11-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bash_completion/2.11_x86_64/bash_completion-2.11-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bash_completion/2.11-1_armv7l/bash_completion-2.11-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bash_completion/2.11-1_armv7l/bash_completion-2.11-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bash_completion/2.11-1_i686/bash_completion-2.11-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bash_completion/2.11-1_x86_64/bash_completion-2.11-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'dc426ff82ec4b0feb70d9a8b271269873127f95a5f8b8cde27c4aa38468afd27',
-     armv7l: 'dc426ff82ec4b0feb70d9a8b271269873127f95a5f8b8cde27c4aa38468afd27',
-       i686: '35c16db77e47df16451bfd3ecc9759c6debe9e74523a3644cf47fbc3b211fa3e',
-     x86_64: '75f84fe83ae7e4c308dc62ea26a1dffd886f1efe486f0ed9ba8587ee3e7f42bc'
+    aarch64: 'f08fa79964a1f0077f8c523ab3f72afcf287bab069aae3c475ef49a515689508',
+     armv7l: 'f08fa79964a1f0077f8c523ab3f72afcf287bab069aae3c475ef49a515689508',
+       i686: '3a8cd80d863f72a2f88fa27e4cdce054c9133361cfcea693c8fa23ddd3b692d1',
+     x86_64: 'ff8dce6b4da22853b8e558cbf814ed86fd1793b39a0123f64569cd09f80af27f'
   })
 
   def self.build
@@ -30,12 +30,5 @@ class Bash_completion < Package
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/bash.d/"
-    @bashcompletionenv = <<~BASHCOMPLETIONEOF
-      # Bash completion configuration
-      source #{CREW_PREFIX}/share/bash-completion/bash_completion
-    BASHCOMPLETIONEOF
-    File.write("#{CREW_DEST_PREFIX}/etc/bash.d/bash_completion", @bashcompletionenv)
   end
 end

--- a/packages/wayland.rb
+++ b/packages/wayland.rb
@@ -4,23 +4,23 @@ class Wayland < Package
   description 'Wayland is intended as a simpler replacement for X, easier to develop and maintain.'
   homepage 'https://wayland.freedesktop.org'
   @_ver = '1.21.0'
-  version @_ver.to_s
+  version "#{@_ver}-1"
   license 'MIT'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/wayland/wayland.git'
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland/1.21.0_armv7l/wayland-1.21.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland/1.21.0_armv7l/wayland-1.21.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland/1.21.0_i686/wayland-1.21.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland/1.21.0_x86_64/wayland-1.21.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland/1.21.0-1_armv7l/wayland-1.21.0-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland/1.21.0-1_armv7l/wayland-1.21.0-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland/1.21.0-1_i686/wayland-1.21.0-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland/1.21.0-1_x86_64/wayland-1.21.0-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '22d6cee271f0f480d15abcb2c6a8da1c827028c0a0ed7769c203bfccf4d6b19f',
-     armv7l: '22d6cee271f0f480d15abcb2c6a8da1c827028c0a0ed7769c203bfccf4d6b19f',
-       i686: 'b67a09052c16255f20eca0229c35fbc72a82249b4ecb7c2d3f5782a9048e66e0',
-     x86_64: '3581887e7e979738b82a9c4aecc8677797bed0b7702192e65f508d7ba487c637'
+    aarch64: '4a655aa1bab807fc82eaabc6c62489c0e0d576d1e16d01cebd536ba203d81832',
+     armv7l: '4a655aa1bab807fc82eaabc6c62489c0e0d576d1e16d01cebd536ba203d81832',
+       i686: 'b0c830aa7f4b7970b45b48b57b47ed4d765b2af6908ebf71e72f1814719bdd0e',
+     x86_64: '27ef241ce34cc01b8a36ccd4ae4b7dc83e080d9e6c3fdb12a1d99a5303fddf15'
   })
 
   depends_on 'expat'
@@ -29,6 +29,7 @@ class Wayland < Package
   depends_on 'icu4c'
   depends_on 'zlibpkg'
   depends_on 'libffi'
+  depends_on 'glibc' # R
 
   def self.build
     @wayland_env = <<~WAYLAND_ENV_EOF
@@ -40,6 +41,7 @@ class Wayland < Package
       : "${WAYLAND_DISPLAY:=wayland-0}"
       : "${CLUTTER_BACKEND:=wayland}"
       : "${GDK_BACKEND:=wayland}"
+      set +a
     WAYLAND_ENV_EOF
 
     system "meson #{CREW_MESON_OPTIONS} -Ddocumentation=false builddir"


### PR DESCRIPTION
Fixes #7462

## Description
- Fix wayland `env.d` file which didn't have a closing `set +a`. This was the primary problem.
- These are bash fixes to make startup more robust.
  - Change sommelier startup scripts:
    - Modification of `/usr/local/etc/bash.d/sommelier` in the sommelier package thus:
      `source /usr/local/bin/startsommelier`
    - Modification of `/usr/local/bin/startsommelier` in the sommelier package thus:
      Change `exit 1` to `return 1`. 
  - Move loading of Chromebrew bash (if installed) to /usr/local/etc/profile, so it is loaded as early as possible. This is actually in https://github.com/chromebrew/crew-profile-base/pull/10 and is independent, but bash is modified in this PR not to have this logic in `/usr/local/etc/bash.d/bash`.
  - Remove `bash.d` file from bash_completion since to avoid issues with it being loaded twice.

- _Tested by opening multiple subshells with wayland and sommelier installed._

<!-- (let GitHub automatically close an issue when this pull request gets merged) -->

<!--
## Before you submit a pull request

This template is not necessary when you do simple things like updating packages to the latest version. But in doubt, it's always better so provide some information.
-->


<!--
Provide a description, what your changes do and why they are important

Please link issues and other pull requests connected to this one.
-->

## Additional information
<!-- Mention things we might need to know. Like: -->

Works properly:
- [x] `x86_64` (tested on hardware - sommelier still works.)
- [x] `i686` (tested in container)
- [x] `armv7l` (tested in container)

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=fix_bash  CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
