### PR TITLE
zstd => 1.5.4

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1553,7 +1553,7 @@ def archive_package(pwd)
   if File.file?("#{CREW_PREFIX}/bin/zstd")
     @crew_prefix_zstd_available = `#{CREW_PREFIX}/bin/zstd --version`.include?('zstd command line interface') ? true : nil
   end
-  if @pkg.no_zstd? || (!@crew_prefix_zstd_available)
+  if @pkg.no_zstd? || !@crew_prefix_zstd_available
     puts 'Using xz to compress package. This may take some time.'.lightblue
     pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.tar.xz"
     Dir.chdir CREW_DEST_DIR do

--- a/bin/crew
+++ b/bin/crew
@@ -811,14 +811,14 @@ def download
         # No git branch specified, just a git commit or tag
         if @pkg.git_branch.to_s.empty?
           abort('No Git branch, commit, or tag specified!').lightred if @pkg.git_hashtag.to_s.empty?
-          cachefile = "#{CREW_CACHE_DIR}#{filename}#{@pkg.git_hashtag.gsub('/', '_')}.tar.xz"
+          cachefile = "#{CREW_CACHE_DIR}#{filename}#{@pkg.git_hashtag.gsub('/', '_')}.tar.zst"
         # Git branch and git commit specified
         elsif !@pkg.git_hashtag.to_s.empty?
-          cachefile = "#{CREW_CACHE_DIR}#{filename}#{@pkg.git_branch.gsub(/[^0-9A-Za-z.-]/, '_')}_#{@pkg.git_hashtag.gsub('/', '_')}.tar.xz"
+          cachefile = "#{CREW_CACHE_DIR}#{filename}#{@pkg.git_branch.gsub(/[^0-9A-Za-z.-]/, '_')}_#{@pkg.git_hashtag.gsub('/', '_')}.tar.zst"
         # Git branch specified, without a specific git commit.
         else
           # Use to the day granularity for a branch timestamp with no specific commit specified.
-          cachefile = "#{CREW_CACHE_DIR}#{filename}#{@pkg.git_branch.gsub(/[^0-9A-Za-z.-]/, '_')}#{Time.now.strftime('%m%d%Y')}.tar.xz"
+          cachefile = "#{CREW_CACHE_DIR}#{filename}#{@pkg.git_branch.gsub(/[^0-9A-Za-z.-]/, '_')}#{Time.now.strftime('%m%d%Y')}.tar.zst"
         end
         puts "Git cachefile is #{cachefile}".orange if @opt_verbose
         if File.file?(cachefile) && File.file?("#{cachefile}.sha256")
@@ -861,8 +861,10 @@ def download
         Dir.chdir @extract_dir do
           # Do not use --exclude-vcs to exclude .git
           # because some builds will use that information.
-          system "tar c#{@verbose}Jf #{cachefile} \
-            $(find -mindepth 1 -maxdepth 1 -printf '%P\n')"
+          system "tar c#{@verbose} \
+            $(find -mindepth 1 -maxdepth 1 -printf '%P\n') | \
+            nice -n 20 #{CREW_PREFIX}/bin/zstd -c -T0 --ultra -20 - >  \
+            #{cachefile}"
         end
         system 'sha256sum', cachefile, out: "#{cachefile}.sha256"
         puts 'Git repo cached.'.lightgreen

--- a/bin/crew
+++ b/bin/crew
@@ -1300,7 +1300,7 @@ def install_package(pkgdir)
     # check if the available rsync command support ACLs
 
     rsync_available = (File.executable?("#{CREW_PREFIX}/bin/rsync") && `#{CREW_PREFIX}/bin/rsync --version`.include?('rsync  version'))
-    puts 'rsync is not working. Please (re)install it with \'crew remove musl_zstd zstd ; crew install musl_zstd ; crew install rsync\''.lightred unless rsync_available || (@pkg.name == 'rsync')
+    puts 'rsync is not working. Please (re)install it with \'crew reinstall rsync\''.lightred unless rsync_available || (@pkg.name == 'rsync')
     if Dir.exist? "#{pkgdir}/#{HOME}"
       if rsync_available
         system "rsync -ahHAXW --remove-source-files ./#{HOME.delete_prefix('/')}/ #{HOME}"
