### PR TITLE
vim,gvim,xxd => 9.x

### DIFF
--- a/packages/gvim.rb
+++ b/packages/gvim.rb
@@ -104,7 +104,6 @@ class Gvim < Package
     puts
     puts 'If you are upgrading from an earlier version, edit ~/.bashrc'.orange
     puts "and remove the 'export VIMRUNTIME' and 'export LC_ALL=C' lines.".orange
-    puts
     # Set vim to be the default vi if there is no vi or if a default
     # vi does not exist.
     @crew_vi = File.file?("#{CREW_PREFIX}/bin/vi")

--- a/packages/gvim.rb
+++ b/packages/gvim.rb
@@ -3,27 +3,43 @@ require 'package'
 class Gvim < Package
   description 'Vim is a highly configurable text editor built to make creating and changing any kind of text very efficient. (with advanced features, such as a GUI)'
   homepage 'http://www.vim.org/'
-  @_ver = '8.2.4594'
+  @_ver = '9.0.1145'
   version @_ver
   license 'GPL-2'
-  compatibility 'aarch64,armv7l,x86_64'
+  compatibility 'all'
   source_url 'https://github.com/vim/vim.git'
   git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gvim/8.2.4594_armv7l/gvim-8.2.4594-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gvim/8.2.4594_armv7l/gvim-8.2.4594-chromeos-armv7l.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gvim/8.2.4594_x86_64/gvim-8.2.4594-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gvim/9.0.1145_armv7l/gvim-9.0.1145-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gvim/9.0.1145_armv7l/gvim-9.0.1145-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gvim/9.0.1145_i686/gvim-9.0.1145-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gvim/9.0.1145_x86_64/gvim-9.0.1145-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'a778b458c9111ccedf0c84b2cdd472c52bf80c9e52e40f6c22f22f2ccf27d50a',
-     armv7l: 'a778b458c9111ccedf0c84b2cdd472c52bf80c9e52e40f6c22f22f2ccf27d50a',
-     x86_64: '0b238d45425755746cf68dd398f33ca5e22345a3fcab50dfb472bf7fe574f402'
+    aarch64: 'd8edb31697fd1e5f229f4e6cd508fbc63dc8a6c6eb48cdf38f4e5f058b9a2aa4',
+     armv7l: 'd8edb31697fd1e5f229f4e6cd508fbc63dc8a6c6eb48cdf38f4e5f058b9a2aa4',
+       i686: '61bc60db3c6ec2c9ecc3f6805880858f35be16037846cd4cd3d16608c6c35d86',
+     x86_64: '0e83d2ea39503b2e2214a800a9c6008b81f27fde3d24318ec05c5ec04f4a5e75'
   })
 
   depends_on 'vim_runtime'
   depends_on 'gtk3'
   depends_on 'sommelier'
+  depends_on 'acl' # R
+  depends_on 'gcc' # R
+  depends_on 'gdk_pixbuf' # R
+  depends_on 'glib' # R
+  depends_on 'glibc' # R
+  depends_on 'gpm' # R
+  depends_on 'gtk2' # R
+  depends_on 'libice' # R
+  depends_on 'libsm' # R
+  depends_on 'libsodium' # R
+  depends_on 'libx11' # R
+  depends_on 'libxt' # R
+  depends_on 'ncurses' # R
+  depends_on 'pango' # R
 
   def self.preflight
     vim = `which #{CREW_PREFIX}/bin/vim 2> /dev/null`.chomp
@@ -31,7 +47,6 @@ class Gvim < Package
   end
 
   def self.patch
-    abort('Please remove libiconv before building.') if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
     # set the system-wide vimrc path
     FileUtils.cd('src') do
       system 'sed', '-i', "s|^.*#define SYS_VIMRC_FILE.*$|#define SYS_VIMRC_FILE \"#{CREW_PREFIX}/etc/vimrc\"|",
@@ -43,10 +58,7 @@ class Gvim < Package
 
   def self.build
     system '[ -x configure ] || autoreconf -fvi'
-    system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      ./configure \
+    system "./configure \
       #{CREW_OPTIONS} \
       --localstatedir=#{CREW_PREFIX}/var/lib/vim \
       --with-features=huge \
@@ -86,11 +98,40 @@ class Gvim < Package
 
   def self.postinstall
     puts
-    puts "The config files are located in #{CREW_PREFIX}/etc".lightblue
-    puts 'User-specific configuration should go in ~/.gvimrc'.lightblue
+    puts "The config files are located in #{CREW_PREFIX}/etc.".lightblue
+    puts 'User-specific configuration should go in ~/.vimrc.'.lightblue
     puts
     puts 'If you are upgrading from an earlier version, edit ~/.bashrc'.orange
     puts "and remove the 'export VIMRUNTIME' and 'export LC_ALL=C' lines.".orange
     puts
