### PR TITLE
Update gimp and dependencies

### DIFF
--- a/packages/gimp.rb
+++ b/packages/gimp.rb
@@ -3,23 +3,23 @@ require 'package'
 class Gimp < Package
   description 'GIMP is a cross-platform image editor available for GNU/Linux, OS X, Windows and more operating systems.'
   homepage 'https://www.gimp.org/'
-  version '2.99.14'
+  version '2.10.32'
   license 'GPL-3 and LGPL-3'
   compatibility 'all'
-  source_url 'https://download.gimp.org/gimp/v2.99/gimp-2.99.14.tar.xz'
-  source_sha256 '313a205475d1ff03c5c4d9602f09f5c975ba6c1c79d8843e2396f9fe2abdf7a8'
+  source_url 'https://download.gimp.org/gimp/v2.10/gimp-2.10.32.tar.bz2'
+  source_sha256 '3f15c70554af5dcc1b46e6dc68f3d8f0a6cc9fe56b6d78ac08c0fd859ab89a25'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gimp/2.99.14_armv7l/gimp-2.99.14-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gimp/2.99.14_armv7l/gimp-2.99.14-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gimp/2.99.14_i686/gimp-2.99.14-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gimp/2.99.14_x86_64/gimp-2.99.14-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gimp/2.10.32_armv7l/gimp-2.10.32-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gimp/2.10.32_armv7l/gimp-2.10.32-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gimp/2.10.32_i686/gimp-2.10.32-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gimp/2.10.32_x86_64/gimp-2.10.32-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'a1e0ae2ca1ed77cb11d746745fa4103231c7fd61959d745f2c803dcc5de29e8d',
-     armv7l: 'a1e0ae2ca1ed77cb11d746745fa4103231c7fd61959d745f2c803dcc5de29e8d',
-       i686: '0508068761b35033e80f25866f54d835a63f967da7eec4547b32f0f213d272d0',
-     x86_64: '40972b5410efa1d614286ea762d2dfcf969e346f893b172000d4e06784dbca22'
+    aarch64: 'c07455d117cb5401425eb1da195c49084949b35228b33e00b8e162e1a4c37978',
+     armv7l: 'c07455d117cb5401425eb1da195c49084949b35228b33e00b8e162e1a4c37978',
+       i686: 'da489078f0e946f11e2ac57111b37f6dbca73fdf9c591d1b2fa23150769d02d1',
+     x86_64: 'fa589a17ab1af432be4de739a2597d8df992d4573b7a3ebaffee073160acdb43'
   })
 
   depends_on 'aalib' # R
@@ -44,6 +44,7 @@ class Gimp < Package
   depends_on 'gtk3' # R
   depends_on 'harfbuzz' # R
   depends_on 'ilmbase' # R
+  depends_on 'iso_codes' # R
   depends_on 'jsonc' => :build
   depends_on 'json_glib' # R
   depends_on 'lcms' # R
@@ -79,9 +80,11 @@ class Gimp < Package
   depends_on 'pango' # R
   depends_on 'poppler_data'
   depends_on 'poppler' # R
-  depends_on 'py3_pycairo' => :build
+  depends_on 'py2_pycairo' => :build
   depends_on 'pygtk' => :build
+  depends_on 'python2' => :build
   depends_on 'shared_mime_info' => :build
+  depends_on 'webkit2gtk' # R
   depends_on 'xdg_base' => :build
   depends_on 'xzutils' # R
   depends_on 'zlibpkg' # R
@@ -89,15 +92,11 @@ class Gimp < Package
   gnome
 
   def self.build
-    system "meson \
-      #{CREW_MESON_OPTIONS} \
-      -Dbug-report-url=https://github.com/chromebrew/chromebrew/issues \
-      builddir"
-    system 'meson configure builddir'
-    system 'ninja -C builddir'
+    system "./configure #{CREW_OPTIONS}"
+    system 'make'
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/libavif.rb
+++ b/packages/libavif.rb
@@ -3,24 +3,24 @@ require 'package'
 class Libavif < Package
   description 'Library for encoding and decoding .avif files'
   homepage 'https://github.com/AOMediaCodec/libavif'
-  @_ver = '0.10.1'
-  version "#{@_ver}-1"
+  @_ver = '0.11.1'
+  version @_ver
   license 'BSD-2'
   compatibility 'all'
   source_url 'https://github.com/AOMediaCodec/libavif.git'
   git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libavif/0.10.1-1_armv7l/libavif-0.10.1-1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libavif/0.10.1-1_armv7l/libavif-0.10.1-1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libavif/0.10.1-1_i686/libavif-0.10.1-1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libavif/0.10.1-1_x86_64/libavif-0.10.1-1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libavif/0.11.1_armv7l/libavif-0.11.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libavif/0.11.1_armv7l/libavif-0.11.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libavif/0.11.1_i686/libavif-0.11.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libavif/0.11.1_x86_64/libavif-0.11.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '6742660c503f4e1ac5f39e8b5e3c5ef04b064d5d01ab9b36ebf6c8d0d912db64',
