### PR TITLE
Webkit2gtk{_4,_4_1} Builds added for armv7l, i686

### DIFF
--- a/packages/epiphany.rb
+++ b/packages/epiphany.rb
@@ -8,14 +8,18 @@ class Epiphany < Package
   homepage 'https://wiki.gnome.org/Apps/Web'
   version '43.0'
   license 'GPL'
-  compatibility 'x86_64 aarch64 armv7l'
+  compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/epiphany.git'
   git_hashtag version
 
   binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/epiphany/43.0_armv7l/epiphany-43.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/epiphany/43.0_armv7l/epiphany-43.0-chromeos-armv7l.tar.zst',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/epiphany/43.0_x86_64/epiphany-43.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
+    aarch64: 'd494c6e107ea6fb881b5d28ff67fa3e6ec2f6091ce4b8e00e3c6253d4d3de7cb',
+     armv7l: 'd494c6e107ea6fb881b5d28ff67fa3e6ec2f6091ce4b8e00e3c6253d4d3de7cb',
      x86_64: '143a6f9be5dbd4df49fee28c43ae4eabfc7820cffacf186e9d729f7eb6572ae2'
   })
 
@@ -51,6 +55,7 @@ class Epiphany < Package
   depends_on 'libxml2' # R
   depends_on 'nettle' # R
   depends_on 'sqlite' # R
+  depends_on 'gcc' # R
   gnome
 
   def self.build

--- a/packages/epiphany.rb
+++ b/packages/epiphany.rb
@@ -8,7 +8,7 @@ class Epiphany < Package
   homepage 'https://wiki.gnome.org/Apps/Web'
   version '43.0'
   license 'GPL'
-  compatibility 'all'
+  compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.gnome.org/GNOME/epiphany.git'
   git_hashtag version
 

--- a/packages/gemacs.rb
+++ b/packages/gemacs.rb
@@ -5,15 +5,19 @@ class Gemacs < Package
   homepage 'https://www.gnu.org/software/emacs/'
   version '28.2'
   license 'GPL-3+, FDL-1.3+, BSD, HPND, MIT, W3C, unicode, PSF-2'
-  compatibility 'x86_64 i686'
+  compatibility 'all'
   source_url 'https://ftpmirror.gnu.org/emacs/emacs-28.2.tar.xz'
   source_sha256 'ee21182233ef3232dc97b486af2d86e14042dbb65bbc535df562c3a858232488'
 
   binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gemacs/28.2_armv7l/gemacs-28.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gemacs/28.2_armv7l/gemacs-28.2-chromeos-armv7l.tar.zst',
        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gemacs/28.2_i686/gemacs-28.2-chromeos-i686.tar.zst',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gemacs/28.2_x86_64/gemacs-28.2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
+    aarch64: 'ee40e23f622347d65983dc172acf7727238f963e3ac12ad7456c5409dc6bf323',
+     armv7l: 'ee40e23f622347d65983dc172acf7727238f963e3ac12ad7456c5409dc6bf323',
        i686: 'd3c1c2133ca735512de8b77069093f78110a41377962080a69271d5052d18a46',
      x86_64: 'ed1a8eacde7a8a17be9fb11a2bcdf83d3ce03ba3d78ebbb71884f808f515debd'
   })
@@ -58,7 +62,7 @@ class Gemacs < Package
   depends_on 'ncurses' # R
   depends_on 'pango' # R
   depends_on 'texinfo'
-  depends_on 'webkit2gtk'
+  depends_on 'webkit2gtk_4'
   depends_on 'zlibpkg' # R
 
   def self.build

