### PR TITLE
Add some wayland apps (cage, wlroots) & updates foot

### DIFF
--- a/packages/cage.rb
+++ b/packages/cage.rb
@@ -8,7 +8,7 @@ class Cage < Package
   homepage 'https://www.hjdskes.nl/projects/cage/'
   version '0.1.6-46f0ec1'
   license 'MIT'
-  compatibility 'all'
+  compatibility 'aarch64, armv7l, x86_64'
   source_url 'https://github.com/Hjdskes/cage.git'
   git_hashtag '46f0ec1b729cf2e4fb9c69bb8660e908d1311ea0'
 

--- a/packages/cage.rb
+++ b/packages/cage.rb
@@ -1,0 +1,44 @@
+# Adapted from Arch Linux cage PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/cage/trunk/PKGBUILD
+
+require 'package'
+
+class Cage < Package
+  description 'A kiosk compositor for Wayland'
+  homepage 'https://www.hjdskes.nl/projects/cage/'
+  version '0.1.6-46f0ec1'
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://github.com/Hjdskes/cage.git'
+  git_hashtag '46f0ec1b729cf2e4fb9c69bb8660e908d1311ea0'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cage/0.1.6-46f0ec1_armv7l/cage-0.1.6-46f0ec1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cage/0.1.6-46f0ec1_armv7l/cage-0.1.6-46f0ec1-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cage/0.1.6-46f0ec1_x86_64/cage-0.1.6-46f0ec1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: 'dd95b7154eabc887c43cc93b68036f4f6cd71fd1eb81e51643cf5ca4c366b390',
+     armv7l: 'dd95b7154eabc887c43cc93b68036f4f6cd71fd1eb81e51643cf5ca4c366b390',
+     x86_64: '672f755177ce9f77c4d3d20fd3f7b0b99e6be657067cb61ed02841b2460d13ae'
+  })
+
+  depends_on 'glibc' # R
+  depends_on 'libxkbcommon' # R
+  depends_on 'pixman' => :build
+  depends_on 'scdoc' => :build
+  depends_on 'wayland' # R
+  depends_on 'wayland_protocols' => :build
+  depends_on 'wlroots' # R
+
+  def self.build
+    system "meson setup #{CREW_MESON_OPTIONS} \
+      -Dxwayland=true \
+      builddir"
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} meson install -C builddir"
+  end
+end

--- a/packages/foot.rb
+++ b/packages/foot.rb
@@ -6,22 +6,20 @@ require 'package'
 class Foot < Package
   description 'Wayland terminal emulator - fast, lightweight and minimalistic'
   homepage 'https://codeberg.org/dnkl/foot'
-  version '1.10.3'
-  compatibility 'all'
+  version '1.13.1'
+  compatibility 'aarch64, armv7l, x86_64'
   source_url 'https://codeberg.org/dnkl/foot.git'
   git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/foot/1.10.3_armv7l/foot-1.10.3-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/foot/1.10.3_armv7l/foot-1.10.3-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/foot/1.10.3_i686/foot-1.10.3-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/foot/1.10.3_x86_64/foot-1.10.3-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/foot/1.13.1_armv7l/foot-1.13.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/foot/1.13.1_armv7l/foot-1.13.1-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/foot/1.13.1_x86_64/foot-1.13.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '3d452085480e5439a082ef18e3c98fe334db9baed0d361d09fb4c658073e3f2e',
-     armv7l: '3d452085480e5439a082ef18e3c98fe334db9baed0d361d09fb4c658073e3f2e',
-       i686: '5785c65916a60a59fb8afa793a867baed0f24c64860f88a525870610a3fada0f',
-     x86_64: '73cb08a9df0cc25858a2cad4a2b2d5d299dc3f5a430c4d82771af2385447c9ea'
+    aarch64: 'a1c2d52499b3c842c1a9c01dfb14024cf435f37d88d53f4bff1a2741cee89e02',
+     armv7l: 'a1c2d52499b3c842c1a9c01dfb14024cf435f37d88d53f4bff1a2741cee89e02',
+     x86_64: '7586ac28caae7ffd3cb38e700f9455582d7a2a5e47e8e6bd7c78eb2c6a32c0de'
   })
 
   depends_on 'libxkbcommon'
@@ -33,19 +31,13 @@ class Foot < Package
   depends_on 'fcft'
   depends_on 'wayland_protocols' => :build
   depends_on 'tllist' => :build
+  depends_on 'freetype' # R
+  depends_on 'glibc' # R
+  depends_on 'harfbuzz' # R
+  depends_on 'gcc' # R
 
