### PR TITLE
fixup prompts

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1405,11 +1405,11 @@ def resolve_dependencies
   puts @dependencies.join(' ')
 
   print 'Do you agree? [Y/n] '
-  response = $stdin.getc
+  response = $stdin.gets.chomp.downcase
   case response
-  when 'n'
+  when 'n', 'no'
     abort 'No changes made.'
-  when "\n", 'y', 'Y'
+  when '', 'y', 'yes'
     puts 'Proceeding...'
   else
     puts "I don't understand `#{response}`. :(".lightred

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.30.6'
+CREW_VERSION = '1.30.7'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/packages/android_studio.rb
+++ b/packages/android_studio.rb
@@ -37,13 +37,13 @@ class Android_studio < Package
 
   def self.remove
     print 'Would you like to remove the config directories? [y/N] '
-    response = $stdin.getc
+    response = $stdin.gets.chomp.downcase
     config_dirs = ["#{HOME}/.android", "#{HOME}/Android"]
     config_dirs.each do |config_dir|
       next unless Dir.exist? config_dir
 
       case response
-      when 'y', 'Y'
+      when '', 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/android_studio.rb
+++ b/packages/android_studio.rb
@@ -43,7 +43,7 @@ class Android_studio < Package
       next unless Dir.exist? config_dir
 
       case response
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/bluefish.rb
+++ b/packages/bluefish.rb
@@ -64,7 +64,7 @@ class Bluefish < Package
       puts 'WARNING: This will remove all bluefish config!'.orange
       print "Would you like to remove the #{config_dir} directory? [y/N] "
       case $stdin.gets.chomp.downcase
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightgreen
       else

--- a/packages/bluefish.rb
+++ b/packages/bluefish.rb
@@ -63,8 +63,8 @@ class Bluefish < Package
     if Dir.exist? config_dir
       puts 'WARNING: This will remove all bluefish config!'.orange
       print "Would you like to remove the #{config_dir} directory? [y/N] "
-      case $stdin.getc
-      when 'y', 'Y'
+      case $stdin.gets.chomp.downcase
+      when '', 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightgreen
       else

--- a/packages/cheat.rb
+++ b/packages/cheat.rb
@@ -33,8 +33,8 @@ class Cheat < Package
     if Dir.exist? config_dir
       puts 'WARNING: This will remove all cheat config!'.orange
       print "Would you like to remove the #{config_dir} directory? [y/N] "
-      case $stdin.getc
-      when 'y', 'Y'
+      case $stdin.gets.chomp.downcase
+      when '', 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightgreen
       else

--- a/packages/cheat.rb
+++ b/packages/cheat.rb
@@ -34,7 +34,7 @@ class Cheat < Package
       puts 'WARNING: This will remove all cheat config!'.orange
       print "Would you like to remove the #{config_dir} directory? [y/N] "
       case $stdin.gets.chomp.downcase
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightgreen
       else

--- a/packages/clamav.rb
+++ b/packages/clamav.rb
@@ -72,7 +72,7 @@ class Clamav < Package
       puts 'WARNING: This will remove the clamav database!'.orange
       print "Would you like to remove the #{config_dir} directory? [y/N] "
       case $stdin.gets.chomp.downcase
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightgreen
       else

--- a/packages/clamav.rb
+++ b/packages/clamav.rb
@@ -71,8 +71,8 @@ class Clamav < Package
     if Dir.exist? config_dir
       puts 'WARNING: This will remove the clamav database!'.orange
       print "Would you like to remove the #{config_dir} directory? [y/N] "
-      case $stdin.getc
-      when 'y', 'Y'
+      case $stdin.gets.chomp.downcase
+      when '', 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightgreen
       else

--- a/packages/clamtk.rb
+++ b/packages/clamtk.rb
@@ -83,7 +83,7 @@ class Clamtk < Package
       puts 'WARNING: This will remove all clamtk config!'.orange
       print "Would you like to remove the #{config_dir} directory? [y/N] "
       case $stdin.gets.chomp.downcase
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightgreen
       else

--- a/packages/clamtk.rb
+++ b/packages/clamtk.rb
@@ -82,8 +82,8 @@ class Clamtk < Package
     if Dir.exist? config_dir
       puts 'WARNING: This will remove all clamtk config!'.orange
       print "Would you like to remove the #{config_dir} directory? [y/N] "
