### PR TITLE
x updates

### DIFF
--- a/packages/glslang.rb
+++ b/packages/glslang.rb
@@ -6,51 +6,39 @@ require 'package'
 class Glslang < Package
   description 'OpenGL and OpenGL ES shader front end and validator'
   homepage 'https://github.com/KhronosGroup/glslang'
-  version '8.13.3743'
+  version '12.0.0'
   license 'BSD-3, MIT, BSD-2, Apache-2.0 and NVIDIA'
   compatibility 'all'
-  source_url 'https://github.com/KhronosGroup/glslang/archive/8.13.3743.tar.gz'
-  source_sha256 '639ebec56f1a7402f2fa094469a5ddea1eceecfaf2e9efe361376a0f73a7ee2f'
+  source_url 'https://github.com/KhronosGroup/glslang.git'
+  git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glslang/8.13.3743_armv7l/glslang-8.13.3743-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glslang/8.13.3743_armv7l/glslang-8.13.3743-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glslang/8.13.3743_i686/glslang-8.13.3743-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glslang/8.13.3743_x86_64/glslang-8.13.3743-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glslang/12.0.0_armv7l/glslang-12.0.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glslang/12.0.0_armv7l/glslang-12.0.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glslang/12.0.0_i686/glslang-12.0.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glslang/12.0.0_x86_64/glslang-12.0.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '927f23fc3390cc2b66da76f8ebab2ed55e04c2544d8ed5ce3ce84f734d6631d6',
-     armv7l: '927f23fc3390cc2b66da76f8ebab2ed55e04c2544d8ed5ce3ce84f734d6631d6',
-       i686: '73a6dd675301d314921c69f016659cfe1c520176ece194eac6e47b934706b213',
-     x86_64: '51de97dab57fb0e21f4b0746b1117cca66481d8dfe63065edda8f122feaceb6f'
+    aarch64: 'faf914601e515f39d2ef854e427cea8a75fa70aa3d0fa9ebd70a6d9ee21c13f8',
+     armv7l: 'faf914601e515f39d2ef854e427cea8a75fa70aa3d0fa9ebd70a6d9ee21c13f8',
+       i686: 'a0e1b631baa510e7d7baeda275bade2b4518a9c31273c156dbdc7cd837c5e5b6',
+     x86_64: '2247c659389a1b6b31d95f365addb9267cfcacae5f69af321945ceeea4d300ae'
   })
 
+  depends_on 'spirv_headers' => :build
+  depends_on 'spirv_tools' => :build
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+
   def self.build
-    system './update_glslang_sources.py'
-    Dir.mkdir 'build-shared'
-    Dir.chdir 'build-shared' do
-      system "cmake .. \
-      -GNinja \
-      -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX} \
-      -DCMAKE_INSTALL_LIBDIR=#{CREW_LIB_PREFIX} \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DBUILD_SHARED_LIBS=ON"
-    end
-    system 'ninja -C build-shared'
-    Dir.mkdir 'build-static'
-    Dir.chdir 'build-static' do
-      system "cmake .. \
-      -GNinja \
-      -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX} \
-      -DCMAKE_INSTALL_LIBDIR=#{CREW_LIB_PREFIX} \
-      -DCMAKE_BUILD_TYPE=Release \
+    system "cmake -B build-static \
+      -G Ninja \
+      #{CREW_CMAKE_OPTIONS} \
       -DBUILD_SHARED_LIBS=OFF"
-    end
     system 'ninja -C build-static'
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C build-shared install"
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C build-static install"
   end
 end

--- a/packages/libfontenc.rb
+++ b/packages/libfontenc.rb
@@ -4,7 +4,7 @@ class Libfontenc < Package
   description 'Fontenc Library from X.org'
   homepage 'https://xorg.freedesktop.org/'
   version '1.1.7'
