### PR TITLE
fix linuxheaders builds

### DIFF
--- a/packages/linuxheaders.rb
+++ b/packages/linuxheaders.rb
@@ -78,8 +78,14 @@ class Linuxheaders < Package
     FileUtils.mkdir_p('crew_bin')
     @workdir = Dir.pwd
     FileUtils.ln_sf "#{CREW_PREFIX}/bin/ld.bfd", "#{@workdir}/crew_bin/ld"
-    system "PATH=#{@workdir}/crew_bin:$PATH make defconfig"
-    system "PATH=#{@workdir}/crew_bin:$PATH make headers_install INSTALL_HDR_PATH=#{CREW_DEST_PREFIX}"
+    @kbuild_arch = case ARCH
+                   when 'armv7l', 'aarch64'
+                     'arm'
+                   else
+                     'x86'
+                   end
+    system "ARCH=#{@kbuild_arch} PATH=#{@workdir}/crew_bin:$PATH make defconfig"
+    system "ARCH=#{@kbuild_arch} PATH=#{@workdir}/crew_bin:$PATH make headers_install INSTALL_HDR_PATH=#{CREW_DEST_PREFIX}"
     Dir.chdir("#{CREW_DEST_PREFIX}/include") do
       system "for file in $(find . -not -type d -name '.*'); do
                 rm ${file};


### PR DESCRIPTION
Fixes #7752
- The ARCH env variable was confusing `make defconfig` so now it is set correctly during linuxheader builds.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes and test locally:
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=linuxheaders CREW_TESTING=1 crew update
unset CREW_CACHE_ENABLED
CREW_KERNEL_VERSION=5.10 crew reinstall -sk linuxheaders
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
