### PR TITLE
meson -> 0.64.1, update meson setup code in packages

### DIFF
--- a/packages/amtk.rb
+++ b/packages/amtk.rb
@@ -28,7 +28,7 @@ class Amtk < Package
   depends_on 'llvm' => :build
 
   def self.build
-    system "meson #{CREW_MESON_FNO_LTO_OPTIONS} \
+    system "meson setup #{CREW_MESON_FNO_LTO_OPTIONS} \
     -Dc_args='-fuse-ld=lld' \
     builddir"
     system 'meson configure builddir'

--- a/packages/appstream_glib.rb
+++ b/packages/appstream_glib.rb
@@ -45,7 +45,7 @@ class Appstream_glib < Package
   depends_on 'util_linux'
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Dtests=false \
       -Dsysprof=disabled \
       -Dintrospection=true \

--- a/packages/at_spi2_atk.rb
+++ b/packages/at_spi2_atk.rb
@@ -27,7 +27,7 @@ class At_spi2_atk < Package
   depends_on 'atk'
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} builddir"
+    system "meson setup #{CREW_MESON_OPTIONS} builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
   end

--- a/packages/at_spi2_core.rb
+++ b/packages/at_spi2_core.rb
@@ -39,7 +39,7 @@ class At_spi2_core < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/atk.rb
+++ b/packages/atk.rb
@@ -29,7 +29,7 @@ class Atk < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
     system 'mold -run samu -C builddir'

--- a/packages/atkmm.rb
+++ b/packages/atkmm.rb
@@ -32,7 +32,7 @@ class Atkmm < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     --default-library=both \
     -Dbuild-documentation=false \
     builddir"

--- a/packages/babl.rb
+++ b/packages/babl.rb
@@ -29,7 +29,7 @@ class Babl < Package
   depends_on 'gcc' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Denable-gir=true \
       builddir"
     system 'meson configure builddir'

--- a/packages/baobab.rb
+++ b/packages/baobab.rb
@@ -38,7 +38,7 @@ class Baobab < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
     system 'mold -run samu -C builddir'

--- a/packages/cairo.rb
+++ b/packages/cairo.rb
@@ -35,7 +35,7 @@ class Cairo < Package
   conflicts_ok # because this overwrites the limited cairo from harfbuzz
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     --default-library=both \
     -Dgl-backend=auto \
     -Dglesv3=enabled \

--- a/packages/cairomm_1_0.rb
+++ b/packages/cairomm_1_0.rb
@@ -29,7 +29,7 @@ class Cairomm_1_0 < Package
   depends_on 'libxrender'
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     --default-library=both \
     -Dbuild-documentation=false \
     -Dbuild-examples=false \

--- a/packages/cairomm_1_16.rb
+++ b/packages/cairomm_1_16.rb
@@ -29,7 +29,7 @@ class Cairomm_1_16 < Package
   depends_on 'libxrender'
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     --default-library=both \
     -Dbuild-documentation=false \
     -Dbuild-examples=false \

--- a/packages/cantarell_fonts.rb
+++ b/packages/cantarell_fonts.rb
@@ -28,7 +28,7 @@ class Cantarell_fonts < Package
   depends_on 'graphite' => :build
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Duseprebuilt=true \
       -Dfontsdir=#{CREW_PREFIX}/share/fonts/opentype/cantarell \
       builddir"

--- a/packages/clutter_gtk.rb
+++ b/packages/clutter_gtk.rb
@@ -29,7 +29,7 @@ class Clutter_gtk < Package
   depends_on 'valgrind' => :build
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} builddir"
+    system "meson setup #{CREW_MESON_OPTIONS} builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
   end

--- a/packages/colord.rb
+++ b/packages/colord.rb
@@ -39,7 +39,7 @@ class Colord < Package
   end
 
   def self.build
-    system "meson #{CREW_MESON_FNO_LTO_OPTIONS} -Dsystemd=false -Ddaemon_user=#{USER} builddir"
+    system "meson setup #{CREW_MESON_FNO_LTO_OPTIONS} -Dsystemd=false -Ddaemon_user=#{USER} builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
   end

--- a/packages/curtail.rb
+++ b/packages/curtail.rb
@@ -31,7 +31,7 @@ class Curtail < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} build"
+    system "meson setup #{CREW_MESON_OPTIONS} build"
     system 'ninja -C build'
   end
 

--- a/packages/dav1d.rb
+++ b/packages/dav1d.rb
@@ -27,7 +27,7 @@ class Dav1d < Package
   depends_on 'glibc' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/dconf.rb
+++ b/packages/dconf.rb
@@ -29,7 +29,7 @@ class Dconf < Package
   depends_on 'bash_completion' => :build
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/dconf_editor.rb
+++ b/packages/dconf_editor.rb
@@ -32,7 +32,7 @@ class Dconf_editor < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
             builddir"
     system 'ninja -C builddir'
   end

--- a/packages/elogind.rb
+++ b/packages/elogind.rb
@@ -35,7 +35,7 @@ class Elogind < Package
   depends_on 'polkit'
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Dc_args='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto -fuse-ld=gold' \
       -Dc_link_args='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto -fuse-ld=gold' \
       -Dcpp_args='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto -fuse-ld=gold' \

