### PR TITLE
revert package.rb set_property as unnecessary

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.28.1'
+CREW_VERSION = '1.28.2'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -28,11 +28,6 @@ class Package
   class << self
     attr_accessor :name, :cached_build, :in_build, :build_from_source,
                   :in_upgrade
-    # Via https://stackoverflow.com/questions/7849521/set-attribute-dynamically-of-ruby-object/39063481#39063481
-    def set_property(name, value)
-      prop_name = "@#{name}".to_sym # you need the property name, prefixed with a '@', as a symbol
-      instance_variable_set(prop_name, value)
-    end
   end
 
   def self.load_package(pkgFile, pkgName = File.basename(pkgFile, '.rb'))

--- a/packages/linux_sources.rb
+++ b/packages/linux_sources.rb
@@ -4,7 +4,7 @@ class Linux_sources < Package
   description 'Sources for the Linux kernel'
   homepage 'https://kernel.org/'
   @version = CREW_KERNEL_VERSION == '4.14' ? "#{CREW_KERNEL_VERSION}-1" : CREW_KERNEL_VERSION
-  set_property('version', @version)
+  version @version
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://chromium.googlesource.com/chromiumos/third_party/kernel.git'

--- a/packages/linuxheaders.rb
+++ b/packages/linuxheaders.rb
@@ -4,7 +4,7 @@ class Linuxheaders < Package
   description 'Linux headers for Chrome OS.'
   homepage 'https://kernel.org/'
   @version = CREW_KERNEL_VERSION == '4.14' ? "#{CREW_KERNEL_VERSION}-1" : CREW_KERNEL_VERSION
-  set_property('version', @version)
+  version @version
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://chromium.googlesource.com/chromiumos/third_party/kernel.git'


### PR DESCRIPTION
- Turns out the `set_property` code wasn't necessary. I just had to use logic with a dummy variable, and then I could do `version @dummy_variable` and that took care of the issue.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=fixup_version CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