--- a/packages/webkit2gtk_4.rb
+++ b/packages/webkit2gtk_4.rb
@@ -8,12 +8,16 @@ class Webkit2gtk_4 < Package
   source_sha256 '02e195b3fb9e057743b3364ee7f1eec13f71614226849544c07c32a73b8f1848'
 
   binary_url({
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.38.1_i686/webkit2gtk_4-2.38.1-chromeos-i686.tar.zst',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.38.1_x86_64/webkit2gtk_4-2.38.1-chromeos-x86_64.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.38.1_i686/webkit2gtk_4-2.38.1-chromeos-i686.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.38.1_armv7l/webkit2gtk_4-2.38.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.38.1_armv7l/webkit2gtk_4-2.38.1-chromeos-armv7l.tar.zst'
   })
   binary_sha256({
+       i686: '82925fa9774bddd1385b6deb2eef4738cba73aeff6e18df92294c446ca2752fc',
      x86_64: '117945f103fe1af58638451841fff222d5b8c699eb65c05215cce6613f765a65',
-       i686: '82925fa9774bddd1385b6deb2eef4738cba73aeff6e18df92294c446ca2752fc'
+    aarch64: 'e3f889dc849f2f2038dbe702c128e8e111707e35d4e719eff07d7e58ab2c9fc2',
+     armv7l: 'e3f889dc849f2f2038dbe702c128e8e111707e35d4e719eff07d7e58ab2c9fc2'
   })
 
   depends_on 'atk' # R
@@ -79,44 +83,44 @@ class Webkit2gtk_4 < Package
     @arch_flags = ''
     @gcc_ver = ''
     if ARCH == 'armv7l' || ARCH == 'aarch64'
-      # Patch from https://bugs.webkit.org/show_bug.cgi?id=226557#c27 to
-      # handle issue with gcc > 11.
-      @gcc_patch = <<~'GCCEOF'
-        diff --git a/Source/cmake/WebKitCompilerFlags.cmake b/Source/cmake/WebKitCompilerFlags.cmake
-        index 77ebb802ebb03450b5e96629a47b6819a68672c6..d49d6e43d7eeb6673c624e00eadf3edfca0674eb 100644
-        --- a/Source/cmake/WebKitCompilerFlags.cmake
-        +++ b/Source/cmake/WebKitCompilerFlags.cmake
-        @@ -143,6 +143,13 @@ if (COMPILER_IS_GCC_OR_CLANG)
-                 WEBKIT_PREPEND_GLOBAL_CXX_FLAGS(-Wno-nonnull)
-             endif ()
+      ## Patch from https://bugs.webkit.org/show_bug.cgi?id=226557#c27 to
+      ## handle issue with gcc > 11.
+      # @gcc_patch = <<~'GCCEOF'
+      # diff --git a/Source/cmake/WebKitCompilerFlags.cmake b/Source/cmake/WebKitCompilerFlags.cmake
+      # index 77ebb802ebb03450b5e96629a47b6819a68672c6..d49d6e43d7eeb6673c624e00eadf3edfca0674eb 100644
+      #--- a/Source/cmake/WebKitCompilerFlags.cmake
+      #+++ b/Source/cmake/WebKitCompilerFlags.cmake
+      # @@ -143,6 +143,13 @@ if (COMPILER_IS_GCC_OR_CLANG)
+      # WEBKIT_PREPEND_GLOBAL_CXX_FLAGS(-Wno-nonnull)
+      # endif ()
 
-        +    # This triggers warnings in wtf/Packed.h, a header that is included in many places. It does not
-        +    # respect ignore warning pragmas and we cannot easily suppress it for all affected files.
-        +    # https://bugs.webkit.org/show_bug.cgi?id=226557
-        +    if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "11.0")
-        +        WEBKIT_PREPEND_GLOBAL_CXX_FLAGS(-Wno-stringop-overread)
-        +    endif ()
-        +
-             # -Wexpansion-to-defined produces false positives with GCC but not Clang
-             # https://bugs.webkit.org/show_bug.cgi?id=167643#c13
-             if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-      GCCEOF
-      File.write('gcc.patch', @gcc_patch)
-      system 'patch -Np1 -F 10 -i gcc.patch'
+      #+    # This triggers warnings in wtf/Packed.h, a header that is included in many places. It does not
+      #+    # respect ignore warning pragmas and we cannot easily suppress it for all affected files.
+      #+    # https://bugs.webkit.org/show_bug.cgi?id=226557
+      #+    if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "11.0")
+      #+        WEBKIT_PREPEND_GLOBAL_CXX_FLAGS(-Wno-stringop-overread)
+      #+    endif ()
+      #+
+      ## -Wexpansion-to-defined produces false positives with GCC but not Clang
+      ## https://bugs.webkit.org/show_bug.cgi?id=167643#c13
+      # if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+      # GCCEOF
+      # File.write('gcc.patch', @gcc_patch)
+      # system 'patch -Np1 -F 10 -i gcc.patch'
       # Patch from https://github.com/WebKit/WebKit/pull/1233