--- a/packages/epiphany.rb
+++ b/packages/epiphany.rb
@@ -59,7 +59,7 @@ class Epiphany < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/evince.rb
+++ b/packages/evince.rb
@@ -48,7 +48,7 @@ class Evince < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Dgtk_doc=false \
       -Dnautilus=false \
       -Dps=enabled \

--- a/packages/fcft.rb
+++ b/packages/fcft.rb
@@ -41,7 +41,7 @@ class Fcft < Package
   end
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Dgrapheme-shaping=enabled \
       -Drun-shaping=enabled \
       builddir"

--- a/packages/flatseal.rb
+++ b/packages/flatseal.rb
@@ -31,7 +31,7 @@ class Flatseal < Package
   depends_on 'sommelier'
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} builddir"
+    system "meson setup #{CREW_MESON_OPTIONS} builddir"
     system 'samu -C builddir'
   end
 

--- a/packages/folks.rb
+++ b/packages/folks.rb
@@ -35,7 +35,7 @@ class Folks < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Dbluez_backend=false \
     -Ddocs=false \
     -Deds_backend=false \

--- a/packages/foot.rb
+++ b/packages/foot.rb
@@ -49,7 +49,7 @@ class Foot < Package
   end
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Dterminfo=disabled \
       -Dthemes=false \
       builddir"

--- a/packages/fuse3.rb
+++ b/packages/fuse3.rb
@@ -26,7 +26,7 @@ class Fuse3 < Package
   depends_on 'py3_pytest' => :build
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Ddisable-mtab=true \
     -Dudevrulesdir=#{CREW_PREFIX}/etc/udev/rules.d/ \
     -Dexamples=true \

--- a/packages/gcab.rb
+++ b/packages/gcab.rb
@@ -32,7 +32,7 @@ class Gcab < Package
   end
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Ddocs=false \
       -Dtests=false \
       -Dvapi=false \

--- a/packages/gcr_3.rb
+++ b/packages/gcr_3.rb
@@ -48,7 +48,7 @@ class Gcr_3 < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Dgtk_doc=false \
     builddir"
     system 'meson configure builddir'

--- a/packages/gcr_4.rb
+++ b/packages/gcr_4.rb
@@ -46,7 +46,7 @@ class Gcr_4 < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Dgtk_doc=false \
     builddir"
     system 'meson configure builddir'

--- a/packages/gdk_pixbuf.rb
+++ b/packages/gdk_pixbuf.rb
@@ -44,7 +44,7 @@ class Gdk_pixbuf < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Dinstalled_tests=false \
       -Dbuiltin_loaders=all \
       -Drelocatable=true \

--- a/packages/gedit.rb
+++ b/packages/gedit.rb
@@ -56,7 +56,7 @@ class Gedit < Package
   end
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Drequire_all_tests=false \
     -Duser_documentation=false \
     builddir"

--- a/packages/gegl.rb
+++ b/packages/gegl.rb
@@ -50,7 +50,7 @@ class Gegl < Package
   depends_on 'vala' => :build
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Dlibjpeg=enabled \
       -Dlibpng=enabled \
     builddir"

--- a/packages/geoclue.rb
+++ b/packages/geoclue.rb
@@ -33,7 +33,7 @@ class Geoclue < Package
   depends_on 'modemmanager'
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Dsystemd=disabled \
       -Ddbus-sys-dir=#{CREW_PREFIX}/share/dbus-1 \
       -D3g-source=true \

--- a/packages/geocode_glib.rb
+++ b/packages/geocode_glib.rb
@@ -37,7 +37,7 @@ class Geocode_glib < Package
   end
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/geocode_glib2.rb
+++ b/packages/geocode_glib2.rb
@@ -38,7 +38,7 @@ class Geocode_glib2 < Package
   end
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Dsoup2=false \
       builddir"
     system 'meson configure builddir'

--- a/packages/gexiv2.rb
+++ b/packages/gexiv2.rb
@@ -31,7 +31,7 @@ class Gexiv2 < Package
   depends_on 'glibc' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/gjs.rb
+++ b/packages/gjs.rb
@@ -37,7 +37,7 @@ class Gjs < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Dinstalled_tests=false \
     -Dskip_dbus_tests=true \
     -Dskip_gtk_tests=true \

--- a/packages/glib_networking.rb
+++ b/packages/glib_networking.rb
@@ -26,7 +26,7 @@ class Glib_networking < Package
   depends_on 'gsettings_desktop_schemas'
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Dstatic_modules=true builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/glibmm_2_4.rb
+++ b/packages/glibmm_2_4.rb
@@ -28,7 +28,7 @@ class Glibmm_2_4 < Package
   depends_on 'mm_common' => :build
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     --default-library=both \
     -Dbuild-documentation=false \
     -Dbuild-demos=false \

--- a/packages/glibmm_2_68.rb
+++ b/packages/glibmm_2_68.rb
@@ -31,7 +31,7 @@ class Glibmm_2_68 < Package
   depends_on 'glibc' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     --default-library=both \
     -Dbuild-documentation=false \
     builddir"

