### PR TITLE
Github_cli 2.4.0 => 2.21.1

### DIFF
--- a/packages/github_cli.rb
+++ b/packages/github_cli.rb
@@ -3,32 +3,28 @@ require 'package'
 class Github_cli < Package
   description 'Official Github CLI tool'
   homepage 'https://cli.github.com/'
-  version '2.4.0'
+  version '2.21.1'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://github.com/cli/cli.git'
-  git_hashtag "v#{version}"
-
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/github_cli/2.4.0_armv7l/github_cli-2.4.0-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/github_cli/2.4.0_armv7l/github_cli-2.4.0-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/github_cli/2.4.0_i686/github_cli-2.4.0-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/github_cli/2.4.0_x86_64/github_cli-2.4.0-chromeos-x86_64.tpxz'
+  source_url({
+    aarch64: 'https://github.com/cli/cli/releases/download/v2.21.1/gh_2.21.1_linux_armv6.tar.gz',
+     armv7l: 'https://github.com/cli/cli/releases/download/v2.21.1/gh_2.21.1_linux_armv6.tar.gz',
+       i686: 'https://github.com/cli/cli/releases/download/v2.21.1/gh_2.21.1_linux_386.tar.gz',
+     x86_64: 'https://github.com/cli/cli/releases/download/v2.21.1/gh_2.21.1_linux_amd64.tar.gz'
   })
-  binary_sha256({
-    aarch64: 'ed4d15c5f5463c3e32154794546d2e5bef9fa0243244b75f4f0830b67fa538e6',
-     armv7l: 'ed4d15c5f5463c3e32154794546d2e5bef9fa0243244b75f4f0830b67fa538e6',
-       i686: '70b4a04ba267fabcc8c2a31ca83e707ab7840797f5b8b83e54023ac1ff657f86',
-     x86_64: 'e9b0e62bcbedde56e3ffc7e2e32fade7af6c3de1848c557c36ee738c3be8275d'
+  source_sha256({
+    aarch64: '4218c205359a8f4b94e56419d6383301ae43265c4217f6567f054cf76aac9490',
+     armv7l: '4218c205359a8f4b94e56419d6383301ae43265c4217f6567f054cf76aac9490',
+       i686: '562d304de4e28029159fd805c755c2f7f204d03027bd65ea4ca02bce58e24c2d',
+     x86_64: '0c0ab559721d2ff05df9d64fcdaca4f8f0b76d177832379116bd5c4d032fea88'
   })
 
-  depends_on 'go' => :build
-
-  def self.build
-    system 'make'
-  end
+  no_compile_needed
+  no_strip # ./usr/local/bin/gh: 1: ./usr/local/bin/gh: Syntax error: redirection unexpected (expecting ")")
 
   def self.install
-    system "install -Dm755 bin/gh #{CREW_DEST_PREFIX}/bin/gh"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    FileUtils.install 'bin/gh', "#{CREW_DEST_PREFIX}/bin", mode: 0o755
+    FileUtils.mv 'share', CREW_DEST_PREFIX.to_s
   end
 end


### PR DESCRIPTION
Let's update this instead.  The go build no longer works so switching to binary releases.  We could continue to struggle with the source build but why if the binaries are available?  Tested on all architectures.