### PR TITLE
gcc rebuild with new armv7l flags

### DIFF
--- a/packages/gcc.rb
+++ b/packages/gcc.rb
@@ -10,16 +10,16 @@ class Gcc < Package
   git_hashtag 'b80a690673272919896ee5939250e50d882f2418'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc/12.2.1-b80a690_i686/gcc-12.2.1-b80a690-chromeos-i686.tar.xz',
- aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc/12.2.1-b80a690_armv7l/gcc-12.2.1-b80a690-chromeos-armv7l.tar.zst',
-  armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc/12.2.1-b80a690_armv7l/gcc-12.2.1-b80a690-chromeos-armv7l.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc/12.2.1-b80a690_x86_64/gcc-12.2.1-b80a690-chromeos-x86_64.tar.zst'
+      i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc/12.2.1-b80a690_i686/gcc-12.2.1-b80a690-chromeos-i686.tar.xz',
+   aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc/12.2.1-b80a690_armv7l/gcc-12.2.1-b80a690-chromeos-armv7l.tar.zst',
+    armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc/12.2.1-b80a690_armv7l/gcc-12.2.1-b80a690-chromeos-armv7l.tar.zst',
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc/12.2.1-b80a690_x86_64/gcc-12.2.1-b80a690-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    i686: '14de19fc4bf6d97c936541593e79638b4661855d1b3bfe3f14d3d520870951de',
- aarch64: '423cf37574ab4844dd27214c3f048730eacf2af114c6973cb1236e498cb655c2',
-  armv7l: '423cf37574ab4844dd27214c3f048730eacf2af114c6973cb1236e498cb655c2',
-  x86_64: '62a41fb9a13969fe9ecca02f4f8db153abd15ae66874154735aeee22009e7c8e'
+      i686: '14de19fc4bf6d97c936541593e79638b4661855d1b3bfe3f14d3d520870951de',
+   aarch64: '423cf37574ab4844dd27214c3f048730eacf2af114c6973cb1236e498cb655c2',
+    armv7l: '423cf37574ab4844dd27214c3f048730eacf2af114c6973cb1236e498cb655c2',
+    x86_64: '62a41fb9a13969fe9ecca02f4f8db153abd15ae66874154735aeee22009e7c8e'
   })
 
   depends_on 'binutils' => :build

--- a/packages/gcc.rb
+++ b/packages/gcc.rb
@@ -3,23 +3,23 @@ require 'package'
 class Gcc < Package
   description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, and Go.'
   homepage 'https://www.gnu.org/software/gcc/'
-  version '12.2'
+  version '12.2.1-b80a690'
   license 'GPL-3, LGPL-3, libgcc, FDL-1.2'
   compatibility 'all'
-  source_url 'https://gcc.gnu.org/pub/gcc/releases/gcc-12.2.0/gcc-12.2.0.tar.xz'
-  source_sha256 'e549cf9cf3594a00e27b6589d4322d70e0720cdd213f39beb4181e06926230ff'
+  source_url 'https://github.com/gcc-mirror/gcc.git'
+  git_hashtag 'b80a690673272919896ee5939250e50d882f2418'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc/12.2_armv7l/gcc-12.2-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc/12.2_armv7l/gcc-12.2-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc/12.2_i686/gcc-12.2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc/12.2_x86_64/gcc-12.2-chromeos-x86_64.tar.zst'
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc/12.2.1-b80a690_i686/gcc-12.2.1-b80a690-chromeos-i686.tar.xz',
+ aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc/12.2.1-b80a690_armv7l/gcc-12.2.1-b80a690-chromeos-armv7l.tar.zst',
+  armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc/12.2.1-b80a690_armv7l/gcc-12.2.1-b80a690-chromeos-armv7l.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gcc/12.2.1-b80a690_x86_64/gcc-12.2.1-b80a690-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '0b6ba2549556fdcfe489253ee99362bf4d5278411f695433121ac82665a5521e',
-     armv7l: '0b6ba2549556fdcfe489253ee99362bf4d5278411f695433121ac82665a5521e',
-       i686: '80d91fa11b291a5e89f7f14a31149c96ebcb26ed2a34560a216d8f184ee788a6',
-     x86_64: '01efdcdab6bebc32fd5608f6a061c7ceebd69e9f96084293a903f5af9c3576f3'
+    i686: '14de19fc4bf6d97c936541593e79638b4661855d1b3bfe3f14d3d520870951de',
+ aarch64: '423cf37574ab4844dd27214c3f048730eacf2af114c6973cb1236e498cb655c2',
+  armv7l: '423cf37574ab4844dd27214c3f048730eacf2af114c6973cb1236e498cb655c2',
+  x86_64: '62a41fb9a13969fe9ecca02f4f8db153abd15ae66874154735aeee22009e7c8e'
   })
 
   depends_on 'binutils' => :build
