### PR TITLE
Updates to removable disk reading and ripping apps.

### DIFF
--- a/packages/asunder.rb
+++ b/packages/asunder.rb
@@ -1,0 +1,48 @@
+# Adapted from Arch Linux asunder PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/asunder/trunk/PKGBUILD
+
+require 'package'
+
+class Asunder < Package
+  description 'a graphical CD ripper and encoder'
+  homepage 'http://littlesvr.ca/asunder/'
+  version '2.9.7'
+  license 'GPL2'
+  compatibility 'all'
+  source_url 'https://littlesvr.ca/asunder/releases/asunder-2.9.7.tar.bz2'
+  source_sha256 'c1c97cd34c04b8595e95df8a9a7dbc64a1e61f494b7a0cd2873802ad111874f4'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/asunder/2.9.7_armv7l/asunder-2.9.7-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/asunder/2.9.7_armv7l/asunder-2.9.7-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/asunder/2.9.7_i686/asunder-2.9.7-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/asunder/2.9.7_x86_64/asunder-2.9.7-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '4c004dfe3a8287cdb7f422bd808f7cead56bfaa496ec915e5dcb0f2816dad742',
+     armv7l: '4c004dfe3a8287cdb7f422bd808f7cead56bfaa496ec915e5dcb0f2816dad742',
+       i686: '3cadd358e80a33c3573e2ab4da3661587f23d1ba2bc40cc813175bd760423266',
+     x86_64: '46865361e0deeaef1539d52dc35daeb28c1b322b947a00a3b7c15580212ba686'
+  })
+
+  depends_on 'atk' # R
+  depends_on 'at_spi2_core' # R
+  depends_on 'cdparanoia' # R
+  depends_on 'freetype' # R
+  depends_on 'gdk_pixbuf' # R
+  depends_on 'glibc' # R
+  depends_on 'glib' # R
+  depends_on 'gtk2' # R
+  depends_on 'harfbuzz' # R
+  depends_on 'libcddb' # R
+  depends_on 'pango' # R
+
+  def self.build
+    system "./configure #{CREW_OPTIONS}"
+    system 'make'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end

--- a/packages/cdparanoia.rb
+++ b/packages/cdparanoia.rb
@@ -1,0 +1,46 @@
+# Adapted from Arch Linux cdparanoia PKGBUILD at:
+# https://github.com/archlinux/svntogit-packages/raw/packages/cdparanoia/trunk/PKGBUILD
+
+require 'package'
+
+class Cdparanoia < Package
+  description 'Compact Disc Digital Audio extraction tool'
+  homepage 'https://www.xiph.org/paranoia/'
+  version '10.2'
+  license 'GPL'
+  compatibility 'all'
+  source_url 'https://downloads.xiph.org/releases/cdparanoia/cdparanoia-III-10.2.src.tgz'
+  source_sha256 '005db45ef4ee017f5c32ec124f913a0546e77014266c6a1c50df902a55fe64df'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cdparanoia/10.2_armv7l/cdparanoia-10.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cdparanoia/10.2_armv7l/cdparanoia-10.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cdparanoia/10.2_i686/cdparanoia-10.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cdparanoia/10.2_x86_64/cdparanoia-10.2-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '30175dd7636d51bbcc7c0feb194c7671ac80607abc8e2934d204279a2a5eda16',
+     armv7l: '30175dd7636d51bbcc7c0feb194c7671ac80607abc8e2934d204279a2a5eda16',
+       i686: 'eb06f87aaf715e636efcc5a2411c619c4fb8581e2d59bddfae37300ab1c23859',
+     x86_64: '14c5f3136ce27847166d7947c22a3b31440113f8d21b8f3d9b29176df8e89bbf'
+  })
+
+  depends_on 'glibc'
+
+  no_env_options
+
+  def self.patch
+    downloader 'https://raw.githubusercontent.com/archlinux/svntogit-packages/packages/cdparanoia/trunk/gcc.patch',
+               '9a3f3802856e96080fb30562a10899ef3378723e85f289fa29619b21d6051575'
+    system 'patch -Np0 -i gcc.patch'
+  end
+
+  def self.build
+    system "#{CREW_ENV_FNO_LTO_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system 'make'
+  end
+
+  def self.install
+    system "make prefix=#{CREW_DEST_PREFIX} MANDIR=#{CREW_DEST_MAN_PREFIX} install"
+  end
+end