-      case $stdin.getc
-      when 'y', 'Y'
+      case $stdin.gets.chomp.downcase
+      when '', 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightgreen
       else

--- a/packages/dbeaver.rb
+++ b/packages/dbeaver.rb
@@ -42,8 +42,8 @@ class Dbeaver < Package
     config_dir = "#{HOME}/.local/share/DBeaverData"
     if Dir.exist? config_dir
       print "Would you like to remove the #{config_dir} directory? [y/N] "
-      case $stdin.getc
-      when 'y', 'Y'
+      case $stdin.gets.chomp.downcase
+      when '', 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/dbeaver.rb
+++ b/packages/dbeaver.rb
@@ -43,7 +43,7 @@ class Dbeaver < Package
     if Dir.exist? config_dir
       print "Would you like to remove the #{config_dir} directory? [y/N] "
       case $stdin.gets.chomp.downcase
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/dosbox.rb
+++ b/packages/dosbox.rb
@@ -47,7 +47,7 @@ class Dosbox < Package
     config_dir = "#{HOME}/.dosbox"
     if Dir.exist? config_dir
       case response
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/dosbox.rb
+++ b/packages/dosbox.rb
@@ -43,11 +43,11 @@ class Dosbox < Package
 
   def self.remove
     print 'Would you like to remove the config directory? [y/N] '
-    response = $stdin.getc
+    response = $stdin.gets.chomp.downcase
     config_dir = "#{HOME}/.dosbox"
     if Dir.exist? config_dir
       case response
-      when 'y', 'Y'
+      when '', 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/electric.rb
+++ b/packages/electric.rb
@@ -38,7 +38,7 @@ class Electric < Package
     if File.exist? log_file
       print "Would you like to remove #{log_file}? [y/N] "
       case $stdin.gets.chomp.downcase
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_f log_file
         puts "#{log_file} removed.".lightred
       else

--- a/packages/electric.rb
+++ b/packages/electric.rb
@@ -37,8 +37,8 @@ class Electric < Package
     log_file = "#{HOME}/electric.log"
     if File.exist? log_file
       print "Would you like to remove #{log_file}? [y/N] "
-      case $stdin.getc
-      when 'y', 'Y'
+      case $stdin.gets.chomp.downcase
+      when '', 'y', 'yes'
         FileUtils.rm_f log_file
         puts "#{log_file} removed.".lightred
       else

--- a/packages/exodus.rb
+++ b/packages/exodus.rb
@@ -36,7 +36,7 @@ class Exodus < Package
       puts 'WARNING: This will remove all Exodus data!'.orange
       print "Would you like to remove the #{config_dir} directory? [y/N] "
       case $stdin.gets.chomp.downcase
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightgreen
       else

--- a/packages/exodus.rb
+++ b/packages/exodus.rb
@@ -35,8 +35,8 @@ class Exodus < Package
     if Dir.exist? config_dir
       puts 'WARNING: This will remove all Exodus data!'.orange
       print "Would you like to remove the #{config_dir} directory? [y/N] "
-      case $stdin.getc
-      when 'y', 'Y'
+      case $stdin.gets.chomp.downcase
+      when '', 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightgreen
       else

--- a/packages/ferdi.rb
+++ b/packages/ferdi.rb
@@ -44,8 +44,8 @@ class Ferdi < Package
     config_dir = "#{HOME}/.config/autostart"
     if Dir.exist? config_dir
       print "Would you like to remove the config directory #{config_dir}? [y/N] "
-      case $stdin.getc
-      when 'y', 'Y'
+      case $stdin.gets.chomp.downcase
+      when '', 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/ferdi.rb
+++ b/packages/ferdi.rb
@@ -45,7 +45,7 @@ class Ferdi < Package
     if Dir.exist? config_dir
       print "Would you like to remove the config directory #{config_dir}? [y/N] "
       case $stdin.gets.chomp.downcase
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/firefox.rb
+++ b/packages/firefox.rb
@@ -97,8 +97,8 @@ class Firefox < Package
 
   def self.postinstall
     print "\nSet Firefox as your default browser? [Y/n]: "