--- a/packages/gnome_autoar.rb
+++ b/packages/gnome_autoar.rb
@@ -40,7 +40,7 @@ class Gnome_autoar < Package
   depends_on 'zlibpkg' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
     system 'mold -run samu -C builddir'

--- a/packages/gnome_calculator.rb
+++ b/packages/gnome_calculator.rb
@@ -44,7 +44,7 @@ class Gnome_calculator < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} builddir"
+    system "meson setup #{CREW_MESON_OPTIONS} builddir"
     system 'meson configure builddir'
     system 'samu -C builddir'
   end

--- a/packages/gnome_console.rb
+++ b/packages/gnome_console.rb
@@ -45,7 +45,7 @@ class Gnome_console < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
     system 'mold -run samu -C builddir'

--- a/packages/gnome_desktop.rb
+++ b/packages/gnome_desktop.rb
@@ -49,7 +49,7 @@ class Gnome_desktop < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Dsystemd=disabled \
     builddir"
     system 'meson configure builddir'

--- a/packages/gnome_klotski.rb
+++ b/packages/gnome_klotski.rb
@@ -16,7 +16,7 @@ class Gnome_klotski < Package
   depends_on 'libgnome_games_support'
 
   def self.build
-    system "meson #{CREW_MESON_FNO_LTO_OPTIONS} builddir"
+    system "meson setup #{CREW_MESON_FNO_LTO_OPTIONS} builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
   end

--- a/packages/gnome_maps.rb
+++ b/packages/gnome_maps.rb
@@ -48,7 +48,7 @@ class Gnome_maps < Package
   end
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/gnome_mines.rb
+++ b/packages/gnome_mines.rb
@@ -17,7 +17,7 @@ class Gnome_mines < Package
   depends_on 'wayland'
 
   def self.build
-    system "meson #{CREW_MESON_FNO_LTO_OPTIONS} builddir"
+    system "meson setup #{CREW_MESON_FNO_LTO_OPTIONS} builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
   end

--- a/packages/gnome_nibbles.rb
+++ b/packages/gnome_nibbles.rb
@@ -17,7 +17,7 @@ class Gnome_nibbles < Package
   depends_on 'wayland'
 
   def self.build
-    system "meson #{CREW_MESON_FNO_LTO_OPTIONS} builddir"
+    system "meson setup #{CREW_MESON_FNO_LTO_OPTIONS} builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
   end

--- a/packages/gnome_online_accounts.rb
+++ b/packages/gnome_online_accounts.rb
@@ -34,7 +34,7 @@ class Gnome_online_accounts < Package
   depends_on 'vala' => :build
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Dgtk_doc=true \
     builddir"
     system 'meson configure builddir'

--- a/packages/gnome_session.rb
+++ b/packages/gnome_session.rb
@@ -47,7 +47,7 @@ class Gnome_session < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS}\
+    system "meson setup #{CREW_MESON_OPTIONS}\
       -Dsystemd=false \
       -Dsystemd_session=disable \
       -Dsystemd_journal=false \

--- a/packages/gnome_settings_daemon.rb
+++ b/packages/gnome_settings_daemon.rb
@@ -62,7 +62,7 @@ class Gnome_settings_daemon < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Dsystemd=false \
     -Dcolord=false \
     builddir"

--- a/packages/gnome_shell.rb
+++ b/packages/gnome_shell.rb
@@ -39,7 +39,7 @@ class Gnome_shell < Package
   depends_on 'vulkan_icd_loader' => :build
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Dgtk_doc=true \
     -Dsystemd=false \
     -Dnetworkmanager=false \

--- a/packages/gnome_sudoku.rb
+++ b/packages/gnome_sudoku.rb
@@ -17,7 +17,7 @@ class Gnome_sudoku < Package
   depends_on 'sommelier'
 
   def self.build
-    system "meson #{CREW_MESON_FNO_LTO_OPTIONS} builddir"
+    system "meson setup #{CREW_MESON_FNO_LTO_OPTIONS} builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
   end

--- a/packages/gnome_terminal.rb
+++ b/packages/gnome_terminal.rb
@@ -31,7 +31,7 @@ class Gnome_terminal < Package
   depends_on 'gtk_doc'
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     --default-library=both \
     -Ddocs=false \
     -Dsearch_provider=false \

--- a/packages/gnome_text_editor.rb
+++ b/packages/gnome_text_editor.rb
@@ -37,7 +37,7 @@ class Gnome_text_editor < Package
   depends_on 'gtk_doc' => :build
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
             builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/gnome_weather.rb
+++ b/packages/gnome_weather.rb
@@ -32,7 +32,7 @@ class Gnome_weather < Package
   depends_on 'libhandy'
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Dsystemd=disabled \
     builddir"
     system 'meson configure builddir'

--- a/packages/gobject_introspection.rb
+++ b/packages/gobject_introspection.rb
@@ -29,7 +29,7 @@ class Gobject_introspection < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       builddir"
     system 'meson configure builddir'
     system 'mold -run samu -C builddir'