-  def self.patch
-    # threads.h was introduced in glibc 2.28. This is a workaround for
-    # pre-M92 systems.
-    return unless LIBC_VERSION < '2.28'
-
-    system 'curl -Lf https://github.com/jtsiomb/c11threads/raw/19abeee43272002301ddece2f7d5df37394bb54f/c11threads.h -o threads.h'
-    abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest(File.read('threads.h')) == 'c945fd352449174d3b6107c715b622206ebb81694ac23239637439d78e33ee5a'
-    # Older kernel versions do not have linux header input-event-codes.h Use libc version as a proxy for linux header version.
-    return unless LIBC_VERSION < '2.27'
-
-    FileUtils.mkdir 'linux'
-    FileUtils.ln_s "#{CREW_PREFIX}/include/linux/input.h", 'linux/input-event-codes.h'
+  def self.preflight
+    abort 'Foot requires glibc > 2.28.' if Gem::Version.new(LIBC_VERSION.to_s) < Gem::Version.new('2.28')
   end
 
   def self.build

--- a/packages/wlroots.rb
+++ b/packages/wlroots.rb
@@ -1,0 +1,54 @@
+# Adapted from Arch Linux wlroots PKGBUILD at:
+# https://github.com/archlinux/svntogit-community/raw/packages/wlroots/trunk/PKGBUILD
+
+require 'package'
+
+class Wlroots < Package
+  description 'Modular Wayland compositor library'
+  homepage 'https://gitlab.freedesktop.org/wlroots/wlroots'
+  version '0.16.1'
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://gitlab.freedesktop.org/wlroots/wlroots.git'
+  git_hashtag version
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wlroots/0.16.1_armv7l/wlroots-0.16.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wlroots/0.16.1_armv7l/wlroots-0.16.1-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wlroots/0.16.1_x86_64/wlroots-0.16.1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '0722ae885c1a247b03319bfb9092d9bd429209fe7b4cec3ff26276904d7b7e34',
+     armv7l: '0722ae885c1a247b03319bfb9092d9bd429209fe7b4cec3ff26276904d7b7e34',
+     x86_64: 'e06e99287393b51a5cfde4adf5fc81eaf22cb67d7aae762cd864d907c22c6209'
+  })
+
+  depends_on 'eudev' # R
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  depends_on 'hwdata' => :build
+  depends_on 'libdrm' # R
+  depends_on 'libglvnd' # R
+  depends_on 'libxcb' # R
+  depends_on 'libxkbcommon' # R
+  depends_on 'mesa' # R
+  depends_on 'pixman' # R
+  depends_on 'seatd' # R
+  depends_on 'vulkan_headers' => :build
+  depends_on 'vulkan_icd_loader' # R
+  depends_on 'wayland' # R
+  depends_on 'xcb_util_wm' # R
+  depends_on 'xwayland' # L
+
+  def self.build
+    system "meson setup #{CREW_MESON_OPTIONS} \
+      -Dxwayland=enabled \
+      builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end

--- a/packages/wlroots.rb
+++ b/packages/wlroots.rb
@@ -8,7 +8,7 @@ class Wlroots < Package
   homepage 'https://gitlab.freedesktop.org/wlroots/wlroots'
   version '0.16.1'
   license 'MIT'
-  compatibility 'all'
+  compatibility 'aarch64, armv7l, x86_64'
   source_url 'https://gitlab.freedesktop.org/wlroots/wlroots.git'
   git_hashtag version
 

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -700,6 +700,11 @@ url: https://packages.ubuntu.com/source/xenial/cadaver
 activity: none
 ---
 kind: url
+name: cage
+url: https://github.com/Hjdskes/cage/releases
+activity: low
+---
+kind: url
 name: cairo
 url: https://www.cairographics.org/releases
 activity: low
@@ -8448,6 +8453,11 @@ activity: low
 kind: url
 name: wl_clipboard
 url: https://github.com/bugaevc/wl-clipboard/releases/
+activity: medium
+---
+kind: url
+name: wlroots
+url: https://gitlab.freedesktop.org/wlroots/wlroots/-/tags
 activity: medium
 ---
 kind: url


### PR DESCRIPTION
- Adds `cage`, `wlroots`, and updates `foot`
- Note the `builds` below... as there are incompatibilities with the Exo Wayland server (read that as insufficient support of current wayland capabilities) we can hopefully complain about upstream at crbug.com ...

Builds properly:
- [x] `x86_64`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=wayland_apps CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