--- a/packages/cdparanoia.rb
+++ b/packages/cdparanoia.rb
@@ -19,10 +19,10 @@ class Cdparanoia < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cdparanoia/10.2_x86_64/cdparanoia-10.2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '30175dd7636d51bbcc7c0feb194c7671ac80607abc8e2934d204279a2a5eda16',
-     armv7l: '30175dd7636d51bbcc7c0feb194c7671ac80607abc8e2934d204279a2a5eda16',
-       i686: 'eb06f87aaf715e636efcc5a2411c619c4fb8581e2d59bddfae37300ab1c23859',
-     x86_64: '14c5f3136ce27847166d7947c22a3b31440113f8d21b8f3d9b29176df8e89bbf'
+    aarch64: '355295c34b89f75440bcd3aa003d1c4132dce8bf68b11bc164031f25086ae573',
+     armv7l: '355295c34b89f75440bcd3aa003d1c4132dce8bf68b11bc164031f25086ae573',
+       i686: '74db8c9126b6dc858120def2a959205c5189e85a01232a18f31a90c8423c80b7',
+     x86_64: '1cc714af1c8617cc10a6bc893e17beece810f851057a444e1813d79f495ceafe'
   })
 
   depends_on 'glibc'
@@ -37,10 +37,13 @@ class Cdparanoia < Package
 
   def self.build
     system "#{CREW_ENV_FNO_LTO_OPTIONS} ./configure #{CREW_OPTIONS}"
-    system 'make'
+    system 'make -j1'
   end
 
   def self.install
-    system "make prefix=#{CREW_DEST_PREFIX} MANDIR=#{CREW_DEST_MAN_PREFIX} install"
+    system "make prefix=#{CREW_DEST_PREFIX} \
+      MANDIR=#{CREW_DEST_MAN_PREFIX} \
+      LIBDIR=#{CREW_DEST_LIB_PREFIX} \
+      install"
   end
 end

--- a/packages/gmmlib.rb
+++ b/packages/gmmlib.rb
@@ -3,7 +3,7 @@ require 'package'
 class Gmmlib < Package
   description 'The Intel(R) Graphics Memory Management Library provides device specific and buffer management for the Intel(R) Graphics Compute Runtime for OpenCL(TM) and the Intel(R) Media Driver for VAAPI.'
   homepage 'https://github.com/intel/gmmlib/'
-  @_ver = '22.2.0'
+  @_ver = '22.3.1'
   version @_ver
   license 'MIT'
   compatibility 'x86_64'
@@ -11,10 +11,10 @@ class Gmmlib < Package
   git_hashtag "intel-gmmlib-#{@_ver}"
 
   binary_url({
-    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gmmlib/22.2.0_x86_64/gmmlib-22.2.0-chromeos-x86_64.tar.zst'
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gmmlib/22.3.1_x86_64/gmmlib-22.3.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    x86_64: 'b9e65594d3579bd7a3a72c477c7ccdc21a83bcdfa24f2e49336df1e3d22a32f8'
+    x86_64: '6d3b479fc5505fabc13d61b0b3e2a8ca929061cff0629ca57456ce828cbf337e'
   })
 
   depends_on 'libva'
@@ -25,9 +25,10 @@ class Gmmlib < Package
     FileUtils.mkdir('builddir')
     Dir.chdir('builddir') do
       system "cmake -G Ninja \
-            #{CREW_CMAKE_OPTIONS} \
-            -DRUN_TEST_SUITE=OFF \
-            .."
+        #{CREW_CMAKE_OPTIONS} \
+        -DRUN_TEST_SUITE=OFF \
+        -Wno-dev \
+        .."
     end
     system 'ninja -C builddir'
   end

--- a/packages/libcddb.rb
+++ b/packages/libcddb.rb
@@ -3,28 +3,40 @@ require 'package'
 class Libcddb < Package
   description 'Libcddb is a C library to access data on a CDDB server (freedb.org).'
   homepage 'http://libcddb.sourceforge.net/'
