### PR TITLE
py3_codespell: Wrap variables in `self.preflight`

### DIFF
--- a/packages/py3_codespell.rb
+++ b/packages/py3_codespell.rb
@@ -25,9 +25,11 @@ class Py3_codespell < Package
 
   depends_on 'py3_setuptools' => :build
 
-  python_major = `python3 -V | cut -d' ' -f2 | cut -d'.' -f1`.chomp
-  python_minor = `python3 -V | cut -d' ' -f2 | cut -d'.' -f2`.chomp
-  @python_ver = "python#{python_major}.#{python_minor}"
+  def self.preflight
+    python_major = `python3 -V | cut -d' ' -f2 | cut -d'.' -f1`.chomp
+    python_minor = `python3 -V | cut -d' ' -f2 | cut -d'.' -f2`.chomp
+    @python_ver = "python#{python_major}.#{python_minor}"
+  end
 
   def self.build
     system "python3 setup.py build #{PY3_SETUP_BUILD_OPTIONS}"

--- a/packages/py3_codespell.rb
+++ b/packages/py3_codespell.rb
@@ -26,9 +26,7 @@ class Py3_codespell < Package
   depends_on 'py3_setuptools' => :build
 
   def self.preflight
-    python_major = `python3 -V | cut -d' ' -f2 | cut -d'.' -f1`.chomp
-    python_minor = `python3 -V | cut -d' ' -f2 | cut -d'.' -f2`.chomp
-    @python_ver = "python#{python_major}.#{python_minor}"
+    @python_ver = "python#{`python3 -V`[/\d.\d+/]}"
   end
 
   def self.build


### PR DESCRIPTION
Fix #7601 

Please define the variable inside the `def self.preflight` function next time if external commands are involved, otherwise the command will be triggered always (i.e when updating/removing)