--- a/packages/graphene.rb
+++ b/packages/graphene.rb
@@ -27,7 +27,7 @@ class Graphene < Package
   def self.build
     ENV['CFLAGS'] = '-fuse-ld=lld'
     ENV['CXXFLAGS'] = '-fuse-ld=lld'
-    system "meson #{CREW_MESON_FNO_LTO_OPTIONS} \
+    system "meson setup #{CREW_MESON_FNO_LTO_OPTIONS} \
       -Darm_neon=false \
       -Dinstalled_tests=false \
       -Dtests=false \

--- a/packages/gsettings_desktop_schemas.rb
+++ b/packages/gsettings_desktop_schemas.rb
@@ -31,7 +31,7 @@ class Gsettings_desktop_schemas < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} builddir"
+    system "meson setup #{CREW_MESON_OPTIONS} builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
   end

--- a/packages/gst_editing_services.rb
+++ b/packages/gst_editing_services.rb
@@ -30,7 +30,7 @@ class Gst_editing_services < Package
   depends_on 'pygobject' => :build
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Ddoc=disabled \
       -Dvalidate=disabled \
       builddir"

--- a/packages/gstreamer.rb
+++ b/packages/gstreamer.rb
@@ -115,7 +115,7 @@ class Gstreamer < Package
     when 'i686'
       @plugins = '-Dgst-plugins-bad:msdk=disabled'
     end
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Dgpl=enabled \
     -Dtests=disabled #{@plugins}\
     builddir"

--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -80,7 +80,7 @@ class Gtk3 < Package
   end
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Dbroadway_backend=true \
       -Ddemos=false \
       -Dexamples=false \

--- a/packages/gtk4.rb
+++ b/packages/gtk4.rb
@@ -90,7 +90,7 @@ class Gtk4 < Package
   end
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Dbroadway-backend=true \
       -Dbuild-examples=false \
       -Dbuild-tests=false \

--- a/packages/gtk_doc.rb
+++ b/packages/gtk_doc.rb
@@ -29,7 +29,7 @@ class Gtk_doc < Package
   depends_on 'py3_pygments' => :build
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} builddir"
+    system "meson setup #{CREW_MESON_OPTIONS} builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
   end

--- a/packages/gtkmm3.rb
+++ b/packages/gtkmm3.rb
@@ -27,7 +27,7 @@ class Gtkmm3 < Package
   depends_on 'pangomm'
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     --default-library=both \
     -Dbuild-documentation=false \
     -Dbuild-demos=false \

--- a/packages/gtkmm4.rb
+++ b/packages/gtkmm4.rb
@@ -28,7 +28,7 @@ class Gtkmm4 < Package
   depends_on 'cairomm'
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/gtksourceview_4.rb
+++ b/packages/gtksourceview_4.rb
@@ -48,7 +48,7 @@ class Gtksourceview_4 < Package
   end
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Db_asneeded=false \
     builddir"
     system 'meson configure builddir'

--- a/packages/gtksourceview_5.rb
+++ b/packages/gtksourceview_5.rb
@@ -48,7 +48,7 @@ class Gtksourceview_5 < Package
   end
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Db_asneeded=false \
     builddir"
     system 'meson configure builddir'

--- a/packages/gusb.rb
+++ b/packages/gusb.rb
@@ -33,7 +33,7 @@ class Gusb < Package
   end
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Dc_args='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto -fuse-ld=gold' \
     -Dc_link_args='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto -fuse-ld=gold' \
     -Dcpp_args='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto -fuse-ld=gold' \

--- a/packages/gvfs.rb
+++ b/packages/gvfs.rb
@@ -51,7 +51,7 @@ class Gvfs < Package
   depends_on 'libxml2' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Dfuse=true \
     -Dgoa=false \
     -Dgoogle=false \

--- a/packages/igt_gpu_tools.rb
+++ b/packages/igt_gpu_tools.rb
@@ -32,7 +32,7 @@ class Igt_gpu_tools < Package
   depends_on 'gtk_doc' => :build
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Ddocs=disabled \
     -Dtests=disabled \
     -Doping=disabled \

--- a/packages/iputils.rb
+++ b/packages/iputils.rb
@@ -23,7 +23,7 @@ class Iputils < Package
   depends_on 'libcap'
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} builddir"
+    system "meson setup #{CREW_MESON_OPTIONS} builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
   end

--- a/packages/json_glib.rb
+++ b/packages/json_glib.rb
@@ -27,7 +27,7 @@ class Json_glib < Package
   depends_on 'gobject_introspection'
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/jsoncpp.rb
+++ b/packages/jsoncpp.rb
@@ -25,7 +25,7 @@ class Jsoncpp < Package
   depends_on 'meson'
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
     system 'samu -C builddir'

--- a/packages/jsonrpc_glib.rb
+++ b/packages/jsonrpc_glib.rb
@@ -33,7 +33,7 @@ class Jsonrpc_glib < Package
   depends_on 'glibc' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
     system 'mold -run samu -C builddir'

--- a/packages/ksh.rb
+++ b/packages/ksh.rb
@@ -23,7 +23,7 @@ class Ksh < Package
   })
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Daudit-file=#{CREW_PREFIX}/etc/ksh_audit build"
     system 'ninja -C build'
   end

