### PR TITLE
remove extra line from libcyrussasl package

### DIFF
--- a/packages/libcyrussasl.rb
+++ b/packages/libcyrussasl.rb
@@ -30,7 +30,6 @@ class Libcyrussasl < Package
   depends_on 'linux_pam' # R
   depends_on 'openssl' # R
 
-
   def self.patch
     system 'filefix'
   end


### PR DESCRIPTION
- This is the most straightforward linter fix that showed up first...
 
Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
