### PR TITLE
py3_codespell: remove need for python3 during preflight

### DIFF
--- a/packages/py3_codespell.rb
+++ b/packages/py3_codespell.rb
@@ -23,6 +23,7 @@ class Py3_codespell < Package
      x86_64: '1f2e5d809b529d6934686e7e2af476dd066f224896f2b5f0efde061e2e5fba37'
   })
 
+  depends_on 'python3'
   depends_on 'py3_setuptools' => :build
 
   def self.build

--- a/packages/py3_codespell.rb
+++ b/packages/py3_codespell.rb
@@ -25,15 +25,12 @@ class Py3_codespell < Package
 
   depends_on 'py3_setuptools' => :build
 
-  def self.preflight
-    @python_ver = "python#{`python3 -V`[/\d.\d+/]}"
-  end
-
   def self.build
     system "python3 setup.py build #{PY3_SETUP_BUILD_OPTIONS}"
   end
 
   def self.install
+    @python_ver = "python#{`python3 -V`[/\d.\d+/]}"
     system "python3 setup.py install #{PY_SETUP_INSTALL_OPTIONS}"
     # Fixes ModuleNotFoundError: No module named 'codespell_lib._version'
     _version_tuple = "(#{@_ver.gsub('.', ', ')})"
@@ -49,6 +46,7 @@ class Py3_codespell < Package
   end
 
   def self.remove
+    @python_ver = "python#{`python3 -V`[/\d.\d+/]}"
     # Remove data, __pycache__ and tests directories.
     FileUtils.rm_rf "#{CREW_PREFIX}/lib/#{@python_ver}/site-packages/codespell_lib"
   end


### PR DESCRIPTION
- adjust preflight
- add python3 dep

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