-  version '1.3.2-1'
-  compatibility 'all'
+  version '1.3.2-2'
   license 'LGPL-2'
+  compatibility 'all'
   source_url 'https://sourceforge.net/projects/libcddb/files/libcddb/1.3.2/libcddb-1.3.2.tar.bz2'
   source_sha256 '35ce0ee1741ea38def304ddfe84a958901413aa829698357f0bee5bb8f0a223b'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcddb/1.3.2-1_armv7l/libcddb-1.3.2-1-chromeos-armv7l.tpxz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcddb/1.3.2-1_armv7l/libcddb-1.3.2-1-chromeos-armv7l.tpxz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcddb/1.3.2-1_i686/libcddb-1.3.2-1-chromeos-i686.tpxz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcddb/1.3.2-1_x86_64/libcddb-1.3.2-1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcddb/1.3.2-2_armv7l/libcddb-1.3.2-2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcddb/1.3.2-2_armv7l/libcddb-1.3.2-2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcddb/1.3.2-2_i686/libcddb-1.3.2-2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcddb/1.3.2-2_x86_64/libcddb-1.3.2-2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '20b533d43dc7f61a9a1c72c1a8343688dbf4b9e0353788ee80f43760636ebea3',
-      armv7l: '20b533d43dc7f61a9a1c72c1a8343688dbf4b9e0353788ee80f43760636ebea3',
-        i686: '99667ddb37115fe554a88104f10c5690a23fe55bc40468c878b7c437984ea313',
-      x86_64: '5106dc4d2ca03f158baa7f187df0f75ab19c5cc480f0ba85ae6d1ccfc8af71ef'
+    aarch64: '509230e87045ad19ebe5d807cc2ab6cc28759d5a8bec9c211dd0d71825b23cc6',
+     armv7l: '509230e87045ad19ebe5d807cc2ab6cc28759d5a8bec9c211dd0d71825b23cc6',
+       i686: '9a270eee0aadee941543741d495ce49ddc073baebcb55273b2eb40f5e1d08baa',
+     x86_64: 'b99165bbe3988b2f68dfc716a8a4f7deac042e2def97f9df35ae5eb83a3cb6af'
   })
 
+  depends_on 'libcdio'
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+
+  def self.patch
+    downloader 'https://sources.debian.org/data/main/libc/libcddb/1.3.2-7/debian/patches/0001-Switch-default-server-to-gnudb.org.patch',
+               '3ee8610efa71322adb9095405da11b56386ac2c5825f976a84410c6270e59149'
+    system 'patch -Np1 -i 0001-Switch-default-server-to-gnudb.org.patch'
+    downloader 'https://sources.debian.org/data/main/libc/libcddb/1.3.2-7/debian/patches/0002-Disable-use-SIGALRM-for-DNS-lookup-timeout.patch',
+               'cba6d6008b569e59b381623642c4fdde0fe8177d0063238b22a367e389cbdeb5'
+    system 'patch -Np1 -i 0002-Disable-use-SIGALRM-for-DNS-lookup-timeout.patch'
+  end
+
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
-              --without-cdio"
+    system "./configure #{CREW_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libdvdcss.rb
+++ b/packages/libdvdcss.rb
@@ -1,0 +1,38 @@
+# Adapted from Arch Linux libdvdcss PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/libdvdcss/trunk/PKGBUILD
+
+require 'package'
+
+class Libdvdcss < Package
+  description 'Portable abstraction library for DVD decryption'
+  homepage 'https://www.videolan.org/developers/libdvdcss.html'
+  version '1.4.3'
+  license 'GPL'
+  compatibility 'all'
+  source_url 'https://download.videolan.org/pub/libdvdcss/1.4.3/libdvdcss-1.4.3.tar.bz2'
+  source_sha256 '233cc92f5dc01c5d3a96f5b3582be7d5cee5a35a52d3a08158745d3d86070079'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdvdcss/1.4.3_armv7l/libdvdcss-1.4.3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdvdcss/1.4.3_armv7l/libdvdcss-1.4.3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdvdcss/1.4.3_i686/libdvdcss-1.4.3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdvdcss/1.4.3_x86_64/libdvdcss-1.4.3-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: 'dcda013e9e88b050507d38ace902d48d1330811e5e5c2218a9573158e0f4acf7',
+     armv7l: 'dcda013e9e88b050507d38ace902d48d1330811e5e5c2218a9573158e0f4acf7',
+       i686: '49c01747d762f5a9180a86a9f1df55412cf51888d45f7c70fcfaeb5ad5b3e111',
+     x86_64: 'b7d83cd09f981bb3fadd013526f41854695961108e0b5b65e3d90e0bb44c0c0d'
+  })
+
+  depends_on 'glibc' # R
+
+  def self.build
+    system "./configure #{CREW_OPTIONS}"
+    system 'make'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end