-  license 'custom'
+  license 'MIT'
   compatibility 'all'
   source_url 'https://www.x.org/releases/individual/lib/libfontenc-1.1.7.tar.xz'
   source_sha256 'c0d36991faee06551ddbaf5d99266e97becdc05edfae87a833c3ff7bf73cfec2'

--- a/packages/libfontenc.rb
+++ b/packages/libfontenc.rb
@@ -3,23 +3,23 @@ require 'package'
 class Libfontenc < Package
   description 'Fontenc Library from X.org'
   homepage 'https://xorg.freedesktop.org/'
-  version '1.1.6'
-  compatibility 'all'
+  version '1.1.7'
   license 'custom'
-  source_url 'https://www.x.org/releases/individual/lib/libfontenc-1.1.5.tar.xz'
-  source_sha256 '43ef0387090ea526faf8d3b0907ee0e4be0fb433c17e0b1bdb8433aa1de2b12c'
+  compatibility 'all'
+  source_url 'https://www.x.org/releases/individual/lib/libfontenc-1.1.7.tar.xz'
+  source_sha256 'c0d36991faee06551ddbaf5d99266e97becdc05edfae87a833c3ff7bf73cfec2'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libfontenc/1.1.4_armv7l/libfontenc-1.1.4-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libfontenc/1.1.4_armv7l/libfontenc-1.1.4-chromeos-armv7l.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libfontenc/1.1.4_x86_64/libfontenc-1.1.4-chromeos-x86_64.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libfontenc/1.1.6_i686/libfontenc-1.1.6-chromeos-i686.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libfontenc/1.1.7_armv7l/libfontenc-1.1.7-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libfontenc/1.1.7_armv7l/libfontenc-1.1.7-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libfontenc/1.1.7_i686/libfontenc-1.1.7-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libfontenc/1.1.7_x86_64/libfontenc-1.1.7-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'cf093d4545369715602df5d61ed7338a867bbe11a07a26ddcd563c95478c78c5',
-     armv7l: 'cf093d4545369715602df5d61ed7338a867bbe11a07a26ddcd563c95478c78c5',
-     x86_64: '08bc791449cfabb5833a5cbd7c35c541032bae3bf3f8755455935ec61fd815c4',
-       i686: '8929d18ee367196ebaf989813abe51979929896d2f881e8775babe37a49ba65f'
+    aarch64: '8d2dee2568b7a2389cff4435c26653fe56c8b3bda1132ec74215ed87ca8eb287',
+     armv7l: '8d2dee2568b7a2389cff4435c26653fe56c8b3bda1132ec74215ed87ca8eb287',
+       i686: '20d2b4358c6b10ac9f215919ec0b57691565d7dd1e8883d32397ed5b1d773b32',
+     x86_64: '4331cdbb4108722b6fc8d05249cdba21b67e917270ccba8b03b17808176dc30f'
   })
 
   depends_on 'xorg_proto'

--- a/packages/libsixel.rb
+++ b/packages/libsixel.rb
@@ -1,0 +1,48 @@
+# Adapted from Arch Linux libsixel PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/libsixel/trunk/PKGBUILD
+
+require 'package'
+
+class Libsixel < Package
+  description 'Provides a codec for DEC SIXEL graphics and some converter programs'
+  homepage 'https://github.com/libsixel/libsixel'
+  version '1.10.3'
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://github.com/libsixel/libsixel/archive/v1.10.3.tar.gz'
+  source_sha256 '028552eb8f2a37c6effda88ee5e8f6d87b5d9601182ddec784a9728865f821e0'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsixel/1.10.3_armv7l/libsixel-1.10.3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsixel/1.10.3_armv7l/libsixel-1.10.3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsixel/1.10.3_i686/libsixel-1.10.3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsixel/1.10.3_x86_64/libsixel-1.10.3-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: 'e6908061d6984a1ba7dcbe41eadeec82a71bf61bd7046a2f18123be69c8a675a',
+     armv7l: 'e6908061d6984a1ba7dcbe41eadeec82a71bf61bd7046a2f18123be69c8a675a',
+       i686: '14b320168e6068a82613f5efc498d201020421b2c1681823e5d7653bd62f8f60',
+     x86_64: '16d7382c5229870d3954338748174d402db8542408b33bea49e6c3066a9c942a'
+  })
+
+  depends_on 'libjpeg' => :build
+  depends_on 'libpng' => :build
+  depends_on 'python3' => :build
+  depends_on 'gdk_pixbuf' => :build
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  depends_on 'gdk_pixbuf' # R
+  depends_on 'glib' # R
+
+  def self.build
+    system "meson setup #{CREW_MESON_OPTIONS} \
+       -Dgdk-pixbuf2=enabled \
+       builddir"
+    system 'meson configure builddir'
+    system 'samu -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
+  end
+end

