### PR TITLE
Adding package: helix_editor

### DIFF
--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -49,7 +49,7 @@ class Helix_editor < Package
     command_status = system 'hx --version', exception: false
     puts 'Warning: hx is not in PATH'.lightred unless command_status == true
     # Check if helix can find its runtime path
-    if command_status == true
+    if command_status
       command_output = `hx --health`
       unless command_output.include? @helix_runtime_dir
         puts "Warning: helix cannot find its runtime dir. \

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -30,12 +30,12 @@ class Helix_editor < Package
     # Copy executable
     helix_executable_dest_dir = "#{CREW_DEST_PREFIX}/bin"
     FileUtils.mkdir_p helix_executable_dest_dir.to_s
-    FileUtils.install ".#{@build_folder_suffix}/hx", helix_executable_dest_dir, mode: 0o755
+    FileUtils.install ".#{@build_folder_suffix}/hx", helix_executable_dest_dir.to_s, mode: 0o755
     # Copy runtime dir (without the sources)
     FileUtils.rm_rf './runtime/grammars/sources' # remove the sources
     helix_runtime_dest_dir = "#{CREW_DEST_DIR}#{@helix_runtime_dir}"
-    FileUtils.mkdir_p helix_runtime_dest_dir
-    FileUtils.cp_r './runtime', helix_runtime_dest_dir
+    FileUtils.mkdir_p helix_runtime_dest_dir.to_s
+    FileUtils.cp_r './runtime', helix_runtime_dest_dir.to_s
   end
 
   def self.check

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -12,10 +12,10 @@ class Helix_editor < Package
   depends_on 'rust' => :build
   depends_on 'xdg_base'
 
-  @no_fhs = true
-  @no_shrink = true
-  @no_strip = true
-  @no_patchelf = true
+  @no_fhs
+  @no_shrink
+  @no_strip
+  @no_patchelf
 
   @xdg_config_home = ENV.fetch 'XDG_CONFIG_HOME', "#{CREW_PREFIX}/.config"
   @helix_runtime_dir = "#{@xdg_config_home}/helix"

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -43,12 +43,12 @@ class Helix_editor < Package
   def self.postinstall
     # This will print a warning if "hx" is not a valid command
     command_status = system 'hx --version', exception: false
-    puts 'Warning: hx is not in path'.red unless command_status == true
+    puts 'Warning: hx is not in path'.lightred unless command_status == true
     # Check if helix can find its runtime path
     command_output = `hx --health`, exception: false
-    puts 'Warning: helix cannot find its runtime dir'.red unless command_output.include? @helix_runtime_dir
+    puts 'Warning: helix cannot find its runtime dir'.lightred unless command_output.include? @helix_runtime_dir
 
-    puts <<~EOT2.orange
+    puts <<~EOT2.lightblue
       Use the 'hx' command to start helix.
       Use 'hx --health' to see if helix can find its runtime and to see which LSP
       servers are detected.
@@ -67,9 +67,9 @@ class Helix_editor < Package
     case $stdin.gets.chomp.downcase
     when 'y', 'yes'
       FileUtils.rm_rf config_dir
-      puts "#{config_dir} removed.".lightred
+      puts "#{config_dir} removed.".lightgreen
     else
-      puts "#{config_dir} was not removed.".lightgreen
+      puts "#{config_dir} was not removed.".lightblue
     end
   end
 end

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -49,9 +49,13 @@ class Helix_editor < Package
     command_status = system 'hx --version', exception: false
     puts 'Warning: hx is not in PATH'.lightred unless command_status == true
     # Check if helix can find its runtime path
-    command_output = `hx --health`
-    puts 'Warning: helix cannot find its runtime dir'.lightred unless command_output.include? @helix_runtime_dir
-
+    if command_status == true
+      command_output = `hx --health`
+      unless command_output.include? @helix_runtime_dir
+        puts "Warning: helix cannot find its runtime dir. \
+        The environment variable HELIX_RUNTIME may need to be set.".lightred
+      end
+    end
     puts <<~EOT2.lightblue
       Use the 'hx' command to start helix.
       Use 'hx --health' to see if helix can find its runtime and to see which LSP

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -1,52 +1,62 @@
 require 'package'
 
