### PR TITLE
Fix glibc postinstall crash on devices with older kernels.

### DIFF
--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -705,7 +705,7 @@ class Glibc < Package
         end
       end
     end
-    return unless @libc_version.to_f >= 2.32 and CREW_KERNEL_VERSION.to_f >= 5.4
+    return unless @libc_version.to_f >= 2.32 && CREW_KERNEL_VERSION.to_f >= 5.4
 
     puts 'Paring locales to a minimal set.'.lightblue
     system 'localedef --list-archive | grep -v -i -e ^en -e ^cs -e ^de -e ^es -e ^fa -e ^fe -e ^it -e ^ja -e ^ru -e ^tr -e ^zh -e ^C| xargs localedef --delete-from-archive',

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -705,7 +705,7 @@ class Glibc < Package
         end
       end
     end
-    return unless @libc_version.to_f >= 2.32
+    return unless @libc_version.to_f >= 2.32 and CREW_KERNEL_VERSION.to_f >= 5.4
 
     puts 'Paring locales to a minimal set.'.lightblue
     system 'localedef --list-archive | grep -v -i -e ^en -e ^cs -e ^de -e ^es -e ^fa -e ^fe -e ^it -e ^ja -e ^ru -e ^tr -e ^zh -e ^C| xargs localedef --delete-from-archive',


### PR DESCRIPTION
- Running the glibc postinstall on a machine with glibc 2.35 but kernel `4.14` errors out due to `build-locale-archive` throwing a `FATAL: kernel too old` error. So don't run that portion of the postinstall if the kernel is older than `5.4`.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=glibc_postinstall_kcheck  CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
