### PR TITLE
terraform => 1.3.8

### DIFF
--- a/packages/terraform.rb
+++ b/packages/terraform.rb
@@ -3,7 +3,7 @@ require 'package'
 class Terraform < Package
   description 'Terraform is a tool for building, changing, and combining infrastructure safely and efficiently.'
   homepage 'https://www.terraform.io/'
-  version '1.3.7'
+  version '1.3.8'
   license 'Apache-2.0, BSD-2, BSD-4, ECL-2.0, imagemagick, ISC, JSON, MIT, MIT-with-advertising, MPL-2.0 and unicode'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Terraform < Package
      x86_64: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_amd64.zip"
   })
   source_sha256({
-    aarch64: '80f981e15f6da52f1825de9bbf582449a8da934a9664214b0a417f21cede8e18',
-     armv7l: '80f981e15f6da52f1825de9bbf582449a8da934a9664214b0a417f21cede8e18',
-       i686: '02ed959001d2380ee3902775d73df3e515dba297c74333b2eecc204ad635dda6',
-     x86_64: 'b8cf184dee15dfa89713fe56085313ab23db22e17284a9a27c0999c67ce3021e'
+    aarch64: 'a42bf3c7d6327f45d2b212b692ab4229285fb44dbb8adb7c39e18be2b26167c8',
+     armv7l: 'a42bf3c7d6327f45d2b212b692ab4229285fb44dbb8adb7c39e18be2b26167c8',
+       i686: '7497a13307b9f3e1e8d163f8cd3f6b31800bd71af54ca03d795ac20d9caafbf0',
+     x86_64: '9d9e7d6a9b41cef8b837af688441d4fbbd84b503d24061d078ad662441c70240'
   })
 
   def self.install


### PR DESCRIPTION
Update Terraform CLI to 1.3.8

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/JasonPratt/chromebrew.git CREW_TESTING_BRANCH=update-terraform CREW_TESTING=1 crew update
```