--- a/packages/libutempter.rb
+++ b/packages/libutempter.rb
@@ -1,0 +1,43 @@
+# Adapted from Arch Linux libutempter PKGBUILD at:
+# https://github.com/archlinux/svntogit-packages/raw/packages/libutempter/trunk/PKGBUILD
+
+require 'package'
+
+class Libutempter < Package
+  description 'Interface for terminal emulators such as screen and xterm to record user sessions to utmp and wtmp files'
+  homepage 'http://ftp.altlinux.org/pub/people/ldv/utempter'
+  version '1.2.1'
+  license 'LGPL'
+  compatibility 'all'
+  source_url 'http://ftp.altlinux.org/pub/people/ldv/utempter/libutempter-1.2.1.tar.gz'
+  source_sha256 '967fef372f391de501843ad87570c6cf5dabd9651f00f1783090fbc12b2a34cb'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libutempter/1.2.1_armv7l/libutempter-1.2.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libutempter/1.2.1_armv7l/libutempter-1.2.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libutempter/1.2.1_i686/libutempter-1.2.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libutempter/1.2.1_x86_64/libutempter-1.2.1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: 'b770b584f1fbdc24d77c0fd82dcbd6c473926b2c3de234ecce7ef4c76221fe4c',
+     armv7l: 'b770b584f1fbdc24d77c0fd82dcbd6c473926b2c3de234ecce7ef4c76221fe4c',
+       i686: 'ea4f18fff033f4fe370af032178e72d77b8d6fb072c3f83c884b3c607be9c7ea',
+     x86_64: 'ca10f3ea99a63c58fbc07fd6e6d8a16fb34cc18b0110c05bba80bd8b84ce195f'
+  })
+
+  depends_on 'glibc'
+
+  def self.patch
+    system "sed -i 's,/usr/lib,#{CREW_LIB_PREFIX},g' Makefile"
+    system "sed -i 's,/usr/include,#{CREW_PREFIX}/include,g' Makefile"
+    system "sed -i 's,/usr/share/man,#{CREW_MAN_PREFIX},g' Makefile"
+  end
+
+  def self.build
+    system 'make'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end

--- a/packages/luit.rb
+++ b/packages/luit.rb
@@ -10,7 +10,7 @@ class Luit < Package
   license 'custom'
   compatibility 'all'
   source_url 'https://github.com/ThomasDickey/luit-snapshots.git'
-  git_hashtag 'v2_0_20230201'
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luit/2_0_20230201_armv7l/luit-2_0_20230201-chromeos-armv7l.tar.zst',

