### PR TITLE
Gobject Introspection rebuild for python 3.11

### DIFF
--- a/packages/gobject_introspection.rb
+++ b/packages/gobject_introspection.rb
@@ -26,6 +26,7 @@ class Gobject_introspection < Package
   depends_on 'glib'
   depends_on 'glibc' # R
   depends_on 'libffi' # R
+  depends_on 'python3' # R
 
   gnome
 

--- a/packages/gobject_introspection.rb
+++ b/packages/gobject_introspection.rb
@@ -4,28 +4,29 @@ class Gobject_introspection < Package
   description 'GObject introspection is a middleware layer between C libraries (using GObject) and language bindings.'
   homepage 'https://wiki.gnome.org/action/show/Projects/GObjectIntrospection'
   @_ver = '1.74.0'
-  version @_ver
+  version "#{@_ver}-py3.11"
   license 'LGPL-2+ and GPL-2+'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/gobject-introspection.git'
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gobject_introspection/1.74.0_armv7l/gobject_introspection-1.74.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gobject_introspection/1.74.0_armv7l/gobject_introspection-1.74.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gobject_introspection/1.74.0_i686/gobject_introspection-1.74.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gobject_introspection/1.74.0_x86_64/gobject_introspection-1.74.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gobject_introspection/1.74.0-py3.11_armv7l/gobject_introspection-1.74.0-py3.11-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gobject_introspection/1.74.0-py3.11_armv7l/gobject_introspection-1.74.0-py3.11-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gobject_introspection/1.74.0-py3.11_i686/gobject_introspection-1.74.0-py3.11-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gobject_introspection/1.74.0-py3.11_x86_64/gobject_introspection-1.74.0-py3.11-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'e73d05327bde784c6ce36fd07fb25add2add359d536a41d33b5f5c3ec7e10ef2',
-     armv7l: 'e73d05327bde784c6ce36fd07fb25add2add359d536a41d33b5f5c3ec7e10ef2',
-       i686: '65c36e3f95172f94640649a086862d596addaae078dc1f870b1f4f234fc23b99',
-     x86_64: '93f359dc31635cc0516f50595f2f33304d80d01e7d1d118708e4eced734cea3c'
+    aarch64: 'f80268d2aa4a64bd4564fb300f04b1e6618bb074ff8d9b777c0a11a62ad26ea2',
+     armv7l: 'f80268d2aa4a64bd4564fb300f04b1e6618bb074ff8d9b777c0a11a62ad26ea2',
+       i686: '374471d4c306d795c431257531057d42aee57455604ba739f3d753ee203ab4f1',
+     x86_64: '8799e7dd4c312185f7b2f2950fe001cbd2c232237f171ac3022d16b1fc2719c0'
   })
 
   depends_on 'glib'
   depends_on 'glibc' # R
   depends_on 'libffi' # R
+
   gnome
 
   def self.build


### PR DESCRIPTION
Builds requiring gobject introspection need a python built binary which is built for the specific python version.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=gi_py311 CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