-class Helix_editor < Package                 # The first character of the class name must be upper case
+class Helix_editor < Package
   description 'A vim inspired editor with LSP support'
   homepage 'https://helix-editor.com/'
   version '22.12'
   license 'MPL-2.0' # license of source
   compatibility 'all'
-  source_url 'https://github.com/helix-editor/helix/archive/refs/tags/22.12.tar.gz'
-  source_sha256 'edae8af46401b45c3e71c38b4fa99f931c4458127978ccd1b29aaae79331d972'   # Use the command "sha256sum"
-  
+  source_url 'https://t.ly/-vk7'
+  source_sha256 'edae8af46401b45c3e71c38b4fa99f931c4458127978ccd1b29aaae79331d972' # Use the command "sha256sum"
+  source_url 'file:///usr/local/home/helix/deleteme.tar.gz'
+  source_sha256 'c3a0e022a7bcd6b139ae7abf1e0dae33c8f9ec82dc680076d9e5ea6593b85bc6'
+
   depends_on 'rust' => :build
+  depends_on 'xdg_base'
 
   @no_fhs = true
-  
+
+  @xdg_config_home = ENV.fetch 'XDG_CONFIG_HOME', '/usr/local/.config'
+  @helix_runtime_dir = "#{@xdg_config_home}/helix"
+
   def self.build
-   puts "Building. This may be long."
-   system "cargo build \
+    puts 'Building. This may be long.'
+    puts 'cargo build \
       --release \
       --locked \
-     "
+     '
   end
+
+  def self.check
+    # This will raise an error if "hx" is not a valid command
+    `hx --version`
+    # Check if helix can find its runtime path
+    command_output = `hx --health`
+    if !command_output.include?(@helix_runtime_dir.to_s)
+      raise 'Helix cannot find its runtime dir'
+    end
+  end
+
 
   def self.install
     # Copy executable
     helix_executable_dest_dir = "#{CREW_DEST_PREFIX}/bin"
-    FileUtils.mkdir_p("#{helix_executable_dest_dir}")
-    FileUtils.cp("./target/release/hx", "#{helix_executable_dest_dir}")
+    FileUtils.mkdir_p helix_executable_dest_dir.to_s
+    FileUtils.install './target/release/hx', helix_executable_dest_dir.to_s, :mode => 0755
     # Copy runtime dir
-    helix_runtime_dest_dir = "#{CREW_DEST_DIR}#{ENV['XDG_CONFIG_HOME']}/helix"
-    FileUtils.mkdir_p("#{helix_runtime_dest_dir}")
-    FileUtils.cp_r("./runtime", "#{helix_runtime_dest_dir}")
-  end
-
-  def self.check
-    puts "self.check is called"
-    return false
-    # Check "hx --version" status code and if hx found its runtime directory
-    # return (system "hx --version") && (`hx --health`.include?("#{ENV['XDG_CONFIG_HOME']}"))
+    helix_runtime_dest_dir = "#{CREW_DEST_DIR}#{@helix_runtime_dir}"
+    FileUtils.mkdir_p helix_runtime_dest_dir.to_s
+    FileUtils.cp_r './runtime', helix_runtime_dest_dir.to_s
   end
 
   def self.postinstall
     puts <<~EOT2.orange
       Use the 'hx' command to start helix.
-    
-      Use 'hx --health' to see if helix detects its runtime and to see which LSP 
+
+      Use 'hx --health' to see if helix can find its runtime and to see which LSP
       servers are detected.
-    
-      To be able to load some themes, helix neefds to be started in a terminal it recognizes 
+
+      To be able to load some themes, helix needs to be started in a terminal it recognizes#{' '}
       as supporting true colors.
     EOT2
   end

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -6,10 +6,8 @@ class Helix_editor < Package
   version '22.12'
   license 'MPL-2.0' # license of source
   compatibility 'all'
-  source_url 'https://t.ly/-vk7'
+  source_url 'https://github.com/helix-editor/helix/archive/22.12.tar.gz' #'https://t.ly/-vk7'
   source_sha256 'edae8af46401b45c3e71c38b4fa99f931c4458127978ccd1b29aaae79331d972' # Use the command "sha256sum"
-  source_url 'file:///usr/local/home/helix/deleteme.tar.gz'
-  source_sha256 'c3a0e022a7bcd6b139ae7abf1e0dae33c8f9ec82dc680076d9e5ea6593b85bc6'
 
   depends_on 'rust' => :build
   depends_on 'xdg_base'
