### PR TITLE
Some updates

### DIFF
--- a/packages/gcc10.rb
+++ b/packages/gcc10.rb
@@ -3,23 +3,23 @@ require 'package'
 class Gcc10 < Package
   description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, and Go.'
   homepage 'https://www.gnu.org/software/gcc/'
-  version '10.4.0'
-  license 'GPL-3'
+  version '10.4.0-1'
   compatibility 'all'
+  license 'GPL-3'
   source_url 'https://ftpmirror.gnu.org/gcc/gcc-10.4.0/gcc-10.4.0.tar.xz'
   source_sha256 'c9297d5bcd7cb43f3dfc2fed5389e948c9312fd962ef6a4ce455cff963ebe4f1'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc10/10.4.0_armv7l/gcc10-10.4.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc10/10.4.0_armv7l/gcc10-10.4.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc10/10.4.0_i686/gcc10-10.4.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc10/10.4.0_x86_64/gcc10-10.4.0-chromeos-x86_64.tar.zst'
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc10/10.4.0-1_i686/gcc10-10.4.0-1-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc10/10.4.0-1_x86_64/gcc10-10.4.0-1-chromeos-x86_64.tar.zst',
+ aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc10/10.4.0-1_armv7l/gcc10-10.4.0-1-chromeos-armv7l.tar.zst',
+  armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc10/10.4.0-1_armv7l/gcc10-10.4.0-1-chromeos-armv7l.tar.zst'
   })
   binary_sha256({
-    aarch64: 'b6c6a28cb3942b25d283b77420f850883e9d32aded05d2de079d4f8436e23e28',
-     armv7l: 'b6c6a28cb3942b25d283b77420f850883e9d32aded05d2de079d4f8436e23e28',
-       i686: 'f1cd1b358a700b07400af645a324a26a6895cf8f2bc93d2b1c21782e2eb9b750',
-     x86_64: 'd0f1cb59380cf1bf7806372752f8b3f9d472058cef7b63a33df3bfc18e9fb985'
+    i686: 'f1cd1b358a700b07400af645a324a26a6895cf8f2bc93d2b1c21782e2eb9b750',
+  x86_64: 'd0f1cb59380cf1bf7806372752f8b3f9d472058cef7b63a33df3bfc18e9fb985',
+ aarch64: 'dab3fe7fa5c509f18cc20e2c067e37363f3471688cfbd6c1d875bf1b71ce77b4',
+  armv7l: 'dab3fe7fa5c509f18cc20e2c067e37363f3471688cfbd6c1d875bf1b71ce77b4'
   })
 
   depends_on 'binutils' => :build
@@ -32,6 +32,7 @@ class Gcc10 < Package
   depends_on 'mpfr' # R
   depends_on 'zlibpkg' # R
   depends_on 'zstd' # R
+  depends_on 'gcc' # R
 
   conflicts_ok
   no_env_options
@@ -90,12 +91,14 @@ class Gcc10 < Package
     @languages = 'c,c++,jit,objc,fortran'
     case ARCH
     when 'armv7l', 'aarch64'
-      @archflags = '--with-arch=armv8-a+crc+simd --with-float=hard --with-fpu=neon --with-tune=cortex-a15'
+      @archflags = '--with-arch=armv7-a+fp --with-float=hard --with-tune=cortex-a15'
     when 'x86_64'
       @archflags = '--with-arch-64=x86-64'
     when 'i686'
       @archflags = '--with-arch-32=i686'
     end
+
+    @path = "#{CREW_PREFIX}/bin:/usr/bin:/bin"
 
     # Install prereqs using the standard gcc method so they can be
     # linked statically.

--- a/packages/gcc10.rb
+++ b/packages/gcc10.rb
@@ -10,16 +10,16 @@ class Gcc10 < Package
   source_sha256 'c9297d5bcd7cb43f3dfc2fed5389e948c9312fd962ef6a4ce455cff963ebe4f1'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc10/10.4.0-1_i686/gcc10-10.4.0-1-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc10/10.4.0-1_x86_64/gcc10-10.4.0-1-chromeos-x86_64.tar.zst',
- aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc10/10.4.0-1_armv7l/gcc10-10.4.0-1-chromeos-armv7l.tar.zst',
-  armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc10/10.4.0-1_armv7l/gcc10-10.4.0-1-chromeos-armv7l.tar.zst'
+        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc10/10.4.0-1_i686/gcc10-10.4.0-1-chromeos-i686.tar.zst',
+      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc10/10.4.0-1_x86_64/gcc10-10.4.0-1-chromeos-x86_64.tar.zst',
+     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc10/10.4.0-1_armv7l/gcc10-10.4.0-1-chromeos-armv7l.tar.zst',
+      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc10/10.4.0-1_armv7l/gcc10-10.4.0-1-chromeos-armv7l.tar.zst'
   })
   binary_sha256({
-    i686: 'f1cd1b358a700b07400af645a324a26a6895cf8f2bc93d2b1c21782e2eb9b750',
-  x86_64: 'd0f1cb59380cf1bf7806372752f8b3f9d472058cef7b63a33df3bfc18e9fb985',
- aarch64: 'dab3fe7fa5c509f18cc20e2c067e37363f3471688cfbd6c1d875bf1b71ce77b4',
-  armv7l: 'dab3fe7fa5c509f18cc20e2c067e37363f3471688cfbd6c1d875bf1b71ce77b4'
+        i686: 'f1cd1b358a700b07400af645a324a26a6895cf8f2bc93d2b1c21782e2eb9b750',
+      x86_64: 'd0f1cb59380cf1bf7806372752f8b3f9d472058cef7b63a33df3bfc18e9fb985',
+     aarch64: 'dab3fe7fa5c509f18cc20e2c067e37363f3471688cfbd6c1d875bf1b71ce77b4',
+      armv7l: 'dab3fe7fa5c509f18cc20e2c067e37363f3471688cfbd6c1d875bf1b71ce77b4'
   })
 
   depends_on 'binutils' => :build

--- a/packages/icu4c.rb
+++ b/packages/icu4c.rb
@@ -3,27 +3,29 @@ require 'package'
 class Icu4c < Package
   description 'ICU is a mature, widely used set of C/C++ and Java libraries providing Unicode and Globalization support for software applications.'
   homepage 'http://site.icu-project.org/'
-  version '72.1'
+  version '72.1-1'
   license 'BSD'
   compatibility 'all'
   source_url 'https://github.com/unicode-org/icu/releases/download/release-72-1/icu4c-72_1-src.tgz'
   source_sha256 'a2d2d38217092a7ed56635e34467f92f976b370e20182ad325edea6681a71d68'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/icu4c/72.1_armv7l/icu4c-72.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/icu4c/72.1_armv7l/icu4c-72.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/icu4c/72.1_i686/icu4c-72.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/icu4c/72.1_x86_64/icu4c-72.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/icu4c/72.1-1_armv7l/icu4c-72.1-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/icu4c/72.1-1_armv7l/icu4c-72.1-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/icu4c/72.1-1_i686/icu4c-72.1-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/icu4c/72.1-1_x86_64/icu4c-72.1-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'c48a08ef474cf15375659a1a4e95db3cca08416c7943492ac539aa3d1d17ac64',
-     armv7l: 'c48a08ef474cf15375659a1a4e95db3cca08416c7943492ac539aa3d1d17ac64',
-       i686: '1572cb682daab3c6e65b4407c7c6f74d5f72f394cd08a9784f4e3f8e4d0c445f',
-     x86_64: 'fd6fdebe976e837378174b6923067491c2d965cdf1b9f252c6728cf98c32b932'
+    aarch64: '9ad0f6474bb946741894b8617b98e8fbf32425c63180fa423976030528a68fec',
+     armv7l: '9ad0f6474bb946741894b8617b98e8fbf32425c63180fa423976030528a68fec',
+       i686: 'e5615e175709b26a73c1721816fa68a704de2580fddb1ab76c58d89d721693af',
+     x86_64: '7b759ad277ee961d76520a430cd50f2245758490110933d8af326fb3345c8691'
   })
 
   depends_on 'gcc' # R
   depends_on 'glibc' # R
