### PR TITLE
Adjust py3 deps with new dependency versioning functionality

### DIFF
--- a/packages/py3_pip.rb
+++ b/packages/py3_pip.rb
@@ -23,15 +23,9 @@ class Py3_pip < Package
      x86_64: 'af52f8111904a49684b37251cc65c8d5dc9235238ecf49aa56a27fb95bd1c994'
   })
 
-  depends_on 'python3'
-  depends_on 'python3'
+  depends_on 'python3', '< 3.11.0'
 
   conflicts_ok
-
-  def self.preflight
-    @pyver = `python3 --version | cut -d" " -f2 | cut -d"." -f1,2`.chomp
-    abort unless @pyver.to_f < 3.11
-  end
 
   def self.build
     system "python3 setup.py build #{PY3_SETUP_BUILD_OPTIONS}"

--- a/packages/py3_setuptools.rb
+++ b/packages/py3_setuptools.rb
@@ -23,15 +23,10 @@ class Py3_setuptools < Package
      x86_64: '483166d8742478f87585c5a10d10fafd5953dabb1c6e435d2c13d5bccebcd74a'
   })
 
-  depends_on 'python3'
+  depends_on 'python3', '< 3.11.0'
   depends_on 'py3_packaging'
 
   conflicts_ok
-
-  def self.preflight
-    @pyver = `python3 --version | cut -d" " -f2 | cut -d"." -f1,2`.chomp
-    abort unless @pyver.to_f < 3.11
-  end
 
   def self.build
     system "SETUPTOOLS_SCM_PRETEND_VERSION=#{@_ver} python3 -m build #{PY3_BUILD_OPTIONS}"


### PR DESCRIPTION
- disable `py3_pip` and `py3_setuptools` with new `depends_on` versioning functionality.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=python_pip CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
