### PR TITLE
Fixup CREW_KERNEL_VERSION comparisons

### DIFF
--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -705,7 +705,7 @@ class Glibc < Package
         end
       end
     end
-    return unless @libc_version.to_f >= 2.32 && CREW_KERNEL_VERSION.to_f >= 5.10
+    return unless @libc_version.to_f >= 2.32 && Gem::Version.new(CREW_KERNEL_VERSION.to_s) >= Gem::Version.new('5.10')
 
     puts 'Paring locales to a minimal set.'.lightblue
     system 'localedef --list-archive | grep -v -i -e ^en -e ^cs -e ^de -e ^es -e ^fa -e ^fe -e ^it -e ^ja -e ^ru -e ^tr -e ^zh -e ^C| xargs localedef --delete-from-archive',

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -5,7 +5,7 @@ class Mesa < Package
   homepage 'https://www.mesa3d.org'
   # We use mesa amber (derived from the 21.3 series) for older kernels
   # and current mesa versions for newer kernels.
-  if CREW_KERNEL_VERSION.to_f < 5.10
+  if Gem::Version.new(CREW_KERNEL_VERSION.to_s) < Gem::Version.new('5.10')
     # Built off of the mesa amber branch
     git_hashtag 'acfef002a081f36e6eebc6e8ab908a36ab18f68c'
     @_ver = git_hashtag[0, 7]
@@ -19,7 +19,7 @@ class Mesa < Package
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/mesa/mesa.git'
 
-  if CREW_KERNEL_VERSION.to_f < 5.10
+  if Gem::Version.new(CREW_KERNEL_VERSION.to_s) < Gem::Version.new('5.10')
     binary_url({
       aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/amber-acfef00_armv7l/mesa-amber-acfef00-chromeos-armv7l.tar.zst',
        armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mesa/amber-acfef00_armv7l/mesa-amber-acfef00-chromeos-armv7l.tar.zst',
@@ -81,7 +81,7 @@ class Mesa < Package
   depends_on 'zlibpkg' # R
   depends_on 'zstd' # R
 
-  if CREW_KERNEL_VERSION.to_f < 5.10
+  if Gem::Version.new(CREW_KERNEL_VERSION.to_s) < Gem::Version.new('5.10')
     def self.patch
       case ARCH
       when 'aarch64', 'armv7l'

--- a/packages/pipewire.rb
+++ b/packages/pipewire.rb
@@ -3,7 +3,7 @@ require 'package'
 class Pipewire < Package
   description 'PipeWire is a project that aims to greatly improve handling of audio and video under Linux.'
   homepage 'https://pipewire.org'
-  @_ver = if CREW_KERNEL_VERSION.to_f < 3.9
+  @_ver = if Gem::Version.new(CREW_KERNEL_VERSION.to_s) < Gem::Version.new('3.9')
             '0.3.29'
           else
             '0.3.60'
@@ -14,7 +14,7 @@ class Pipewire < Package
   source_url 'https://gitlab.freedesktop.org/pipewire/pipewire.git'
   git_hashtag @_ver
 
-  if CREW_KERNEL_VERSION.to_f < 3.9
+  if Gem::Version.new(CREW_KERNEL_VERSION.to_s) < Gem::Version.new('3.9')
     binary_url({
      i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pipewire/0.3.29_i686/pipewire-0.3.29-chromeos-i686.tpxz'
     })

--- a/packages/pipewire.rb
+++ b/packages/pipewire.rb
@@ -5,8 +5,10 @@ class Pipewire < Package
   homepage 'https://pipewire.org'
   @_ver = if Gem::Version.new(CREW_KERNEL_VERSION.to_s) < Gem::Version.new('3.9')
             '0.3.29'
-          else
+          elsif Gem::Version.new(CREW_KERNEL_VERSION.to_s) <= Gem::Version.new('5.4')
             '0.3.60'
+          else
+            '0.3.65'
           end
   version @_ver
   license 'LGPL-2.1+'
@@ -21,7 +23,7 @@ class Pipewire < Package
     binary_sha256({
      i686: '0dbeda58c4e1db7a180ebfb2b7bc3057cc6966927f4d5ee543953b734dfc4510'
     })
-  else
+  elsif Gem::Version.new(CREW_KERNEL_VERSION.to_s) <= Gem::Version.new('5.4')
     binary_url({
       aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pipewire/0.3.60_armv7l/pipewire-0.3.60-chromeos-armv7l.tar.zst',
        armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pipewire/0.3.60_armv7l/pipewire-0.3.60-chromeos-armv7l.tar.zst',
@@ -31,6 +33,17 @@ class Pipewire < Package
       aarch64: '237ad8299b16e6d294a6561a4959efb47fc72ee66d06f51a3863f55dbdedcf78',
        armv7l: '237ad8299b16e6d294a6561a4959efb47fc72ee66d06f51a3863f55dbdedcf78',
        x86_64: '1534c6a7d71870ac60ec77aab0f795e148e63cf2eac61ff6ec58a5d3af23d994'
+    })
+  else
+    binary_url({
+      aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pipewire/0.3.65_armv7l/pipewire-0.3.65-chromeos-armv7l.tar.zst',
+       armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pipewire/0.3.65_armv7l/pipewire-0.3.65-chromeos-armv7l.tar.zst',
+       x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pipewire/0.3.65_x86_64/pipewire-0.3.65-chromeos-x86_64.tar.zst'
+    })
+    binary_sha256({
+      aarch64: '6a67e384a6beadaa6884732609d4e3aa8e4067f4e46d7e823358494fa804d5e9',
+       armv7l: '6a67e384a6beadaa6884732609d4e3aa8e4067f4e46d7e823358494fa804d5e9',
+       x86_64: '26dd5457a4c334f87f038108c30db60b7e8de0f5d7259fe5452bef3a60f73bbc'
     })
   end
 


### PR DESCRIPTION
Fixes #7872

- Thanks to @supechicken for the major assist here!
- Also updates pipewire to 0.3.65 for kernel >= 5.10...

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=glibc_fix2 CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
