### PR TITLE
add linuxheader binaries: for 4.19, add armv7l binaries for 5.10

### DIFF
--- a/packages/linuxheaders.rb
+++ b/packages/linuxheaders.rb
@@ -25,16 +25,31 @@ class Linuxheaders < Package
        x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linuxheaders/4.14-1_x86_64/linuxheaders-4.14-1-chromeos-x86_64.tpxz'
     })
     binary_sha256({
-      aarch64: '75f253ac2cf0dd785ea8d9cdf9430d23d601ccc372e9f7afa95523a28273a340',
-       armv7l: '75f253ac2cf0dd785ea8d9cdf9430d23d601ccc372e9f7afa95523a28273a340',
+      aarch64: 'cc9227b5b3af3abdaba4c1eb6b5df066af6c5f20629cee3a4e351b3e40521760',
+       armv7l: 'cc9227b5b3af3abdaba4c1eb6b5df066af6c5f20629cee3a4e351b3e40521760',
        x86_64: '5d58b327ca9bab5630f0df387a3036125e1f367e6c43cd551f4734ee3e634073'
+    })
+  when '4.19'
+    binary_url({
+      aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linuxheaders/4.19_armv7l/linuxheaders-4.19-chromeos-armv7l.tar.zst',
+       armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linuxheaders/4.19_armv7l/linuxheaders-4.19-chromeos-armv7l.tar.zst',
+       x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linuxheaders/4.19_x86_64/linuxheaders-4.19-chromeos-x86_64.tar.zst'
+    })
+    binary_sha256({
+      aarch64: 'cc9227b5b3af3abdaba4c1eb6b5df066af6c5f20629cee3a4e351b3e40521760',
+       armv7l: 'cc9227b5b3af3abdaba4c1eb6b5df066af6c5f20629cee3a4e351b3e40521760',
+       x86_64: 'ea112d55cb33823a473791d146d124ae5d2cce7fb72ebe0b047d5937957ee994'
     })
   when '5.10'
     binary_url({
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linuxheaders/5.10_x86_64/linuxheaders-5.10-chromeos-x86_64.tar.zst'
+      aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linuxheaders/5.10_armv7l/linuxheaders-5.10-chromeos-armv7l.tar.zst',
+       armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linuxheaders/5.10_armv7l/linuxheaders-5.10-chromeos-armv7l.tar.zst',
+       x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/linuxheaders/5.10_x86_64/linuxheaders-5.10-chromeos-x86_64.tar.zst'
     })
     binary_sha256({
-      x86_64: '797e7a8369f613b50b049b2352f82d5842a2c9ae766d6d5b1165b90a528ac139'
+      aarch64: '23b6f70dad19663d42a1bb8707e66eb1b35c4934ef051577701397b4708e8cff',
+       armv7l: '23b6f70dad19663d42a1bb8707e66eb1b35c4934ef051577701397b4708e8cff',
+       x86_64: '797e7a8369f613b50b049b2352f82d5842a2c9ae766d6d5b1165b90a528ac139'
     })
   end
 
@@ -49,8 +64,8 @@ class Linuxheaders < Package
     system "PATH=#{@workdir}/crew_bin:$PATH make defconfig"
     system "PATH=#{@workdir}/crew_bin:$PATH make headers_install INSTALL_HDR_PATH=#{CREW_DEST_PREFIX}"
     Dir.chdir("#{CREW_DEST_PREFIX}/include") do
-      system "for file in \$(find . -not -type d -name '.*'); do
-                rm \${file};
+      system "for file in $(find . -not -type d -name '.*'); do
+                rm ${file};
               done"
     end
   end


### PR DESCRIPTION
Fixes #7620

<!-- (let GitHub automatically close an issue when this pull request gets merged) -->

<!--
## Before you submit a pull request

This template is not necessary when you do simple things like updating packages to the latest version. But in doubt, it's always better so provide some information.
-->

## Description
<!--
Provide a description, what your changes do and why they are important

Please link issues and other pull requests connected to this one.
-->

## Additional information
<!-- Mention things we might need to know. Like: -->

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=add_more_linuxheaders CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