--- a/packages/onevpl.rb
+++ b/packages/onevpl.rb
@@ -21,6 +21,7 @@ class Onevpl < Package
 
   depends_on 'gcc' # R
   depends_on 'glibc' # R
+  depends_on 'intel_media_sdk' # R
   depends_on 'libdrm' # R
   depends_on 'libva' # R
   depends_on 'libx11' # R

--- a/packages/onevpl.rb
+++ b/packages/onevpl.rb
@@ -1,0 +1,47 @@
+# Adapted from Arch Linux onevpl PKGBUILD at:
+# https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=onevpl
+
+require 'package'
+
+class Onevpl < Package
+  description 'oneAPI Video Processing Library'
+  homepage 'https://www.intel.com/content/www/us/en/developer/tools/oneapi/onevpl.html'
+  version '2023.1.0'
+  license 'MIT'
+  compatibility 'x86_64'
+  source_url 'https://github.com/oneapi-src/oneVPL/archive/refs/tags/v2023.1.0.tar.gz'
+  source_sha256 '0a1991278c64849f471e4b307a7c01f465a308674f359054886c32352e887b60'
+
+  binary_url({
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/onevpl/2023.1.0_x86_64/onevpl-2023.1.0-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    x86_64: 'ad119dc97568f728a42b909a6c3980d9245fc10fa81bab64a261e3c8c6e6d634'
+  })
+
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  depends_on 'libdrm' # R
+  depends_on 'libva' # R
+  depends_on 'libx11' # R
+  depends_on 'libxcb' # R
+  depends_on 'wayland_protocols' => :build
+  depends_on 'wayland' # R
+
+  def self.build
+    FileUtils.mkdir_p 'builddir'
+    Dir.chdir 'builddir' do
+      system "cmake -G Ninja \
+        #{CREW_CMAKE_OPTIONS} \
+        -DBUILD_TESTS:BOOL='OFF' \
+        -DINSTALL_EXAMPLE_CODE:BOOL='OFF' \
+        -Wno-dev \
+        .."
+    end
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -5695,6 +5695,11 @@ url: https://httpredir.debian.org/debian/pool/main/o/oneko/
 activity: low
 ---
 kind: url
+name: onevpl
+url: https://github.com/oneapi-src/oneVPL/releases
+activity: medium
+---
+kind: url
 name: oniguruma
 url: https://github.com/kkos/oniguruma/releases
 activity: medium

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -280,6 +280,11 @@ url: https://ftpmirror.gnu.org/aspell/dict/fr/
 activity: none
 ---
 kind: url
+name: asunder
+url: https://littlesvr.ca/asunder/releases
+activity: low
+---
+kind: url
 name: aspell_es
 url: https://ftpmirror.gnu.org/aspell/dict/es/
 activity: none
@@ -702,6 +707,11 @@ activity: low
 kind: url
 name: cdargs
 url: http://www.skamphausen.de/downloads/cdargs
+activity: none
+---
+kind: url
+name: cdparanoia
+url: https://downloads.xiph.org/releases/cdparanoia
 activity: none
 ---
 kind: url

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -3625,6 +3625,11 @@ url: https://download.videolan.org/pub/libdvbpsi/
 activity: none
 ---
 kind: url
+name: libdvdcss
+url: http://get.videolan.org/libdvdcss/
+activity: low
+---
+kind: url
 name: libdvdnav
 url: http://get.videolan.org/libdvdnav/
 activity: medium


### PR DESCRIPTION
- Adds `cdparanoia`, `asunder`, `libdvdcss`, `onevpl`

Builds properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=disk CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