--- a/packages/luit.rb
+++ b/packages/luit.rb
@@ -1,0 +1,40 @@
+# Adapted from Arch Linux luit PKGBUILD at:
+# https://github.com/archlinux/svntogit-packages/raw/packages/luit/trunk/PKGBUILD
+
+require 'package'
+
+class Luit < Package
+  description 'Filter that can be run between an arbitrary application and a UTF-8 terminal emulator'
+  homepage 'https://invisible-island.net/luit/luit.html'
+  version '2_0_20230201'
+  license 'custom'
+  compatibility 'all'
+  source_url 'https://github.com/ThomasDickey/luit-snapshots.git'
+  git_hashtag 'v2_0_20230201'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luit/2_0_20230201_armv7l/luit-2_0_20230201-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luit/2_0_20230201_armv7l/luit-2_0_20230201-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luit/2_0_20230201_i686/luit-2_0_20230201-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/luit/2_0_20230201_x86_64/luit-2_0_20230201-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '04d87e98277c2b522ea8f088b11a79a46abb15700dc44db9cd85e17e4c37d111',
+     armv7l: '04d87e98277c2b522ea8f088b11a79a46abb15700dc44db9cd85e17e4c37d111',
+       i686: '76a095380f067f4e1e50a0f52fa9c7fca2764d4fef9f44872d51bb6fa3102d12',
+     x86_64: '038cf6925d94fdb7ab7f9982c998eadeedd254e6e0a13c5e7db4b4ef6dc0a094'
+  })
+
+  depends_on 'glibc' # R
+  depends_on 'libfontenc' # R
+  depends_on 'libx11' => ':build'
+
+  def self.build
+    system "./configure #{CREW_OPTIONS} --enable-fontenc"
+    system 'make'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end

--- a/packages/spirv_headers.rb
+++ b/packages/spirv_headers.rb
@@ -5,40 +5,33 @@ require 'package'
 
 class Spirv_headers < Package
   description 'SPIR-V Headers'
-  version '1.5.4-f88a'
+  version '1.3.239.0'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://github.com/KhronosGroup/SPIRV-Headers/archive/f88a1f98fa7a44ccfcf33d810c72b200e7d9a78a.zip'
-  source_sha256 'b209fe7fd0db5a2eb61db5d93525ce0f39e4d615f2f82bd02ff0ee512bd45a1e'
+  source_url 'https://github.com/KhronosGroup/SPIRV-Headers.git'
+  git_hashtag "sdk-#{version}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/spirv_headers/1.5.4-f88a_armv7l/spirv_headers-1.5.4-f88a-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/spirv_headers/1.5.4-f88a_armv7l/spirv_headers-1.5.4-f88a-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/spirv_headers/1.5.4-f88a_i686/spirv_headers-1.5.4-f88a-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/spirv_headers/1.5.4-f88a_x86_64/spirv_headers-1.5.4-f88a-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/spirv_headers/1.3.239.0_armv7l/spirv_headers-1.3.239.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/spirv_headers/1.3.239.0_armv7l/spirv_headers-1.3.239.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/spirv_headers/1.3.239.0_i686/spirv_headers-1.3.239.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/spirv_headers/1.3.239.0_x86_64/spirv_headers-1.3.239.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '7fbc45daafcb8a8d2a2b677321df22f86797cc3cdd17b57e6ff6e56e6f00bc79',
-     armv7l: '7fbc45daafcb8a8d2a2b677321df22f86797cc3cdd17b57e6ff6e56e6f00bc79',
-       i686: '3b7e2d5cddd5a470bc44a2429559bd03aaa339e6fc2c16eee018b1758de5d6c6',
-     x86_64: 'fe9c5758664a18559627bb5b1fda22ca5d5c6c6308ebf2d5bf6c65be393bf33a'
+    aarch64: '6720cd5bf305167e12ad4055ed9ca1c3bf89506ca1ca82c8f3789f1decfd8aa5',
+     armv7l: '6720cd5bf305167e12ad4055ed9ca1c3bf89506ca1ca82c8f3789f1decfd8aa5',
+       i686: '105ae0fa19df004896b558969432b713cb18e793b75c54fa763a47b76dec1ad9',
+     x86_64: '8178f815c883270d734f637e27a1588f7b2115b89398c1d1f4423912dca4cc64'
   })
 
   def self.build
-    Dir.mkdir 'builddir'
-    Dir.chdir 'builddir' do
-      system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      cmake \
-        -G Ninja \
-        #{CREW_CMAKE_OPTIONS} \
-        .."
-    end
-    system 'ninja -C builddir'
+    system "cmake -B builddir \
+      -G Ninja \
+      #{CREW_CMAKE_OPTIONS}"
+    system 'samu -C builddir'
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
   end
 end