@@ -21,10 +19,10 @@ class Helix_editor < Package
 
   def self.build
     puts 'Building. This may be long.'
-    puts 'cargo build \
+    system "cargo build \
       --release \
       --locked \
-     '
+     "
   end
 
   def self.check
@@ -59,5 +57,21 @@ class Helix_editor < Package
       To be able to load some themes, helix needs to be started in a terminal it recognizes#{' '}
       as supporting true colors.
     EOT2
+  end
+
+  def self.remove
+    # Some files in the directory are write protected...
+    FileUtils.rm_rf @helix_runtime_dir
+    # If the user added a configuration dir, we ask if he wishes to remove it as well
+    config_dir = "#{HOME}/.config/helix"
+    Dir.exist? config_dir
+      puts "\nWould you like to remove the configuration folder: #{config_dir}? [y/N] "
+      case $stdin.gets.chomp.downcase
+      when 'y', 'yes'
+        FileUtils.rm_rf config_dir
+        puts "#{config_dir} removed.".lightred
+      else
+        puts "#{config_dir} was not removed.".lightgreen
+      end
   end
 end

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -13,6 +13,9 @@ class Helix_editor < Package
   depends_on 'xdg_base'
 
   @no_fhs = true
+  @no_shrink = true
+  @no_strip = true
+  @no_patchelf = true
 
   @xdg_config_home = ENV.fetch 'XDG_CONFIG_HOME', "#{CREW_PREFIX}/.config"
   @helix_runtime_dir = "#{@xdg_config_home}/helix"

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -58,8 +58,7 @@ class Helix_editor < Package
     end
     puts <<~EOT2.lightblue
       Use the 'hx' command to start helix.
-      Use 'hx --health' to see if helix can find its runtime and to see which LSP
-      servers are detected.
+      Use 'hx --health' to see if helix can find its runtime and to see which LSP servers are detected.
       Note that to be able to load some themes, helix needs to be started in a terminal it recognizes
       as supporting true colors.
     EOT2

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -8,7 +8,7 @@ class Helix_editor < Package                 # The first character of the class 
   compatibility 'all'
   source_url 'https://github.com/helix-editor/helix/archive/refs/tags/22.12.tar.gz'
   source_sha256 'edae8af46401b45c3e71c38b4fa99f931c4458127978ccd1b29aaae79331d972'   # Use the command "sha256sum"
-
+  
   depends_on 'rust' => :build
 
   @no_fhs = true
@@ -33,10 +33,10 @@ class Helix_editor < Package                 # The first character of the class 
   end
 
   def self.check
-    # TODO: check seems to be never called
-    # system "hx --version"
-    # helix_health_output = capture(:stdout) { system("hx --health") }
-    # return helix_health_output.include?("#{CREW_PREFIX}#{ENV['XDG_CONFIG_HOME']}/helix")
+    puts "self.check is called"
+    return false
+    # Check "hx --version" status code and if hx found its runtime directory
+    # return (system "hx --version") && (`hx --health`.include?("#{ENV['XDG_CONFIG_HOME']}"))
   end
 
   def self.postinstall
@@ -46,7 +46,7 @@ class Helix_editor < Package                 # The first character of the class 
       Use 'hx --health' to see if helix detects its runtime and to see which LSP 
       servers are detected.
     
-      To use the default theme, helix has to be started in a terminal it recognizes 
+      To be able to load some themes, helix neefds to be started in a terminal it recognizes 
       as supporting true colors.
     EOT2
   end

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -41,13 +41,13 @@ class Helix_editor < Package
   def self.check
     # Ensure hx is executable
     command_status = system ".#{@build_folder_suffix}/hx --version", exception: false
-    raise 'hx is not executable'.lightred unless command_status == true
+    raise 'hx is not executable'.lightred unless command_status
   end
 
   def self.postinstall
     # This will print a warning if "hx" is not a valid command
     command_status = system 'hx --version', exception: false
-    puts 'Warning: hx is not in PATH'.lightred unless command_status == true
+    puts 'Warning: hx is not in PATH'.lightred unless command_status
     # Check if helix can find its runtime path
     if command_status
       command_output = `hx --health`

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -69,14 +69,15 @@ class Helix_editor < Package
     FileUtils.rm_rf @helix_runtime_dir
     # If the user added a configuration dir, we ask if he wishes to remove it as well
     config_dir = "#{HOME}/.config/helix"