-    case $stdin.getc
-    when "\n", 'Y', 'y'
+    case $stdin.gets.chomp.downcase
+    when '', 'y', 'yes'
       Dir.chdir("#{CREW_PREFIX}/bin") do
         FileUtils.ln_sf 'firefox', 'x-www-browser'
       end

--- a/packages/flutter.rb
+++ b/packages/flutter.rb
@@ -39,7 +39,7 @@ class Flutter < Package
       next unless Dir.exist? config_dir
 
       case response
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/flutter.rb
+++ b/packages/flutter.rb
@@ -33,13 +33,13 @@ class Flutter < Package
 
   def self.remove
     print 'Would you like to remove the config directories? [y/N] '
-    response = $stdin.getc
+    response = $stdin.gets.chomp.downcase
     config_dirs = ["#{HOME}/.flutter", "#{CREW_PREFIX}/share/flutter"]
     config_dirs.each do |config_dir|
       next unless Dir.exist? config_dir
 
       case response
-      when 'y', 'Y'
+      when '', 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/fpc.rb
+++ b/packages/fpc.rb
@@ -48,11 +48,11 @@ class Fpc < Package
 
   def self.remove
     print 'Would you like to remove the config directories? [y/N] '
-    response = $stdin.getc
+    response = $stdin.gets.chomp.downcase
     config_dirs = ["#{HOME}/.fpc.cfg", "#{HOME}/.config/fppkg.cfg", "#{HOME}/.fppkg"]
     config_dirs.each do |config_dir|
       case response
-      when 'y', 'Y'
+      when '', 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/fpc.rb
+++ b/packages/fpc.rb
@@ -52,7 +52,7 @@ class Fpc < Package
     config_dirs = ["#{HOME}/.fpc.cfg", "#{HOME}/.config/fppkg.cfg", "#{HOME}/.fppkg"]
     config_dirs.each do |config_dir|
       case response
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/freecad.rb
+++ b/packages/freecad.rb
@@ -49,8 +49,8 @@ class Freecad < Package
     config_dir = "#{HOME}/.FreeCAD"
     if Dir.exist? config_dir.to_s
       print "\nWould you like to remove #{config_dir}? [y/N] "
-      case $stdin.getc
-      when 'y', 'Y'
+      case $stdin.gets.chomp.downcase
+      when '', 'y', 'yes'
         FileUtils.rm_rf config_dir.to_s
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/freecad.rb
+++ b/packages/freecad.rb
@@ -50,7 +50,7 @@ class Freecad < Package
     if Dir.exist? config_dir.to_s
       print "\nWould you like to remove #{config_dir}? [y/N] "
       case $stdin.gets.chomp.downcase
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf config_dir.to_s
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/gcloud.rb
+++ b/packages/gcloud.rb
@@ -56,13 +56,13 @@ class Gcloud < Package
 
   def self.remove
     print 'Would you like to remove the config directories? [y/N] '
-    response = $stdin.getc
+    response = $stdin.gets.chomp.downcase
     config_dirs = ["#{HOME}/.config/gcloud", "#{CREW_PREFIX}/share/gcloud"]
     config_dirs.each do |config_dir|
       next unless Dir.exist? config_dir
 
       case response
-      when 'y', 'Y'
+      when '', 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/gcloud.rb
+++ b/packages/gcloud.rb
@@ -62,7 +62,7 @@ class Gcloud < Package
       next unless Dir.exist? config_dir
 
       case response
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/geany.rb
+++ b/packages/geany.rb
@@ -66,8 +66,8 @@ class Geany < Package
       next unless Dir.exist? config_dir
 
       print "\nWould you like to remove #{config_dir}? [y/N] "
-      case $stdin.getc
-      when 'y', 'Y'
+      case $stdin.gets.chomp.downcase
+      when '', 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/geany.rb
+++ b/packages/geany.rb
@@ -67,7 +67,7 @@ class Geany < Package
 
       print "\nWould you like to remove #{config_dir}? [y/N] "
       case $stdin.gets.chomp.downcase
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/github_desktop.rb
+++ b/packages/github_desktop.rb
@@ -47,7 +47,7 @@ class Github_desktop < Package
       system "echo '#{config_dir}'; ls '#{config_dir}'"
       print "\nWould you like to remove the config directories above? [y/N] "
       case $stdin.gets.chomp.downcase
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "'#{config_dir}' removed.".lightred
       else

