### PR TITLE
upx => 4.0.2

### DIFF
--- a/packages/upx.rb
+++ b/packages/upx.rb
@@ -6,23 +6,23 @@ require 'package'
 class Upx < Package
   description 'Extendable, high-performance executable packer for several executable formats'
   homepage 'https://github.com/upx/upx'
-  version '4.0.1'
+  version '4.0.2'
   license 'custom GPL2'
   compatibility 'all'
   source_url 'https://github.com/upx/upx.git'
   git_hashtag "v#{version}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.1_armv7l/upx-4.0.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.1_armv7l/upx-4.0.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.1_i686/upx-4.0.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.1_x86_64/upx-4.0.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.2_armv7l/upx-4.0.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.2_armv7l/upx-4.0.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.2_i686/upx-4.0.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.2_x86_64/upx-4.0.2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'c7d3497ad54f327ae9cd8de79fe00c6515dae6e57c80beb247cf5165f3498397',
-     armv7l: 'c7d3497ad54f327ae9cd8de79fe00c6515dae6e57c80beb247cf5165f3498397',
-       i686: '2b7b9b0ceeafd6393741abbaf693465e632759a690e5dedebd84ccf882b8b2ff',
-     x86_64: '1d60d569bffecf477e82a58e6285bfdc62c673c8b5329075d776a548e89d65ac'
+    aarch64: 'dc9823913706ce2e9d31679fb733ebbc947b000b1e70ef80b621f6cf7fcb1efe',
+     armv7l: 'dc9823913706ce2e9d31679fb733ebbc947b000b1e70ef80b621f6cf7fcb1efe',
+       i686: '3944e0d6ad263b5fef6318940f7e2b67f9f236dc71f61cf33c638068e8aa3481',
+     x86_64: '19c01ac6154add7e3376c01ec179230118ea87147ef72874b69a4e466d80617e'
   })
 
   # depends_on 'ucl'


### PR DESCRIPTION
- bugfixes...
- the fixing of compressed libraries (which we don't use, on purpose) is targeted for upx 4.0.3...

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=upx402 CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