-    Dir.exist? config_dir
-    puts "\nWould you like to remove the configuration folder: #{config_dir}? [y/N] "
-    case $stdin.gets.chomp.downcase
-    when 'y', 'yes'
-      FileUtils.rm_rf config_dir
-      puts "#{config_dir} removed.".lightgreen
-    else
-      puts "#{config_dir} was not removed.".lightblue
+    if Dir.exist? config_dir
+      puts "\nWould you like to remove the configuration folder: #{config_dir}? [y/N] "
+      case $stdin.gets.chomp.downcase
+      when 'y', 'yes'
+        FileUtils.rm_rf config_dir
+        puts "#{config_dir} removed.".lightgreen
+      else
+        puts "#{config_dir} was not removed.".lightblue
+      end
     end
   end
 end

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -6,7 +6,7 @@ class Helix_editor < Package
   version '22.12'
   license 'MPL-2.0' # license of source
   compatibility 'all'
-  source_url 'https://t.ly/-vk7'
+  source_url 'https://github.com/helix-editor/helix/archive/22.12.tar.gz' #'https://t.ly/-vk7'
   source_sha256 'edae8af46401b45c3e71c38b4fa99f931c4458127978ccd1b29aaae79331d972' # Use the command "sha256sum"
 
   depends_on 'rust' => :build
@@ -51,7 +51,7 @@ class Helix_editor < Package
       Use 'hx --health' to see if helix can find its runtime and to see which LSP
       servers are detected.
 
-      To be able to load some themes, helix needs to be started in a terminal it recognizes#{' '}
+      To be able to load some themes, helix needs to be started in a terminal it recognizes
       as supporting true colors.
     EOT2
   end

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -49,7 +49,7 @@ class Helix_editor < Package
     command_status = system 'hx --version', exception: false
     puts 'Warning: hx is not in path'.lightred unless command_status == true
     # Check if helix can find its runtime path
-    command_output = `hx --health`, exception: false
+    command_output = `hx --health`
     puts 'Warning: helix cannot find its runtime dir'.lightred unless command_output.include? @helix_runtime_dir
 
     puts <<~EOT2.lightblue

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -36,16 +36,16 @@ class Helix_editor < Package
 
   def self.check
     # Ensure hx is executable
-    command_status = system ".#{@build_folder_suffix}/hx --version"
+    command_status = system ".#{@build_folder_suffix}/hx --version", exception: false
     raise 'hx is not executable' unless command_status == true
   end
 
   def self.postinstall
     # This will print a warning if "hx" is not a valid command
-    command_status = system 'hx --version'
+    command_status = system 'hx --version', exception: false
     puts 'Warning: hx is not in path'.red unless command_status == true
     # Check if helix can find its runtime path
-    command_output = `hx --health`
+    command_output = `hx --health`, exception: false
     puts 'Warning: helix cannot find its runtime dir'.red unless command_output.include? @helix_runtime_dir
 
     puts <<~EOT2.orange

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -14,7 +14,7 @@ class Helix_editor < Package
 
   @no_fhs = true
 
-  @xdg_config_home = ENV.fetch 'XDG_CONFIG_HOME', '/usr/local/.config'
+  @xdg_config_home = ENV.fetch 'XDG_CONFIG_HOME', "#{CREW_PREFIX}/.config"
   @helix_runtime_dir = "#{@xdg_config_home}/helix"
 
   def self.build

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -12,10 +12,10 @@ class Helix_editor < Package
   depends_on 'rust' => :build
   depends_on 'xdg_base'
 
-  @no_fhs
-  @no_shrink
-  @no_strip
-  @no_patchelf
+  no_fhs
+  no_shrink
+  no_strip
+  no_patchelf
 
   @xdg_config_home = ENV.fetch 'XDG_CONFIG_HOME', "#{CREW_PREFIX}/.config"
   @helix_runtime_dir = "#{@xdg_config_home}/helix"

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -30,7 +30,7 @@ class Helix_editor < Package
     `hx --version`
     # Check if helix can find its runtime path
     command_output = `hx --health`
-    if !command_output.include?(@helix_runtime_dir.to_s)
+    if !command_output.include? @helix_runtime_dir
       raise 'Helix cannot find its runtime dir'
     end
   end
