### PR TITLE
crew: Add support for dependency version ranges

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1357,19 +1357,19 @@ def resolve_dependencies
 
   # compare dependency version with required range (if installed)
   @dependencies.each do |dep|
-    next unless version_check
-
     depName  = dep.keys[0]
-    dep_info = @device[:install_package].select {|pkg| pkg[:name] == depName }
+    dep_info = @device[:installed_packages].select {|pkg| pkg[:name] == depName } [0]
 
     # skip if dependency is not installed
     next if dep_info.empty?
 
-    tags, version_check = deps.values[0]
+    tags, version_check = dep.values[0]
     installed_version   = dep_info[:version]
 
+    next unless dep.version_check
+
     # abort if the range is not fulfilled
-    abort unless version_check.call(installed_version)
+    abort unless dep.version_check.call(installed_version)
   end
 
   # leave only dependency names (remove all package attributes returned by @pkg.get_deps_list)

--- a/bin/crew
+++ b/bin/crew
@@ -1357,6 +1357,8 @@ def resolve_dependencies
 
   # compare dependency version with required range (if installed)
   @dependencies.each do |dep|
+    next unless version_check
+
     depName  = dep.keys[0]
     dep_info = @device[:install_package].select {|pkg| pkg[:name] == depName }
 

--- a/bin/crew
+++ b/bin/crew
@@ -1352,9 +1352,6 @@ end
 def resolve_dependencies
   @dependencies = @pkg.get_deps_list(return_attr: true)
 
-  # leave only not installed packages in dependencies
-  @dependencies.reject! { |dep| @device[:installed_packages].any? { |pkg| pkg[:name] == dep.keys[0] } }
-
   # compare dependency version with required range (if installed)
   @dependencies.each do |dep|
     depName  = dep.keys[0]
@@ -1374,6 +1371,9 @@ def resolve_dependencies
 
   # leave only dependency names (remove all package attributes returned by @pkg.get_deps_list)
   @dependencies.map!(&:keys).flatten!
+
+  # leave only not installed packages in dependencies
+  @dependencies.reject! { |depName| @device[:installed_packages].any? { |pkg| pkg[:name] == depName } }
 
   # run preflight check for dependencies
   @dependencies.each do |depName|

--- a/bin/crew
+++ b/bin/crew
@@ -1353,7 +1353,7 @@ def resolve_dependencies
   @dependencies = @pkg.get_deps_list(return_attr: true)
 
   # leave only not installed packages in dependencies
-  @dependencies.reject! { |name| @device[:installed_packages].any? { |pkg| pkg[:name] == name } }
+  @dependencies.reject! { |dep| @device[:installed_packages].any? { |pkg| pkg[:name] == dep.keys[0] } }
 
   # compare dependency version with required range (if installed)
   @dependencies.each do |dep|

--- a/bin/crew
+++ b/bin/crew
@@ -1358,7 +1358,7 @@ def resolve_dependencies
     dep_info = @device[:installed_packages].select {|pkg| pkg[:name] == depName } [0]
 
     # skip if dependency is not installed
-    next if dep_info
+    next unless dep_info
 
     tags, version_check = dep.values[0]
     installed_version   = dep_info[:version]

--- a/bin/crew
+++ b/bin/crew
@@ -1358,7 +1358,7 @@ def resolve_dependencies
     dep_info = @device[:installed_packages].select {|pkg| pkg[:name] == depName } [0]
 
     # skip if dependency is not installed
-    next if dep_info.empty?
+    next if dep_info
 
     tags, version_check = dep.values[0]
     installed_version   = dep_info[:version]

--- a/bin/crew
+++ b/bin/crew
@@ -1349,16 +1349,29 @@ def resolve_dependencies_and_install
   @resolve_dependencies_and_install = 0
 end
 
-def expand_dependencies
-  @dependencies = @pkg.get_deps_list.reject { |depName| @device[:installed_packages].any? { |pkg| pkg[:name] == depName } }
-end
-
 def resolve_dependencies