-      downloader 'https://patch-diff.githubusercontent.com/raw/WebKit/WebKit/pull/1233.diff',
-                 '70c990ced72c5551b01c9d7c72da7900d609d0f7891e7b99ab132ac1b4aa33ea'
-      system "sed -i 's,data.pixels->bytes(),data.pixels->data(),' 1233.diff"
-      system 'patch -Np1 -F 10 -i 1233.diff'
+      # downloader 'https://patch-diff.githubusercontent.com/raw/WebKit/WebKit/pull/1233.diff',
+      #           '70c990ced72c5551b01c9d7c72da7900d609d0f7891e7b99ab132ac1b4aa33ea'
+      # system "sed -i 's,data.pixels->bytes(),data.pixels->data(),' 1233.diff"
+      # system 'patch -Np1 -F 10 -i 1233.diff'
       # Patch from https://github.com/WebKit/WebKit/pull/2926
       # downloader 'https://patch-diff.githubusercontent.com/raw/WebKit/WebKit/pull/2926.diff',
       # '26a8d5a9dd9d61865645158681b766e13cf05b3ed07f30bebb79ff73259d0664'
       # system "sed -i '22,63d' 2926.diff"
       # system 'patch -Np1 -F 10 -i 2926.diff'
-      @arch_flags = '-mtune=cortex-a15 -mfloat-abi=hard -mfpu=neon -mtls-dialect=gnu -marm -mlibarch=armv8-a+crc+simd -march=armv8-a+crc+simd'
-      @gcc_ver = '-10'
+      # @arch_flags = '-mtune=cortex-a15 -mfloat-abi=hard -mfpu=neon -mtls-dialect=gnu -marm -mlibarch=armv8-a+crc+simd -march=armv8-a+crc+simd'
+      @arch_flags = '-mfloat-abi=hard -mtls-dialect=gnu -mthumb -mfpu=vfpv3-d16 -mlibarch=armv7-a+fp -march=armv7-a+fp'
     end
-    @gcc_ver = '-10' if ARCH == 'i686'
+    @gcc_ver = '-10' if ARCH == 'i686' || ARCH == 'armv7l' || ARCH == 'aarch64'
     @new_gcc = <<~NEW_GCCEOF
       #!/bin/bash
       gcc#{@gcc_ver} #{@arch_flags} $@

--- a/packages/webkit2gtk_4.rb
+++ b/packages/webkit2gtk_4.rb
@@ -29,7 +29,7 @@ class Webkit2gtk_4 < Package
   depends_on 'fontconfig'
   depends_on 'freetype' # R
   depends_on 'gcc' # R
-  depends_on 'gcc10' if ARCH == 'armv7l' || ARCH == 'aarch64' || ARCH == 'i686'
+  depends_on 'gcc10' if %w[aarch64 armv7l i686].include? ARCH
   depends_on 'gdk_pixbuf' # R
   depends_on 'glibc' # R
   depends_on 'glib' # R

--- a/packages/webkit2gtk_4.rb
+++ b/packages/webkit2gtk_4.rb
@@ -120,7 +120,7 @@ class Webkit2gtk_4 < Package
       # @arch_flags = '-mtune=cortex-a15 -mfloat-abi=hard -mfpu=neon -mtls-dialect=gnu -marm -mlibarch=armv8-a+crc+simd -march=armv8-a+crc+simd'
       @arch_flags = '-mfloat-abi=hard -mtls-dialect=gnu -mthumb -mfpu=vfpv3-d16 -mlibarch=armv7-a+fp -march=armv7-a+fp'
     end
