### PR TITLE
openssh => 9.2

### DIFF
--- a/packages/openssh.rb
+++ b/packages/openssh.rb
@@ -3,23 +3,23 @@ require 'package'
 class Openssh < Package
   description 'OpenSSH is the premier connectivity tool for remote login with the SSH protocol.'
   homepage 'https://www.openssh.com/'
-  version '9.1'
+  version '9.2'
   license 'BSD and GPL-2'
   compatibility 'all'
   source_url 'https://github.com/openssh/openssh-portable.git'
-  git_hashtag 'V_9_1_P1'
+  git_hashtag 'V_9_2_P1'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssh/9.1_armv7l/openssh-9.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssh/9.1_armv7l/openssh-9.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssh/9.1_i686/openssh-9.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssh/9.1_x86_64/openssh-9.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssh/9.2_armv7l/openssh-9.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssh/9.2_armv7l/openssh-9.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssh/9.2_i686/openssh-9.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssh/9.2_x86_64/openssh-9.2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '4a16590d6708883779e99ed0b53a59a0fda3ebcc3f3528c3a8198496c8868d7b',
-     armv7l: '4a16590d6708883779e99ed0b53a59a0fda3ebcc3f3528c3a8198496c8868d7b',
-       i686: '9fdbb5717755a3a3a2400c4a4d3f7d0de65910a4a70f855cd8554075665f2ede',
-     x86_64: '37e07e2b07840fd71ea6fa75c2fb91f299bf5f827371c0f5f0fc52908988c6ba'
+    aarch64: 'b6b52c354cdfbaed0106310c665a3589d12246ff54b6d203eca450026c7dd8bc',
+     armv7l: 'b6b52c354cdfbaed0106310c665a3589d12246ff54b6d203eca450026c7dd8bc',
+       i686: '44360be3865797524ce9ae1b35903945ec15bbfcbd9f636797c99fa4c8003431',
+     x86_64: '989eb709d54b431f481127d60fa492b76bbcc24b8db3af6ad9f1d2b23eff62ff'
   })
 
   depends_on 'gcc' # R


### PR DESCRIPTION

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=openssh92 CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