--- a/packages/spirv_tools.rb
+++ b/packages/spirv_tools.rb
@@ -4,32 +4,34 @@ require 'package'
 
 class Spirv_tools < Package
   description 'API and commands for processing SPIR-V modules'
-  version '2020.7'
+  version '2023.1'
   license 'custom'
   compatibility 'all'
-  source_url 'https://github.com/KhronosGroup/SPIRV-Tools/archive/v2020.7.tar.gz'
-  source_sha256 'c06eed1c7a1018b232768481184b5ae4d91d614d7bd7358dc2fe306bd0a39c6e'
+  source_url 'https://github.com/KhronosGroup/SPIRV-Tools.git'
+  git_hashtag "v#{version}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/spirv_tools/2020.7_armv7l/spirv_tools-2020.7-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/spirv_tools/2020.7_armv7l/spirv_tools-2020.7-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/spirv_tools/2020.7_i686/spirv_tools-2020.7-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/spirv_tools/2020.7_x86_64/spirv_tools-2020.7-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/spirv_tools/2023.1_armv7l/spirv_tools-2023.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/spirv_tools/2023.1_armv7l/spirv_tools-2023.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/spirv_tools/2023.1_i686/spirv_tools-2023.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/spirv_tools/2023.1_x86_64/spirv_tools-2023.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '11f7b470632a94066cae7c546fc8a826c2cc34e11aab3544bb1fff64dc3627d4',
-     armv7l: '11f7b470632a94066cae7c546fc8a826c2cc34e11aab3544bb1fff64dc3627d4',
-       i686: '4a35f21e49c67571334444318560c9f182c1c31d82290927f83330ba7178f3f1',
-     x86_64: 'deaebf001fa0d2d78c24b1b7cb6a6b1c062afa88c3c8ae80d79a73db86595597'
+    aarch64: '06d70d4c9b44c43fb48f3d413b87469cab743e6046de89259333425f872fb327',
+     armv7l: '06d70d4c9b44c43fb48f3d413b87469cab743e6046de89259333425f872fb327',
+       i686: '5d6cd3cbbc05608ed3edde1d0d491dbe2ec9fb3a6408103ee6c5e6091e58715e',
+     x86_64: '17df444ceba1275d0cfc130aa8ce83ce789aa6d906e2fe7aff94cc54bd6fca8f'
   })
 
-  depends_on 'spirv_headers'
+  depends_on 'spirv_headers' => :build
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
 
   def self.patch
     # Source needs spirv-headers repo as submodule
     @git_dir = 'external/SPIRV-Headers'
-    @git_hash = 'f88a1f98fa7a44ccfcf33d810c72b200e7d9a78a'
-    @git_url = 'https://github.com/KhronosGroup/SPIRV-Headers'
+    @git_hash = "sdk-#{Spirv_headers.version}"
+    @git_url = 'https://github.com/KhronosGroup/SPIRV-Headers.git'
     FileUtils.rm_rf(@git_dir)
     FileUtils.mkdir_p(@git_dir)
     Dir.chdir @git_dir do
@@ -41,22 +43,15 @@ class Spirv_tools < Package
   end
 
   def self.build
-    Dir.mkdir 'builddir'
-    Dir.chdir 'builddir' do
-      system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      cmake \
-        -G Ninja \
-        #{CREW_CMAKE_OPTIONS} \
-        -DSPIRV_WERROR=Off \
-        -DBUILD_SHARED_LIBS=ON \
-        .."
-    end
-    system 'ninja -C builddir'
+    system "cmake -B builddir \
+      -G Ninja \
+      #{CREW_CMAKE_OPTIONS} \
+      -DSPIRV_WERROR=Off \
+      -DBUILD_SHARED_LIBS=ON"
+    system 'samu -C builddir'
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
   end
 end