@@ -40,11 +40,11 @@ class Helix_editor < Package
     # Copy executable
     helix_executable_dest_dir = "#{CREW_DEST_PREFIX}/bin"
     FileUtils.mkdir_p helix_executable_dest_dir.to_s
-    FileUtils.install './target/release/hx', helix_executable_dest_dir.to_s, :mode => 0755
+    FileUtils.install './target/release/hx', helix_executable_dest_dir, :mode => 0755
     # Copy runtime dir
     helix_runtime_dest_dir = "#{CREW_DEST_DIR}#{@helix_runtime_dir}"
-    FileUtils.mkdir_p helix_runtime_dest_dir.to_s
-    FileUtils.cp_r './runtime', helix_runtime_dest_dir.to_s
+    FileUtils.mkdir_p helix_runtime_dest_dir
+    FileUtils.cp_r './runtime', helix_runtime_dest_dir
   end
 
   def self.postinstall

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -1,24 +1,18 @@
 require 'package'
 
 class Helix_editor < Package                 # The first character of the class name must be upper case
-  description 'A vim like editor with LSP support'
+  description 'A vim inspired editor with LSP support'
   homepage 'https://helix-editor.com/'
   version '22.12'
   license 'MPL-2.0' # license of source
   compatibility 'all'
   source_url 'https://github.com/helix-editor/helix/archive/refs/tags/22.12.tar.gz'
   source_sha256 'edae8af46401b45c3e71c38b4fa99f931c4458127978ccd1b29aaae79331d972'   # Use the command "sha256sum"
-  #source_url 'file:///usr/local/home/helix/deleteme.tar.gz'
-  #source_sha256 'c3a0e022a7bcd6b139ae7abf1e0dae33c8f9ec82dc680076d9e5ea6593b85bc6'
 
   depends_on 'rust' => :build
 
-  # TODO is it the appropriate location?
-  # By default, helix expects runtime to be in ~/.config or XDG_CONFIG_HOME.
-  # The first location is not appropriate because helix will not be installed in ~/
-  # With the second location crew complaints that it is not  FHS3 compliant.
-  @runtime_dest_dir_suffix = "/var/lib/helix"
-
+  @no_fhs = true
+  
   def self.build
    puts "Building. This may be long."
    system "cargo build \
@@ -33,34 +27,20 @@ class Helix_editor < Package                 # The first character of the class 
     FileUtils.mkdir_p("#{helix_executable_dest_dir}")
     FileUtils.cp("./target/release/hx", "#{helix_executable_dest_dir}")
     # Copy runtime dir
-    FileUtils.mkdir_p("#{CREW_DEST_PREFIX}#{@runtime_dest_dir_suffix}")
-    FileUtils.cp_r("./runtime", "#{CREW_DEST_PREFIX}#{@runtime_dest_dir_suffix}")
-    # Set env var for runtime dir
-    env_dir = "#{CREW_DEST_PREFIX}/etc/env.d"
-    FileUtils.mkdir_p "#{env_dir}"
-    File.write("#{env_dir}/helix",
-               "export HELIX_RUNTIME=#{CREW_PREFIX}#{@runtime_dest_dir_suffix}/runtime")
-    # system "source #{env_dir}/helix"
+    helix_runtime_dest_dir = "#{CREW_DEST_DIR}#{ENV['XDG_CONFIG_HOME']}/helix"
+    FileUtils.mkdir_p("#{helix_runtime_dest_dir}")
+    FileUtils.cp_r("./runtime", "#{helix_runtime_dest_dir}")
   end
 
   def self.check
-    # # TODO (verify that this check works, and if it fails when the system language
-    # #  is not english)
-    # helix_health = capture(:stdout) { system("hx --health") }
-    # return !helix_health.contains('Runtime directory does not exist')
-    return true
-  end
-
-  def self.remove
-    # Some files in the directory are write protected...
-    FileUtils.rm_rf("#{CREW_PREFIX}#{@runtime_dest_dir_suffix}")
-    # TODO if a local ~/.config/helix folder is found, ask user if he wishes to remove it
+    # TODO: check seems to be never called
+    # system "hx --version"
+    # helix_health_output = capture(:stdout) { system("hx --health") }
+    # return helix_health_output.include?("#{CREW_PREFIX}#{ENV['XDG_CONFIG_HOME']}/helix")
   end
 
   def self.postinstall
     puts <<~EOT2.orange