+    # Set vim to be the default vi if there is no vi or if a default
+    # vi does not exist.
+    @crew_vi = File.file?("#{CREW_PREFIX}/bin/vi")
+    @system_vi = File.file?('/usr/bin/vi')
+    @create_vi_symlink = true if !@system_vi && !@crew_vi
+    @create_vi_symlink_ask = true if @crew_vi || @system_vi
+    if @create_vi_symlink_ask
+      print "\nWould you like to set vim to be the default vi [y/N] "
+      case $stdin.getc
+      when 'y', 'Y'
+        @create_vi_symlink = true
+      else
+        @create_vi_symlink = false
+        puts 'Default vi left unchanged.'.lightgreen
+      end
+    end
+    return unless @create_vi_symlink
+
+    FileUtils.ln_sf "#{CREW_PREFIX}/bin/vim", "#{CREW_PREFIX}/bin/vi"
+    puts 'Default vi set to vim.'.lightgreen
+  end
+
+  def self.remove
+    # Remove vi symlink if it is to vim.
+    unless File.symlink?("#{CREW_PREFIX}/bin/vi") && (File.readlink("#{CREW_PREFIX}/bin/vi") == "#{CREW_PREFIX}/bin/vim")
+      return
+    end
+
+    FileUtils.rm "#{CREW_PREFIX}/bin/vi"
   end
 end

--- a/packages/gvim.rb
+++ b/packages/gvim.rb
@@ -128,9 +128,7 @@ class Gvim < Package
 
   def self.remove
     # Remove vi symlink if it is to vim.
-    unless File.symlink?("#{CREW_PREFIX}/bin/vi") && (File.readlink("#{CREW_PREFIX}/bin/vi") == "#{CREW_PREFIX}/bin/vim")
-      return
-    end
+    return unless File.symlink?("#{CREW_PREFIX}/bin/vi") && (File.readlink("#{CREW_PREFIX}/bin/vi") == "#{CREW_PREFIX}/bin/vim")
 
     FileUtils.rm "#{CREW_PREFIX}/bin/vi"
   end

--- a/packages/gvim.rb
+++ b/packages/gvim.rb
@@ -99,7 +99,8 @@ class Gvim < Package
   def self.postinstall
     puts
     puts "The config files are located in #{CREW_PREFIX}/etc.".lightblue
-    puts 'User-specific configuration should go in ~/.vimrc.'.lightblue
+    puts 'User-specific configuration should go in ~/.vimrc and'.lightblue
+    puts '~/.gvimrc.'.lightblue
     puts
     puts 'If you are upgrading from an earlier version, edit ~/.bashrc'.orange
     puts "and remove the 'export VIMRUNTIME' and 'export LC_ALL=C' lines.".orange

--- a/packages/vim.rb
+++ b/packages/vim.rb
@@ -96,7 +96,6 @@ class Vim < Package
     puts
     puts 'If you are upgrading from an earlier version, edit ~/.bashrc'.orange
     puts "and remove the 'export VIMRUNTIME' and 'export LC_ALL=C' lines.".orange
-    puts
     # Set vim to be the default vi if there is no vi or if a default
     # vi does not exist.
     @crew_vi = File.file?("#{CREW_PREFIX}/bin/vi")

--- a/packages/vim.rb
+++ b/packages/vim.rb
@@ -3,7 +3,7 @@ require 'package'
 class Vim < Package
   description 'Vim is a highly configurable text editor built to make creating and changing any kind of text very efficient.'
   homepage 'http://www.vim.org/'
-  @_ver = '8.2.4594'
+  @_ver = '9.0.1145'
   version @_ver
   license 'GPL-2'
   compatibility 'all'
@@ -11,19 +11,24 @@ class Vim < Package
   git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vim/8.2.4594_armv7l/vim-8.2.4594-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vim/8.2.4594_armv7l/vim-8.2.4594-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vim/8.2.4594_i686/vim-8.2.4594-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vim/8.2.4594_x86_64/vim-8.2.4594-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vim/9.0.1145_armv7l/vim-9.0.1145-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vim/9.0.1145_armv7l/vim-9.0.1145-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vim/9.0.1145_i686/vim-9.0.1145-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vim/9.0.1145_x86_64/vim-9.0.1145-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '67807f3bb5fa193a8997e484b01f7e187a183e6060e602240a26065b4f96f623',
