### PR TITLE
Update sommelier to 20221117

### DIFF
--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -16,10 +16,10 @@ class Sommelier < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20221117-1_x86_64/sommelier-20221117-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'bebd8e71c33b4ad5e75addcf27c29c38ebf8c232c2ef0698c701a7984930d944',
-     armv7l: 'bebd8e71c33b4ad5e75addcf27c29c38ebf8c232c2ef0698c701a7984930d944',
-       i686: 'cc65f33b8cb9369dea7ef4aec0230e668fabe5ea0fa2daa032a49af8725696de',
-     x86_64: 'c8b0e73e7cfbe631dead10678204950e7f4f163985b8a3f5ca60c314ca48a6ca'
+    aarch64: '131485e6c60091254347fd906d729b1a3280cec40c40341459cad38caa574b1e',
+     armv7l: '131485e6c60091254347fd906d729b1a3280cec40c40341459cad38caa574b1e',
+       i686: '541474d7ab640e71990a6ac3dfe35fa28774b47af337e38757a7913c619be3b4',
+     x86_64: '5e553206ed88581d3948dd6920ab42331e80100976016d59b37bc5a66c444a9c'
   })
 
   depends_on 'libdrm'
@@ -187,17 +187,6 @@ class Sommelier < Package
         File.write 'sommelierd', <<~SOMMELIERDEOF
           #!/bin/bash -a
 
-          source ${CREW_PREFIX}/etc/env.d/sommelier.env &>/dev/null
-          set +a
-          mkdir -p #{CREW_PREFIX}/var/{log,run}
-          checksommelierwayland () {
-            [[ -f "#{CREW_PREFIX}/var/run/sommelier-wayland.pid" ]] || return 1
-            /sbin/ss --unix -a -p | grep "\b$(cat #{CREW_PREFIX}/var/run/sommelier-wayland.pid)" | grep wayland &>/dev/null
-          }
-          checksommelierxwayland () {
-            DISPLAY="${DISPLAY}" timeout 1s xset q &>/dev/null
-          }
-
           # get a list of all available DRM render nodes
           DRM_DEVICES_LIST=( /sys/class/drm/renderD* )
 
@@ -217,6 +206,17 @@ class Sommelier < Package
             # if only one node available, use it directly
             SOMMELIER_DRM_DEVICE="/dev/dri/${DRM_DEVICES_LIST[0]##*/}"
           fi
+
+          source ${CREW_PREFIX}/etc/env.d/sommelier.env &>/dev/null
+          set +a
+          mkdir -p #{CREW_PREFIX}/var/{log,run}
+          checksommelierwayland () {
+            [[ -f "#{CREW_PREFIX}/var/run/sommelier-wayland.pid" ]] || return 1
+            /sbin/ss --unix -a -p | grep "\b$(cat #{CREW_PREFIX}/var/run/sommelier-wayland.pid)" | grep wayland &>/dev/null
+          }
+          checksommelierxwayland () {
+            DISPLAY="${DISPLAY}" timeout 1s xset q &>/dev/null
+          }
 
           ## As per https://www.reddit.com/r/chromeos/comments/8r5pvh/crouton_sommelier_openjdk_and_oracle_sql/e0pfknx/
           ## One needs a second sommelier instance for wayland clients since at some point wl-drm was not implemented
@@ -283,7 +283,7 @@ class Sommelier < Package
           }
           if ! checksommelierwayland || ! checksommelierxwayland ; then
             [ -f  #{CREW_PREFIX}/bin/stopbroadway ] && stopbroadway
-            #{CREW_PREFIX}/sbin/sommelierd &> /dev/null &
+            #{CREW_PREFIX}/sbin/sommelierd &
           fi
           wait=3
           until checksommelierwayland && checksommelierxwayland; do

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -16,10 +16,10 @@ class Sommelier < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20221117-2_x86_64/sommelier-20221117-2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '832e36890c7c18bfce16511d65199591994fdc1b8524f20eeef7aa6fdde734cd',
-     armv7l: '832e36890c7c18bfce16511d65199591994fdc1b8524f20eeef7aa6fdde734cd',
-       i686: 'dc64bf8903d8d3451c37b176a8a57372c384ba8da64e84ed84cc8abb62233159',
-     x86_64: '5d903a6f99d4212236bff8979febf71d50a2763ac2c357f600451ac8c67730c0'
+    aarch64: '2e066165bf94ed26d18773f08ad67250a43e1bd0413df5d6232dfbce7d1a9eeb',
+     armv7l: '2e066165bf94ed26d18773f08ad67250a43e1bd0413df5d6232dfbce7d1a9eeb',
+       i686: '1f08e04a4ad45c56fb772dbd29e17029a0fa45fb004b4e32d23ffdc857cbee79',
+     x86_64: '26345fb7b9b3ac1466600532003b7d28dd929b3fc707f6486e9ebe3b0b561855'
   })
 
   depends_on 'libdrm'