-      Restart a new shell for helix environnement variables to be set. 
-      
       Use the 'hx' command to start helix.
     
       Use 'hx --health' to see if helix detects its runtime and to see which LSP 

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -6,7 +6,7 @@ class Helix_editor < Package
   version '22.12'
   license 'MPL-2.0' # license of source
   compatibility 'all'
-  source_url 'https://github.com/helix-editor/helix/archive/22.12.tar.gz' #'https://t.ly/-vk7'
+  source_url 'https://github.com/helix-editor/helix/archive/22.12.tar.gz' # 'https://t.ly/-vk7'
   source_sha256 'edae8af46401b45c3e71c38b4fa99f931c4458127978ccd1b29aaae79331d972' # Use the command "sha256sum"
 
   depends_on 'rust' => :build
@@ -39,8 +39,8 @@ class Helix_editor < Package
 
   def self.check
     # Ensure hx is executable
-    command_status = system".#{@build_folder_suffix}/hx --version"
-    raise "hx is not executable" unless command_status == true
+    command_status = system ".#{@build_folder_suffix}/hx --version"
+    raise 'hx is not executable' unless command_status == true
   end
 
   def self.postinstall

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -20,10 +20,7 @@ class Helix_editor < Package
 
   def self.build
     puts 'Building. This may be long.'
-    system 'cargo build \
-      --release \
-      --locked \
-     '
+    system 'cargo build --release --locked'
   end
 
   def self.install

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -65,8 +65,6 @@ class Helix_editor < Package
   end
 
   def self.remove
-    # Some files in the directory are write protected...
-    FileUtils.rm_rf @helix_runtime_dir
     # If the user added a configuration dir, we ask if he wishes to remove it as well
     config_dir = "#{HOME}/.config/helix"
     if Dir.exist? config_dir

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -46,7 +46,7 @@ class Helix_editor < Package
   def self.postinstall
     # This will print a warning if "hx" is not a valid command
     command_status = system 'hx --version'
-    puts 'Warning: hx is not path'.red unless command_status == true
+    puts 'Warning: hx is not in path'.red unless command_status == true
     # Check if helix can find its runtime path
     command_output = `hx --health`
     puts 'Warning: helix cannot find its runtime dir'.red unless command_output.include? @helix_runtime_dir

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -20,10 +20,10 @@ class Helix_editor < Package
 
   def self.build
     puts 'Building. This may be long.'
-    system "cargo build \
+    system 'cargo build \
       --release \
       --locked \
-     "
+     '
   end
 
   def self.install

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -6,7 +6,7 @@ class Helix_editor < Package
   version '22.12'
   license 'MPL-2.0' # license of source
   compatibility 'all'