--- a/packages/github_desktop.rb
+++ b/packages/github_desktop.rb
@@ -46,8 +46,8 @@ class Github_desktop < Package
     if Dir.exist? config_dir.to_s
       system "echo '#{config_dir}'; ls '#{config_dir}'"
       print "\nWould you like to remove the config directories above? [y/N] "
-      case $stdin.getc
-      when 'y', 'Y'
+      case $stdin.gets.chomp.downcase
+      when '', 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "'#{config_dir}' removed.".lightred
       else

--- a/packages/gvim.rb
+++ b/packages/gvim.rb
@@ -113,7 +113,7 @@ class Gvim < Package
     if @create_vi_symlink_ask
       print "\nWould you like to set vim to be the default vi [y/N] "
       case $stdin.gets.chomp.downcase
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         @create_vi_symlink = true
       else
         @create_vi_symlink = false

--- a/packages/gvim.rb
+++ b/packages/gvim.rb
@@ -112,8 +112,8 @@ class Gvim < Package
     @create_vi_symlink_ask = true if @crew_vi || @system_vi
     if @create_vi_symlink_ask
       print "\nWould you like to set vim to be the default vi [y/N] "
-      case $stdin.getc
-      when 'y', 'Y'
+      case $stdin.gets.chomp.downcase
+      when '', 'y', 'yes'
         @create_vi_symlink = true
       else
         @create_vi_symlink = false

--- a/packages/idea.rb
+++ b/packages/idea.rb
@@ -43,7 +43,7 @@ class Idea < Package
       next unless Dir.exist? config_dir
 
       case response
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/idea.rb
+++ b/packages/idea.rb
@@ -37,13 +37,13 @@ class Idea < Package
 
   def self.remove
     print 'Would you like to remove the config directories? [y/N] '
-    response = $stdin.getc
+    response = $stdin.gets.chomp.downcase
     config_dirs = ["#{CREW_PREFIX}/.config/JetBrains/.IdeaIC2022.3", "#{HOME}/.IdeaIC2022.3"]
     config_dirs.each do |config_dir|
       next unless Dir.exist? config_dir
 
       case response
-      when 'y', 'Y'
+      when '', 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/imagemagick.rb
+++ b/packages/imagemagick.rb
@@ -18,7 +18,7 @@ class Imagemagick < Package
     puts '  7 = ImageMagick 7.0.11-2'
     puts '  0 = Cancel'
 
-    while version = $stdin.gets.chomp
+    while version = $stdin.gets.chomp.downcase
       case version
       when '6'
         depends_on 'imagemagick6'

--- a/packages/komodo.rb
+++ b/packages/komodo.rb
@@ -31,7 +31,7 @@ class Komodo < Package
       next unless Dir.exist? config_dir
 
       case response
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/komodo.rb
+++ b/packages/komodo.rb
@@ -25,13 +25,13 @@ class Komodo < Package
 
   def self.remove
     print 'Would you like to remove the config directories? [y/N] '
-    response = $stdin.getc
+    response = $stdin.gets.chomp.downcase
     config_dirs = ["#{HOME}/.komodoide", "#{HOME}/.activestate"]
     config_dirs.each do |config_dir|
       next unless Dir.exist? config_dir
 
       case response
-      when 'y', 'Y'
+      when '', 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/leiningen.rb
+++ b/packages/leiningen.rb
@@ -24,8 +24,8 @@ class Leiningen < Package
     config_dir = "#{HOME}/.lein"
     if Dir.exist? config_dir
       print "Would you like to remove the #{config_dir} directory? [y/N] "
-      case $stdin.getc
-      when 'y', 'Y'
+      case $stdin.gets.chomp.downcase
+      when '', 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/leiningen.rb
+++ b/packages/leiningen.rb
@@ -25,7 +25,7 @@ class Leiningen < Package
     if Dir.exist? config_dir
       print "Would you like to remove the #{config_dir} directory? [y/N] "
       case $stdin.gets.chomp.downcase
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/mysql.rb
+++ b/packages/mysql.rb
@@ -63,8 +63,8 @@ class Mysql < Package
     if Dir.exist? data_dir.to_s
       puts "\nWARNING: This will delete all your databases!".orange
       print "Would you like to remove #{data_dir}? [y/N] "