--- a/packages/vulkan_headers.rb
+++ b/packages/vulkan_headers.rb
@@ -3,7 +3,7 @@ require 'package'
 class Vulkan_headers < Package
   description 'Vulkan header files'
   homepage 'https://github.com/KhronosGroup/Vulkan-Headers'
-  @_ver = '1.3.231'
+  @_ver = '1.3.240'
   version @_ver
   license 'Apache-2.0'
   compatibility 'all'
@@ -11,16 +11,16 @@ class Vulkan_headers < Package
   git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.231_armv7l/vulkan_headers-1.3.231-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.231_armv7l/vulkan_headers-1.3.231-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.231_i686/vulkan_headers-1.3.231-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.231_x86_64/vulkan_headers-1.3.231-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.240_armv7l/vulkan_headers-1.3.240-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.240_armv7l/vulkan_headers-1.3.240-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.240_i686/vulkan_headers-1.3.240-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.240_x86_64/vulkan_headers-1.3.240-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'b19c5a426f01cf251c5660abccae19f6ab5082bdd12c7b6470856579664e0897',
-     armv7l: 'b19c5a426f01cf251c5660abccae19f6ab5082bdd12c7b6470856579664e0897',
-       i686: '12f2ae15bff517cbefbbe61e59b408431235f60b78d6adef55740d5eb3ca83b2',
-     x86_64: 'b627b23a35c7f934e7eed6227091dd897e8c4554102cc387fbf75379dd3de1d5'
+    aarch64: 'e9d8e8462372341d053a1cff4750449abc594b344f382101af2a65834e02235b',
+     armv7l: 'e9d8e8462372341d053a1cff4750449abc594b344f382101af2a65834e02235b',
+       i686: 'aceec0f02f2da30a3a0d64ccf747b2d94e745029accb1f93698c067171f21cdd',
+     x86_64: 'a56eeecc0442fc11dfa6b499c0efe9dd3acfe0b10c49af1f1354d1fac5e2ccf9'
   })
 
   def self.build

--- a/packages/vulkan_icd_loader.rb
+++ b/packages/vulkan_icd_loader.rb
@@ -3,7 +3,7 @@ require 'package'
 class Vulkan_icd_loader < Package
   description 'Vulkan Installable Client Driver ICD Loader'
   homepage 'https://github.com/KhronosGroup/Vulkan-Loader'
-  @_ver = '1.3.231'
+  @_ver = '1.3.240'
   version @_ver
   license 'Apache-2.0'
   compatibility 'all'
@@ -11,16 +11,16 @@ class Vulkan_icd_loader < Package
   git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.231_armv7l/vulkan_icd_loader-1.3.231-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.231_armv7l/vulkan_icd_loader-1.3.231-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.231_i686/vulkan_icd_loader-1.3.231-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.231_x86_64/vulkan_icd_loader-1.3.231-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.240_armv7l/vulkan_icd_loader-1.3.240-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.240_armv7l/vulkan_icd_loader-1.3.240-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.240_i686/vulkan_icd_loader-1.3.240-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.240_x86_64/vulkan_icd_loader-1.3.240-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'd48edf42f7c448182905ddeeb9651f2db0dfdbb331b19f3b67ac1f97d3e34b0a',
-     armv7l: 'd48edf42f7c448182905ddeeb9651f2db0dfdbb331b19f3b67ac1f97d3e34b0a',
-       i686: '9d546f058735fc9ae488e8cbc7adf064a2b5ff4649cc732ad066dc359475d662',
-     x86_64: 'bb1c74e5a6dc3ecde467665561d59992b22a577e8fa3b03613d2b32ef162f1d9'
+    aarch64: '408b04b10b60ce62556b712231e7233516f64afba574028793770bd72d299e9f',
+     armv7l: '408b04b10b60ce62556b712231e7233516f64afba574028793770bd72d299e9f',
+       i686: '4285135802a87ba1673e829a7e1b0ac0c37da18e4fea164d977ef40fcf4f4b2f',
+     x86_64: '61aff99407ac07e4c61b848a3ffcfabf916d515a970c7ba6c93e2acd03fc9b66'
   })
 
   depends_on 'libx11'

