### PR TITLE
update crew_profile_base to 0.0.8

### DIFF
--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -3,12 +3,12 @@ require 'package'
 class Crew_profile_base < Package
   description 'Crew-profile-base sets up Chromebrew\'s environment capabilities.'
   homepage 'https://github.com/chromebrew/crew-profile-base'
-  @_ver = '0.0.7'
+  @_ver = '0.0.8'
   version @_ver
   license 'GPL-3+'
   compatibility 'all'
   source_url "https://github.com/chromebrew/crew-profile-base/archive/#{@_ver}.tar.gz"
-  source_sha256 '05c8cfd4ea46c3321b2004675668cc92e9c9ce808d4de4a0eb2378081ed4f697'
+  source_sha256 '95642b0a8c7fe83ade2338ca68425ebf4598705633e8c0655cce8991b04697b7'
 
   no_compile_needed
   no_patchelf

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -3,12 +3,12 @@ require 'package'
 class Crew_profile_base < Package
   description 'Crew-profile-base sets up Chromebrew\'s environment capabilities.'
   homepage 'https://github.com/chromebrew/crew-profile-base'
-  @_ver = '0.0.6'
+  @_ver = '0.0.7'
   version @_ver
   license 'GPL-3+'
   compatibility 'all'
   source_url "https://github.com/chromebrew/crew-profile-base/archive/#{@_ver}.tar.gz"
-  source_sha256 'ead52834926a8af03f972cf8db85f9dd3a7d52da7e265e1958fffdc7c5595480'
+  source_sha256 '05c8cfd4ea46c3321b2004675668cc92e9c9ce808d4de4a0eb2378081ed4f697'
 
   no_compile_needed
   no_patchelf


### PR DESCRIPTION
- works locally, just needs to be tested during installs.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=profile_fix CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