-      case $stdin.getc
-      when 'y', 'Y'
+      case $stdin.gets.chomp.downcase
+      when '', 'y', 'yes'
         FileUtils.rm_rf data_dir.to_s
         puts "#{data_dir} removed.".lightred
       else

--- a/packages/mysql.rb
+++ b/packages/mysql.rb
@@ -64,7 +64,7 @@ class Mysql < Package
       puts "\nWARNING: This will delete all your databases!".orange
       print "Would you like to remove #{data_dir}? [y/N] "
       case $stdin.gets.chomp.downcase
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf data_dir.to_s
         puts "#{data_dir} removed.".lightred
       else

--- a/packages/natron.rb
+++ b/packages/natron.rb
@@ -39,8 +39,8 @@ class Natron < Package
     config_dir = "#{HOME}/.Natron"
     if Dir.exist? config_dir
       print "Would you like to remove the config directory #{config_dir}? [y/N] "
-      case $stdin.getc
-      when 'y', 'Y'
+      case $stdin.gets.chomp.downcase
+      when '', 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/natron.rb
+++ b/packages/natron.rb
@@ -40,7 +40,7 @@ class Natron < Package
     if Dir.exist? config_dir
       print "Would you like to remove the config directory #{config_dir}? [y/N] "
       case $stdin.gets.chomp.downcase
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/neovim.rb
+++ b/packages/neovim.rb
@@ -60,7 +60,7 @@ class Neovim < Package
     if @create_vi_symlink_ask
       print "\nWould you like to set nvim to be the default vi [y/N] "
       case $stdin.gets.chomp.downcase
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         @create_vi_symlink = true
       else
         @create_vi_symlink = false

--- a/packages/neovim.rb
+++ b/packages/neovim.rb
@@ -59,8 +59,8 @@ class Neovim < Package
     @create_vi_symlink_ask = true if @crew_vi || @system_vi
     if @create_vi_symlink_ask
       print "\nWould you like to set nvim to be the default vi [y/N] "
-      case $stdin.getc
-      when 'y', 'Y'
+      case $stdin.gets.chomp.downcase
+      when '', 'y', 'yes'
         @create_vi_symlink = true
       else
         @create_vi_symlink = false

--- a/packages/netbeans.rb
+++ b/packages/netbeans.rb
@@ -30,8 +30,8 @@ class Netbeans < Package
     config_dir = "#{HOME}/.netbeans"
     if Dir.exist? config_dir
       print "Would you like to remove the config directory #{config_dir}? [y/N] "
-      case $stdin.getc
-      when 'y', 'Y'
+      case $stdin.gets.chomp.downcase
+      when '', 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightgreen
       else

--- a/packages/netbeans.rb
+++ b/packages/netbeans.rb
@@ -31,7 +31,7 @@ class Netbeans < Package
     if Dir.exist? config_dir
       print "Would you like to remove the config directory #{config_dir}? [y/N] "
       case $stdin.gets.chomp.downcase
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightgreen
       else

--- a/packages/newsboat.rb
+++ b/packages/newsboat.rb
@@ -52,8 +52,8 @@ class Newsboat < Package
     config_dir = "#{HOME}/.newsboat"
     if Dir.exist? config_dir
       print "Would you like to remove the config directory #{config_dir}? [y/N] "
-      case $stdin.getc
-      when 'y', 'Y'
+      case $stdin.gets.chomp.downcase
+      when '', 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/newsboat.rb
+++ b/packages/newsboat.rb
@@ -53,7 +53,7 @@ class Newsboat < Package
     if Dir.exist? config_dir
       print "Would you like to remove the config directory #{config_dir}? [y/N] "
       case $stdin.gets.chomp.downcase
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/nginx.rb
+++ b/packages/nginx.rb
@@ -85,9 +85,9 @@ class Nginx < Package
     if Dir.exist? "#{CREW_PREFIX}/share/nginx"
       puts
       print "Would you like to remove #{CREW_PREFIX}/share/nginx? [y/N] "
-      response = $stdin.getc
+      response = $stdin.gets.chomp.downcase
       case response