-  source_url 'https://github.com/helix-editor/helix/archive/22.12.tar.gz' # 'https://t.ly/-vk7'
+  source_url 'https://github.com/helix-editor/helix/archive/22.12.tar.gz'
   source_sha256 'edae8af46401b45c3e71c38b4fa99f931c4458127978ccd1b29aaae79331d972' # Use the command "sha256sum"
 
   depends_on 'rust' => :build

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -1,0 +1,73 @@
+require 'package'
+
+class Helix_editor < Package                 # The first character of the class name must be upper case
+  description 'A vim like editor with LSP support'
+  homepage 'https://helix-editor.com/'
+  version '22.12'
+  license 'MPL-2.0' # license of source
+  compatibility 'all'
+  source_url 'https://github.com/helix-editor/helix/archive/refs/tags/22.12.tar.gz'
+  source_sha256 'edae8af46401b45c3e71c38b4fa99f931c4458127978ccd1b29aaae79331d972'   # Use the command "sha256sum"
+  #source_url 'file:///usr/local/home/helix/deleteme.tar.gz'
+  #source_sha256 'c3a0e022a7bcd6b139ae7abf1e0dae33c8f9ec82dc680076d9e5ea6593b85bc6'
+
+  depends_on 'rust' => :build
+
+  # TODO is it the appropriate location?
+  # By default, helix expects runtime to be in ~/.config or XDG_CONFIG_HOME.
+  # The first location is not appropriate because helix will not be installed in ~/
+  # With the second location crew complaints that it is not  FHS3 compliant.
+  @runtime_dest_dir_suffix = "/var/lib/helix"
+
+  def self.build
+   puts "Building. This may be long."
+   system "cargo build \
+      --release \
+      --locked \
+     "
+  end
+
+  def self.install
+    # Copy executable
+    helix_executable_dest_dir = "#{CREW_DEST_PREFIX}/bin"
+    FileUtils.mkdir_p("#{helix_executable_dest_dir}")
+    FileUtils.cp("./target/release/hx", "#{helix_executable_dest_dir}")
+    # Copy runtime dir
+    FileUtils.mkdir_p("#{CREW_DEST_PREFIX}#{@runtime_dest_dir_suffix}")
+    FileUtils.cp_r("./runtime", "#{CREW_DEST_PREFIX}#{@runtime_dest_dir_suffix}")
+    # Set env var for runtime dir
+    env_dir = "#{CREW_DEST_PREFIX}/etc/env.d"
+    FileUtils.mkdir_p "#{env_dir}"
+    File.write("#{env_dir}/helix",
+               "export HELIX_RUNTIME=#{CREW_PREFIX}#{@runtime_dest_dir_suffix}/runtime")
+    # system "source #{env_dir}/helix"
+  end
+
+  def self.check
+    # # TODO (verify that this check works, and if it fails when the system language
+    # #  is not english)
+    # helix_health = capture(:stdout) { system("hx --health") }
+    # return !helix_health.contains('Runtime directory does not exist')
+    return true
+  end
+
+  def self.remove
+    # Some files in the directory are write protected...
+    FileUtils.rm_rf("#{CREW_PREFIX}#{@runtime_dest_dir_suffix}")
+    # TODO if a local ~/.config/helix folder is found, ask user if he wishes to remove it
+  end
+
+  def self.postinstall
+    puts <<~EOT2.orange
+      Restart a new shell for helix environnement variables to be set. 
+      
+      Use the 'hx' command to start helix.
+    
+      Use 'hx --health' to see if helix detects its runtime and to see which LSP 
+      servers are detected.
+    
+      To use the default theme, helix has to be started in a terminal it recognizes 
+      as supporting true colors.
+    EOT2
+  end
+end

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -28,7 +28,8 @@ class Helix_editor < Package
     helix_executable_dest_dir = "#{CREW_DEST_PREFIX}/bin"
     FileUtils.mkdir_p helix_executable_dest_dir.to_s
     FileUtils.install ".#{@build_folder_suffix}/hx", helix_executable_dest_dir, mode: 0o755
-    # Copy runtime dir
+    # Copy runtime dir (without the sources)
+    FileUtils.rm_rf './runtime/grammars/sources' # remove the sources
     helix_runtime_dest_dir = "#{CREW_DEST_DIR}#{@helix_runtime_dir}"
     FileUtils.mkdir_p helix_runtime_dest_dir
     FileUtils.cp_r './runtime', helix_runtime_dest_dir

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -41,7 +41,7 @@ class Helix_editor < Package
   def self.check
     # Ensure hx is executable
     command_status = system ".#{@build_folder_suffix}/hx --version", exception: false
-    raise 'hx is not executable' unless command_status == true
+    raise 'hx is not executable'.lightred unless command_status == true
   end
 
   def self.postinstall

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -15,7 +15,6 @@ class Helix_editor < Package
   no_fhs
   no_shrink
   no_strip
-  no_patchelf
 
   @xdg_config_home = ENV.fetch 'XDG_CONFIG_HOME', "#{CREW_PREFIX}/.config"
   @helix_runtime_dir = "#{@xdg_config_home}/helix"

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -6,7 +6,7 @@ class Helix_editor < Package
   version '22.12'
   license 'MPL-2.0' # license of source
   compatibility 'all'
-  source_url 'https://github.com/helix-editor/helix/archive/22.12.tar.gz' #'https://t.ly/-vk7'
+  source_url 'https://t.ly/-vk7'
   source_sha256 'edae8af46401b45c3e71c38b4fa99f931c4458127978ccd1b29aaae79331d972' # Use the command "sha256sum"
 
   depends_on 'rust' => :build
@@ -30,17 +30,14 @@ class Helix_editor < Package
     `hx --version`
     # Check if helix can find its runtime path
     command_output = `hx --health`
