### PR TITLE
Add @_ver comment to ca_certificates.rb

### DIFF
--- a/packages/ca_certificates.rb
+++ b/packages/ca_certificates.rb
@@ -3,7 +3,7 @@ require 'package'
 class Ca_certificates < Package
   description 'Common CA Certificates PEM files'
   homepage 'https://salsa.debian.org/debian/ca-certificates'
-  version '20210119-2'
+  version '20210119-2' # Do not replace version with @_ver, the install will break.
   @_ver = "#{version}[0..-3]"
   license 'MPL-1.1'
   compatibility 'all'


### PR DESCRIPTION
I dislike sed.

Anyways, this comment is necessary for the install to work, and I cannot be bothered fixing it, and fixing it would make the install.sh sed even more complicated.