### PR TITLE
Fix FHS3 compliance bug

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -976,7 +976,7 @@ def prepare_package(destdir)
     # check for FHS3 compliance
     puts 'Checking for FHS3 compliance...'
     @_errors = false
-    @fhs_compliant_prefix = %W[bin etc include lib lib#{ARCH_LIB} libexec opt sbin share var].uniq
+    @fhs_compliant_prefix = %W[bin etc include lib #{ARCH_LIB} libexec opt sbin share var].uniq
 
     Dir.foreach(CREW_DEST_PREFIX) do |filename|
       next if %w[. ..].include?(filename)

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.30.2'
+CREW_VERSION = '1.30.3'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
Fixes #7782.

Explanation:
```
$ crew const ARCH_LIB
ARCH_LIB=lib64
```
The current crew version outputs `lib#{ARCH_LIB}` as `liblib64` so `lib64` is never compliant since it isn't included in the list of directories.

Note: Merge this before #7785.