### PR TITLE
glibc: make symlinks in postinstall to system symlink

### DIFF
--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -632,11 +632,11 @@ class Glibc < Package
       puts 'Creating symlinks to system glibc version to prevent breakage.'.lightblue
       case ARCH
       when 'aarch64', 'armv7l'
-        FileUtils.ln_sf "/lib/ld-linux-armhf.so.3", 'ld-linux-armhf.so.3'
+        FileUtils.ln_sf '/lib/ld-linux-armhf.so.3', 'ld-linux-armhf.so.3'
       when 'i686'
         FileUtils.ln_sf "/lib/ld-#{@crew_libc_version}.so", 'ld-linux-i686.so.2'
       when 'x86_64'
-        FileUtils.ln_sf "/lib64/ld-linux-x86-64.so.2", 'ld-linux-x86-64.so.2'
+        FileUtils.ln_sf '/lib64/ld-linux-x86-64.so.2', 'ld-linux-x86-64.so.2'
       end
       @libraries.each do |lib|
         # Reject entries which aren't libraries ending in .so, and which aren't files.

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -632,11 +632,11 @@ class Glibc < Package
       puts 'Creating symlinks to system glibc version to prevent breakage.'.lightblue
       case ARCH
       when 'aarch64', 'armv7l'
-        FileUtils.ln_sf "/lib/ld-#{@crew_libc_version}.so", 'ld-linux-armhf.so.3'
+        FileUtils.ln_sf "/lib/ld-linux-armhf.so.3", 'ld-linux-armhf.so.3'
       when 'i686'
         FileUtils.ln_sf "/lib/ld-#{@crew_libc_version}.so", 'ld-linux-i686.so.2'
       when 'x86_64'
-        FileUtils.ln_sf "/lib64/ld-#{@crew_libc_version}.so", 'ld-linux-x86-64.so.2'
+        FileUtils.ln_sf "/lib64/ld-linux-x86-64.so.2", 'ld-linux-x86-64.so.2'
       end
       @libraries.each do |lib|
         # Reject entries which aren't libraries ending in .so, and which aren't files.


### PR DESCRIPTION
- `/lib64/ld-2.35.so` does not exist in M108 on some machines, so make postinstall symlink to `/lib64/ld-linux-x86-64.so.2` file.
- This should fix sommelier breakage on M108.
- glibc 2.35 can be built as soon as my machine gets an update to M108. :)

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=glibc_fix CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