@@ -1553,10 +1553,7 @@ def archive_package(pwd)
   if File.file?("#{CREW_PREFIX}/bin/zstd")
     @crew_prefix_zstd_available = `#{CREW_PREFIX}/bin/zstd --version`.include?('zstd command line interface') ? true : nil
   end
-  if File.file?("#{CREW_MUSL_PREFIX}/bin/zstd")
-    @crew_musl_prefix_zstd_available = `#{CREW_MUSL_PREFIX}/bin/zstd --version`.include?('zstd command line interface') ? true : nil
-  end
-  if @pkg.no_zstd? || (!@crew_prefix_zstd_available && !@crew_musl_prefix_zstd_available)
+  if @pkg.no_zstd? || (!@crew_prefix_zstd_available)
     puts 'Using xz to compress package. This may take some time.'.lightblue
     pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.tar.xz"
     Dir.chdir CREW_DEST_DIR do
@@ -1573,9 +1570,6 @@ def archive_package(pwd)
       if @crew_prefix_zstd_available
         puts 'Using standard zstd'.lightblue if @opt_verbose
         system "tar c#{@verbose} * | nice -n 20 #{CREW_PREFIX}/bin/zstd -c -T0 --ultra -20 - > #{pwd}/#{pkg_name}"
-      elsif @crew_musl_prefix_zstd_available
-        puts 'Using musl zstd'.lightblue if @opt_verbose
-        system "tar c#{@verbose} * | nice -n 20 #{CREW_MUSL_PREFIX}/bin/zstd -c -T0 --ultra -20 - > #{pwd}/#{pkg_name}"
       end
     end
   end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.31.0'
+CREW_VERSION = '1.31.1'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/packages/musl_zstd.rb
+++ b/packages/musl_zstd.rb
@@ -3,24 +3,24 @@ require 'package'
 class Musl_zstd < Package
   description 'Zstandard - Fast real-time compression algorithm'
   homepage 'http://www.zstd.net'
-  @_ver = '1.5.2'
-  version "#{@_ver}-2"
+  @_ver = '1.5.4'
+  version @_ver
   license 'BSD or GPL-2'
   compatibility 'all'
   source_url 'https://github.com/facebook/zstd.git'
   git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zstd/1.5.2-2_armv7l/musl_zstd-1.5.2-2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zstd/1.5.2-2_armv7l/musl_zstd-1.5.2-2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zstd/1.5.2-2_i686/musl_zstd-1.5.2-2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zstd/1.5.2-2_x86_64/musl_zstd-1.5.2-2-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zstd/1.5.4_armv7l/musl_zstd-1.5.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zstd/1.5.4_armv7l/musl_zstd-1.5.4-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zstd/1.5.4_i686/musl_zstd-1.5.4-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zstd/1.5.4_x86_64/musl_zstd-1.5.4-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'fc17f3e5f3456deed345eced630e6c7836e81525a494c365bc54277ad6ee0d77',
-     armv7l: 'fc17f3e5f3456deed345eced630e6c7836e81525a494c365bc54277ad6ee0d77',
-       i686: '6c695a6fe0933b98f4b6bde67af84017975894fcd476318fc9b53f6f7006fb30',
-     x86_64: '57510ec4dd8dd6846d11c6d426023fea918399dda184b748d9b508dd10f76696'
+    aarch64: 'cc967734abc1d7a5bcd5d98145c320f503681e4e61a8778bc3c10cb398b3ddde',
+     armv7l: 'cc967734abc1d7a5bcd5d98145c320f503681e4e61a8778bc3c10cb398b3ddde',
+       i686: 'd2f19e7f400ee1837bae1274eb194cda2bcfa21bd15865fd29ac8f780d0334bb',
+     x86_64: '0b0fe1d9610000330402df3863897a21afb45e42f23a222e21de1b19ea76c6b3'
   })
 
   depends_on 'musl_native_toolchain' => :build

--- a/packages/zstd.rb
+++ b/packages/zstd.rb
@@ -48,7 +48,9 @@ class Zstd < Package
     end
     # Convert symlinks to hard links in libdir.
     Dir.chdir CREW_DEST_LIB_PREFIX do
