### PR TITLE
Update fuse3, stack, and update crun

### DIFF
--- a/packages/crun.rb
+++ b/packages/crun.rb
@@ -9,7 +9,7 @@ class Crun < Package
   @_ver = '1.7.2'
   version "#{@_ver}-1"
   license 'LGPL'
-  compatibility 'all'
+  compatibility 'aarch64 armv7l x86_64'
   source_url 'https://github.com/containers/crun.git'
   git_hashtag @_ver
 

--- a/packages/crun.rb
+++ b/packages/crun.rb
@@ -6,21 +6,22 @@ require 'package'
 class Crun < Package
   description 'A fast and lightweight fully featured OCI runtime and C library for running containers'
   homepage 'https://github.com/containers/crun'
-  version '1.7.2'
+  @_ver = '1.7.2'
+  version "#{@_ver}-1"
   license 'LGPL'
-  compatibility 'aarch64 armv7l x86_64'
+  compatibility 'all'
   source_url 'https://github.com/containers/crun.git'
-  git_hashtag version
+  git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/crun/1.7.2_armv7l/crun-1.7.2-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/crun/1.7.2_armv7l/crun-1.7.2-chromeos-armv7l.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/crun/1.7.2_x86_64/crun-1.7.2-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/crun/1.7.2-1_armv7l/crun-1.7.2-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/crun/1.7.2-1_armv7l/crun-1.7.2-1-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/crun/1.7.2-1_x86_64/crun-1.7.2-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'fe7f3f3282a8d05e76e9dd4036fa8b1761eee0cd5f7eed93c991365c9c17fc8e',
-     armv7l: 'fe7f3f3282a8d05e76e9dd4036fa8b1761eee0cd5f7eed93c991365c9c17fc8e',
-     x86_64: '49d7b8323992b044cd6a4658e7a66ce1f14f13c74ebf534870ff999819ddac4e'
+    aarch64: '401dc1443e32bf8e4f53542fb08ff18194c1000ead10dca8abba9ae3613f3d07',
+     armv7l: '401dc1443e32bf8e4f53542fb08ff18194c1000ead10dca8abba9ae3613f3d07',
+     x86_64: '4b03b460ae56fdf34c421a01659bdee53119763670ac794cfde70edd89444b1f'
   })
 
   depends_on 'criu' if ARCH == 'x86_64'
@@ -32,6 +33,103 @@ class Crun < Package
   depends_on 'libgpgerror' # R
   depends_on 'libseccomp' # R
   depends_on 'yajl' # R