-     armv7l: '6742660c503f4e1ac5f39e8b5e3c5ef04b064d5d01ab9b36ebf6c8d0d912db64',
-       i686: '88f3295861a9005e0dda42b4ffe1f7b9a5950fd5d024498aa009387fa4991639',
-     x86_64: '5913a00db3f91eb5c64e95aa844ea6d7be2605b9e6244bb1dc640644ca1df634'
+    aarch64: '9c5152797b36c3da157ac4e43ba462617fe4c173f0dfda6ffc3f2f83250e8a06',
+     armv7l: '9c5152797b36c3da157ac4e43ba462617fe4c173f0dfda6ffc3f2f83250e8a06',
+       i686: '970d2f65e8dac8eaec92c0847deeb5aa25d557bebddc904bdc60f968e135e484',
+     x86_64: 'd8473a785ecd42c53652973068f65c3462114539339194937e36e3e9301127ec'
   })
 
   depends_on 'libaom'
@@ -31,6 +31,7 @@ class Libavif < Package
   depends_on 'libjpeg'
   depends_on 'libyuv'
   depends_on 'nasm' => :build
+  depends_on 'pandoc' => :build
   depends_on 'pkgconf' => :build
   depends_on 'gcc' # R
   depends_on 'gdk_pixbuf' # R
@@ -50,6 +51,7 @@ class Libavif < Package
         -DAVIF_CODEC_RAV1E=ON \
         -DAVIF_CODEC_SVT=ON \
         -DAVIF_BUILD_GDK_PIXBUF=ON \
+        -DAVIF_BUILD_MAN_PAGES=ON \
         .."
     end
     system 'ninja -C builddir'

--- a/packages/libffi.rb
+++ b/packages/libffi.rb
@@ -3,24 +3,24 @@ require 'package'
 class Libffi < Package
   description 'The libffi library provides a portable, high level programming interface to various calling conventions.'
   homepage 'https://github.com/libffi/libffi/'
-  @_ver = '3.4.2'
-  version "#{@_ver}-1"
+  @_ver = '3.4.4'
+  version @_ver
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/libffi/libffi.git'
   git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libffi/3.4.2-1_armv7l/libffi-3.4.2-1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libffi/3.4.2-1_armv7l/libffi-3.4.2-1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libffi/3.4.2-1_i686/libffi-3.4.2-1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libffi/3.4.2-1_x86_64/libffi-3.4.2-1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libffi/3.4.4_armv7l/libffi-3.4.4-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libffi/3.4.4_armv7l/libffi-3.4.4-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libffi/3.4.4_i686/libffi-3.4.4-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libffi/3.4.4_x86_64/libffi-3.4.4-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'd975c1b4764f7108d1c3ede80a34d1cfaddf6a293ca0a6a4348c071d6a8ed22a',
-     armv7l: 'd975c1b4764f7108d1c3ede80a34d1cfaddf6a293ca0a6a4348c071d6a8ed22a',
-       i686: '5558c0372d20b5cb54bc75aa7fbc2ca24be8166e1515f4b91cffb26032a4a071',
-     x86_64: 'fec954fcb51b1186ab2d084e29edf05773cf31b0543ad947bf9f325186022ab5'
+    aarch64: '14026a74658574e2f7dfe5516f16bff43ed8d0c4ed3c65764216c72602cb6b54',
+     armv7l: '14026a74658574e2f7dfe5516f16bff43ed8d0c4ed3c65764216c72602cb6b54',
+       i686: '6fa26f0ad0e3d78315dbb50e7fc1f059711d75beae1d10d4a23c425cbb5da653',
+     x86_64: '4a2afb9850e7ab6b723a9df9279282479ce60a1db4fdb336b60e2244d327902a'
   })
 
   depends_on 'glibc' # R
@@ -31,11 +31,11 @@ class Libffi < Package
     system 'make'
   end
 
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
-
   def self.check
     # system "make check"         # DejaGNU required
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end

--- a/packages/py2_pycairo.rb
+++ b/packages/py2_pycairo.rb
@@ -1,0 +1,42 @@
+require 'package'
+
+class Py2_pycairo < Package
+  description 'Pycairo is a Python module providing bindings for the cairo graphics library.'
+  homepage 'https://pycairo.readthedocs.io/'
+  @_ver = '1.18.1'
+  version @_ver
+  license 'LGPL-2.1'
+  compatibility 'all'
+  source_url 'https://github.com/pygobject/pycairo.git'
+  git_hashtag "v#{@_ver}"
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py2_pycairo/1.18.1_armv7l/py2_pycairo-1.18.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py2_pycairo/1.18.1_armv7l/py2_pycairo-1.18.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py2_pycairo/1.18.1_i686/py2_pycairo-1.18.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py2_pycairo/1.18.1_x86_64/py2_pycairo-1.18.1-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '04d409c68c699d496a5b8a189eb65cfe90e921f5853b1f22c0549a9b2f1f916a',
+     armv7l: '04d409c68c699d496a5b8a189eb65cfe90e921f5853b1f22c0549a9b2f1f916a',
+       i686: '6dda826d659758343fe36f257283811cfc0c55bffd58983c550d48c5bba3b2f4',
+     x86_64: '2265a6ad25ca47bca4217dd75a49a753f4e0e9cdeb339f3774769aebd18a5a61'
+  })
+
+  depends_on 'python2'
+  depends_on 'cairo'
+  depends_on 'meson' => :build
+
+  def self.build
+    system "meson setup \
+            #{CREW_MESON_OPTIONS} \
+            -Dpython=python2 \
+            builddir"
+    system 'meson configure builddir'
+    system 'ninja -C builddir'
+  end
+
+  def self.install
+    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+  end
+end


### PR DESCRIPTION
Reverting to the stable version.

- gimp 2.99.14 => 2.10.32
- libavif 0.10.1-1 => 0.11.1
- libffi 3.4.2-1 => 3.4.4
- Add py2_pycairo build dependency

Tested on all architectures.