-  @dependencies = []
-  expand_dependencies
+  @dependencies = @pkg.get_deps_list(return_attr: true)
 
   # leave only not installed packages in dependencies
   @dependencies.reject! { |name| @device[:installed_packages].any? { |pkg| pkg[:name] == name } }
+
+  # compare dependency version with required range (if installed)
+  @dependencies.each do |dep|
+    depName  = dep.keys[0]
+    dep_info = @device[:install_package].select {|pkg| pkg[:name] == depName }
+
+    # skip if dependency is not installed
+    next if dep_info.empty?
+
+    tags, version_check = deps.values[0]
+    installed_version   = dep_info[:version]
+
+    # abort if the range is not fulfilled
+    abort unless version_check.call(installed_version)
+  end
+
+  # leave only dependency names (remove all package attributes returned by @pkg.get_deps_list)
+  @dependencies.map!(&:keys).flatten!
 
   # run preflight check for dependencies
   @dependencies.each do |depName|

--- a/bin/crew
+++ b/bin/crew
@@ -1366,10 +1366,10 @@ def resolve_dependencies
     tags, version_check = dep.values[0]
     installed_version   = dep_info[:version]
 
-    next unless dep.version_check
+    next unless version_check
 
     # abort if the range is not fulfilled
-    abort unless dep.version_check.call(installed_version)
+    abort unless version_check.call(installed_version)
   end
 
   # leave only dependency names (remove all package attributes returned by @pkg.get_deps_list)

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.28.6'
+CREW_VERSION = '1.29.0'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -204,7 +204,7 @@ class Package
         unless Gem::Version.new(installed_ver).send( operator.to_sym, Gem::Version.new(target_ver) )
           # print error if the range is not fulfilled
           warn <<~EOT.lightred
-            Package #{name} depends on '#{depName}' (#{operator} #{target_ver}), however version '#{installed_ver}' is installed :/
+            Package #{name} depends on '#{depName}' (#{operator} #{target_ver}), however '#{depName}' with version #{installed_ver} is currently installed :/
 
             Run `crew update && crew upgrade` and try again?
           EOT

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -197,14 +197,14 @@ class Package
     #
     # operator can be '>=', '==', '<=', '<', '>'
     if ver_range
-      operator, ver = ver_check.split(' ', 2)
+      operator, target_ver = ver_range.split(' ', 2)
 
       # lambda for comparing the given range with installed version
-      ver_check = lambda do |ver|
-        unless Gem::Version.new(ver).send( operator.to_sym, Gem::Version.new(ver) )
+      ver_check = lambda do |installed_ver|
+        unless Gem::Version.new(installed_ver).send( operator.to_sym, Gem::Version.new(target_ver) )
           # print error if the range is not fulfilled
           warn <<~EOT.lightred
-            Package #{name} depends on '#{depName}' (#{operator} #{ver}), however version '#{ver}' is installed :/
+            Package #{name} depends on '#{depName}' (#{operator} #{target_ver}), however version '#{installed_ver}' is installed :/
 
             Run `crew update && crew upgrade` and try again?
           EOT

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -53,11 +53,12 @@ class Package
     @dependencies ||= {}
   end
 
-  def self.get_deps_list(pkgName = name, hash: false, include_build_deps: 'auto', include_self: false,
-                         pkgTags: [], highlight_build_deps: true, exclude_buildessential: false, top_level: true)
+  def self.get_deps_list(pkgName = name, return_attr: false, hash: false, include_build_deps: 'auto', include_self: false,
+                         pkgTags: [], ver_check: nil, highlight_build_deps: true, exclude_buildessential: false, top_level: true)
     # get_deps_list: get dependencies list of pkgName (current package by default)
     #
     #                pkgName: package to check dependencies, current package by default