-     armv7l: '67807f3bb5fa193a8997e484b01f7e187a183e6060e602240a26065b4f96f623',
-       i686: '156f8c4cc69a4cdf79ef6fc2d2abaad0bcbf76241d9a16a3f60a3a2340be3d2f',
-     x86_64: '69ea16d8dbdb6f2ea932d766c3222b1a870e0344e5d44dbd84fb16dbbb5f78cb'
+    aarch64: '5839efa28a8e7389fd911c80b08d653b36cd9caa22afc307af0e9890cd9aec55',
+     armv7l: '5839efa28a8e7389fd911c80b08d653b36cd9caa22afc307af0e9890cd9aec55',
+       i686: '834d3acf815ad87ad2ba4ecec6d10e10dde296a9d027190cb2eabbdaa3a5e542',
+     x86_64: 'de6d4be528dcb2903e801cc490918ee4d5c7d5f1fa9f67dfc922a33f0e44c2d7'
   })
 
   depends_on 'vim_runtime'
+  depends_on 'acl' # R
+  depends_on 'glibc' # R
+  depends_on 'gpm' # R
+  depends_on 'libsodium' # R
+  depends_on 'ncurses' # R
 
   def self.preflight
     gvim = `which #{CREW_PREFIX}/bin/gvim 2> /dev/null`.chomp
@@ -31,7 +36,6 @@ class Vim < Package
   end
 
   def self.patch
-    abort('Please remove libiconv before building.') if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
     # set the system-wide vimrc path
     FileUtils.cd('src') do
       system 'sed', '-i', "s|^.*#define SYS_VIMRC_FILE.*$|#define SYS_VIMRC_FILE \"#{CREW_PREFIX}/etc/vimrc\"|",
@@ -43,10 +47,7 @@ class Vim < Package
 
   def self.build
     system '[ -x configure ] || autoreconf -fvi'
-    system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      ./configure \
+    system "./configure \
       #{CREW_OPTIONS} \
       --localstatedir=#{CREW_PREFIX}/var/lib/vim \
       --with-features=huge \
@@ -96,5 +97,32 @@ class Vim < Package
     puts 'If you are upgrading from an earlier version, edit ~/.bashrc'.orange
     puts "and remove the 'export VIMRUNTIME' and 'export LC_ALL=C' lines.".orange
     puts
+    # Set vim to be the default vi if there is no vi or if a default
+    # vi does not exist.
+    @crew_vi = File.file?("#{CREW_PREFIX}/bin/vi")
+    @system_vi = File.file?('/usr/bin/vi')
+    @create_vi_symlink = true if !@system_vi && !@crew_vi
+    @create_vi_symlink_ask = true if @crew_vi || @system_vi
+    if @create_vi_symlink_ask
+      print "\nWould you like to set vim to be the default vi [y/N] "
+      case $stdin.getc
+      when 'y', 'Y'
+        @create_vi_symlink = true
+      else
+        @create_vi_symlink = false
+        puts 'Default vi left unchanged.'.lightgreen
+      end
+    end
+    return unless @create_vi_symlink
+
+    FileUtils.ln_sf "#{CREW_PREFIX}/bin/vim", "#{CREW_PREFIX}/bin/vi"
+    puts 'Default vi set to vim.'.lightgreen
+  end
+
+  def self.remove
+    # Remove vi symlink if it is to vim.
+    return unless File.symlink?("#{CREW_PREFIX}/bin/vi") && (File.readlink("#{CREW_PREFIX}/bin/vi") == "#{CREW_PREFIX}/bin/vim")
+
+    FileUtils.rm "#{CREW_PREFIX}/bin/vi"
   end
 end

--- a/packages/vim_runtime.rb
+++ b/packages/vim_runtime.rb
@@ -3,7 +3,7 @@ require 'package'
 class Vim_runtime < Package
   description 'Vim is a highly configurable text editor built to make creating and changing any kind of text very efficient. (shared runtime)'
   homepage 'http://www.vim.org/'
-  @_ver = '8.2.4594'
+  @_ver = '9.0.1145'
   version @_ver
   license 'GPL-2'
   compatibility 'all'
@@ -11,23 +11,22 @@ class Vim_runtime < Package
   git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vim_runtime/8.2.4594_armv7l/vim_runtime-8.2.4594-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vim_runtime/8.2.4594_armv7l/vim_runtime-8.2.4594-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vim_runtime/8.2.4594_i686/vim_runtime-8.2.4594-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vim_runtime/8.2.4594_x86_64/vim_runtime-8.2.4594-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vim_runtime/9.0.1145_armv7l/vim_runtime-9.0.1145-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vim_runtime/9.0.1145_armv7l/vim_runtime-9.0.1145-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vim_runtime/9.0.1145_i686/vim_runtime-9.0.1145-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vim_runtime/9.0.1145_x86_64/vim_runtime-9.0.1145-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '1e163860d1e33df29dc2298c8916b79eb10e093ee7aa93aa45649b2f24b8717b',