--- a/packages/libadwaita.rb
+++ b/packages/libadwaita.rb
@@ -43,7 +43,7 @@ class Libadwaita < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
             -Dintrospection=enabled \
             -Dexamples=false \
             -Dgtk_doc=false \

--- a/packages/libchamplain.rb
+++ b/packages/libchamplain.rb
@@ -32,7 +32,7 @@ class Libchamplain < Package
   depends_on 'vala' => :build
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/libcloudproviders.rb
+++ b/packages/libcloudproviders.rb
@@ -34,7 +34,7 @@ class Libcloudproviders < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/libdazzle.rb
+++ b/packages/libdazzle.rb
@@ -32,7 +32,7 @@ class Libdazzle < Package
   depends_on 'harfbuzz' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/libdrm.rb
+++ b/packages/libdrm.rb
@@ -31,7 +31,7 @@ class Libdrm < Package
   depends_on 'gcc' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Dfreedreno-kgsl=true \
       -Damdgpu=enabled \
       -Dradeon=enabled \

--- a/packages/libefl.rb
+++ b/packages/libefl.rb
@@ -84,7 +84,7 @@ class Libefl < Package
   depends_on 'zlibpkg' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
        -Dcrypto=gnutls \
        -Dsystemd=false \
        -Dglib=false \

--- a/packages/libepoxy.rb
+++ b/packages/libepoxy.rb
@@ -26,7 +26,7 @@ class Libepoxy < Package
   depends_on 'python3'
 
   def self.build
-    system "meson #{CREW_MESON_FNO_LTO_OPTIONS} builddir"
+    system "meson setup #{CREW_MESON_FNO_LTO_OPTIONS} builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
   end

--- a/packages/libevdev.rb
+++ b/packages/libevdev.rb
@@ -27,7 +27,7 @@ class Libevdev < Package
   depends_on 'python3' => :build
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/libglvnd.rb
+++ b/packages/libglvnd.rb
@@ -30,7 +30,7 @@ class Libglvnd < Package
   depends_on 'glibc' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/libgnome_games_support.rb
+++ b/packages/libgnome_games_support.rb
@@ -15,7 +15,7 @@ class Libgnome_games_support < Package
   depends_on 'clutter'
 
   def self.build
-    system "meson #{CREW_MESON_FNO_LTO_OPTIONS} builddir"
+    system "meson setup #{CREW_MESON_FNO_LTO_OPTIONS} builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
   end

--- a/packages/libgudev.rb
+++ b/packages/libgudev.rb
@@ -28,7 +28,7 @@ class Libgudev < Package
   depends_on 'glibc' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/libgweather.rb
+++ b/packages/libgweather.rb
@@ -39,7 +39,7 @@ class Libgweather < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Dsoup2=true \
     builddir"
     system 'meson configure builddir'

--- a/packages/libgxps.rb
+++ b/packages/libgxps.rb
@@ -45,7 +45,7 @@ class Libgxps < Package
   depends_on 'gcc' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/libhandy.rb
+++ b/packages/libhandy.rb
@@ -36,7 +36,7 @@ class Libhandy < Package
   depends_on 'harfbuzz' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} builddir"
+    system "meson setup #{CREW_MESON_OPTIONS} builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
   end

--- a/packages/libinih.rb
+++ b/packages/libinih.rb
@@ -24,7 +24,7 @@ class Libinih < Package
   })
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Ddefault_library=both \
     -Ddistro_install=true \
     -Dwith_INIReader=true \

--- a/packages/libinput.rb
+++ b/packages/libinput.rb
@@ -35,7 +35,7 @@ class Libinput < Package
   # depends_on 'gtk3' => :build
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Ddebug-gui=false \
       -Ddocumentation=false \
       builddir"

--- a/packages/libmicrodns.rb
+++ b/packages/libmicrodns.rb
@@ -24,7 +24,7 @@ class Libmicrodns < Package
   })
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
               -Dtests=enabled builddir"
     system 'samu -C builddir'
   end

--- a/packages/libnotify.rb
+++ b/packages/libnotify.rb
@@ -27,7 +27,7 @@ class Libnotify < Package
   depends_on 'glib' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Dman=false \
     -Ddocbook_docs=disabled \
     -Dtests=false \

--- a/packages/libnvme.rb
+++ b/packages/libnvme.rb
@@ -28,7 +28,7 @@ class Libnvme < Package
   depends_on 'swig' => :build
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} builddir"
+    system "meson setup #{CREW_MESON_OPTIONS} builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
   end

--- a/packages/libpanel.rb
+++ b/packages/libpanel.rb
@@ -33,7 +33,7 @@ class Libpanel < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
     system 'mold -run samu -C builddir'

--- a/packages/libpeas.rb
+++ b/packages/libpeas.rb
@@ -38,7 +38,7 @@ class Libpeas < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} builddir"
+    system "meson setup #{CREW_MESON_OPTIONS} builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
   end

--- a/packages/libportal.rb
+++ b/packages/libportal.rb
@@ -31,7 +31,7 @@ class Libportal < Package
   depends_on 'vulkan_icd_loader'
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Dbackends=gtk3,gtk4 \
     -Ddocs=false \
     -Dportal-tests=false \