+
+  no_patchelf
 
   def self.build
     FileUtils.cd('source') do
@@ -84,7 +86,7 @@ class Icu4c < Package
         end
         # Mozjs contains an internal icu which will not match this version.
         # Update the following when there is a new version of mozjs.
-        @fileArray.delete_if {|item| item == 'js102'}
+        @fileArray.delete_if { |item| item == 'js102' }
         next if @fileArray.empty?
 
         @fileArray.uniq.sort.each do |item|

--- a/packages/jack.rb
+++ b/packages/jack.rb
@@ -3,39 +3,43 @@ require 'package'
 class Jack < Package
   description 'JACK (JACK Audio Connection Kit) refers to an API that provides a basic infrastructure for audio applications to communicate with each other and with audio hardware.'
   homepage 'https://jackaudio.org/'
-  @_ver = '1.9.17'
+  @_ver = '1.9.21'
   version @_ver
   license 'GPL-2+'
   compatibility 'all'
   source_url "https://github.com/jackaudio/jack2/archive/v#{@_ver}.tar.gz"
-  source_sha256 '38f674bbc57852a8eb3d9faa1f96a0912d26f7d5df14c11005ad499c8ae352f2'
+  source_sha256 '8b044a40ba5393b47605a920ba30744fdf8bf77d210eca90d39c8637fe6bc65d'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jack/1.9.17_armv7l/jack-1.9.17-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jack/1.9.17_armv7l/jack-1.9.17-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jack/1.9.17_i686/jack-1.9.17-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jack/1.9.17_x86_64/jack-1.9.17-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jack/1.9.21_armv7l/jack-1.9.21-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jack/1.9.21_armv7l/jack-1.9.21-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jack/1.9.21_i686/jack-1.9.21-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jack/1.9.21_x86_64/jack-1.9.21-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'd18c47ae88f28ada701a4938cf26db6659ed9425006e0a81b887be1f8868a280',
-     armv7l: 'd18c47ae88f28ada701a4938cf26db6659ed9425006e0a81b887be1f8868a280',
-       i686: '0946a39b386d3f4434e1a4d735342918537f302acfba6641ed888e76c058fae0',
-     x86_64: 'f8cf79f4a8402e8c4cdcfe8d31cc9357ba3404d5bfe57a8dea7fac4ec12bd091'
+    aarch64: '6185f7f83066b59da49430902bf6cb99d3c69922e41d96ef18456bd27fdedaa6',
+     armv7l: '6185f7f83066b59da49430902bf6cb99d3c69922e41d96ef18456bd27fdedaa6',
+       i686: '135adfcefb183334fc3e70d88758e377b37c4d75fcd5509d665f31c70e3e1784',
+     x86_64: 'b4c6d93821733e2f834e460ce7ca206df2ef19e2480338a174adc15bc95cf4b2'
   })
 
   depends_on 'dbus'
   depends_on 'alsa_lib'
   depends_on 'libdb'
   depends_on 'libsndfile'
+  depends_on 'expat' # R
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  depends_on 'opus' # R
 
   def self.patch
     # Set the correct python executable path.
     system "sed -i 's,/usr/bin,#{CREW_PREFIX}/bin,' waf"
+    system "sed -i 's,/usr/bin,#{CREW_PREFIX}/bin,' dbus/jack_control"
   end
 
   def self.build
-    system "env CFLAGS=-fno-stack-protector \
-      ./waf configure \
+    system "./waf configure \
       --dbus \
       --classic \
       --db=yes \

--- a/packages/libxml2.rb
+++ b/packages/libxml2.rb
@@ -3,23 +3,23 @@ require 'package'
 class Libxml2 < Package
   description 'Libxml2 is the XML C parser and toolkit developed for the Gnome project.'
   homepage 'http://xmlsoft.org/'