-      system "find -type l -exec bash -c 'ln -f \"$(readlink -m \"$0\")\" \"$0\"' {} \\;"
+      Dir['*'].each do |f|
+        FileUtils.ln File.realpath(f), f, force: true if File.symlink?(f)
+      end
     end
   end
 end

--- a/packages/zstd.rb
+++ b/packages/zstd.rb
@@ -3,43 +3,41 @@ require 'package'
 class Zstd < Package
   description 'Zstandard - Fast real-time compression algorithm'
   homepage 'http://www.zstd.net'
-  @_ver = '1.5.2'
-  version "#{@_ver}-1"
+  @_ver = '1.5.4'
+  version @_ver
   license 'BSD or GPL-2'
   compatibility 'all'
   source_url 'https://github.com/facebook/zstd.git'
   git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zstd/1.5.2-1_armv7l/zstd-1.5.2-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zstd/1.5.2-1_armv7l/zstd-1.5.2-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zstd/1.5.2-1_i686/zstd-1.5.2-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zstd/1.5.2-1_x86_64/zstd-1.5.2-1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zstd/1.5.4_armv7l/zstd-1.5.4-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zstd/1.5.4_armv7l/zstd-1.5.4-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zstd/1.5.4_i686/zstd-1.5.4-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/zstd/1.5.4_x86_64/zstd-1.5.4-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: 'd8b71760987ab2836e98fd2d8819cbaa95402e88cd9718f0de23f777140c4d7e',
-     armv7l: 'd8b71760987ab2836e98fd2d8819cbaa95402e88cd9718f0de23f777140c4d7e',
-       i686: '6e159bb381c0b5595714d875e486348a05166332056ce2bc4c3f997a2652a93d',
-     x86_64: 'b04d97b3d328f8c0805e2fcee0526b1e955255ca21ceaed6f6e1fb8e6941b312'
+    aarch64: '85cdfe9c3242874f74cdbc31ed8d07a33d1d9e0fc593317e88d36e2b1f1524e1',
+     armv7l: '85cdfe9c3242874f74cdbc31ed8d07a33d1d9e0fc593317e88d36e2b1f1524e1',
+       i686: '077b2e269304567c0a413bc636b789130d3f549ec9272b4040b89ee81231482a',
+     x86_64: 'd3aab25ec7be12f784474f288ebc6818051f8beb5cddf8580e1d5a35ca0b7e4f'
   })
 
   depends_on 'glibc' # R
-  # depends_on 'musl_zstd'
+  depends_on 'gcc' # R
+
   no_patchelf
   no_zstd
 
   def self.build
     Dir.chdir 'build/cmake' do
-      FileUtils.mkdir('builddir')
-      Dir.chdir('builddir') do
-        system "cmake #{CREW_CMAKE_OPTIONS} \
-        -DZSTD_BUILD_STATIC=ON \
-        -DZSTD_BUILD_SHARED=ON \
-        -DZSTD_LEGACY_SUPPORT=ON \
-        -DZSTD_BUILD_CONTRIB=ON \
-        -DZSTD_PROGRAMS_LINK_SHARED=OFF \
-        ../ -G Ninja"
-      end
+      system "cmake -B builddir #{CREW_CMAKE_OPTIONS} \
+      -DZSTD_BUILD_STATIC=ON \
+      -DZSTD_BUILD_SHARED=ON \
+      -DZSTD_LEGACY_SUPPORT=ON \
+      -DZSTD_BUILD_CONTRIB=ON \
+      -DZSTD_PROGRAMS_LINK_SHARED=OFF \
+      -G Ninja"
       system 'samu -C builddir'
     end
   end
@@ -50,7 +48,7 @@ class Zstd < Package
     end
     # Convert symlinks to hard links in libdir.
     Dir.chdir CREW_DEST_LIB_PREFIX do
-      system "find -type l -exec bash -c 'ln -f \"\$(readlink -m \"\$0\")\" \"\$0\"' {} \\\;"
+      system "find -type l -exec bash -c 'ln -f \"$(readlink -m \"$0\")\" \"$0\"' {} \\;"
     end
   end
 end


### PR DESCRIPTION
- Also removes musl_zstd from `crew`
- Changes `crew` to use `zstd` to compress cached git repos too, which should be faster since zstd can do a multithreaded compress...

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=zstd154 CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