-    @gcc_ver = '-10' if ARCH == 'i686' || ARCH == 'armv7l' || ARCH == 'aarch64'
+    @gcc_ver = '-10' if %w[aarch64 armv7l i686].include? ARCH
     @new_gcc = <<~NEW_GCCEOF
       #!/bin/bash
       gcc#{@gcc_ver} #{@arch_flags} $@

--- a/packages/webkit2gtk_4_1.rb
+++ b/packages/webkit2gtk_4_1.rb
@@ -120,7 +120,7 @@ class Webkit2gtk_4_1 < Package
       # @arch_flags = '-mtune=cortex-a15 -mfloat-abi=hard -mfpu=neon -mtls-dialect=gnu -marm -mlibarch=armv8-a+crc+simd -march=armv8-a+crc+simd'
       @arch_flags = '-mfloat-abi=hard -mtls-dialect=gnu -mthumb -mfpu=vfpv3-d16 -mlibarch=armv7-a+fp -march=armv7-a+fp'
     end
-    @gcc_ver = '-10' if ARCH == 'i686' || ARCH == 'armv7l' || ARCH == 'aarch64'
+    @gcc_ver = '-10' if %w[aarch64 armv7l i686].include? ARCH
     @new_gcc = <<~NEW_GCCEOF
       #!/bin/bash
       gcc#{@gcc_ver} #{@arch_flags} $@

--- a/packages/webkit2gtk_4_1.rb
+++ b/packages/webkit2gtk_4_1.rb
@@ -8,10 +8,16 @@ class Webkit2gtk_4_1 < Package
   source_sha256 '02e195b3fb9e057743b3364ee7f1eec13f71614226849544c07c32a73b8f1848'
 
   binary_url({
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4_1/2.38.1_x86_64/webkit2gtk_4_1-2.38.1-chromeos-x86_64.tar.zst'
+      aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4_1/2.38.1_armv7l/webkit2gtk_4_1-2.38.1-chromeos-armv7l.tar.zst',
+       armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4_1/2.38.1_armv7l/webkit2gtk_4_1-2.38.1-chromeos-armv7l.tar.zst',
+         i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4_1/2.38.1_i686/webkit2gtk_4_1-2.38.1-chromeos-i686.tar.zst',
+       x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4_1/2.38.1_x86_64/webkit2gtk_4_1-2.38.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-  x86_64: '6bbadb05897a4a8566eecd6ff7cba5b68d59fe852f1748001cb34b8f726c123d'
+      aarch64: '1fae61429d3afd933d89dde5c2656d02f634584894561a0e053df1e12ad1ce47',
+       armv7l: '1fae61429d3afd933d89dde5c2656d02f634584894561a0e053df1e12ad1ce47',
+         i686: 'c05c22915fdd09683c9ee4336bb9565f0d6e30f2e325b5c1971d28f64bcc2ed9',
+       x86_64: '6bbadb05897a4a8566eecd6ff7cba5b68d59fe852f1748001cb34b8f726c123d'
   })
 
   depends_on 'atk' # R
@@ -23,7 +29,7 @@ class Webkit2gtk_4_1 < Package
   depends_on 'fontconfig'
   depends_on 'freetype' # R
   depends_on 'gcc' # R
-  depends_on 'gcc10' if ARCH == 'armv7l' || ARCH == 'aarch64'
+  depends_on 'gcc10' if ARCH == 'armv7l' || ARCH == 'aarch64' || ARCH == 'i686'
   depends_on 'gdk_pixbuf' # R
   depends_on 'glibc' # R
   depends_on 'glib' # R
@@ -77,43 +83,44 @@ class Webkit2gtk_4_1 < Package
     @arch_flags = ''
     @gcc_ver = ''
     if ARCH == 'armv7l' || ARCH == 'aarch64'