-    if !command_output.include? @helix_runtime_dir
-      raise 'Helix cannot find its runtime dir'
-    end
+    raise 'Helix cannot find its runtime dir' unless command_output.include? @helix_runtime_dir
   end
-
 
   def self.install
     # Copy executable
     helix_executable_dest_dir = "#{CREW_DEST_PREFIX}/bin"
     FileUtils.mkdir_p helix_executable_dest_dir.to_s
-    FileUtils.install './target/release/hx', helix_executable_dest_dir, :mode => 0755
+    FileUtils.install './target/release/hx', helix_executable_dest_dir, mode: 0o755
     # Copy runtime dir
     helix_runtime_dest_dir = "#{CREW_DEST_DIR}#{@helix_runtime_dir}"
     FileUtils.mkdir_p helix_runtime_dest_dir
@@ -65,13 +62,13 @@ class Helix_editor < Package
     # If the user added a configuration dir, we ask if he wishes to remove it as well
     config_dir = "#{HOME}/.config/helix"
     Dir.exist? config_dir
-      puts "\nWould you like to remove the configuration folder: #{config_dir}? [y/N] "
-      case $stdin.gets.chomp.downcase
-      when 'y', 'yes'
-        FileUtils.rm_rf config_dir
-        puts "#{config_dir} removed.".lightred
-      else
-        puts "#{config_dir} was not removed.".lightgreen
-      end
+    puts "\nWould you like to remove the configuration folder: #{config_dir}? [y/N] "
+    case $stdin.gets.chomp.downcase
+    when 'y', 'yes'
+      FileUtils.rm_rf config_dir
+      puts "#{config_dir} removed.".lightred
+    else
+      puts "#{config_dir} was not removed.".lightgreen
+    end
   end
 end

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -47,7 +47,7 @@ class Helix_editor < Package
   def self.postinstall
     # This will print a warning if "hx" is not a valid command
     command_status = system 'hx --version', exception: false
-    puts 'Warning: hx is not in path'.lightred unless command_status == true
+    puts 'Warning: hx is not in PATH'.lightred unless command_status == true
     # Check if helix can find its runtime path
     command_output = `hx --health`
     puts 'Warning: helix cannot find its runtime dir'.lightred unless command_output.include? @helix_runtime_dir

--- a/packages/helix_editor.rb
+++ b/packages/helix_editor.rb
@@ -64,18 +64,22 @@ class Helix_editor < Package
     EOT2
   end
 
-  def self.remove
-    # If the user added a configuration dir, we ask if he wishes to remove it as well
-    config_dir = "#{HOME}/.config/helix"
-    if Dir.exist? config_dir
-      puts "\nWould you like to remove the configuration folder: #{config_dir}? [y/N] "
-      case $stdin.gets.chomp.downcase
-      when 'y', 'yes'
-        FileUtils.rm_rf config_dir
-        puts "#{config_dir} removed.".lightgreen
-      else
-        puts "#{config_dir} was not removed.".lightblue
-      end
+  def ask_to_remove_user_defined_config_files_in(dir)
+    puts "\nRemove user defined files in folder: #{dir}? [y/N] "
+    case $stdin.gets.chomp.downcase
+    when 'y', 'yes'
+      FileUtils.rm_rf config_dir.to_s
+      puts "#{dir} removed.".lightgreen
+    else
+      puts "#{dir} was not removed.".lightblue
     end
+  end
+
+  def self.remove
+    # If the user added configuration files in @helix_runtime_dir, remove them if desired
+    ask_to_remove_user_defined_config_files_in @helix_runtime_dir if Dir.exist? @helix_runtime_dir
+    # If the user added a configuration dir in HOME, remove it if desired
+    config_dir = "#{HOME}/.config/helix"
+    ask_to_remove_user_defined_config_files_in config_dir if Dir.exist? config_dir
   end
 end


### PR DESCRIPTION
## Description
Adding *helix editor*, a vim inspired editor that supports language servers (LSP). See [here](https://helix-editor.com/) for more information.

## Additional information

Works properly:
- [ ] `x86_64` (not tested)
- [ ] `i686` (not tested)
- [x] `armv7l` 

No install binaries at the moment.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/ncdm-stldr/chromebrew.git CREW_TESTING_BRANCH=add-helix_editor CREW_TESTING=1 crew update
```