@@ -119,7 +119,7 @@ class Gcc < Package
     @languages = 'c,c++,jit,objc,fortran'
     case ARCH
     when 'armv7l', 'aarch64'
-      @archflags = '--with-arch=armv7-a+fp --with-float=hard --with-fpu=neon --with-tune=cortex-a15'
+      @archflags = '--with-arch=armv7-a+fp --with-float=hard --with-tune=cortex-a15 --with-fpu=vfpv3-d16'
     when 'x86_64'
       @archflags = '--with-arch-64=x86-64'
     when 'i686'

--- a/packages/libssp.rb
+++ b/packages/libssp.rb
@@ -3,28 +3,29 @@ require 'package'
 class Libssp < Package
   description 'Libssp is a part of the GCC toolkit.'
   homepage 'https://gcc.gnu.org/'
-  version '12.2'
+  version '12.2.1-b80a690'
   license 'GPL-3, LGPL-3, libgcc, FDL-1.2'
   compatibility 'all'
-  source_url 'https://gcc.gnu.org/pub/gcc/releases/gcc-12.2.0/gcc-12.2.0.tar.xz'
-  source_sha256 'e549cf9cf3594a00e27b6589d4322d70e0720cdd213f39beb4181e06926230ff'
+  source_url 'https://github.com/gcc-mirror/gcc.git'
+  git_hashtag 'b80a690673272919896ee5939250e50d882f2418'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/12.2_armv7l/libssp-12.2-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/12.2_armv7l/libssp-12.2-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/12.2_i686/libssp-12.2-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/12.2_x86_64/libssp-12.2-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/12.2.1-b80a690_armv7l/libssp-12.2.1-b80a690-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/12.2.1-b80a690_armv7l/libssp-12.2.1-b80a690-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/12.2.1-b80a690_i686/libssp-12.2.1-b80a690-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssp/12.2.1-b80a690_x86_64/libssp-12.2.1-b80a690-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '12e848c7b5dc490fc1d50de44af5f225791b3cb267aef211b8d5d3cf5402b177',
-     armv7l: '12e848c7b5dc490fc1d50de44af5f225791b3cb267aef211b8d5d3cf5402b177',
-       i686: '77ea4f910386890351fe165865a20befc0b341564a3af20b277e6b1009f0748b',
-     x86_64: 'cee79cece69c1b35aaa1551bb1e581d3b8c4176fc08aefdfe4fe1999fcf5f78b'
+    aarch64: '3776481deeb8dde51144ddf76be645b6a5935d0fc8b8ed72a4371887eb54c78b',
+     armv7l: '3776481deeb8dde51144ddf76be645b6a5935d0fc8b8ed72a4371887eb54c78b',
+       i686: '1031c6b3d3b917c59674fcfb89d36e800d4e4671dfed387b930992cf0ad53484',
+     x86_64: 'f9889ae9a6f85730a203793f891c7152cf6e548d0fd012929bd719230157ee97'
   })
 
   depends_on 'ccache' => :build
   depends_on 'dejagnu' => :build # for test
   depends_on 'glibc' # R
+
   patchelf
 
   @gcc_name = 'libssp'
@@ -62,7 +63,7 @@ class Libssp < Package
   @languages = 'c,c++,jit,objc,fortran,go'
   case ARCH
   when 'armv7l', 'aarch64'
-    @archflags = '--with-arch=armv7-a+fp --with-float=hard --with-fpu=neon --with-tune=cortex-a15'
+    @archflags = '--with-arch=armv7-a+fp --with-float=hard --with-tune=cortex-a15 --with-fpu=vfpv3-d16'
   when 'x86_64'
     @archflags = '--with-arch-64=x86-64'
   when 'i686'


### PR DESCRIPTION
- Goal is to match Debian `armhf` options so that it is easier to debug build failures for builds that work on Debian `armhf`.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=gcc CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