-      # Patch from https://bugs.webkit.org/show_bug.cgi?id=226557#c27 to
-      # handle issue with gcc > 11.
-      @gcc_patch = <<~'GCCEOF'
-        diff --git a/Source/cmake/WebKitCompilerFlags.cmake b/Source/cmake/WebKitCompilerFlags.cmake
-        index 77ebb802ebb03450b5e96629a47b6819a68672c6..d49d6e43d7eeb6673c624e00eadf3edfca0674eb 100644
-        --- a/Source/cmake/WebKitCompilerFlags.cmake
-        +++ b/Source/cmake/WebKitCompilerFlags.cmake
-        @@ -143,6 +143,13 @@ if (COMPILER_IS_GCC_OR_CLANG)
-                 WEBKIT_PREPEND_GLOBAL_CXX_FLAGS(-Wno-nonnull)
-             endif ()
+      ## Patch from https://bugs.webkit.org/show_bug.cgi?id=226557#c27 to
+      ## handle issue with gcc > 11.
+      # @gcc_patch = <<~'GCCEOF'
+      # diff --git a/Source/cmake/WebKitCompilerFlags.cmake b/Source/cmake/WebKitCompilerFlags.cmake
+      # index 77ebb802ebb03450b5e96629a47b6819a68672c6..d49d6e43d7eeb6673c624e00eadf3edfca0674eb 100644
+      #--- a/Source/cmake/WebKitCompilerFlags.cmake
+      #+++ b/Source/cmake/WebKitCompilerFlags.cmake
+      # @@ -143,6 +143,13 @@ if (COMPILER_IS_GCC_OR_CLANG)
+      # WEBKIT_PREPEND_GLOBAL_CXX_FLAGS(-Wno-nonnull)
+      # endif ()
 
-        +    # This triggers warnings in wtf/Packed.h, a header that is included in many places. It does not
-        +    # respect ignore warning pragmas and we cannot easily suppress it for all affected files.
-        +    # https://bugs.webkit.org/show_bug.cgi?id=226557
-        +    if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "11.0")
-        +        WEBKIT_PREPEND_GLOBAL_CXX_FLAGS(-Wno-stringop-overread)
-        +    endif ()
-        +
-             # -Wexpansion-to-defined produces false positives with GCC but not Clang
-             # https://bugs.webkit.org/show_bug.cgi?id=167643#c13
-             if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-      GCCEOF
-      File.write('gcc.patch', @gcc_patch)
-      system 'patch -Np1 -F 10 -i gcc.patch'
+      #+    # This triggers warnings in wtf/Packed.h, a header that is included in many places. It does not
+      #+    # respect ignore warning pragmas and we cannot easily suppress it for all affected files.
+      #+    # https://bugs.webkit.org/show_bug.cgi?id=226557
+      #+    if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "11.0")
+      #+        WEBKIT_PREPEND_GLOBAL_CXX_FLAGS(-Wno-stringop-overread)
+      #+    endif ()
+      #+
+      ## -Wexpansion-to-defined produces false positives with GCC but not Clang
+      ## https://bugs.webkit.org/show_bug.cgi?id=167643#c13
+      # if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+      # GCCEOF
+      # File.write('gcc.patch', @gcc_patch)
+      # system 'patch -Np1 -F 10 -i gcc.patch'
       # Patch from https://github.com/WebKit/WebKit/pull/1233
-      downloader 'https://patch-diff.githubusercontent.com/raw/WebKit/WebKit/pull/1233.diff',
-                 '70c990ced72c5551b01c9d7c72da7900d609d0f7891e7b99ab132ac1b4aa33ea'
-      system "sed -i 's,data.pixels->bytes(),data.pixels->data(),' 1233.diff"
-      system 'patch -Np1 -F 10 -i 1233.diff'
+      # downloader 'https://patch-diff.githubusercontent.com/raw/WebKit/WebKit/pull/1233.diff',
+      #           '70c990ced72c5551b01c9d7c72da7900d609d0f7891e7b99ab132ac1b4aa33ea'
+      # system "sed -i 's,data.pixels->bytes(),data.pixels->data(),' 1233.diff"
+      # system 'patch -Np1 -F 10 -i 1233.diff'
       # Patch from https://github.com/WebKit/WebKit/pull/2926
       # downloader 'https://patch-diff.githubusercontent.com/raw/WebKit/WebKit/pull/2926.diff',
       # '26a8d5a9dd9d61865645158681b766e13cf05b3ed07f30bebb79ff73259d0664'
       # system "sed -i '22,63d' 2926.diff"
       # system 'patch -Np1 -F 10 -i 2926.diff'
