### PR TITLE
Add dvtm package

### DIFF
--- a/packages/dvtm.rb
+++ b/packages/dvtm.rb
@@ -1,0 +1,37 @@
+require 'package'
+
+class Dvtm < Package
+  description 'dynamic virtual terminal manager'
+  homepage 'https://www.brain-dump.org/projects/dvtm/'
+  version '0.15'
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://github.com/martanne/dvtm/releases/download/v0.15/dvtm-0.15.tar.gz'
+  source_sha256 '8f2015c05e2ad82f12ae4cf12b363d34f527a4bbc8c369667f239e4542e1e510'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dvtm/0.15_armv7l/dvtm-0.15-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dvtm/0.15_armv7l/dvtm-0.15-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dvtm/0.15_i686/dvtm-0.15-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dvtm/0.15_x86_64/dvtm-0.15-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '572ac426b7ab0e524663f1379bcad050bcb83461d23c362dad52726a97c18c1a',
+     armv7l: '572ac426b7ab0e524663f1379bcad050bcb83461d23c362dad52726a97c18c1a',
+       i686: '3c583a0044d4715fb239461a77f74ec5e5dbfb0d26eee2e2fbbdbe8135fc391c',
+     x86_64: 'b9933b25910f69410b25b3d0e771d3daff8454c9e7bdb52a394e661acd2a3012'
+  })
+
+  depends_on 'ncurses'
+
+  def self.build
+    system "PREFIX=#{CREW_PREFIX} \
+            CFLAGS='-I#{CREW_PREFIX}/include/ncursesw' \
+            LDFLAGS='-ltinfow' \
+            make"
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/packages/libtinfo.rb
+++ b/packages/libtinfo.rb
@@ -3,23 +3,24 @@ require 'package'
 class Libtinfo < Package
   description 'Missing ncurses library reference.'
   homepage 'https://www.gnu.org/software/ncurses/'
-  version '5.9'
+  @_ver = 5.9
+  version "#{@_ver}-1"
   license 'MIT' # Ncurses license
   compatibility 'all'
   source_url 'https://github.com/mirror/ncurses.git'
-  git_hashtag "v#{version}"
+  git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtinfo/5.9_armv7l/libtinfo-5.9-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtinfo/5.9_armv7l/libtinfo-5.9-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtinfo/5.9_i686/libtinfo-5.9-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtinfo/5.9_x86_64/libtinfo-5.9-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtinfo/5.9-1_armv7l/libtinfo-5.9-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtinfo/5.9-1_armv7l/libtinfo-5.9-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtinfo/5.9-1_i686/libtinfo-5.9-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libtinfo/5.9-1_x86_64/libtinfo-5.9-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '2e94b9a42682306f5c05eae9a9b28fb797a79b7f782ed4e291c66224fb2a09b4',
-     armv7l: '2e94b9a42682306f5c05eae9a9b28fb797a79b7f782ed4e291c66224fb2a09b4',
-       i686: 'c884149bf8c6dea3fc3d16ba1ac316c811d318fbfa18ef35171e2bf2c81f4bd9',
-     x86_64: '6ff14ec1bdcdbf55e145b4a8c450b09526803c1450fb3a06fc233a9e85e4ea3e'
+    aarch64: '4cd214446b4d34eb7c00166986e746c8cc84b123d8cb3bbff61d486384c746f2',
+     armv7l: '4cd214446b4d34eb7c00166986e746c8cc84b123d8cb3bbff61d486384c746f2',
+       i686: '1391890981de5c9b70cc86e8ac3e0b87076ea6cdf7a73c89e3b5aa3c8500a67d',
+     x86_64: '9527bba23a9c551e0865996aeedf0d13a87572b8049125cbff24bf2d137e5e23'
   })
 
   def self.build
@@ -72,10 +73,9 @@ class Libtinfo < Package
       system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install.libs'
     end
     # Save only the libtinfo libraries.
-    FileUtils.mv Dir["ncurses_build/#{ARCH_LIB}/libtinfo.so.5*"], CREW_DEST_DIR
-    FileUtils.mv Dir["ncursesw_build/#{ARCH_LIB}/libtinfow.so.5*"], CREW_DEST_DIR
     FileUtils.rm_rf CREW_DEST_PREFIX
     FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
