### PR TITLE
downloader: Fix endless download

### DIFF
--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -77,9 +77,9 @@ class ProgressBar
   end
 
   def show
-    return Thread.new do
-      @progress_bar_showing = true
+    @progress_bar_showing = true
 
+    return Thread.new do
       print "\e[?25l" # hide cursor to prevent cursor flickering
 
       while @progress_bar_showing


### PR DESCRIPTION
Fix #7932 

Sometimes the download is completed before the progress bar show, which causes `@progress_bar_showing` always be covered with `true`

Now the `@progress_bar_showing` variable will initialize before the thread start to prevent the race issue

Tested on `arm`