-  version '2.10.2-1'
+  version '2.10.3'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.10.2/libxml2-v2.10.2.tar.bz2'
-  source_sha256 'd50e8a55b2797501929d3411b81d5d37ec44e9a4aa58eae9052572977c632d7a'
+  source_url 'https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.10.3/libxml2-v2.10.3.tar.bz2'
+  source_sha256 '302bbb86400b8505bebfbf7b3d1986e9aa05073198979f258eed4be481ff5f83'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.10.2-1_armv7l/libxml2-2.10.2-1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.10.2-1_armv7l/libxml2-2.10.2-1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.10.2-1_i686/libxml2-2.10.2-1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.10.2-1_x86_64/libxml2-2.10.2-1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.10.3_armv7l/libxml2-2.10.3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.10.3_armv7l/libxml2-2.10.3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.10.3_i686/libxml2-2.10.3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libxml2/2.10.3_x86_64/libxml2-2.10.3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '69c9c14c155c554bb8a093f65537233c6844fc2e8bb4c4700942091a3e1bb8db',
-     armv7l: '69c9c14c155c554bb8a093f65537233c6844fc2e8bb4c4700942091a3e1bb8db',
-       i686: 'f416b5a9c84e55e249cfb8249bb5b67f67d5d2b32ce28a8b80678f22a1516fac',
-     x86_64: '14cc527ce6f0f9622974069459a1d931910de6df810fecb91e806d813a34ad93'
+    aarch64: 'dd632f61bf378aa089500a377e1192650e7ee22d373f09ee3be981a54db764be',
+     armv7l: 'dd632f61bf378aa089500a377e1192650e7ee22d373f09ee3be981a54db764be',
+       i686: '5a49faa80100a3a7d893ead1a324773c671550cb6647cab48660acec35dbfcde',
+     x86_64: 'a54015b9df27a83262c999d2e00946c928206900a4303ee0f6b3e44b46597d56'
   })
 
   depends_on 'gcc' # R
@@ -28,11 +28,12 @@ class Libxml2 < Package
   depends_on 'ncurses'
   depends_on 'readline' # R
   depends_on 'zlibpkg' # R
+
   no_patchelf
 
   def self.patch
     # Fix encoding.c:1961:31: error: ‘TRUE’ undeclared (first use in this function)
-    system "for f in \$(grep -rl \'TRUE)\'); do sed -i 's,TRUE),true),g' \$f; done"
+    system "for f in $(grep -rl 'TRUE)'); do sed -i 's,TRUE),true),g' $f; done"
   end
 
   def self.build

--- a/packages/py3_libxml2.rb
+++ b/packages/py3_libxml2.rb
@@ -3,28 +3,31 @@ require 'package'
 class Py3_libxml2 < Package
   description 'Libxml2-python provides access to libxml2 and libxslt in Python.'
   homepage 'https://gitlab.gnome.org/GNOME/libxml2/'
-  version '2.10.2'
+  @_ver = '2.10.3'
+  version "#{@_ver}-py3.10"
   license 'MIT'
   compatibility 'all'
-  source_url 'https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.10.2/libxml2-v2.10.2.tar.bz2'
-  source_sha256 'd50e8a55b2797501929d3411b81d5d37ec44e9a4aa58eae9052572977c632d7a'
+  source_url 'https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.10.3/libxml2-v2.10.3.tar.bz2'
+  source_sha256 '302bbb86400b8505bebfbf7b3d1986e9aa05073198979f258eed4be481ff5f83'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_libxml2/2.10.2_armv7l/py3_libxml2-2.10.2-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_libxml2/2.10.2_armv7l/py3_libxml2-2.10.2-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_libxml2/2.10.2_i686/py3_libxml2-2.10.2-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_libxml2/2.10.2_x86_64/py3_libxml2-2.10.2-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_libxml2/2.10.3-py3.10_armv7l/py3_libxml2-2.10.3-py3.10-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_libxml2/2.10.3-py3.10_armv7l/py3_libxml2-2.10.3-py3.10-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_libxml2/2.10.3-py3.10_i686/py3_libxml2-2.10.3-py3.10-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_libxml2/2.10.3-py3.10_x86_64/py3_libxml2-2.10.3-py3.10-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '198aec6c86c106f45a2d945032ec232a5650a7a5f2630da11ad9d11eb40a7592',
-     armv7l: '198aec6c86c106f45a2d945032ec232a5650a7a5f2630da11ad9d11eb40a7592',
-       i686: '16f08ba727a13268c8a0a4516a9c81f1bcc9291a81d8a4c1e5cdeb2aa6473a98',
-     x86_64: 'd5578c3e0aac30896b6f198e9b93988e055b5deca57dbaed7c9fda12b60aaa80'
+    aarch64: '78aa7d4890fe6890dfa4d61d285a193ba57d4856db0bd31037c8f0ec563debcd',
+     armv7l: '78aa7d4890fe6890dfa4d61d285a193ba57d4856db0bd31037c8f0ec563debcd',
+       i686: '58b5d28a139656758a015d580943a8a6a049e31526d21e09e57aee8358100ee3',
+     x86_64: 'e66f9d4928223c33cbd1ae060f39da55b87ff1a4cb4ded49272650b97481c4cd'
   })
 
   depends_on 'libxml2'
   depends_on 'libxslt'
   depends_on 'py3_setuptools' => :build