--- a/packages/libpsl.rb
+++ b/packages/libpsl.rb
@@ -27,7 +27,7 @@ class Libpsl < Package
   depends_on 'libidn2'
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
     system 'mold -run samu -C builddir'

--- a/packages/libsecret.rb
+++ b/packages/libsecret.rb
@@ -30,7 +30,7 @@ class Libsecret < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Dgtk_doc=false \
       -Dmanpage=false \
       build"

--- a/packages/libshumate.rb
+++ b/packages/libshumate.rb
@@ -42,7 +42,7 @@ class Libshumate < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/libsigcplusplus.rb
+++ b/packages/libsigcplusplus.rb
@@ -29,7 +29,7 @@ class Libsigcplusplus < Package
   depends_on 'glibc' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Dmaintainer-mode=true \
     -Dbuild-deprecated-api=true \
     -Dbuild-examples=false \

--- a/packages/libsigcplusplus3.rb
+++ b/packages/libsigcplusplus3.rb
@@ -24,7 +24,7 @@ class Libsigcplusplus3 < Package
   })
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Dbuild-examples=false \
     builddir"
     system 'meson configure builddir'

--- a/packages/libsoup.rb
+++ b/packages/libsoup.rb
@@ -40,7 +40,7 @@ class Libsoup < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Dtests=false \
       -Dsysprof=disabled \
       -Dintrospection=enabled \

--- a/packages/libsoup2.rb
+++ b/packages/libsoup2.rb
@@ -38,7 +38,7 @@ class Libsoup2 < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Dtests=false \
       -Dsysprof=disabled \
       -Dintrospection=enabled \

--- a/packages/libva.rb
+++ b/packages/libva.rb
@@ -32,7 +32,7 @@ class Libva < Package
   depends_on 'wayland'
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     --default-library=both \
     builddir"
     system 'meson configure builddir'

--- a/packages/libva_intel_driver_hybrid.rb
+++ b/packages/libva_intel_driver_hybrid.rb
@@ -27,7 +27,7 @@ class Libva_intel_driver_hybrid < Package
   end
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
             -Denable_hybrid_codec=true builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/libva_utils.rb
+++ b/packages/libva_utils.rb
@@ -26,7 +26,7 @@ class Libva_utils < Package
   depends_on 'libva'
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} builddir"
+    system "meson setup #{CREW_MESON_OPTIONS} builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
   end

--- a/packages/libwacom.rb
+++ b/packages/libwacom.rb
@@ -31,7 +31,7 @@ class Libwacom < Package
   depends_on 'py3_pytest' => :build
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Dtests=disabled \
       builddir"
     system 'samu -C builddir'

--- a/packages/libwpe.rb
+++ b/packages/libwpe.rb
@@ -28,7 +28,7 @@ class Libwpe < Package
   depends_on 'glibc' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/libxcvt.rb
+++ b/packages/libxcvt.rb
@@ -25,7 +25,7 @@ class Libxcvt < Package
   })
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/libxvmc.rb
+++ b/packages/libxvmc.rb
@@ -26,7 +26,7 @@ class Libxvmc < Package
   depends_on 'libx11'
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
             builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/luajit_lgi.rb
+++ b/packages/luajit_lgi.rb
@@ -37,7 +37,7 @@ class Luajit_lgi < Package
     @lua_include = `pkg-config --cflags-only-I luajit | sed 's/-I//'`.chomp
     system "make LUA_INCDIR=#{@lua_include} \
        LUA_CFLAGS=#{@lua_cflags}"
-    # system "meson #{CREW_MESON_OPTIONS} \
+    # system "meson setup #{CREW_MESON_OPTIONS} \
     #-Dlua-pc=luajit \
     #-Dlua-bin=#{CREW_PREFIX}/bin/luajit \
     #-Dtests=false \

--- a/packages/meld.rb
+++ b/packages/meld.rb
@@ -27,7 +27,7 @@ class Meld < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
     system 'mold -run samu -C builddir'

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -331,7 +331,7 @@ class Mesa < Package
     end
   else
     def self.build
-      system "meson #{CREW_MESON_OPTIONS} \
+      system "meson setup #{CREW_MESON_OPTIONS} \
       -Db_asneeded=false \
       -Ddri3=enabled \
       -Degl=enabled \

--- a/packages/meson.rb
+++ b/packages/meson.rb
@@ -3,7 +3,7 @@ require 'package'
 class Meson < Package
   description 'Meson is an open source build system meant to be both extremely fast and user friendly.'
   homepage 'https://mesonbuild.com/'
-  @_ver = '0.64.0'
+  @_ver = '0.64.1'
   version @_ver
   license 'Apache-2.0'
   compatibility 'all'
