### PR TITLE
Musl OpenSSL -> 3.0.7

### DIFF
--- a/packages/musl_openssl.rb
+++ b/packages/musl_openssl.rb
@@ -3,24 +3,24 @@ require 'package'
 class Musl_openssl < Package
   description 'The Open Source toolkit for Secure Sockets Layer and Transport Layer Security'
   homepage 'https://www.openssl.org'
-  @_ver = '3.0.5'
+  @_ver = '3.0.7'
   version @_ver
   license 'openssl'
   compatibility 'all'
   source_url "https://www.openssl.org/source/openssl-#{@_ver}.tar.gz"
-  source_sha256 'aa7d8d9bef71ad6525c55ba11e5f4397889ce49c2c9349dcea6d3e4f0b024a7a'
+  source_sha256 '83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.5_armv7l/musl_openssl-3.0.5-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.5_armv7l/musl_openssl-3.0.5-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.5_i686/musl_openssl-3.0.5-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.5_x86_64/musl_openssl-3.0.5-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.7_armv7l/musl_openssl-3.0.7-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.7_armv7l/musl_openssl-3.0.7-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.7_i686/musl_openssl-3.0.7-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_openssl/3.0.7_x86_64/musl_openssl-3.0.7-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '3ebcd412658d981868446b6f981a0cad2c1d2a4d071551a5ec9bc08b260d152f',
-     armv7l: '3ebcd412658d981868446b6f981a0cad2c1d2a4d071551a5ec9bc08b260d152f',
-       i686: '682ee9aecdfd610a3578edc9b1d6250bf927d368711dde8acd16fedb771b0c62',
-     x86_64: 'c90fa52f2088f1d5b4c442807cd75b128f2b9b798eb4020a9f4af4b81b07cffe'
+    aarch64: '3d9aa6f889b0b804025ce70eed32894e1c07b7762ae94374a29137bf1b564e90',
+     armv7l: '3d9aa6f889b0b804025ce70eed32894e1c07b7762ae94374a29137bf1b564e90',
+       i686: '3ac71992c6298f746d4bb497b1091acf1a18d09c4337ee733ae0b38a842cc18f',
+     x86_64: '1601e49a3221acab4897b99e4de3c975b6128f304eb7a99b89de72381ed1203e'
   })
 
   depends_on 'musl_native_toolchain' => :build


### PR DESCRIPTION
- Obviously this doesn't fixup the static linked musl binary packages which use OpenSSL, which are no longer in use, but this is useful if someone does want to rebuild those.

Builds properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=openssl307 CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