+    #            return_attr: return package attribute (tags and version lambda) also
     #                   hash: return result in nested hash, used by `print_deps_tree` (`bin/crew`)
     #
     #     include_build_deps: if set to true, force all build dependencies to be returned.
@@ -91,7 +92,7 @@ class Package
     end
 
     # parse dependencies recursively
-    expandedDeps = deps.uniq.map do |dep, depTags|
+    expandedDeps = deps.uniq.map do |dep, depTags, ver_check|
       # check build dependencies only if building from source is needed/specified
       # Do not recursively find :build based build dependencies.
       next unless (include_build_deps == true && @crew_current_package == pkgObj.name) || \
@@ -104,15 +105,11 @@ class Package
 
       if @checked_list.keys.none?(dep)
         # check dependency by calling this function recursively
-        next send(__method__, dep,
-                  hash: hash,
-               pkgTags: tags,
-    include_build_deps: include_build_deps,
-  highlight_build_deps: highlight_build_deps,
-exclude_buildessential: exclude_buildessential,
-          include_self: true,
-             top_level: false)
-
+        next \
+          send(
+            __method__, dep, pkgTags: tags, ver_check:, include_self: true, top_level: false,
+            hash:, return_attr:, include_build_deps:, highlight_build_deps:, exclude_buildessential:
+          )
       elsif hash && top_level
         # will be dropped here if current dependency is already checked and #{top_level} is set to true
         #
@@ -137,7 +134,11 @@ exclude_buildessential: exclude_buildessential,
       end
     elsif include_self
       # return pkgName itself if this function is called as a recursive loop (see `expandedDeps`)
-      return [expandedDeps, pkgName].flatten
+      if return_attr
+        return [expandedDeps, { pkgName => [pkgTags, ver_check] }].flatten
+      else
+        return [expandedDeps, pkgName].flatten
+      end
     else
       # if this function is called outside of this function, return parsed dependencies only
       return expandedDeps.flatten
@@ -173,24 +174,47 @@ exclude_buildessential: exclude_buildessential,
     end
   end
 
-  def self.depends_on(dependency = nil)
+  def self.depends_on(dependency, ver_range = nil)
     @dependencies ||= {}
-    if dependency
-      # add element in "[ name, [ tag1, tag2, ... ] ]" format
-      if dependency.is_a?(Hash)
-        if dependency.first[1].is_a?(Array)
-          # parse "depends_on name => [ tag1, tag2 ]"
-          @dependencies.store(dependency.first[0], dependency.first[1])
-        else
-          # parse "depends_on name => tag"
-          @dependencies.store(dependency.first[0], [dependency.first[1]])
+    ver_check = nil
+    dep_tags  = []
+
+    # add element in "[ name, [ tag1, tag2, ... ] ]" format
+    if dependency.is_a?(Hash)
+      # parse "depends_on name => <tags: Symbol|Array>"
+      depName, tags = dependency.first
+
+      # convert `tags` to array in case `tags` is a symbol
+      dep_tags += [tags].flatten
+    else
+      # parse "depends_on name"
+      depName = dependency
+    end
+
+    # process dependency version range if specified
+    # example:
+    #   depends_on name, '>= 1.0'
+    #
+    # operator can be '>=', '==', '<=', '<', '>'
+    if ver_range
+      operator, ver = ver_check.split(' ', 2)
+
+      # lambda for comparing the given range with installed version
+      ver_check = lambda do |ver|
+        unless Gem::Version.new(ver).send( operator.to_sym, Gem::Version.new(ver) )
+          # print error if the range is not fulfilled
+          warn <<~EOT.lightred
+            Package #{name} depends on '#{depName}' (#{operator} #{ver}), however version '#{ver}' is installed :/
+
+            Run `crew update && crew upgrade` and try again?
+          EOT
+          return false
         end
-      else
-        # parse "depends_on name"
-        @dependencies.store(dependency, [])
+        return true
       end
     end