@@ -11,20 +11,21 @@ class Meson < Package
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.64.0_armv7l/meson-0.64.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.64.0_armv7l/meson-0.64.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.64.0_i686/meson-0.64.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.64.0_x86_64/meson-0.64.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.64.1_armv7l/meson-0.64.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.64.1_armv7l/meson-0.64.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.64.1_i686/meson-0.64.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/meson/0.64.1_x86_64/meson-0.64.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '390bbe54efc8b46ecbfa06dd89d90d8f2a45bb7e785ffa7d421e3c5372e43d34',
-     armv7l: '390bbe54efc8b46ecbfa06dd89d90d8f2a45bb7e785ffa7d421e3c5372e43d34',
-       i686: '9242e8ef0d5ae7c2fde6f8a3bf20dc6e127847f66fa8a53c9799a68be4fcf7c5',
-     x86_64: 'f46f931ebfceb1576f52082e27a3d6f55668885d1fea7c1a8678442755db6e7c'
+    aarch64: 'b1dddc4342c0afe9627533ea94cddcd34e2c6b0d3dd227b933eb3e69807cb531',
+     armv7l: 'b1dddc4342c0afe9627533ea94cddcd34e2c6b0d3dd227b933eb3e69807cb531',
+       i686: 'c934b00d3b9b9ca144fb5d134e079d446f5e0f3624ab8d9782a4d7c4018193e8',
+     x86_64: 'f0f16322ba9dc7448cb5b1c15aea7c8b7d6b19e29df0ab773aefe6b007bd01a3'
   })
 
   depends_on 'ninja'
   depends_on 'samurai'
+  depends_on 'python3'
   depends_on 'py3_setuptools' => :build
 
   def self.build

--- a/packages/mm_common.rb
+++ b/packages/mm_common.rb
@@ -24,7 +24,7 @@ class Mm_common < Package
   })
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Duse-network=true \
     builddir"
     system 'meson configure builddir'

--- a/packages/mutter.rb
+++ b/packages/mutter.rb
@@ -34,7 +34,7 @@ class Mutter < Package
   depends_on 'xwayland'
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Dtests=false \
     -Dprofiler=false \
     -Dopengl=true \

--- a/packages/nautilus.rb
+++ b/packages/nautilus.rb
@@ -56,7 +56,7 @@ class Nautilus < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Ddocs=false \
     -Dpackagekit=false \
     -Dtests=headless \

--- a/packages/networkmanager.rb
+++ b/packages/networkmanager.rb
@@ -127,7 +127,7 @@ class Networkmanager < Package
   end
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       --default-library=both \
       -Ddbus_conf_dir=#{CREW_PREFIX}/share/dbus-1/system.d \
       -Dsystem_ca_path=#{CREW_PREFIX}/etc/ssl/certs \

--- a/packages/pango.rb
+++ b/packages/pango.rb
@@ -39,7 +39,7 @@ class Pango < Package
   depends_on 'glibc' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Dinstall-tests=false \
     -Dcairo=enabled \
     -Dfreetype=enabled \

--- a/packages/pangomm_1_4.rb
+++ b/packages/pangomm_1_4.rb
@@ -30,7 +30,7 @@ class Pangomm_1_4 < Package
   depends_on 'mm_common'
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Dmaintainer-mode=true \
     -Dbuild-documentation=false \
     builddir"

--- a/packages/pangomm_2_48.rb
+++ b/packages/pangomm_2_48.rb
@@ -30,7 +30,7 @@ class Pangomm_2_48 < Package
   depends_on 'mm_common'
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Dmaintainer-mode=true \
     -Dbuild-documentation=false \
     builddir"

--- a/packages/pixman.rb
+++ b/packages/pixman.rb
@@ -26,7 +26,7 @@ class Pixman < Package
   depends_on 'glibc' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     --default-library=both \
     -Dgtk=disabled \
     -Dlibpng=disabled \

--- a/packages/polkit.rb
+++ b/packages/polkit.rb
@@ -61,7 +61,7 @@ class Polkit < Package
   end
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Dsession_tracking=libelogind \
     -Dsystemdsystemunitdir=#{CREW_PREFIX}/etc/elogind/ \
     -Djs_engine=duktape \

--- a/packages/pulseaudio.rb
+++ b/packages/pulseaudio.rb
@@ -60,7 +60,7 @@ class Pulseaudio < Package
   git_fetchtags
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     -Dsystem_user=chronos \
     -Dsystem_group=cras \
     -Daccess_group=cras \

--- a/packages/rest.rb
+++ b/packages/rest.rb
@@ -47,7 +47,7 @@ class Rest < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
     system 'mold -run samu -C builddir'

--- a/packages/rlottie.rb
+++ b/packages/rlottie.rb
@@ -24,7 +24,7 @@ class Rlottie < Package
   })
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} builddir"
+    system "meson setup #{CREW_MESON_OPTIONS} builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
   end

--- a/packages/seatd.rb
+++ b/packages/seatd.rb
@@ -26,7 +26,7 @@ class Seatd < Package
   depends_on 'glibc' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
         -Dlibseat-logind=disabled \
         -Dlibseat-seatd=enabled \
         -Dlibseat-builtin=enabled \

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -89,7 +89,7 @@ class Sommelier < Package
 
       system <<~BUILD
         env CC=clang CXX=clang++ \
-          meson #{CREW_MESON_OPTIONS} \
+          meson setup #{CREW_MESON_OPTIONS} \
           -Db_asneeded=false \
           -Db_lto=true \
           -Db_lto_mode=thin \