-      when 'y', 'Y'
+      when '', 'y', 'yes'
         FileUtils.rm_rf "#{CREW_PREFIX}/share/nginx"
         puts "#{CREW_PREFIX}/share/nginx removed.".lightred
       else

--- a/packages/nginx.rb
+++ b/packages/nginx.rb
@@ -87,7 +87,7 @@ class Nginx < Package
       print "Would you like to remove #{CREW_PREFIX}/share/nginx? [y/N] "
       response = $stdin.gets.chomp.downcase
       case response
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf "#{CREW_PREFIX}/share/nginx"
         puts "#{CREW_PREFIX}/share/nginx removed.".lightred
       else

--- a/packages/nodebrew.rb
+++ b/packages/nodebrew.rb
@@ -84,7 +84,7 @@ class Nodebrew < Package
       print "Would you like to remove #{CREW_PREFIX}/share/nodebrew? [y/N] "
       response = $stdin.gets.chomp.downcase
       case response
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf "#{CREW_PREFIX}/share/nodebrew"
         puts "#{CREW_PREFIX}/share/nodebrew removed.".lightred
       else

--- a/packages/nodebrew.rb
+++ b/packages/nodebrew.rb
@@ -82,9 +82,9 @@ class Nodebrew < Package
     if Dir.exist? "#{CREW_PREFIX}/share/nodebrew"
       puts
       print "Would you like to remove #{CREW_PREFIX}/share/nodebrew? [y/N] "
-      response = $stdin.getc
+      response = $stdin.gets.chomp.downcase
       case response
-      when 'y', 'Y'
+      when '', 'y', 'yes'
         FileUtils.rm_rf "#{CREW_PREFIX}/share/nodebrew"
         puts "#{CREW_PREFIX}/share/nodebrew removed.".lightred
       else

--- a/packages/opam.rb
+++ b/packages/opam.rb
@@ -62,7 +62,7 @@ class Opam < Package
     print "Would you like to remove #{@OPAMROOT}? [y/N] "
     response = $stdin.gets.chomp.downcase
     case response
-    when '', 'y', 'yes'
+    when 'y', 'yes'
       FileUtils.rm_rf @OPAMROOT
       puts "#{@OPAMROOT} removed.".lightred
     else

--- a/packages/opam.rb
+++ b/packages/opam.rb
@@ -60,9 +60,9 @@ class Opam < Package
 
     puts
     print "Would you like to remove #{@OPAMROOT}? [y/N] "
-    response = $stdin.getc
+    response = $stdin.gets.chomp.downcase
     case response
-    when 'y', 'Y'
+    when '', 'y', 'yes'
       FileUtils.rm_rf @OPAMROOT
       puts "#{@OPAMROOT} removed.".lightred
     else

--- a/packages/opera.rb
+++ b/packages/opera.rb
@@ -38,8 +38,8 @@ class Opera < Package
   def self.postinstall
     puts
     print 'Set Opera as your default browser? [Y/n]: '
-    case $stdin.getc
-    when "\n", 'Y', 'y'
+    case $stdin.gets.chomp.downcase
+    when '', 'y', 'yes'
       Dir.chdir("#{CREW_PREFIX}/bin") do
         FileUtils.ln_sf "#{CREW_LIB_PREFIX}/opera/opera", 'x-www-browser'
       end

--- a/packages/php.rb
+++ b/packages/php.rb
@@ -28,7 +28,7 @@ class Php < Package
     puts '8.2 = PHP 8.2.1'
     puts '  0 = Cancel'
 
-    while version = $stdin.gets.chomp
+    while version = $stdin.gets.chomp.downcase
       case version
       when '5.6'
         depends_on 'php5'

--- a/packages/postgres.rb
+++ b/packages/postgres.rb
@@ -76,7 +76,7 @@ class Postgres < Package
       puts 'WARNING: This will delete all databases!'.orange
       print "Would you like to remove #{PGDATA}? [y/N] "
       case $stdin.gets.chomp.downcase
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf PGDATA
         FileUtils.rm_rf "#{CREW_PREFIX}/pgsql"
         puts "#{PGDATA} removed.".lightred

