### PR TITLE
initial attempt at functionalizing replaces in python3 package

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -959,6 +959,17 @@ def pre_install(dest_dir)
   Dir.chdir dest_dir do
     puts 'Performing pre-install...'
     @pkg.preinstall
+    # Reload device.json in case preinstall modified it via
+    # running 'crew remove packages...'
+    @device = JSON.parse(File.read("#{CREW_CONFIG_PATH}device.json"), symbolize_names: true)
+    # symbolize also values
+    @device.each do |key, _elem|
+      @device[key] = begin
+        @device[key].to_sym
+      rescue StandardError
+        @device[key]
+      end
+    end
   end
 end
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.28.5'
+CREW_VERSION = '1.28.6'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/packages/python3.rb
+++ b/packages/python3.rb
@@ -49,11 +49,15 @@ class Python3 < Package
   def self.preinstall
     @device = JSON.load_file("#{CREW_CONFIG_PATH}/device.json", symbolize_names: true)
     @replaces = %w[py3_pip py3_setuptools]
+    @replaces_installed = []
     @replaces.each do |package|
       if @device[:installed_packages].any? { |elem| elem[:name] == package }
-        puts "Removing superseded package #{package}...".orange
-        system "crew remove #{package}", exception: false
+        @replaces_installed.push(package)
       end
+    end
+    unless @replaces_installed.empty?
+      puts "Removing superseded package(s): #{@replaces_installed.join(' ')}...".orange
+      system "crew remove #{@replaces_installed.join(' ')}", exception: false
     end
   end
 

--- a/packages/python3.rb
+++ b/packages/python3.rb
@@ -47,7 +47,14 @@ class Python3 < Package
   conflicts_ok
 
   def self.preinstall
-    system 'crew remove py3_setuptools py3_pip', exception: false
+    @device = JSON.load_file("#{CREW_CONFIG_PATH}/device.json", symbolize_names: true)
+    @replaces = %w[py3_pip py3_setuptools]
+    @replaces.each do |package|
+      if @device[:installed_packages].any? { |elem| elem[:name] == package }
+        puts "Removing superseded package #{package}...".orange
+        system "crew remove #{package}", exception: false
+      end
+    end
   end
 
   def self.patch

--- a/packages/python3.rb
+++ b/packages/python3.rb
@@ -51,9 +51,7 @@ class Python3 < Package
     @replaces = %w[py3_pip py3_setuptools]
     @replaces_installed = []
     @replaces.each do |package|
-      if @device[:installed_packages].any? { |elem| elem[:name] == package }
-        @replaces_installed.push(package)
-      end
+      @replaces_installed.push(package) if @device[:installed_packages].any? { |elem| elem[:name] == package }
     end
     unless @replaces_installed.empty?
       puts "Removing superseded package(s): #{@replaces_installed.join(' ')}...".orange

--- a/packages/python3.rb
+++ b/packages/python3.rb
@@ -130,9 +130,6 @@ class Python3 < Package
       system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     end
 
-    # Remove conflicting binaries
-    # FileUtils.rm_f "#{CREW_DEST_PREFIX}/bin/wheel"
-
     # Make python3 the default python
     FileUtils.ln_sf 'python3', "#{CREW_DEST_PREFIX}/bin/python"
   end


### PR DESCRIPTION
- Adds generalizable code for removing packages in preinstall. (This should move into crew at some point.)

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=python3_tweak  CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