--- a/packages/tepl_5.rb
+++ b/packages/tepl_5.rb
@@ -33,7 +33,7 @@ class Tepl_5 < Package
   depends_on 'vala' => :build
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} builddir"
+    system "meson setup #{CREW_MESON_OPTIONS} builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
   end

--- a/packages/tepl_6.rb
+++ b/packages/tepl_6.rb
@@ -32,7 +32,7 @@ class Tepl_6 < Package
   depends_on 'vala' => :build
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} builddir"
+    system "meson setup #{CREW_MESON_OPTIONS} builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
   end

--- a/packages/tllist.rb
+++ b/packages/tllist.rb
@@ -25,7 +25,7 @@ class Tllist < Package
   })
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       builddir"
     system 'meson configure builddir'
     system 'samu -C builddir'

--- a/packages/totem_pl_parser.rb
+++ b/packages/totem_pl_parser.rb
@@ -26,7 +26,7 @@ class Totem_pl_parser < Package
   depends_on 'libsoup'
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} build"
+    system "meson setup #{CREW_MESON_OPTIONS} build"
     system 'meson configure build'
     system 'ninja -C build'
   end

--- a/packages/tracker3.rb
+++ b/packages/tracker3.rb
@@ -42,7 +42,7 @@ class Tracker3 < Package
   depends_on 'sqlite' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Ddbus_services_dir=#{CREW_PREFIX}/share/dbus-1/services/ \
       -Ddocs=false \
       -Dman=false \

--- a/packages/tracker3_miners.rb
+++ b/packages/tracker3_miners.rb
@@ -48,7 +48,7 @@ class Tracker3_miners < Package
   depends_on 'util_linux' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Ddbus_services_dir=#{CREW_PREFIX}/share/dbus-1/services/ \
       -Dman=false \
       -Dsystemd_user_services=false \

--- a/packages/upower.rb
+++ b/packages/upower.rb
@@ -35,7 +35,7 @@ class Upower < Package
   depends_on 'gcc' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Dos_backend=linux \
       -Dsystemdsystemunitdir=no \
       -Dhistorydir=#{CREW_PREFIX}/var \

--- a/packages/vmaf.rb
+++ b/packages/vmaf.rb
@@ -29,7 +29,7 @@ class Vmaf < Package
     @avx512 = ARCH == 'x86_64' ? 'true' : 'false'
 
     Dir.chdir 'libvmaf' do
-      system "meson #{CREW_MESON_OPTIONS} \
+      system "meson setup #{CREW_MESON_OPTIONS} \
       -Denable_docs=false \
       -Denable_tests=false \
       -Denable_avx512=#{@avx512} \

--- a/packages/wayland.rb
+++ b/packages/wayland.rb
@@ -44,7 +44,7 @@ class Wayland < Package
       set +a
     WAYLAND_ENV_EOF
 
-    system "meson #{CREW_MESON_OPTIONS} -Ddocumentation=false builddir"
+    system "meson setup #{CREW_MESON_OPTIONS} -Ddocumentation=false builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
   end

--- a/packages/weston.rb
+++ b/packages/weston.rb
@@ -58,7 +58,7 @@ class Weston < Package
   depends_on 'wayland' # R
 
   def self.build
-    system "LIBRARY_PATH=#{CREW_LIB_PREFIX} meson #{CREW_MESON_OPTIONS} \
+    system "LIBRARY_PATH=#{CREW_LIB_PREFIX} meson setup #{CREW_MESON_OPTIONS} \
         -Dshell-ivi=false \
         -Dremoting=true \
         -Dbackend-default=wayland \

--- a/packages/wpebackend_fdo.rb
+++ b/packages/wpebackend_fdo.rb
@@ -33,7 +33,7 @@ class Wpebackend_fdo < Package
   depends_on 'glibc' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/xorg_intel_driver.rb
+++ b/packages/xorg_intel_driver.rb
@@ -27,7 +27,7 @@ class Xorg_intel_driver < Package
   def self.build
     # LTO is broken with this build.
     # See https://gitlab.freedesktop.org/xorg/driver/xf86-video-intel/-/issues/28
-    system "meson #{CREW_MESON_FNO_LTO_OPTIONS} \
+    system "meson setup #{CREW_MESON_FNO_LTO_OPTIONS} \
             -Ddefault-dri=3 \
             -Dxvmc=false \
             builddir"

--- a/packages/xorg_proto.rb
+++ b/packages/xorg_proto.rb
@@ -23,7 +23,7 @@ class Xorg_proto < Package
   })
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'

--- a/packages/yelp_tools.rb
+++ b/packages/yelp_tools.rb
@@ -31,7 +31,7 @@ class Yelp_tools < Package
   end
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
     system 'samu -C builddir'


### PR DESCRIPTION
meson now shows this warning during builds:
```
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.
```
- This changes all instances of `meson #CREW_*` in packages to `meson setup #{CREW_*` in packages.
  - (Just ran `sed -i "s/meson #{CREW/meson setup #{CREW/g" *.rb`)
- Also updates meson to 0.64.1

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=meson_formatting  CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
