### PR TITLE
Change required kernel version to 5.10 for running postinstall build-locale-archive

### DIFF
--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -705,7 +705,7 @@ class Glibc < Package
         end
       end
     end
-    return unless @libc_version.to_f >= 2.32 && CREW_KERNEL_VERSION.to_f >= 5.4
+    return unless @libc_version.to_f >= 2.32 && CREW_KERNEL_VERSION.to_f >= 5.10
 
     puts 'Paring locales to a minimal set.'.lightblue
     system 'localedef --list-archive | grep -v -i -e ^en -e ^cs -e ^de -e ^es -e ^fa -e ^fe -e ^it -e ^ja -e ^ru -e ^tr -e ^zh -e ^C| xargs localedef --delete-from-archive',


### PR DESCRIPTION
Fixes #7872 
- Looks like `build-locale-archive` doesn't work with kernel 5.4 either. :/

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=glibc_ver_fix CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