-    FileUtils.mv Dir["#{CREW_DEST_DIR}/libtinfo*.so.5*"], CREW_DEST_LIB_PREFIX
+    FileUtils.mv Dir['ncurses_build/lib/libtinfo.so.5*'], CREW_DEST_LIB_PREFIX
+    FileUtils.mv Dir['ncursesw_build/lib/libtinfow.so.5*'], CREW_DEST_LIB_PREFIX
   end
 end

--- a/packages/ncurses.rb
+++ b/packages/ncurses.rb
@@ -3,23 +3,23 @@ require 'package'
 class Ncurses < Package
   description 'The ncurses (new curses) library is a free software emulation of curses in System V Release 4.0 (SVr4), and more. — Wide character'
   homepage 'https://www.gnu.org/software/ncurses/'
-  version '6.3-20211106'
+  version '6.3-20221119'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/mirror/ncurses.git'
-  git_hashtag 'f399f54c6c4ea2143afcbf704ce9af0be52b63fc'
+  git_hashtag '18c5cff3297b96ac5988a716c66b374734a7de90'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ncurses/6.3-20211106_armv7l/ncurses-6.3-20211106-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ncurses/6.3-20211106_armv7l/ncurses-6.3-20211106-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ncurses/6.3-20211106_i686/ncurses-6.3-20211106-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ncurses/6.3-20211106_x86_64/ncurses-6.3-20211106-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ncurses/6.3-20221119_armv7l/ncurses-6.3-20221119-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ncurses/6.3-20221119_armv7l/ncurses-6.3-20221119-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ncurses/6.3-20221119_i686/ncurses-6.3-20221119-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ncurses/6.3-20221119_x86_64/ncurses-6.3-20221119-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'ca5672be1713a202243f5c13bbb688254cf0c93b075dcfc5c3d51677d6861b1e',
-     armv7l: 'ca5672be1713a202243f5c13bbb688254cf0c93b075dcfc5c3d51677d6861b1e',
-       i686: '208930e9bb95aa70c7111e3ea22fcdc4f03295153feed0b7b2b79ff179a42d13',
-     x86_64: '567cf7a40682009b0b817795e62e248374e87896ab76e5bd5fc69f98d252bf31'
+    aarch64: '1844aeda65822d900646d847782912b4aed6fe9811a15c9e277aee1b08c9520f',
+     armv7l: '1844aeda65822d900646d847782912b4aed6fe9811a15c9e277aee1b08c9520f',
+       i686: '3eb7cc37c8f63c6aeb7a46233db1bbc2305a8914670e9f111c0fb3fe2cf5e321',
+     x86_64: 'a24d0ce6a592d593e561e921521979bdad3688d1cf606bbaba01a6ceedeacea0'
   })
 
   depends_on 'gcc' # R
@@ -70,13 +70,9 @@ class Ncurses < Package
     Dir.chdir 'ncursesw_build' do
       system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     end
-    # Make symlinks for non-wide software
-    # Dir.chdir CREW_DEST_LIB_PREFIX.to_s do
-    #  Dir.glob('*w.so*').each do |f|
-    #    @basefile_nowide = f.gsub('w.so', '.so')
-    #    puts "Symlinking #{f} to #{@basefile_nowide}"
-    #    FileUtils.ln_sf f, @basefile_nowide
-    #  end
-    # end
+    # Remove conflicts with dvtm package.
+    Dir.chdir "#{CREW_DEST_PREFIX}/share/terminfo/d" do
+      FileUtils.rm %w[dvtm dvtm-256color]
+    end
   end
 end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -1315,6 +1315,11 @@ url: https://launchpad.net/duplicity/+download
 activity: medium
 ---
 kind: url
+name: dvtm
+url: https://github.com/martanne/dvtm/releases
+activity: none
+---
+kind: url
 name: e2fsprogs
 url: https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs
 activity: medium


### PR DESCRIPTION
dvtm brings the concept of tiling window management, popularized by X11-window managers like dwm to the console. As a console window manager it tries to make it easy to work with multiple console based programs.  See https://www.brain-dump.org/projects/dvtm/.  Tested on all architectures.