### PR TITLE
gettext: fix deps, remove openmp runtime dep

### DIFF
--- a/packages/gettext.rb
+++ b/packages/gettext.rb
@@ -23,12 +23,15 @@ class Gettext < Package
   })
 
   depends_on 'acl' # R
+  depends_on 'attr' # R
   depends_on 'gcc' # R
   depends_on 'glibc' # R
-  depends_on 'openjdk8' => :build
+  depends_on 'icu4c' # R
   depends_on 'libunistring' # R
   depends_on 'libxml2' # R
-  depends_on 'openmp'
+  depends_on 'openjdk8' => :build
+  depends_on 'openmp' => :build
+  depends_on 'zlibpkg' # R
 
   def self.build
     raise StandardError, 'Please remove libiconv before building.' if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")


### PR DESCRIPTION
- gettext does not need openmp, and this removes openmp from buildutils installs.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=gettext_deps  CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