--- a/packages/vulkan_tools.rb
+++ b/packages/vulkan_tools.rb
@@ -6,23 +6,23 @@ require 'package'
 class Vulkan_tools < Package
   description 'Vulkan Utilities and Tools'
   homepage 'https://www.khronos.org/vulkan/'
-  version '1.3.231'
+  version '1.3.240'
   license 'custom'
   compatibility 'all'
   source_url 'https://github.com/KhronosGroup/Vulkan-Tools.git'
   git_hashtag "v#{version}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_tools/1.3.231_armv7l/vulkan_tools-1.3.231-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_tools/1.3.231_armv7l/vulkan_tools-1.3.231-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_tools/1.3.231_i686/vulkan_tools-1.3.231-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_tools/1.3.231_x86_64/vulkan_tools-1.3.231-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_tools/1.3.240_armv7l/vulkan_tools-1.3.240-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_tools/1.3.240_armv7l/vulkan_tools-1.3.240-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_tools/1.3.240_i686/vulkan_tools-1.3.240-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_tools/1.3.240_x86_64/vulkan_tools-1.3.240-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '51bb8acd2988d6b166d02aef12deca99f2043a9cfa14b7fc1d482c5423ff6e58',
-     armv7l: '51bb8acd2988d6b166d02aef12deca99f2043a9cfa14b7fc1d482c5423ff6e58',
-       i686: 'e6b5506c8a5e21c9d6acef7ef2fcd9044531d3e09a5c7e957d9c258bc2076ac2',
-     x86_64: 'aefe2651e6d31b6b1acd5e7604ffaad046e3a391e538ae4bbf79b6e9394cd236'
+    aarch64: 'b3f3b0490b311b16d6d589369679ee46df7df92e9b09af1da06242a6fec1e32a',
+     armv7l: 'b3f3b0490b311b16d6d589369679ee46df7df92e9b09af1da06242a6fec1e32a',
+       i686: '414ecb4752b785f2328a9a52ba922554404cbc7e2dd0711b0c3b70cc24ad352c',
+     x86_64: '1d42540b628e8ebcd42a83cbfe10673f203e99e80248f7b58731c679d9c86eec'
   })
 
   depends_on 'gcc' # R

--- a/packages/xorg_server.rb
+++ b/packages/xorg_server.rb
@@ -3,7 +3,7 @@ require 'package'
 class Xorg_server < Package
   description 'The Xorg Server is the core of the X Window system.'
   homepage 'https://www.x.org'
-  @_ver = '21.1.5'
+  @_ver = '21.1.7'
   version @_ver
   license 'BSD-3, MIT, BSD-4, MIT-with-advertising, ISC and custom'
   compatibility 'all'
@@ -11,16 +11,16 @@ class Xorg_server < Package
   git_hashtag "xorg-server-#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.5_armv7l/xorg_server-21.1.5-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.5_armv7l/xorg_server-21.1.5-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.5_i686/xorg_server-21.1.5-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.5_x86_64/xorg_server-21.1.5-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.7_armv7l/xorg_server-21.1.7-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.7_armv7l/xorg_server-21.1.7-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.7_i686/xorg_server-21.1.7-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.7_x86_64/xorg_server-21.1.7-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '78ad6bfdd97bd1056e0d75f7c5f787178815e8c9404ff08503765b13d9a2d444',
