### PR TITLE
wayland_protocols => 1.30

### DIFF
--- a/packages/wayland_protocols.rb
+++ b/packages/wayland_protocols.rb
@@ -3,23 +3,23 @@ require 'package'
 class Wayland_protocols < Package
   description 'Wayland is a protocol for a compositor to talk to its clients.'
   homepage 'https://wayland.freedesktop.org/'
-  version '1.27'
+  version '1.30'
   license 'MIT'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/wayland/wayland-protocols.git'
   git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_protocols/1.27_armv7l/wayland_protocols-1.27-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_protocols/1.27_armv7l/wayland_protocols-1.27-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_protocols/1.27_i686/wayland_protocols-1.27-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_protocols/1.27_x86_64/wayland_protocols-1.27-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_protocols/1.30_armv7l/wayland_protocols-1.30-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_protocols/1.30_armv7l/wayland_protocols-1.30-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_protocols/1.30_i686/wayland_protocols-1.30-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_protocols/1.30_x86_64/wayland_protocols-1.30-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '3b3db1c642712358e5d640729b1b3753f311facf41629c101f7d49df13807e88',
-     armv7l: '3b3db1c642712358e5d640729b1b3753f311facf41629c101f7d49df13807e88',
-       i686: 'c1ef3b7ee5f3ebe8bbef54898019cfd28b5ac6292efe6cc8b86f3c055536f69c',
-     x86_64: '910af346dff46a95b2d75c04ef4273274a3e09344351e98812fa95bc1275638a'
+    aarch64: 'd704fb7b2384861883eca49f4222e83602c92df18c39ab74ae3903ef7c9c7d42',
+     armv7l: 'd704fb7b2384861883eca49f4222e83602c92df18c39ab74ae3903ef7c9c7d42',
+       i686: 'ed0d349148e03e353cc1e92a02742a5d57c2ab3515e5cc1d673cb47391ee810e',
+     x86_64: 'a05dedebc8b60e559b117119ae55275353509bdfce735db5125e01eee2132a9d'
   })
 
   depends_on 'wayland' # L


### PR DESCRIPTION

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