-      @arch_flags = '-mtune=cortex-a15 -mfloat-abi=hard -mfpu=neon -mtls-dialect=gnu -marm -mlibarch=armv8-a+crc+simd -march=armv8-a+crc+simd'
-      @gcc_ver = '-10'
+      # @arch_flags = '-mtune=cortex-a15 -mfloat-abi=hard -mfpu=neon -mtls-dialect=gnu -marm -mlibarch=armv8-a+crc+simd -march=armv8-a+crc+simd'
+      @arch_flags = '-mfloat-abi=hard -mtls-dialect=gnu -mthumb -mfpu=vfpv3-d16 -mlibarch=armv7-a+fp -march=armv7-a+fp'
     end
+    @gcc_ver = '-10' if ARCH == 'i686' || ARCH == 'armv7l' || ARCH == 'aarch64'
     @new_gcc = <<~NEW_GCCEOF
       #!/bin/bash
       gcc#{@gcc_ver} #{@arch_flags} $@
@@ -138,8 +145,8 @@ class Webkit2gtk_4_1 < Package
       # bwrap: Can't make symlink at /var/run: File exists
       # LDFLAGS from debian: -Wl,--no-keep-memory
       unless File.file?('build.ninja')
-        @arch_linker_flags = ARCH == 'x86_64' || ARCH == 'i686' ? '' : '-Wl,--no-keep-memory'
-        system "CREW_LINKER_FLAGS='#{@arch_linker_flags}' CC='#{@workdir}/bin/gcc' CXX='#{@workdir}/bin/g++' mold -run cmake \
+        @arch_linker_flags = ARCH == 'x86_64' ? '' : '-Wl,--no-keep-memory'
+        system "CREW_LINKER_FLAGS='#{@arch_linker_flags}' CC='#{@workdir}/bin/gcc' CXX='#{@workdir}/bin/g++' cmake \
             -G Ninja \
             #{CREW_CMAKE_FNO_LTO_OPTIONS.gsub('mold', 'gold').sub('-pipe', '-pipe -Wno-error').gsub('-fno-lto', '')} \
             -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
@@ -156,7 +163,7 @@ class Webkit2gtk_4_1 < Package
             -DUSER_AGENT_BRANDING='Chromebrew' \
             .."
       end
-      system "ninja -j #{CREW_NPROC} || ninja -j #{CREW_NPROC.to_f.fdiv(2).ceil} || ninja -j #{CREW_NPROC.to_f.fdiv(2).ceil}"
+      system "ninja -j #{CREW_NPROC} || ninja -j #{CREW_NPROC.to_f.fdiv(2).ceil} || ninja -j #{CREW_NPROC.to_f.fdiv(2).ceil} || ninja -j #{CREW_NPROC.to_f.fdiv(3).ceil} || ninja -j #{CREW_NPROC.to_f.fdiv(4).ceil}"
     end
   end
 

--- a/packages/webkit2gtk_4_1.rb
+++ b/packages/webkit2gtk_4_1.rb
@@ -29,7 +29,7 @@ class Webkit2gtk_4_1 < Package
   depends_on 'fontconfig'
   depends_on 'freetype' # R
   depends_on 'gcc' # R
-  depends_on 'gcc10' if ARCH == 'armv7l' || ARCH == 'aarch64' || ARCH == 'i686'
+  depends_on 'gcc10' if %w[aarch64 armv7l i686].include? ARCH
   depends_on 'gdk_pixbuf' # R
   depends_on 'glibc' # R
   depends_on 'glib' # R


### PR DESCRIPTION
- Adds `armv7l` builds of `webkit2gtk_4`, `webkit2gtk_4_1`
- Adds `gemacs` build for `armv7l`
- Adds `epiphany` build for `armv7l`
- `webkit2gtk_5` is still building...

Builds properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=webkit CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
