### PR TITLE
Crew remove: Do not remove outside CREW_PREFIX hierarchy

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1616,7 +1616,8 @@ def remove(pkgName)
 
       # remove all directories installed by the package
       File.foreach("meta/#{pkgName}.directorylist", chomp: true) do |line|
-        next unless Dir.exist?(line) && Dir.empty?(line)
+        puts "directorylist contains #{line}".lightred if @opt_verbose && !line.include?(CREW_PREFIX)
+        next unless Dir.exist?(line) && Dir.empty?(line) && line.include?(CREW_PREFIX)
 
         puts "Removing directory #{line}".lightred if @opt_verbose
         FileUtils.rmdir(line)

--- a/bin/crew
+++ b/bin/crew
@@ -1610,7 +1610,8 @@ def remove(pkgName)
           puts "Removing #{line} will break crew. It was #{'NOT'.lightred} deleted." if @opt_verbose
         else
           puts "Removing file #{line}".lightred if @opt_verbose
-          FileUtils.rm_rf line
+          puts "fileist contains #{line}".lightred if @opt_verbose && !line.include?(CREW_PREFIX)
+          FileUtils.rm_rf line if line.include?(CREW_PREFIX)
         end
       end
 

--- a/bin/crew
+++ b/bin/crew
@@ -1049,8 +1049,8 @@ def prepare_package(destdir)
     @pkg.postbuild
 
     # create file list
-    system 'find . -type f > ../filelist'
-    system 'find . -type l >> ../filelist'
+    system "find .#{CREW_PREFIX} -type f > ../filelist"
+    system "find .#{CREW_PREFIX} -type l >> ../filelist"
     system 'cut -c2- ../filelist > filelist'
 
     # check for FHS3 compliance
@@ -1091,7 +1091,7 @@ def prepare_package(destdir)
     abort 'Exiting due to above errors.'.lightred if @_errors
 
     # create directory list
-    system 'find . -type d | cut -c2- | tail -n +2', out: 'dlist'
+    system "find .#{CREW_PREFIX} -type d | cut -c2- | tail -n +2", out: 'dlist'
 
     strip_dir destdir
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.31.3'
+CREW_VERSION = '1.31.4'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
- Only store files in `CREW_PREFIX` during package builds.
- Do not (attempt to) remove files or directories from an installed package outside of `CREW_PREFIX`  during `crew remove packagename`.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=crew_remove CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