@@ -38,6 +38,7 @@ class Sommelier < Package
   depends_on 'xkbcomp' # The sommelier log complains if this isn't installed.
   depends_on 'xorg_xset' # for xset in wrapper script
   depends_on 'xhost' # for xhost in sommelierd script
+  depends_on 'xsetroot' # for xsetroot in /usr/local/etc/sommelierrc script
   depends_on 'xwayland'
   depends_on 'xxd_standalone' # for xxd in wrapper script
   depends_on 'gcc' # R
@@ -242,7 +243,7 @@ class Sommelier < Package
         # startsommelier
         File.write 'startsommelier', <<~STARTSOMMELIEREOF
           #!/bin/bash -a
-
+          set -a
           # Set DRM device here so output is visible, but don't run
           # some of these checks in an env.d file since we don't need
           # them run every time a shell is opened.

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -3,23 +3,23 @@ require 'package'
 class Sommelier < Package
   description 'Sommelier works by redirecting X11 programs to the built-in ChromeOS Exo Wayland server.'
   homepage 'https://chromium.googlesource.com/chromiumos/platform2/+/HEAD/vm_tools/sommelier/'
-  version '20210109-9'
+  version '20221117'
   license 'BSD-Google'
   compatibility 'all'
   source_url 'https://chromium.googlesource.com/chromiumos/platform2.git'
-  git_hashtag 'f3b2e2b6a8327baa2e62ef61036658c258ab4a09'
+  git_hashtag 'b63df163ab11f07b63d0e7a866f044aa07c7e0b2'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-9_armv7l/sommelier-20210109-9-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-9_armv7l/sommelier-20210109-9-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-9_i686/sommelier-20210109-9-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20210109-9_x86_64/sommelier-20210109-9-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20221117_armv7l/sommelier-20221117-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20221117_armv7l/sommelier-20221117-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20221117_i686/sommelier-20221117-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20221117_x86_64/sommelier-20221117-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '74359bcc06aed87aa0b4172f4ef5a620962fbaa476d57db430206390031f2f29',
-     armv7l: '74359bcc06aed87aa0b4172f4ef5a620962fbaa476d57db430206390031f2f29',
-       i686: '0bf67633fa9b4cf68c4feb8f1c8f92493b303e9f86e83a2977295d12e3156853',
-     x86_64: '81559f65c2db3aa8846fe1b99ce1b16e53aafaabc20a8fcdf5dce4137a7c11da'
+    aarch64: '33836582ecb28b3922bc6ae65c9fe4c1f50fe7ecbae947b01b5a6211c1698cfa',
+     armv7l: '33836582ecb28b3922bc6ae65c9fe4c1f50fe7ecbae947b01b5a6211c1698cfa',
+       i686: 'd16a5ff12595632910bc41c3dc737a05ddfedfecc9c9481f7eb834ffad8bc278',
+     x86_64: '8f71356314b68cbe4ebdff2fcec77f9ed281ead1ee441d227e2680d32edea8c6'
   })
 
   depends_on 'libdrm'
@@ -75,10 +75,9 @@ class Sommelier < Package
           -Db_asneeded=false \
           -Db_lto=true \
           -Db_lto_mode=thin \
+          -Dwith_tests=false \
           -Dxwayland_path=#{CREW_PREFIX}/bin/Xwayland \
           -Dxwayland_gl_driver_path=/usr/#{ARCH_LIB}/dri -Ddefault_library=both \
-          -Dxwayland_shm_driver=noop -Dshm_driver=noop -Dvirtwl_device=/dev/null \
-          -Dpeer_cmd_prefix="#{CREW_PREFIX}#{@peer_cmd_prefix}" \
           builddir
       BUILD
 
@@ -200,15 +199,17 @@ class Sommelier < Package
             DISPLAY="${DISPLAY:0:3}"
 
             sommelier -X \
-              --x-display=${DISPLAY}  \
-              --scale=${SCALE} --glamor \
-              --drm-device=/dev/dri/renderD128 \
-              --virtwl-device=/dev/null \
-              --shm-driver=noop --data-driver=noop \
+              --x-display=${DISPLAY} \
+              --scale=${SCALE} \
+              --direct-scale \
+              --glamor \
+              --force-drm-device=/dev/dri/renderD128 \
               --display=wayland-0 \
               --xwayland-path=/usr/local/bin/Xwayland \
               --xwayland-gl-driver-path=#{CREW_LIB_PREFIX}/dri \
               --peer-cmd-prefix="#{CREW_PREFIX}#{@peer_cmd_prefix}" \
+              --enable-xshape \
+              --noop-driver \
               --no-exit-with-child \
               /bin/sh -c "touch ~/.Xauthority
                 xauth -f ~/.Xauthority add ${DISPLAY} . $(xxd -l 16 -p /dev/urandom)


### PR DESCRIPTION
- Updated to the 20221117 version @supechicken noticed.
- Cleaned up output and error messages.

Works properly:
- [x] `x86_64`

Builds properly:
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=sommelier_new CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
