### PR TITLE
fix cached zstd git dir extraction

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -824,7 +824,7 @@ def download
         if File.file?(cachefile) && File.file?("#{cachefile}.sha256")
           if system "cd #{CREW_CACHE_DIR} && sha256sum -c #{cachefile}.sha256"
             FileUtils.mkdir_p @extract_dir
-            system "tar x#{@verbose}f #{cachefile} -C #{@extract_dir}"
+            system "tar -Izstd -x#{@verbose}f #{cachefile} -C #{@extract_dir}"
             return { source:, filename: }
           else
             puts 'Cached git repository checksum mismatch. 😔 Will download.'.lightred

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.31.2'
+CREW_VERSION = '1.31.3'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
- tar needs to be told to use zstd when extracting tar.zst files...

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=zstd_fix2 CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