+  depends_on 'glibc' # R
+  depends_on 'zlibpkg' # R
 
   def self.build
     system 'autoreconf -fiv'

--- a/packages/yelp_tools.rb
+++ b/packages/yelp_tools.rb
@@ -3,28 +3,32 @@ require 'package'
 class Yelp_tools < Package
   description 'yelp-tools is a collection of scripts and build utilities to help create, manage, and publish documentation for Yelp and the web'
   homepage 'https://github.com/GNOME/yelp-tools'
-  version '42.0'
+  version '42.1'
   license 'GPL-2+ or freedist and GPL-2+'
   compatibility 'all'
   source_url "https://gitlab.gnome.org/GNOME/yelp-tools/-/archive/#{version}/yelp-tools-#{version}.tar.bz2"
-  source_sha256 'c71a7b10adb91712887c96541ce6eedf7c6f68d0cd1fa67bce0b27c46c3b2b05'
+  source_sha256 '40aadae0c6f0af41f90bcaba532d20b5b401476d64b2650aa419ef6264c00ecd'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/yelp_tools/42.0_armv7l/yelp_tools-42.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/yelp_tools/42.0_armv7l/yelp_tools-42.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/yelp_tools/42.0_i686/yelp_tools-42.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/yelp_tools/42.0_x86_64/yelp_tools-42.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/yelp_tools/42.1_armv7l/yelp_tools-42.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/yelp_tools/42.1_armv7l/yelp_tools-42.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/yelp_tools/42.1_i686/yelp_tools-42.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/yelp_tools/42.1_x86_64/yelp_tools-42.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'bdf45b19f8c95e000cb32ca96f0b17946177487a1294f5812cb200e3a4d94a58',
-     armv7l: 'bdf45b19f8c95e000cb32ca96f0b17946177487a1294f5812cb200e3a4d94a58',
-       i686: '8431a64a6b7790d78fad98baf9cbddcf129cebe130f337a111f62310b147a7da',
-     x86_64: 'e513576b06f6d6d2a027e120e3dcfb3774fd9222e47d69a4749f0ed3db67b9f8'
+    aarch64: '70792bf80c6bb3f66c959acdad595a2ff08fef8de990e41b700f74d0ae6a931e',
+     armv7l: '70792bf80c6bb3f66c959acdad595a2ff08fef8de990e41b700f74d0ae6a931e',
+       i686: 'eee77db471affeb7110d6c4cff18a1d4ea624d58803420a5654a4f3442fa2d07',
+     x86_64: 'dec4d9bac63673a7fa572d7006d2f139caa4d10da8c1b965e36719135755a99d'
   })
 
   depends_on 'yelp_xsl'
   depends_on 'libxslt'
   depends_on 'py3_lxml'
+
+  def self.patch
+    system "sed -i 's,/usr/bin/python3,#{CREW_PREFIX}/bin/python3,g' tools/*.in"
+  end
 
   def self.build
     system "meson #{CREW_MESON_OPTIONS} \


### PR DESCRIPTION
- libxml2 -> 2.10.3
- yelp_tools -> 42.1
- gcc10 rebuilt for `armv7l`
- jack -> 1.9.21
- icu4c built w/ `no_patchelf` (fixes i686 installs)

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=some_updates  CREW_TESTING=1 crew update
```
