### PR TITLE
Fix `crew sysinfo`, add more info

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1822,6 +1822,7 @@ def sysinfo_command(_args)
 
   puts <<~MD
     <details><summary>Expand</summary>
+
     - Architecture: `#{KERN_ARCH}` (`#{ARCH}`)
     - Processor vendor: `#{CPUINFO['vendor_id'] || 'ARM'}`
     - User space: `#{Dir.exist?('/lib64') ? '64' : '32'}-bit`
@@ -1836,6 +1837,7 @@ def sysinfo_command(_args)
     - OS variant: `#{lsb_release['CHROMEOS_RELEASE_NAME']}`
     - OS version: `#{lsb_release['CHROMEOS_RELEASE_BUILDER_PATH']}`
     - OS channel: `#{lsb_release['CHROMEOS_RELEASE_TRACK']}`
+
     </details>
   MD
 end

--- a/bin/crew
+++ b/bin/crew
@@ -1821,6 +1821,7 @@ def sysinfo_command(_args)
   git_commit_message_format = '%h `%s (%cr)`'
 
   puts <<~MD
+    <details><summary>Expand</summary>
     - Architecture: `#{KERN_ARCH}` (`#{ARCH}`)
     - Processor vendor: `#{CPUINFO['vendor_id'] || 'ARM'}`
     - User space: `#{Dir.exist?('/lib64') ? '64' : '32'}-bit`
@@ -1835,6 +1836,7 @@ def sysinfo_command(_args)
     - OS variant: `#{lsb_release['CHROMEOS_RELEASE_NAME']}`
     - OS version: `#{lsb_release['CHROMEOS_RELEASE_BUILDER_PATH']}`
     - OS channel: `#{lsb_release['CHROMEOS_RELEASE_TRACK']}`
+    </details>
   MD
 end
 

--- a/bin/crew
+++ b/bin/crew
@@ -1821,14 +1821,16 @@ def sysinfo_command(_args)
   git_commit_message_format = '%h `%s (%cr)`'
 
   puts <<~MD
-    - Architecture: `#{ARCH_ACTUAL}` (`#{ARCH}`)
+    - Architecture: `#{KERN_ARCH}` (`#{ARCH}`)
+    - Processor vendor: `#{CPUINFO['vendor_id'] || 'ARM'}`
+    - User space: `#{Dir.exist?('/lib64') ? '64' : '32'}-bit`
     - Kernel version: `#{`uname -r`.chomp}`
 
     - Chromebrew version: `#{CREW_VERSION}`
     - Chromebrew prefix: `#{CREW_PREFIX}`
     - Chromebrew libdir: `#{CREW_LIB_PREFIX}`
 
-    - Last update in local repository: #{`cd '#{CREW_LIB_PATH}'; git show -s --format='#{git_commit_message_format}' '#{CREW_LIB_PATH}'`.chomp}
+    - Last update in local repository: #{`git -C '#{CREW_LIB_PATH}' show -s --format='#{git_commit_message_format}'`.chomp}
 
     - OS variant: `#{lsb_release['CHROMEOS_RELEASE_NAME']}`
     - OS version: `#{lsb_release['CHROMEOS_RELEASE_BUILDER_PATH']}`


### PR DESCRIPTION
Fixes #7602 

### Changes
- Add CPU vendor and userspace arch
- The generated markdown code will collapse by default
<details><summary>Like this</summary>

- Architecture: `armv7l` (`armv7l`)
- Processor vendor: `ARM`
- User space: `32-bit`
- Kernel version: `4.19.122-09121-gd58e3f311e19`

- Chromebrew version: `1.28.0`
- Chromebrew prefix: `/usr/local`
- Chromebrew libdir: `/usr/local/lib`

- Last update in local repository: 42b7b5a3 `Collapse message in markdown (37 seconds ago)`

- OS variant: `Chrome OS`
- OS version: `veyron_speedy-release/R84-13099.110.0`
- OS channel: `stable-channel`

</details>

Tested on `armv7l`
**Need test on `x86_64`**
