### PR TITLE
Ruby -> 3.1.3 official

### DIFF
--- a/packages/ruby.rb
+++ b/packages/ruby.rb
@@ -3,23 +3,24 @@ require 'package'
 class Ruby < Package
   description 'Ruby is a dynamic, open source programming language with a focus on simplicity and productivity.'
   homepage 'https://www.ruby-lang.org/en/'
-  version '3.1.3-9fc7df7'
+  @_ver = '3.1.3'
+  version @_ver
   license 'Ruby-BSD and BSD-2'
   compatibility 'all'
-  source_url 'https://github.com/ruby/ruby/archive/9fc7df7504f41a7f370e62a004c3fc0abc439295.zip'
-  source_sha256 '2c8e6f1f8a6185629f7783e7a9a8c28f98b1ca41450f24fd0f98bf171a6de60a'
+  source_url 'https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.3.zip'
+  source_sha256 '9e5de00a1d259a2c6947605825ecf6742d5216bd389af28f9ed366854e59b09e'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.3-9fc7df7_armv7l/ruby-3.1.3-9fc7df7-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.3-9fc7df7_armv7l/ruby-3.1.3-9fc7df7-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.3-9fc7df7_i686/ruby-3.1.3-9fc7df7-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.3-9fc7df7_x86_64/ruby-3.1.3-9fc7df7-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.3_armv7l/ruby-3.1.3-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.3_armv7l/ruby-3.1.3-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.3_i686/ruby-3.1.3-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ruby/3.1.3_x86_64/ruby-3.1.3-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'e5c31e18f8771a1cbf641adb400cdfecdd05a44167ea5d353c0916f3fb2ab12b',
-     armv7l: 'e5c31e18f8771a1cbf641adb400cdfecdd05a44167ea5d353c0916f3fb2ab12b',
-       i686: 'ab2315e481abb83214b7321fc2274f861a6b9e0d8f07633b871d13c0f2912328',
-     x86_64: '596e3e7e81683a40ef470d6059b1cb679c90311af164a86e29f0008e0df2ee45'
+    aarch64: '312015bb71ba69f5e517dccf482a84cf537c71b9ce595764db05722e917362cd',
+     armv7l: '312015bb71ba69f5e517dccf482a84cf537c71b9ce595764db05722e917362cd',
+       i686: '49129defa8b802cd2ace1edc127e4731269879ca186a9cef85c67f645f062e95',
+     x86_64: '052fe8ad6de10ccbfbb22a39760ad51ff43bdb1e907bbd32dc1ba615010ccd44'
   })
 
   depends_on 'zlibpkg' # R


### PR DESCRIPTION
- Security update for ruby.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=ruby313 CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
