### PR TITLE
Crew strip fix

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1079,12 +1079,15 @@ def patchelf_set_need_paths(dir)
 end
 
 def strip_find_files(find_cmd, strip_option = '')
-  # check whether crew should strip
+  # Check whether crew should strip.
   return if CREW_NOT_STRIP || @pkg.no_strip? || !File.file?("#{CREW_PREFIX}/bin/llvm-strip")
 
-  # run find_cmd and strip only ar or ELF files
+  # Run find_cmd and strip only files with ar or elf magic headers.
   system "#{find_cmd} | xargs -r chmod u+w"
-  system "#{find_cmd} | xargs -P#{CREW_NPROC} -n1 -r sh -c 'header=$(head -c4 ${0}); elfheader='$(printf '\\\177ELF')' ; arheader=\\!\\<ar ; case $header in $elfheader|$arheader) llvm-strip #{strip_option} ;; esac'"
+  @strip_verbose = @opt_verbose ? 'echo "Stripping ${0:1}" &&' : ''
+  # The craziness here is from having to escape the special characters
+  # in the magic headers for these files.
+  system "#{find_cmd} | xargs -P#{CREW_NPROC} -n1 -r bash -c 'header=$(head -c4 ${0}); elfheader='$(printf '\\\177ELF')' ; arheader=\\!\\<ar ; case $header in $elfheader|$arheader) #{@strip_verbose} llvm-strip #{strip_option} ${0} ;; esac'"
 end
 
 def strip_dir(dir)

--- a/bin/crew
+++ b/bin/crew
@@ -1084,7 +1084,7 @@ def strip_find_files(find_cmd, strip_option = '')
 
   # run find_cmd and strip only ar or ELF files
   system "#{find_cmd} | xargs -r chmod u+w"
-  system "#{find_cmd} | xargs -P#{CREW_NPROC} -n1 -r sh -c 'case \"$(head -c7 ${0})\" in \x7FELF*|!<arch>) llvm-strip #{strip_option};; esac ; done'"
+  system "#{find_cmd} | xargs -P#{CREW_NPROC} -n1 -r sh -c 'header=$(head -c4 ${0}); elfheader='$(printf '\\\177ELF')' ; arheader=\\!\\<ar ; case $header in $elfheader|$arheader) llvm-strip #{strip_option} ;; esac'"
 end
 
 def strip_dir(dir)

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.30.4'
+CREW_VERSION = '1.30.5'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
Fixes #7786

- Build with the `-v` flag to also show the files that are being stripped.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=crew_strip_fix CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