--- a/packages/postgres.rb
+++ b/packages/postgres.rb
@@ -75,8 +75,8 @@ class Postgres < Package
     if Dir.exist? PGDATA
       puts 'WARNING: This will delete all databases!'.orange
       print "Would you like to remove #{PGDATA}? [y/N] "
-      case $stdin.getc
-      when 'y', 'Y'
+      case $stdin.gets.chomp.downcase
+      when '', 'y', 'yes'
         FileUtils.rm_rf PGDATA
         FileUtils.rm_rf "#{CREW_PREFIX}/pgsql"
         puts "#{PGDATA} removed.".lightred

--- a/packages/pycharm.rb
+++ b/packages/pycharm.rb
@@ -38,7 +38,7 @@ class Pycharm < Package
       puts 'WARNING: This will remove all PyCharm config!'.orange
       print "Would you like to remove the #{config_dir} directory? [y/N] "
       case $stdin.gets.chomp.downcase
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/pycharm.rb
+++ b/packages/pycharm.rb
@@ -37,8 +37,8 @@ class Pycharm < Package
     if Dir.exist? config_dir
       puts 'WARNING: This will remove all PyCharm config!'.orange
       print "Would you like to remove the #{config_dir} directory? [y/N] "
-      case $stdin.getc
-      when 'y', 'Y'
+      case $stdin.gets.chomp.downcase
+      when '', 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/rust.rb
+++ b/packages/rust.rb
@@ -81,7 +81,7 @@ class Rust < Package
     print config_dirs.to_s
     print "\nWould you like to remove the config directories above? [y/N] "
     case $stdin.gets.chomp.downcase
-    when '', 'y', 'yes'
+    when 'y', 'yes'
       FileUtils.rm_rf config_dirs
       puts "#{config_dirs} removed.".lightgreen
     else