-    @dependencies
+
+    @dependencies.store(depName, dep_tags, ver_check)
   end
 
   def self.get_url(architecture)

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -204,7 +204,7 @@ class Package
         unless Gem::Version.new(installed_ver).send( operator.to_sym, Gem::Version.new(target_ver) )
           # print error if the range is not fulfilled
           warn <<~EOT.lightred
-            Package #{name} depends on '#{depName}' (#{operator} #{target_ver}), however '#{depName}' with version #{installed_ver} is currently installed :/
+            Package #{name} depends on '#{depName}' (#{operator} #{target_ver}), however version '#{installed_ver}' is currently installed :/
 
             Run `crew update && crew upgrade` and try again?
           EOT

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -88,11 +88,11 @@ class Package
        !exclude_buildessential && \
        !@checked_list.keys.include?('buildessential')
 
-      deps = { 'buildessential' => [:build] }.merge(deps)
+      deps = { 'buildessential' => [[:build]] }.merge(deps)
     end
 
     # parse dependencies recursively
-    expandedDeps = deps.uniq.map do |dep, depTags, ver_check|
+    expandedDeps = deps.uniq.map do |dep, (depTags, ver_check)|
       # check build dependencies only if building from source is needed/specified
       # Do not recursively find :build based build dependencies.
       next unless (include_build_deps == true && @crew_current_package == pkgObj.name) || \
@@ -214,7 +214,7 @@ class Package
       end
     end
 
-    @dependencies.store(depName, dep_tags, ver_check)
+    @dependencies.store(depName, [dep_tags, ver_check])
   end
 
   def self.get_url(architecture)

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -54,7 +54,7 @@ class Package
   end
 
   def self.get_deps_list(pkgName = name, return_attr: false, hash: false, include_build_deps: 'auto', include_self: false,
-                         pkgTags: [], ver_check: nil, highlight_build_deps: true, exclude_buildessential: false, top_level: true)
+                         pkgTags: [], verCheck: nil, highlight_build_deps: true, exclude_buildessential: false, top_level: true)
     # get_deps_list: get dependencies list of pkgName (current package by default)
     #
     #                pkgName: package to check dependencies, current package by default
@@ -92,7 +92,7 @@ class Package
     end
 
     # parse dependencies recursively
-    expandedDeps = deps.uniq.map do |dep, (depTags, ver_check)|
+    expandedDeps = deps.uniq.map do |dep, (depTags, verCheck)|
       # check build dependencies only if building from source is needed/specified
       # Do not recursively find :build based build dependencies.
       next unless (include_build_deps == true && @crew_current_package == pkgObj.name) || \
@@ -107,7 +107,7 @@ class Package
         # check dependency by calling this function recursively
         next \
           send(
-            __method__, dep, pkgTags: tags, ver_check:, include_self: true, top_level: false,
+            __method__, dep, pkgTags: tags, verCheck:, include_self: true, top_level: false,
             hash:, return_attr:, include_build_deps:, highlight_build_deps:, exclude_buildessential:
           )
       elsif hash && top_level
@@ -135,7 +135,7 @@ class Package
     elsif include_self
       # return pkgName itself if this function is called as a recursive loop (see `expandedDeps`)
       if return_attr
-        return [expandedDeps, { pkgName => [pkgTags, ver_check] }].flatten
+        return [expandedDeps, { pkgName => [pkgTags, verCheck] }].flatten
       else
         return [expandedDeps, pkgName].flatten
       end


### PR DESCRIPTION
This PR adds the functionality to check whether the installed version of a dependency fulfills the requirement specified by packages

To use this feature, just add a range after the name of dependency
```ruby
depends_on 'python3', '>= 3.12.0' # this version doesn't exist at this moment :)
```

When the installed version of the specified dependency doesn't fulfill the range given, an error message will be thrown:
```
Package py3_setuptools depends on 'python3' (>= 3.12.0), however version '3.11.0' is currently installed :/

Run `crew update && crew upgrade` and try again?
```

Tested on `x86_64`