-     armv7l: '78ad6bfdd97bd1056e0d75f7c5f787178815e8c9404ff08503765b13d9a2d444',
-       i686: '461fb290fa7b5f7237445c9cf6d7ba4e15c69e3a31c651ee91f6de40db939885',
-     x86_64: '6f438b6d48592c9c3b52bd50abbc6040d3048dc357164a96f6c5d42c9b24fc20'
+    aarch64: 'd42c06ceb209fb5fb76efbafddd71d9d70fbf22b1a26eed272260c568df24d59',
+     armv7l: 'd42c06ceb209fb5fb76efbafddd71d9d70fbf22b1a26eed272260c568df24d59',
+       i686: '30050665805c5ff827611a2e5e20ca7a2d7da17c95474f3cb488dcac6686f85f',
+     x86_64: '28d7c2d8632c1dd232cc3847c3161ea494ef8b86108bedc1b69da6d4daf5d782'
   })
 
   depends_on 'dbus' # R

--- a/packages/xwayland.rb
+++ b/packages/xwayland.rb
@@ -3,7 +3,7 @@ require 'package'
 class Xwayland < Package
   description 'X server configured to work with weston or sommelier'
   homepage 'https://x.org'
-  @_ver = '22.1.6'
+  @_ver = '22.1.8'
   version @_ver
   license 'MIT-with-advertising, ISC, BSD-3, BSD and custom'
   compatibility 'all'
@@ -11,16 +11,16 @@ class Xwayland < Package
   git_hashtag "xwayland-#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xwayland/22.1.6_armv7l/xwayland-22.1.6-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xwayland/22.1.6_armv7l/xwayland-22.1.6-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xwayland/22.1.6_i686/xwayland-22.1.6-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xwayland/22.1.6_x86_64/xwayland-22.1.6-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xwayland/22.1.8_armv7l/xwayland-22.1.8-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xwayland/22.1.8_armv7l/xwayland-22.1.8-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xwayland/22.1.8_i686/xwayland-22.1.8-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xwayland/22.1.8_x86_64/xwayland-22.1.8-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'a489685a929c7b12f1ccea0f40c025961fa98d9765396fff6970ff949a66c5a5',
-     armv7l: 'a489685a929c7b12f1ccea0f40c025961fa98d9765396fff6970ff949a66c5a5',
-       i686: '893e7045102d9e22c68b7c936b1ce5f56d2d18b6c9918a856922a9c1c91f86da',
-     x86_64: '078dc6abfaac286f7b805d26ea3db01aa56afe95cc6a3d01ff0b2c514f8655ed'
+    aarch64: 'd38eb4ef182e0ce88625dea2c15ba0bf424d469f535ef7ef8bfd653417d66d5b',
+     armv7l: 'd38eb4ef182e0ce88625dea2c15ba0bf424d469f535ef7ef8bfd653417d66d5b',
+       i686: 'd218eff809c0afaa67bff4b3ae237110d7b7cd1e0d347f28d3e9429326b50e9f',
+     x86_64: '98166b0c68fc229bdc453c333dc1ae9ca4b6c603cd1c00a7a0e144bae5b5c84f'
   })
 
   no_env_options

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -5126,6 +5126,11 @@ url: https://github.com/libmpack/libmpack-lua/releases
 activity: low
 ---
 kind: url
+name: luit
+url: https://github.com/ThomasDickey/luit-snapshots/tags
+activity: medium
+---
+kind: url
 name: lv2
 url: https://github.com/lv2/lv2/tags
 activity: none

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -4501,6 +4501,11 @@ url: http://ftp.gnu.org/gnu/libsigsegv
 activity: low
 ---
 kind: url
+name: libsixel
+url: https://github.com/libsixel/libsixel/releases
+activity: low
+---
+kind: url
 name: libslz
 url: http://www.libslz.org/
 activity: none
@@ -4684,6 +4689,11 @@ kind: url
 name: libusbmuxd
 url: http://www.libimobiledevice.org/downloads/
 activity: none
+---
+kind: url
+name: libutempter
+url: https://github.com/altlinux/libutempter/tags
+activity: low
 ---
 kind: url
 name: libuv


### PR DESCRIPTION
- Fixed for the X security issues announced today, and other updates and also added some packages needed for the incoming xterm update in progress...

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=xupdates CREW_TESTING=1 crew update
```
