### PR TITLE
Add transmission dep to fragments

### DIFF
--- a/packages/fragments.rb
+++ b/packages/fragments.rb
@@ -36,6 +36,7 @@ class Fragments < Package
   depends_on 'openssl' # R
   depends_on 'pango' # R
   depends_on 'rust' => :build
+  depends_on 'transmission' # L
   depends_on 'zlibpkg' # R
 
   gnome


### PR DESCRIPTION
Fixes https://gitlab.gnome.org/World/Fragments/-/issues/179

Works properly:
- [x] `x86_64`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

