### PR TITLE
Fix crew build issue

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1468,10 +1468,19 @@ def build_package(pwd)
 end
 
 def archive_package(pwd)
-  if @pkg.no_zstd?
+  # Check to see that there is a working zstd
+  if File.file?("#{CREW_PREFIX}/bin/zstd")
+    @crew_prefix_zstd_available = `#{CREW_PREFIX}/bin/zstd --version`.include?('zstd command line interface') ? true : nil
+  end
+  if File.file?("#{CREW_MUSL_PREFIX}/bin/zstd")
+    @crew_musl_prefix_zstd_available = `#{CREW_MUSL_PREFIX}/bin/zstd --version`.include?('zstd command line interface') ? true : nil
+  end
+  if @pkg.no_zstd? || (!@crew_prefix_zstd_available && !@crew_musl_prefix_zstd_available)
     puts 'Using xz to compress package. This may take some time.'.lightblue
     pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.tar.xz"
-    system "tar c#{@verbose}Jf #{pwd}/#{pkg_name} *", chdir: CREW_DEST_DIR
+    Dir.chdir CREW_DEST_DIR do
+      system "tar c#{@verbose}Jf #{pwd}/#{pkg_name} *"
+    end
   else
     puts 'Using zstd to compress package. This may take some time.'.lightblue
     pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.tar.zst"

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.30.2'
+CREW_VERSION = '1.30.4'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
Fixes #7784.  Restored `def archive_package` function in crew.

Explanation:
We cannot remove `@crew_prefix_zstd_available` and `@crew_musl_prefix_zstd_available` variables because they are used later in the function.

Note: Merge this after #7783.