+
+  def self.patch
+    @crun_patch = <<~'CRUN_PATCH_EOF'
+      From 47231d5c516e0cb9c0f51f297d9d67f7533730b4 Mon Sep 17 00:00:00 2001
+      From: Giuseppe Scrivano <gscrivan@redhat.com>
+      Date: Thu, 12 Jan 2023 21:07:48 +0100
+      Subject: [PATCH] cgroup: support cpuset mounted with noprefix
+
+      on cgroup v1, it is possible to pass the "noprefix" option for the
+      cpuset mount and that causes the "cpuset." prefix to be dropped from
+      the cgroup files.
+
+      To support this case, attempt to open the file without the prefix when
+      the cpuset.$FILE version fails with ENOENT.
+
+      Closes: https://github.com/containers/crun/issues/1115
+
+      Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
+      ---
+       src/libcrun/cgroup-resources.c | 24 ++++++++++++++++++++++--
+       src/libcrun/cgroup-setup.c     |  8 ++++++--
+       2 files changed, 28 insertions(+), 4 deletions(-)
+
+      diff --git a/src/libcrun/cgroup-resources.c b/src/libcrun/cgroup-resources.c
+      index fbb5777a..df7e4882 100644
+      --- a/src/libcrun/cgroup-resources.c
+      +++ b/src/libcrun/cgroup-resources.c
+      @@ -962,14 +962,34 @@ write_cpuset_resources (int dirfd_cpuset, int cgroup2, runtime_spec_schema_confi
+             ret = write_file_and_check_controllers_at (cgroup2, dirfd_cpuset, "cpuset.cpus", cpu->cpus, strlen (cpu->cpus),
+                                                        err);
+             if (UNLIKELY (ret < 0))
+      -        return ret;
+      +        {
+      +          if (! cgroup2 && errno == ENOENT)
+      +            {
+      +              crun_error_release (err);
+      +
+      +              ret = write_file_and_check_controllers_at (cgroup2, dirfd_cpuset, "cpus", cpu->cpus, strlen (cpu->cpus),
+      +                                                         err);
+      +            }
+      +          if (UNLIKELY (ret < 0))
+      +            return ret;
+      +        }
+           }
+         if (cpu->mems)
+           {
+             ret = write_file_and_check_controllers_at (cgroup2, dirfd_cpuset, "cpuset.mems", cpu->mems, strlen (cpu->mems),
+                                                        err);
+             if (UNLIKELY (ret < 0))
+      -        return ret;
+      +        {
+      +          if (! cgroup2 && errno == ENOENT)
+      +            {
+      +              crun_error_release (err);
+      +
+      +              ret = write_file_and_check_controllers_at (cgroup2, dirfd_cpuset, "mems", cpu->mems, strlen (cpu->mems),
+      +                                                         err);
+      +            }
+      +          if (UNLIKELY (ret < 0))
+      +            return ret;
+      +        }
+           }
+         return 0;
+       }
+      diff --git a/src/libcrun/cgroup-setup.c b/src/libcrun/cgroup-setup.c
+      index b920c70d..8eca7864 100644
+      --- a/src/libcrun/cgroup-setup.c
+      +++ b/src/libcrun/cgroup-setup.c
+      @@ -53,12 +53,14 @@ initialize_cpuset_subsystem_rec (char *path, size_t path_len, char *cpus, char *
+         if (cpus[0] == '\0')
+           {
+             cpus_fd = openat (dirfd, "cpuset.cpus", O_RDWR);
+      +      if (UNLIKELY (cpus_fd < 0 && errno == ENOENT))
+      +        cpus_fd = openat (dirfd, "cpus", O_RDWR);
+             if (UNLIKELY (cpus_fd < 0))
+      -        return crun_make_error (err, errno, "open '%s/%s'", path, "cpuset.cpus");
+      +        return crun_make_error (err, errno, "open `%s/%s`", path, "cpuset.cpus");
+
+             b_len = TEMP_FAILURE_RETRY (read (cpus_fd, cpus, 256));
+             if (UNLIKELY (b_len < 0))
+      -        return crun_make_error (err, errno, "read from 'cpuset.cpus'");
+      +        return crun_make_error (err, errno, "read from `cpuset.cpus`");
+             cpus[b_len] = '\0';
+             if (cpus[0] == '\n')
+               cpus[0] = '\0';
+      @@ -67,6 +69,8 @@ initialize_cpuset_subsystem_rec (char *path, size_t path_len, char *cpus, char *
+         if (mems[0] == '\0')
+           {
+             mems_fd = openat (dirfd, "cpuset.mems", O_RDWR);
+      +      if (UNLIKELY (mems_fd < 0 && errno == ENOENT))
+      +        mems_fd = openat (dirfd, "mems", O_RDWR);
+             if (UNLIKELY (mems_fd < 0))
+               return crun_make_error (err, errno, "open '%s/%s'", path, "cpuset.mems");
+    CRUN_PATCH_EOF
+    File.write('crun.patch', @crun_patch)
+    system 'patch -Np1 -i crun.patch'
+  end
 
   def self.build
     @disable_criu = ARCH == 'x86_64' ? '' : '--disable-criu'

--- a/packages/fuse3.rb
+++ b/packages/fuse3.rb
@@ -3,7 +3,7 @@ require 'package'
 class Fuse3 < Package
   description 'The reference implementation of the Linux FUSE (Filesystem in Userspace) interface.'
   homepage 'https://github.com/libfuse/libfuse/'
-  @_ver = '3.12.0'
+  @_ver = '3.13.0'
   version @_ver
   license 'GPL-2+'
   compatibility 'all'
@@ -11,16 +11,16 @@ class Fuse3 < Package
   git_hashtag "fuse-#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fuse3/3.12.0_armv7l/fuse3-3.12.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fuse3/3.12.0_armv7l/fuse3-3.12.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fuse3/3.12.0_i686/fuse3-3.12.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fuse3/3.12.0_x86_64/fuse3-3.12.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fuse3/3.13.0_armv7l/fuse3-3.13.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fuse3/3.13.0_armv7l/fuse3-3.13.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fuse3/3.13.0_i686/fuse3-3.13.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fuse3/3.13.0_x86_64/fuse3-3.13.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '993575dfb3dd1bd71bdab177b810042b8923750cc5c4453dfedfc985e8d9d7fe',
-     armv7l: '993575dfb3dd1bd71bdab177b810042b8923750cc5c4453dfedfc985e8d9d7fe',
-       i686: '3ede85f339d0730975f3e9a5cec0aecb562ce9886d621d348e13e02f2704fb70',
-     x86_64: '6f554e2c2576556e4dcfe6cb45b6c1416a972d88923a435f8d7528501b2df988'
+    aarch64: '4c1ab96deec6a400b49fdd66b6fc987d91448e55c195dc99e4fe73f581e0472c',
+     armv7l: '4c1ab96deec6a400b49fdd66b6fc987d91448e55c195dc99e4fe73f581e0472c',
+       i686: '764d0748f621b8662af616b2a0f660a2af0af7af0eded78abbafa1811e72bb44',
+     x86_64: '39d22e7a3161362766214d68bd78fb53ae61d4edf9a5c03f422f2a00c8065710'
   })
 
   depends_on 'py3_pytest' => :build
@@ -40,7 +40,16 @@ class Fuse3 < Package
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/sbin"
+    Dir.chdir "#{CREW_DEST_PREFIX}/sbin" do
+      FileUtils.ln_s '../bin/fusermount3', 'fusermount3'
+    end
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/init.d/"
     FileUtils.mv "#{CREW_DEST_DIR}/etc/init.d/fuse3", "#{CREW_DEST_PREFIX}/etc/init.d/fuse3"
+  end
+
+  def self.postinstall
+    system "sudo chown root:root #{CREW_PREFIX}/bin/fusermount3"
+    system "sudo chmod 4755 #{CREW_PREFIX}/bin/fusermount3"
   end
 end

--- a/packages/stack.rb
+++ b/packages/stack.rb
@@ -3,22 +3,24 @@ require 'package'
 class Stack < Package
   description 'The Haskell Tool Stack - Stack is a cross-platform program for developing Haskell projects. It is aimed at Haskellers both new and experienced.'
   homepage 'https://docs.haskellstack.org/'
-  @_ver = '2.5.1'
+  @_ver = '2.9.3'
   version @_ver
   license 'BSD'
   compatibility 'all'
   source_url "https://github.com/commercialhaskell/stack/releases/download/v#{@_ver}/stack-#{@_ver}-linux-x86_64.tar.gz"
-  source_sha256 'c83b6c93d6541c0bce2175085a04062020f4160a86116e20f3b343b562f2d1e8'
+  source_sha256 '938f689dc45e2693ab1ca3ea215790b3786dfd531dcf6c0bf40842c24e579ae9'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/stack/2.5.1_armv7l/stack-2.5.1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/stack/2.5.1_armv7l/stack-2.5.1-chromeos-armv7l.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/stack/2.5.1_x86_64/stack-2.5.1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/stack/2.9.3_armv7l/stack-2.9.3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/stack/2.9.3_armv7l/stack-2.9.3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/stack/2.9.3_i686/stack-2.9.3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/stack/2.9.3_x86_64/stack-2.9.3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '132f347c6b7f956938c8e4190e2828738e77422389247845d9437cb8fe821279',
-     armv7l: '132f347c6b7f956938c8e4190e2828738e77422389247845d9437cb8fe821279',
-     x86_64: '6b6c4ad3fbcaf3c1df90ff04820ee20c4ba90265a51e197aae3d4904cb3f9bf9'
+    aarch64: '3551e29cf348081a27f2e598133b9a9a4498a0e0e4b7a098dd0e4b583ccfc7c9',
+     armv7l: '3551e29cf348081a27f2e598133b9a9a4498a0e0e4b7a098dd0e4b583ccfc7c9',
+       i686: '6df32dce7ba7c5509f93a6b4951a8e1f5cb3e6892f8a402efbe3c46b0d208f15',
+     x86_64: 'd6b30d5262a17ed264eec11dc5076cc16ab5810c25dc3c04bb9f3ba6e75cfd33'
   })
 
   def self.install


### PR DESCRIPTION
- Updates stack (ghc still works properly, though it has not been updated.)
- Updates fuse3 to current version, and sets fusermount3 to suid. (This doesn't interfere with removing the package.)
- Updates crun to a version which is closer to getting podman working.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

