### PR TITLE
jsonc: fix library symlinks

### DIFF
--- a/packages/jsonc.rb
+++ b/packages/jsonc.rb
@@ -3,37 +3,36 @@ require 'package'
 class Jsonc < Package
   description 'JSON-C implements a reference counting object model that allows you to easily construct JSON objects in C, output them as JSON formatted strings and parse JSON formatted strings back into the C representation of JSON objects.'
   homepage 'https://github.com/json-c/json-c'
-  version '0.16-20220414'
+  version '0.16-1741bcd'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://github.com/json-c/json-c/archive/json-c-0.16-20220414.tar.gz'
-  source_sha256 '3ecaeedffd99a60b1262819f9e60d7d983844073abc74e495cb822b251904185'
+  source_url 'https://github.com/json-c/json-c.git'
+  git_hashtag '1741bcd3eaf2603b8256735560de9b0d3244d62f'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jsonc/0.16-20220414_armv7l/jsonc-0.16-20220414-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jsonc/0.16-20220414_armv7l/jsonc-0.16-20220414-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jsonc/0.16-20220414_i686/jsonc-0.16-20220414-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jsonc/0.16-20220414_x86_64/jsonc-0.16-20220414-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jsonc/0.16-1741bcd_armv7l/jsonc-0.16-1741bcd-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jsonc/0.16-1741bcd_armv7l/jsonc-0.16-1741bcd-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jsonc/0.16-1741bcd_i686/jsonc-0.16-1741bcd-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jsonc/0.16-1741bcd_x86_64/jsonc-0.16-1741bcd-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '523484dc50062e441e8c9b79a0accf1af0d5bd4efe480e1e1eaa38890ac8220e',
-     armv7l: '523484dc50062e441e8c9b79a0accf1af0d5bd4efe480e1e1eaa38890ac8220e',
-       i686: '555a7253bb6bb49ca5134e76daebac0d49179ebfdefe96d4c4c164a78b57f75a',
-     x86_64: '5695955d3b4cd29258a09d667ec70fcb5275499777625c242b4c8f93de77df97'
+    aarch64: '5bc684f839c15992a90ee87bfce2b982897cb991ad0e63aecccb193a73705bb4',
+     armv7l: '5bc684f839c15992a90ee87bfce2b982897cb991ad0e63aecccb193a73705bb4',
+       i686: 'e1becda31e7af8b56b106df854b6c6b4722bc67a5cd7ddac970a66f8ea55f263',
+     x86_64: 'e0926875fa85dce385118551f8294d5a4e7455171a49818bab9c9b8040bc8c06'
   })
 
+  depends_on 'glibc' # R
+
   def self.build
-    Dir.mkdir 'build'
-    Dir.chdir 'build' do
-      system "cmake .. #{CREW_CMAKE_OPTIONS}"
-      system 'make'
-    end
+    system "cmake -B builddir #{CREW_CMAKE_OPTIONS} \
+            -G Ninja"
+    system 'samu -C builddir'
   end
 
   def self.install
-    Dir.chdir 'build' do
-      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-      FileUtils.ln_s "#{CREW_LIB_PREFIX}/libjson-c.so.4", "#{CREW_DEST_LIB_PREFIX}/libjson-c.so.3"
-    end
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
+    FileUtils.ln_s "#{CREW_LIB_PREFIX}/libjson-c.so", "#{CREW_DEST_LIB_PREFIX}/libjson-c.so.3"
+    FileUtils.ln_s "#{CREW_LIB_PREFIX}/libjson-c.so", "#{CREW_DEST_LIB_PREFIX}/libjson-c.so.4"
   end
 end


### PR DESCRIPTION
Fixes #7922 

<!-- Mention things we might need to know. Like: -->

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=jsonc CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