--- a/packages/rust.rb
+++ b/packages/rust.rb
@@ -80,8 +80,8 @@ class Rust < Package
     config_dirs = %W[#{HOME}/.rustup #{CREW_PREFIX}/share/rustup #{HOME}/.cargo #{CREW_PREFIX}/share/cargo]
     print config_dirs.to_s
     print "\nWould you like to remove the config directories above? [y/N] "
-    case $stdin.getc
-    when 'y', 'Y'
+    case $stdin.gets.chomp.downcase
+    when '', 'y', 'yes'
       FileUtils.rm_rf config_dirs
       puts "#{config_dirs} removed.".lightgreen
     else

--- a/packages/snowflake.rb
+++ b/packages/snowflake.rb
@@ -45,8 +45,8 @@ class Snowflake < Package
     if Dir.exist? config_dir
       puts 'WARNING: This will remove all saved ssh sessions!'.orange
       print "Would you like to remove the #{config_dir} directory? [y/N] "
-      case $stdin.getc
-      when 'y', 'Y'
+      case $stdin.gets.chomp.downcase
+      when '', 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/snowflake.rb
+++ b/packages/snowflake.rb
@@ -46,7 +46,7 @@ class Snowflake < Package
       puts 'WARNING: This will remove all saved ssh sessions!'.orange
       print "Would you like to remove the #{config_dir} directory? [y/N] "
       case $stdin.gets.chomp.downcase
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/stellarium.rb
+++ b/packages/stellarium.rb
@@ -45,8 +45,8 @@ class Stellarium < Package
     config_dir = "#{HOME}/.stellarium"
     if Dir.exist? config_dir
       print "Would you like to remove the config directory #{config_dir}? [y/N] "
-      case $stdin.getc
-      when 'y', 'Y'
+      case $stdin.gets.chomp.downcase
+      when '', 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/stellarium.rb
+++ b/packages/stellarium.rb
@@ -46,7 +46,7 @@ class Stellarium < Package
     if Dir.exist? config_dir
       print "Would you like to remove the config directory #{config_dir}? [y/N] "
       case $stdin.gets.chomp.downcase
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/teams.rb
+++ b/packages/teams.rb
@@ -47,7 +47,7 @@ class Teams < Package
     end
     print "\nWould you like to remove the config directories above? [y/N] "
     case $stdin.gets.chomp.downcase
-    when '', 'y', 'yes'
+    when 'y', 'yes'
       config_dirs.each do |config_dir|
         next unless Dir.exist? config_dir
 

--- a/packages/teams.rb
+++ b/packages/teams.rb
@@ -46,8 +46,8 @@ class Teams < Package
       system "echo '#{config_dir}'; ls '#{config_dir}'"
     end
     print "\nWould you like to remove the config directories above? [y/N] "
-    case $stdin.getc
-    when 'y', 'Y'
+    case $stdin.gets.chomp.downcase
+    when '', 'y', 'yes'
       config_dirs.each do |config_dir|
         next unless Dir.exist? config_dir
 

--- a/packages/torbrowser.rb
+++ b/packages/torbrowser.rb
@@ -43,8 +43,8 @@ class Torbrowser < Package
 
   def self.postinstall
     print "\nSet Tor as your default browser? [Y/n]: "
-    case $stdin.getc
-    when "\n", 'Y', 'y'
+    case $stdin.gets.chomp.downcase
+    when '', 'y', 'yes'
       Dir.chdir("#{CREW_PREFIX}/bin") do
         FileUtils.ln_sf 'tor', 'x-www-browser'
       end

--- a/packages/uwsgi.rb
+++ b/packages/uwsgi.rb
@@ -21,7 +21,7 @@ class Uwsgi < Package
     system "echo 'Select plugin(s):' && ls plugins"
     puts
     system "echo -n 'Enter selection (separate multiple plugins by a space) [python]: '"
-    plugins = $stdin.gets.chomp
+    plugins = $stdin.gets.chomp.downcase
     puts
     system "make #{plugins}"
   end

--- a/packages/vim.rb
+++ b/packages/vim.rb
@@ -104,8 +104,8 @@ class Vim < Package
     @create_vi_symlink_ask = true if @crew_vi || @system_vi
     if @create_vi_symlink_ask
       print "\nWould you like to set vim to be the default vi [y/N] "
-      case $stdin.getc
-      when 'y', 'Y'
+      case $stdin.gets.chomp.downcase
+      when '', 'y', 'yes'
         @create_vi_symlink = true
       else
         @create_vi_symlink = false

--- a/packages/vim.rb
+++ b/packages/vim.rb
@@ -105,7 +105,7 @@ class Vim < Package
     if @create_vi_symlink_ask
       print "\nWould you like to set vim to be the default vi [y/N] "
       case $stdin.gets.chomp.downcase
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         @create_vi_symlink = true
       else
         @create_vi_symlink = false

--- a/packages/vuze.rb
+++ b/packages/vuze.rb
@@ -67,7 +67,7 @@ class Vuze < Package
     end
     print "\nWould you like to remove the config directories above? [y/N] "
     case $stdin.gets.chomp.downcase
-    when '', 'y', 'yes'
+    when 'y', 'yes'
       config_dirs.each do |config_dir|
         next unless Dir.exist? config_dir
 

--- a/packages/vuze.rb
+++ b/packages/vuze.rb
@@ -66,8 +66,8 @@ class Vuze < Package
       system "echo '#{config_dir}'; ls '#{config_dir}'"
     end
     print "\nWould you like to remove the config directories above? [y/N] "
-    case $stdin.getc
-    when 'y', 'Y'
+    case $stdin.gets.chomp.downcase
+    when '', 'y', 'yes'
       config_dirs.each do |config_dir|
         next unless Dir.exist? config_dir
 

--- a/packages/wine.rb
+++ b/packages/wine.rb
@@ -104,8 +104,8 @@ class Wine < Package
       next unless Dir.exist? config_dir
 
       print "\nWould you like to remove #{config_dir}? [y/N] "
-      case $stdin.getc
-      when 'y', 'Y'
+      case $stdin.gets.chomp.downcase
+      when '', 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else

--- a/packages/wine.rb
+++ b/packages/wine.rb
@@ -105,7 +105,7 @@ class Wine < Package
 
       print "\nWould you like to remove #{config_dir}? [y/N] "
       case $stdin.gets.chomp.downcase
-      when '', 'y', 'yes'
+      when 'y', 'yes'
         FileUtils.rm_rf config_dir
         puts "#{config_dir} removed.".lightred
       else


### PR DESCRIPTION
Fixes #7812 

- Get string, chomp it, downcase it, and then look for `''`, `y`, and `yes` in input string. This allows one to hit enter after the input without having that newline passed to another prompt.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=fix_prompts CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