-     armv7l: '1e163860d1e33df29dc2298c8916b79eb10e093ee7aa93aa45649b2f24b8717b',
-       i686: '8dbf821e3b74d5e881a6939cf711f08e0375cd24be12bdc08fc240beed72ed69',
-     x86_64: '20d6505461857fb25901b3c18ed8a7f20f95111c1cfe8d6dc3306d314bf78264'
+    aarch64: 'abf07f7472d5f2ecd2694d3251da5dc28f9c261fea289087ae8d8ae95aa07bbc',
+     armv7l: 'abf07f7472d5f2ecd2694d3251da5dc28f9c261fea289087ae8d8ae95aa07bbc',
+       i686: '0f80a4d523325e3e4b1dd3a16533f71bc56873d4e234534b71ce042e5312cd33',
+     x86_64: '010794241e8435eb04170737ccae9f8ad22878f49ee642f611361a58e967e590'
   })
 
   depends_on 'gpm'
   depends_on 'libsodium'
 
   def self.patch
-    abort('Please remove libiconv before building.') if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
     # set the system-wide vimrc path
     FileUtils.cd('src') do
       system 'sed', '-i', "s|^.*#define SYS_VIMRC_FILE.*$|#define SYS_VIMRC_FILE \"#{CREW_PREFIX}/etc/vimrc\"|",
@@ -39,10 +38,7 @@ class Vim_runtime < Package
 
   def self.build
     system '[ -x configure ] || autoreconf -fvi'
-    system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      ./configure \
+    system "./configure \
       #{CREW_OPTIONS} \
       --localstatedir=#{CREW_PREFIX}/var/lib/vim \
       --with-features=huge \
@@ -67,6 +63,7 @@ class Vim_runtime < Package
   end
 
   def self.install
+    @vim_version = version.rpartition('.')[0].sub('.', '')
     system 'make', "VIMRCLOC=#{CREW_PREFIX}/etc", "DESTDIR=#{CREW_DEST_DIR}", 'install'
 
     # bin and man will be provided by the 'vim' packages
@@ -128,7 +125,7 @@ class Vim_runtime < Package
         silent! call mkdir(expand(&g:undodir), 'p', 0700)
       endif
     EOF
-    system "sed -i 's/set mouse=a/set mouse-=a/g' #{CREW_DEST_PREFIX}/share/vim/vim82/defaults.vim"
+    system "sed -i 's/set mouse=a/set mouse-=a/g' #{CREW_DEST_PREFIX}/share/vim/vim#{@vim_version}/defaults.vim"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc"
     vimrc = "#{CREW_DEST_PREFIX}/etc/vimrc"
     # by default we will load the global config

--- a/packages/xxd_standalone.rb
+++ b/packages/xxd_standalone.rb
@@ -3,7 +3,7 @@ require 'package'
 class Xxd_standalone < Package
   description 'Hexdump utility from vim'
   homepage 'http://www.vim.org'
-  @_ver = '8.2.2783'
+  @_ver = '9.0.1145'
   version @_ver
   license 'GPL-2'
   compatibility 'all'
@@ -11,23 +11,23 @@ class Xxd_standalone < Package
   git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xxd_standalone/8.2.2783_armv7l/xxd_standalone-8.2.2783-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xxd_standalone/8.2.2783_armv7l/xxd_standalone-8.2.2783-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xxd_standalone/8.2.2783_i686/xxd_standalone-8.2.2783-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xxd_standalone/8.2.2783_x86_64/xxd_standalone-8.2.2783-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xxd_standalone/9.0.1145_armv7l/xxd_standalone-9.0.1145-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xxd_standalone/9.0.1145_armv7l/xxd_standalone-9.0.1145-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xxd_standalone/9.0.1145_i686/xxd_standalone-9.0.1145-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xxd_standalone/9.0.1145_x86_64/xxd_standalone-9.0.1145-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '398383f29decea21b375a83861804a76b8a7f5345ea5d8e632430d596836862e',
-     armv7l: '398383f29decea21b375a83861804a76b8a7f5345ea5d8e632430d596836862e',
-       i686: '25b253e518dd4ad8db7d7ccb4b98b5f68bb84ad242219071c9815cbd77f12c24',
-     x86_64: '83d62f69fcb6ee14ba78175affb5a6d11627b2a1b21b84cf61a859e01b011921'
+    aarch64: '6f0371fe309b6acf9075ffe3d5c39565d265aafd2aae6915aa8e7d34e2497833',
+     armv7l: '6f0371fe309b6acf9075ffe3d5c39565d265aafd2aae6915aa8e7d34e2497833',
+       i686: 'c18efdaca3fdc3c670a044e105968d34c214347763500fd329a0fa610c09f2da',
+     x86_64: 'b6b4db1208ebb85772a18f08aea51a5644cebb8e62473b3008c29e8bd61c153a'
   })
+
+  depends_on 'glibc' # R
 
   def self.build
     Dir.chdir 'src/xxd' do
-      system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-        LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-        make xxd"
+      system 'make xxd'
     end
   end
 


### PR DESCRIPTION
- Uses exact same logic as `neovim` package PR...

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=vim9 CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
