### PR TITLE
boost => 1.81.0 + updates to packages which require boost, plus add packages needed to build current inkscape

### DIFF
--- a/packages/boost.rb
+++ b/packages/boost.rb
@@ -3,33 +3,41 @@ require 'package'
 class Boost < Package
   description 'Boost provides free peer-reviewed portable C++ source libraries.'
   homepage 'https://www.boost.org/'
-  @_ver = '1.76.0'
+  @_ver = '1.81.0'
   version @_ver
   license 'Boost-1.0'
   compatibility 'all'
   source_url "https://boostorg.jfrog.io/artifactory/main/release/#{@_ver}/source/boost_#{@_ver.gsub('.', '_')}.tar.bz2"
-  source_sha256 'f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41'
+  source_sha256 '71feeed900fbccca04a3b4f2f84a7c217186f28a940ed8b7ed4725986baf99fa'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/boost/1.76.0_armv7l/boost-1.76.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/boost/1.76.0_armv7l/boost-1.76.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/boost/1.76.0_i686/boost-1.76.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/boost/1.76.0_x86_64/boost-1.76.0-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/boost/1.81.0_armv7l/boost-1.81.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/boost/1.81.0_armv7l/boost-1.81.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/boost/1.81.0_i686/boost-1.81.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/boost/1.81.0_x86_64/boost-1.81.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '3faf1c0322845086c77e4ef173beee27ec5fa6c780727c3e6eef85584ee8bc40',
-     armv7l: '3faf1c0322845086c77e4ef173beee27ec5fa6c780727c3e6eef85584ee8bc40',
-       i686: 'f5f924e7ccaead8a1db56fff2963233d36e5466dc34fcbf7d9527ee00c117aeb',
-     x86_64: 'b64b49911d39f51b9460e3ae4ba76f6239b5b2aec473a8376780330ea68b2277'
+    aarch64: '82924d65aba189e489e722951e78826136c272d9aa9ddf1dd904357740652752',
+     armv7l: '82924d65aba189e489e722951e78826136c272d9aa9ddf1dd904357740652752',
+       i686: 'd025176329c1186d773a4fdfe756c87cf9347ecd74be4fdee622e45a77480ba3',
+     x86_64: '44cb11073f0f9bb8cb7b4e4e4f436b12b1d8880e68c51178e9ebfb373fec3cd6'
   })
+
+  depends_on 'bz2' # R
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  depends_on 'icu4c' # R
+  depends_on 'xzutils' # R
+  depends_on 'zlibpkg' # R
+  depends_on 'zstd' # R
 
   def self.build
     system './bootstrap.sh'
   end
 
   def self.install
-    system "#{CREW_ENV_OPTIONS} ./b2 \
-            --build-dir=\${PWD}/builddir \
+    system "./b2 \
+            --build-dir=${PWD}/builddir \
             -a --prefix=#{CREW_DEST_PREFIX} \
             --libdir=#{CREW_DEST_LIB_PREFIX} \
             install"

--- a/packages/cppunit.rb
+++ b/packages/cppunit.rb
@@ -2,35 +2,36 @@ require 'package'
 
 class Cppunit < Package
   description 'CppUnit is the C++ port of the famous JUnit framework for unit testing.'
-  homepage 'https://sourceforge.net/projects/cppunit/'
-  version '1.12.1'
-  license 'LGPL-2.1'
+  homepage 'https://www.freedesktop.org/wiki/Software/cppunit'
+  version '1.15.1'
+  license 'LGPL'
   compatibility 'all'
-  source_url 'http://downloads.sourceforge.net/project/cppunit/cppunit/1.12.1/cppunit-1.12.1.tar.gz'
-  source_sha256 'ac28a04c8e6c9217d910b0ae7122832d28d9917fa668bcc9e0b8b09acb4ea44a'
+  source_url 'https://dev-www.libreoffice.org/src/cppunit-1.15.1.tar.gz'
+  source_sha256 '89c5c6665337f56fd2db36bc3805a5619709d51fb136e51937072f63fcc717a7'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cppunit/1.12.1_armv7l/cppunit-1.12.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cppunit/1.12.1_armv7l/cppunit-1.12.1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cppunit/1.12.1_i686/cppunit-1.12.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cppunit/1.12.1_x86_64/cppunit-1.12.1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cppunit/1.15.1_armv7l/cppunit-1.15.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cppunit/1.15.1_armv7l/cppunit-1.15.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cppunit/1.15.1_i686/cppunit-1.15.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cppunit/1.15.1_x86_64/cppunit-1.15.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '5629277d1bb357eb5a1f0cf6a0febe1078b67c63030ecf9c51cf885704c76107',
-     armv7l: '5629277d1bb357eb5a1f0cf6a0febe1078b67c63030ecf9c51cf885704c76107',
-       i686: '3c6ccb427841faf098fc43520f1f288c23c34aadce01f5aa843e35a19100f54a',
-     x86_64: 'e5f432ecd193119cb7201eec9881f3e89dd7bccbb78f3ba4cc8374471acbe236'
+    aarch64: 'ff33e323513beb49457df2f8fd8d5642998664a4eef9e0f1095aa5f99d79e05d',
+     armv7l: 'ff33e323513beb49457df2f8fd8d5642998664a4eef9e0f1095aa5f99d79e05d',
+       i686: '91c258a319a9bb7fc7052e4ed40b057a653125b5a4a9b17d21145d603088bf28',
+     x86_64: '2020d8901ded8bb1123f82ab598b77af77cd08392204a939f1d229c915c353cb'
   })
 
-  depends_on 'doxygen' => :build
-  depends_on 'graphviz' => :build
+  depends_on 'doxygen' => ':build'
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
 
   def self.build
-    system "./configure --prefix=#{CREW_PREFIX} --libdir=#{CREW_LIB_PREFIX}"
+    system "./configure #{CREW_OPTIONS} --disable-static"
     system 'make'
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
   end
 end

--- a/packages/eigen.rb
+++ b/packages/eigen.rb
@@ -3,44 +3,37 @@ require 'package'
 class Eigen < Package
   description 'Eigen is a C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms.'
   homepage 'http://eigen.tuxfamily.org/'
-  version '3.3.7'
+  version '3.4.0'
   license 'MPL-2.0'
   compatibility 'all'
-  source_url 'https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.bz2'
-  source_sha256 '685adf14bd8e9c015b78097c1dc22f2f01343756f196acdc76a678e1ae352e11'
+  source_url 'https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.bz2'
+  source_sha256 'b4c198460eba6f28d34894e3a5710998818515104d6e74e5cc331ce31e46e626'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/eigen/3.3.7_armv7l/eigen-3.3.7-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/eigen/3.3.7_armv7l/eigen-3.3.7-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/eigen/3.3.7_i686/eigen-3.3.7-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/eigen/3.3.7_x86_64/eigen-3.3.7-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/eigen/3.4.0_armv7l/eigen-3.4.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/eigen/3.4.0_armv7l/eigen-3.4.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/eigen/3.4.0_i686/eigen-3.4.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/eigen/3.4.0_x86_64/eigen-3.4.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'd5cf4005c822890e8d6a3a57fd186151dfd36d0fef513200a2e81fa767ddb64e',
-     armv7l: 'd5cf4005c822890e8d6a3a57fd186151dfd36d0fef513200a2e81fa767ddb64e',
-       i686: '11f717b454e479d2f91ad0410aa403fa68c904fab37a8f30499254f3e780964a',
-     x86_64: '4ae4ecb6aed2407f0e4adf84116b91b40e830eaed6d2ef028825a26e89d8bc72'
+    aarch64: '4e98dce7b77978aff8f6991edcc18577e79728f71cda1753a5b3fa75165e141b',
+     armv7l: '4e98dce7b77978aff8f6991edcc18577e79728f71cda1753a5b3fa75165e141b',
+       i686: 'ba97ef42530781794fab541b020104184c188d56c4e13c2de0924b835bd539cb',
+     x86_64: 'b9275bcb88a8f123b1568f23f723f2340b955fb5323845e0891b98596e8813cf'
   })
 
-  depends_on 'boost'
-  depends_on 'fftw'
-  depends_on 'mesa'
-  depends_on 'superlu'
+  depends_on 'boost' => :build
+  depends_on 'fftw' => :build
+  depends_on 'mesa' => :build
+  depends_on 'superlu' => :build
 
   def self.build
-    Dir.mkdir 'build'
-    Dir.chdir 'build' do
-      system 'cmake',
-             '-DCMAKE_BUILD_TYPE=Release',
-             "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
-             '..'
-      system 'make'
-    end
+    system "cmake -B builddir #{CREW_CMAKE_OPTIONS} \
+            -G Ninja"
+    system 'samu -C builddir'
   end
 
   def self.install
-    Dir.chdir 'build' do
-      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    end
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
   end
 end

--- a/packages/exempi.rb
+++ b/packages/exempi.rb
@@ -6,33 +6,36 @@ require 'package'
 class Exempi < Package
   description 'A library to parse XMP metadata'
   homepage 'https://libopenraw.freedesktop.org/wiki/Exempi'
-  @_ver = '2.5.2'
-  version "#{@_ver}-1"
+  @_ver = '2.6.3'
+  version @_ver
   license 'BSD'
   compatibility 'all'
   source_url "https://gitlab.freedesktop.org/libopenraw/exempi/-/archive/#{@_ver}/exempi-#{@_ver}.tar.bz2"
-  source_sha256 'dff105f53bdd971e633b7fcb3bcfb22276716228a9e6063c1fd241a8542b9cec'
+  source_sha256 'e79995bb3c5319293e3f2abfc9da83a9ee5a83102724336599d535d874509632'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/exempi/2.5.2-1_armv7l/exempi-2.5.2-1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/exempi/2.5.2-1_armv7l/exempi-2.5.2-1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/exempi/2.5.2-1_i686/exempi-2.5.2-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/exempi/2.5.2-1_x86_64/exempi-2.5.2-1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/exempi/2.6.3_armv7l/exempi-2.6.3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/exempi/2.6.3_armv7l/exempi-2.6.3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/exempi/2.6.3_i686/exempi-2.6.3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/exempi/2.6.3_x86_64/exempi-2.6.3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '551b3b9ea9078d1ace55df7014d34863ce4708e273cc336ce165775dc6e34c30',
-     armv7l: '551b3b9ea9078d1ace55df7014d34863ce4708e273cc336ce165775dc6e34c30',
-       i686: '5bb4594a18f52103b41d6a9be9c9729d485b68e302cf3ac5afbbb5a150f58384',
-     x86_64: 'fd2cb5b92e6b19a1897ace6d32cb608748d963776011923e41c2580061bbd46c'
+    aarch64: '60ae93ee0ae5c7edd00d3206dff793d5255436d37eb5bf118243bf7142393ac4',
+     armv7l: '60ae93ee0ae5c7edd00d3206dff793d5255436d37eb5bf118243bf7142393ac4',
+       i686: '5febec27428020406e8d6dd85abd5058cd2e72b47ee92dc28be7ea4997d6a29e',
+     x86_64: '17a8c579b9a51f254476675b3d2bcdda6370fae697bf25da191f569321f7cd4e'
   })
 
-  depends_on 'boost' => :build
   depends_on 'autoconf_archive' => :build
+  depends_on 'boost' => :build
+  depends_on 'expat' # R
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  depends_on 'zlibpkg' # R
 
   def self.build
     system 'NOCONFIGURE=1 ./autogen.sh'
-    system "env #{CREW_ENV_OPTIONS} \
-      ./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_OPTIONS}"
     system 'make'
   end
 

--- a/packages/gdb.rb
+++ b/packages/gdb.rb
@@ -6,23 +6,23 @@ require 'package'
 class Gdb < Package
   description 'The GNU Debugger'
   homepage 'https://www.gnu.org/software/gdb/'
-  version '12.1-py3.11'
+  version '12.1-a4418a9-py3.11'
   license 'GPL3'
   compatibility 'all'
-  source_url 'https://ftp.gnu.org/gnu/gdb/gdb-12.1.tar.xz'
-  source_sha256 '0e1793bf8f2b54d53f46dea84ccfd446f48f81b297b28c4f7fc017b818d69fed'
+  source_url 'https://github.com/bminor/binutils-gdb.git'
+  git_hashtag 'a4418a9c6f99fd31c51698b1f6a6f8dbc1b81b6f'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdb/12.1-py3.11_armv7l/gdb-12.1-py3.11-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdb/12.1-py3.11_armv7l/gdb-12.1-py3.11-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdb/12.1-py3.11_i686/gdb-12.1-py3.11-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdb/12.1-py3.11_x86_64/gdb-12.1-py3.11-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdb/12.1-a4418a9-py3.11_armv7l/gdb-12.1-a4418a9-py3.11-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdb/12.1-a4418a9-py3.11_armv7l/gdb-12.1-a4418a9-py3.11-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdb/12.1-a4418a9-py3.11_i686/gdb-12.1-a4418a9-py3.11-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdb/12.1-a4418a9-py3.11_x86_64/gdb-12.1-a4418a9-py3.11-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '5d9c9535e1bd99c0eeecbd194738008561e43d48acef7f7050c0bcba892cc181',
-     armv7l: '5d9c9535e1bd99c0eeecbd194738008561e43d48acef7f7050c0bcba892cc181',
-       i686: '5bdd057f755617dc06a5d06acc201a7a65234c396db046e5c1e6a3d531eca202',
-     x86_64: 'e9aee1dec6dd2d353d1a72d3f97fa7dffeee32b54d52e2b8805138798167f54f'
+    aarch64: 'cdacd167edef7d56254298d1169551996b2910d1dcc97111fbb0740307f60154',
+     armv7l: 'cdacd167edef7d56254298d1169551996b2910d1dcc97111fbb0740307f60154',
+       i686: '87a1644e64b00b86aeed1dd00e6081314129a4658f9609fc2b9aaff06d388809',
+     x86_64: 'a88eabe0cceb8bd0d87d6c54dfb70922e7d810af4629e49cb91b7bf99f7f70d6'
   })
 
   depends_on 'boost' # R
@@ -41,7 +41,7 @@ class Gdb < Package
   depends_on 'zlibpkg' # R
 
   def self.patch
-    @readline8patch = <<~'READLINE8_PATCH_EOF'
+    @readline8patch = <<~READLINE8_PATCH_EOF
       commit 1add37b567a7dee39d99f37b37802034c3fce9c4
       Author: Andreas Schwab <schwab@linux-m68k.org>
       Date:   Sun Mar 20 14:01:54 2022 +0100

--- a/packages/grive.rb
+++ b/packages/grive.rb
@@ -3,42 +3,43 @@ require 'package'
 class Grive < Package
   description 'Google Drive client with support for new Drive REST API and partial sync'
   homepage 'https://github.com/vitalif/grive2'
-  version '0.5.2-e6fcc63'
+  version '0.5.3-648ff8e'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://github.com/vitalif/grive2.git'
-  git_hashtag 'e6fcc637f8d51126312f12d0c0a568046c4f95de'
+  git_hashtag '648ff8eea1a3c7cac8bfba283f75717bf54c67eb'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/grive/0.5.2-e6fcc63_armv7l/grive-0.5.2-e6fcc63-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/grive/0.5.2-e6fcc63_armv7l/grive-0.5.2-e6fcc63-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/grive/0.5.2-e6fcc63_i686/grive-0.5.2-e6fcc63-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/grive/0.5.2-e6fcc63_x86_64/grive-0.5.2-e6fcc63-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/grive/0.5.3-648ff8e_armv7l/grive-0.5.3-648ff8e-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/grive/0.5.3-648ff8e_armv7l/grive-0.5.3-648ff8e-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/grive/0.5.3-648ff8e_i686/grive-0.5.3-648ff8e-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/grive/0.5.3-648ff8e_x86_64/grive-0.5.3-648ff8e-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '2a2c5dae9efd74c5b0497813c895f5bac5c91df8b1b7a9a31ac196ccaf09dd13',
-     armv7l: '2a2c5dae9efd74c5b0497813c895f5bac5c91df8b1b7a9a31ac196ccaf09dd13',
-       i686: '35301f6fe1a3d097341c1ef9b881b2f5dab461b3fd24c5859ddacb4a79b69b0a',
-     x86_64: '6aecea77e9fd0150ac18f2df6444b12cc95e411897800d462d89a1a5f6c8aeae'
+    aarch64: 'f20f7a15dbdc514af123edc914c2ca63b2f5327b1161d5aa981e182654608b4a',
+     armv7l: 'f20f7a15dbdc514af123edc914c2ca63b2f5327b1161d5aa981e182654608b4a',
+       i686: '7f263c2999dccd40fff6955bf6601a37bfcc1ce7c403ccd210de23151119cafd',
+     x86_64: '85e04905425f8e2ab8b6a9843032af15a781aa2c5446e12fbd4444b36c18f5ea'
   })
 
-  depends_on 'yajl'
-  depends_on 'libcurl'
-  depends_on 'libgcrypt'
-  depends_on 'boost'
-  depends_on 'expat'
+  depends_on 'binutils' # R
+  depends_on 'boost' # R
+  depends_on 'cppunit' => :build
+  depends_on 'expat' => :build
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  depends_on 'libcurl' # R
+  depends_on 'libgcrypt' # R
+  depends_on 'libgpgerror' # R
+  depends_on 'yajl' # R
 
   def self.build
-    Dir.mkdir 'build'
-    Dir.chdir 'build' do
-      system "cmake #{CREW_CMAKE_OPTIONS} .."
-      system 'make'
-    end
+    system "cmake -B builddir #{CREW_CMAKE_OPTIONS} \
+            -G Ninja"
+    system 'samu -C builddir'
   end
 
   def self.install
-    Dir.chdir 'build' do
-      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    end
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
   end
 end

--- a/packages/gtksourceview_3.rb
+++ b/packages/gtksourceview_3.rb
@@ -23,22 +23,27 @@ class Gtksourceview_3 < Package
      x86_64: '539da69432b1494f60cdc5d498f0ec13d89835688b3775a1b0a7d72c671b8454'
   })
 
-  depends_on 'atk'
-  depends_on 'cairo'
-  depends_on 'fontconfig'
-  depends_on 'freetype'
-  depends_on 'fribidi'
-  depends_on 'gdk_pixbuf'
-  depends_on 'glib'
-  depends_on 'glade'
-  depends_on 'graphene'
-  depends_on 'gtk3'
-  depends_on 'gtk4'
-  depends_on 'harfbuzz'
-  depends_on 'libsoup'
-  depends_on 'pango'
-  depends_on 'vala'
-  depends_on 'vulkan_icd_loader'
+  depends_on 'atk' # R
+  depends_on 'at_spi2_core' # R
+  depends_on 'cairo' => :build
+  depends_on 'fontconfig' => :build
+  depends_on 'freetype' => :build
+  depends_on 'fribidi' => :build
+  depends_on 'gdk_pixbuf' # R
+  depends_on 'glade' => :build
+  depends_on 'glibc' # R
+  depends_on 'glib' # R
+  depends_on 'graphene' => :build
+  depends_on 'gtk3' # R
+  depends_on 'gtk4' => :build
+  depends_on 'harfbuzz' # R
+  depends_on 'icu4c' # R
+  depends_on 'libsoup' => :build
+  depends_on 'libxml2' # R
+  depends_on 'pango' # R
+  depends_on 'vala' => :build
+  depends_on 'vulkan_icd_loader' => :build
+  depends_on 'zlibpkg' # R
 
   def self.build
     system "./configure #{CREW_OPTIONS} --enable-glade-catalog --enable-gtk-doc --disable-gtk-doc-html"

--- a/packages/gtksourceview_3.rb
+++ b/packages/gtksourceview_3.rb
@@ -6,18 +6,20 @@ class Gtksourceview_3 < Package
   @_ver = '3.24.11'
   version @_ver
   license 'GPL-2'
-  compatibility 'x86_64 aarch64 armv7l'
+  compatibility 'all'
   source_url 'https://download.gnome.org/sources/gtksourceview/3.24/gtksourceview-3.24.11.tar.xz'
   source_sha256 '691b074a37b2a307f7f48edc5b8c7afa7301709be56378ccf9cc9735909077fd'
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtksourceview_3/3.24.11_armv7l/gtksourceview_3-3.24.11-chromeos-armv7l.tar.xz',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtksourceview_3/3.24.11_armv7l/gtksourceview_3-3.24.11-chromeos-armv7l.tar.xz',
+     i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtksourceview_3/3.24.11_i686/gtksourceview_3-3.24.11-chromeos-i686.tar.zst',
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtksourceview_3/3.24.11_x86_64/gtksourceview_3-3.24.11-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
     aarch64: '66c81231c2866221935586f1230a5be8df66685bbe29cc9c44063a0d5999dc5b',
      armv7l: '66c81231c2866221935586f1230a5be8df66685bbe29cc9c44063a0d5999dc5b',
+     i686: '05d72c6ec22ca912ee561db41a42f3ab8ea723f1cdb607f75e8dc60466a40a19',
      x86_64: '539da69432b1494f60cdc5d498f0ec13d89835688b3775a1b0a7d72c671b8454'
   })
 

--- a/packages/inkscape.rb
+++ b/packages/inkscape.rb
@@ -3,47 +3,85 @@ require 'package'
 class Inkscape < Package
   description 'Inkscape is a professional vector graphics editor for Windows, Mac OS X and Linux.'
   homepage 'https://inkscape.org/'
-  version '0.92.3'
+  version '1.2.2'
   license 'GPL-2 and LGPL-2.1'
   compatibility 'all'
-  source_url 'https://inkscape.org/gallery/item/12187/inkscape-0.92.3.tar.bz2'
-  source_sha256 '063296c05a65d7a92a0f627485b66221487acfc64a24f712eb5237c4bd7816b2'
+  source_url 'https://inkscape.org/gallery/item/37360/inkscape-1.2.2.tar.xz'
+  source_sha256 'a0c7fd0d03c0a21535e648ef301dcf80dd7cfc1f3545e51065fbf1ba3ee8a5c4'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/inkscape/0.92.3_armv7l/inkscape-0.92.3-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/inkscape/0.92.3_armv7l/inkscape-0.92.3-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/inkscape/0.92.3_i686/inkscape-0.92.3-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/inkscape/0.92.3_x86_64/inkscape-0.92.3-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/inkscape/1.2.2_armv7l/inkscape-1.2.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/inkscape/1.2.2_armv7l/inkscape-1.2.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/inkscape/1.2.2_i686/inkscape-1.2.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/inkscape/1.2.2_x86_64/inkscape-1.2.2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '99b2d2527b668282d0107327b76dc2f44f5f0cee3b5cc2a4e8259d8d3aae5676',
-     armv7l: '99b2d2527b668282d0107327b76dc2f44f5f0cee3b5cc2a4e8259d8d3aae5676',
-       i686: 'c070cbd4692cea127b45360c7a935ee7e926204cf3fa6eb457d418a80092ae03',
-     x86_64: '82456ad92d50e2167e8e79f8072d1a13fcaf51d8837ab6bec942034ae80ba09d'
+    aarch64: 'c4ef578261aa1fcea6cbaae949671af0146402ff3d872a769296c671df07c101',
+     armv7l: 'c4ef578261aa1fcea6cbaae949671af0146402ff3d872a769296c671df07c101',
+       i686: 'f0e8eade7b45ccd509a65f6e0e4847fccfbaed568355592a2099e63c32888307',
+     x86_64: '529c95134104b67575d8282fe254d2266cd584cb9063604ddb0fc7f28f57eacc'
   })
 
-  depends_on 'bdwgc'
-  depends_on 'boost'
-  depends_on 'gsl'
-  depends_on 'gtkmm2'
+  depends_on 'atkmm' # R
+  depends_on 'atk' # R
+  depends_on 'at_spi2_core' # R
+  depends_on 'bdwgc' # R
+  depends_on 'boost' # R
+  depends_on 'cairo' => :build
+  depends_on 'cairomm_1_0' # R
+  depends_on 'double_conversion' # R
+  depends_on 'enchant' # R
+  depends_on 'freetype' # R
+  depends_on 'gcc' # R
+  depends_on 'gdk_pixbuf' # R
+  depends_on 'glibc' # R
+  depends_on 'glibmm_2_4' # R
+  depends_on 'glib' # R
+  depends_on 'graphicsmagick' # R
+  depends_on 'gsl' # R
+  depends_on 'gspell' # R
+  depends_on 'gtk3' # R
+  depends_on 'gtkmm3' # R
+  depends_on 'gtksourceview' => :build
+  depends_on 'harfbuzz' # R
   depends_on 'hicolor_icon_theme'
-  depends_on 'imagemagick6'
-  depends_on 'imagemagick7'
+  depends_on 'lcms' # R
+  depends_on 'libcdr' # R
+  depends_on 'libice' # R
+  depends_on 'libjpeg' # R
+  depends_on 'libpng' # R
+  depends_on 'librevenge' # R
+  depends_on 'libsigcplusplus' # R
+  depends_on 'libsm' # R
+  depends_on 'libsoup2' # R
+  depends_on 'libvisio' # R
+  depends_on 'libwpg' # R
+  depends_on 'libx11' # R
+  depends_on 'libxext' # R
+  depends_on 'libxml2' # R
+  depends_on 'libxslt' # R
   depends_on 'llvm' => :build
-  depends_on 'popt'
-  depends_on 'xdg_base'
-  depends_on 'sommelier'
+  depends_on 'pangomm_1_4' # R
+  depends_on 'pango' # R
+  depends_on 'poppler' # R
+  depends_on 'popt' => :build
+  depends_on 'potrace' # R
+  depends_on 'readline' # R
+  depends_on 'sommelier' => :build
+  depends_on 'xdg_base' => :build
+  depends_on 'zlibpkg' # R
 
   def self.build
-    system './autogen.sh'
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           '--disable-dependency-tracking'
-    system 'make'
+    system "cmake -B builddir #{CREW_CMAKE_OPTIONS} \
+            -DWITH_IMAGE_MAGICK=OFF \
+            -DWITH_INTERNAL_2GEOM=ON \
+            -DWITH_MANPAGE_COMPRESSION=OFF \
+            -DWITH_X11=ON \
+            -G Ninja"
+    system 'samu -C builddir'
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
   end
 end

--- a/packages/ledger.rb
+++ b/packages/ledger.rb
@@ -3,33 +3,39 @@ require 'package'
 class Ledger < Package
   description 'A double-entry accounting system with a command-line reporting interface'
   homepage 'https://www.ledger-cli.org/'
-  version '3.1.3'
+  version '3.3.0'
   license 'BSD'
   compatibility 'all'
-  source_url 'https://github.com/ledger/ledger/archive/v3.1.3.tar.gz'
-  source_sha256 'b248c91d65c7a101b9d6226025f2b4bf3dabe94c0c49ab6d51ce84a22a39622b'
+  source_url 'https://github.com/ledger/ledger.git'
+  git_hashtag "v#{version}"
 
   binary_url({
-    aarch64: '',
-     armv7l: '',
-       i686: '',
-     x86_64: ''
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ledger/3.3.0_armv7l/ledger-3.3.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ledger/3.3.0_armv7l/ledger-3.3.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ledger/3.3.0_i686/ledger-3.3.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ledger/3.3.0_x86_64/ledger-3.3.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '',
-     armv7l: '',
-       i686: '',
-     x86_64: ''
+    aarch64: '67bd73dd59b25960bc1bf25259929e2bb9606b07a2547e79eca476cf2a03cfad',
+     armv7l: '67bd73dd59b25960bc1bf25259929e2bb9606b07a2547e79eca476cf2a03cfad',
+       i686: '480dec57ad7f8165c6295d8a72e5984858e83bd521862ae8e72fd7ca479ebc19',
+     x86_64: 'bc7a46b64598dcafa85adafcb2377581aeb5f9c44a65f04ec6614aa0dd4f967e'
   })
 
-  depends_on 'boost' => :build
+  depends_on 'boost' # R
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  depends_on 'gmp' # R
+  depends_on 'libedit' # R
+  depends_on 'mpfr' # R
 
   def self.build
-    system './acprep', "--prefix=#{CREW_PREFIX}"
-    system 'make'
+    system "cmake -B builddir #{CREW_CMAKE_OPTIONS} \
+            -G Ninja"
+    system 'samu -C builddir'
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install/strip'
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
   end
 end

--- a/packages/libcdr.rb
+++ b/packages/libcdr.rb
@@ -1,0 +1,47 @@
+# Adapted from Arch Linux libcdr PKGBUILD at:
+# https://github.com/archlinux/svntogit-packages/raw/packages/libcdr/trunk/PKGBUILD
+
+require 'package'
+
+class Libcdr < Package
+  description 'CorelDraw file format importer library for LibreOffice'
+  homepage 'https://wiki.documentfoundation.org/DLP/Libraries/libcdr'
+  version '0.1.7'
+  license 'GPL2 LGPL2.1 MPL'
+  compatibility 'all'
+  source_url 'https://dev-www.libreoffice.org/src/libcdr/libcdr-0.1.7.tar.xz'
+  source_sha256 '5666249d613466b9aa1e987ea4109c04365866e9277d80f6cd9663e86b8ecdd4'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcdr/0.1.7_armv7l/libcdr-0.1.7-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcdr/0.1.7_armv7l/libcdr-0.1.7-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcdr/0.1.7_i686/libcdr-0.1.7-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcdr/0.1.7_x86_64/libcdr-0.1.7-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '9a19cf28a71ebc18454cafd9f32d177a718a2019de4ffb594534e07ad9852bb1',
+     armv7l: '9a19cf28a71ebc18454cafd9f32d177a718a2019de4ffb594534e07ad9852bb1',
+       i686: '59515e0bf500daa535e9132c02b56ef21a92ae94614462a397e2a2c5ecf0bf03',
+     x86_64: '6ef34db988840140936b8c073c718f50e42348b6c7b17ee20b3de2b45b6a56db'
+  })
+
+  depends_on 'boost' => :build
+  depends_on 'cppunit' => :build
+  depends_on 'doxygen' => :build
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  depends_on 'icu4c' # R
+  depends_on 'lcms' # R
+  depends_on 'librevenge' # R
+  depends_on 'libwpg' => :build
+  depends_on 'zlibpkg' # R
+
+  def self.build
+    system "./configure #{CREW_OPTIONS}"
+    system 'make'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end

--- a/packages/librevenge.rb
+++ b/packages/librevenge.rb
@@ -1,0 +1,43 @@
+# Adapted from Arch Linux librevenge PKGBUILD at:
+# https://github.com/archlinux/svntogit-packages/raw/packages/librevenge/trunk/PKGBUILD
+
+require 'package'
+
+class Librevenge < Package
+  description 'library for REVerses ENGineered formats filters'
+  homepage 'https://sf.net/p/libwpd/librevenge/'
+  version '0.0.5'
+  license 'MPL'
+  compatibility 'all'
+  source_url 'https://sourceforge.net/projects/libwpd/files/librevenge/librevenge-0.0.5/librevenge-0.0.5.tar.xz'
+  source_sha256 '106d0c44bb6408b1348b9e0465666fa83b816177665a22cd017e886c1aaeeb34'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librevenge/0.0.5_armv7l/librevenge-0.0.5-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librevenge/0.0.5_armv7l/librevenge-0.0.5-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librevenge/0.0.5_i686/librevenge-0.0.5-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librevenge/0.0.5_x86_64/librevenge-0.0.5-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: 'aec34f24effeb65bf094668a143ee8137620ced6b2b52a36a6c95ec65dddb98f',
+     armv7l: 'aec34f24effeb65bf094668a143ee8137620ced6b2b52a36a6c95ec65dddb98f',
+       i686: '8d0cebf1ba4848e065265ba7fb4c858b94e92dc306ee5b68624db4b24aab1021',
+     x86_64: '3f1b4296f12579b941ce8a32a037a25fe2f28e60dbf7e4d6ce981170cb5c27f8'
+  })
+
+  depends_on 'zlibpkg'
+  depends_on 'boost' => :build
+  depends_on 'cppunit' => :build
+  depends_on 'doxygen' => :build
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+
+  def self.build
+    system "./configure #{CREW_OPTIONS} --disable-werror"
+    system 'make'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR}/ install"
+  end
+end

--- a/packages/librevenge.rb
+++ b/packages/librevenge.rb
@@ -25,12 +25,12 @@ class Librevenge < Package
      x86_64: '3f1b4296f12579b941ce8a32a037a25fe2f28e60dbf7e4d6ce981170cb5c27f8'
   })
 
-  depends_on 'zlibpkg'
   depends_on 'boost' => :build
   depends_on 'cppunit' => :build
   depends_on 'doxygen' => :build
   depends_on 'gcc' # R
   depends_on 'glibc' # R
+  depends_on 'zlibpkg' # R
 
   def self.build
     system "./configure #{CREW_OPTIONS} --disable-werror"

--- a/packages/libvisio.rb
+++ b/packages/libvisio.rb
@@ -1,0 +1,50 @@
+# Adapted from Arch Linux libvisio PKGBUILD at:
+# https://github.com/archlinux/svntogit-packages/raw/packages/libvisio/trunk/PKGBUILD
+
+require 'package'
+
+class Libvisio < Package
+  description 'Library providing ability to interpret and import visio diagrams'
+  homepage 'https://wiki.documentfoundation.org/DLP/Libraries/libvisio'
+  version '0.1.7'
+  license 'LGPL'
+  compatibility 'all'
+  source_url 'https://dev-www.libreoffice.org/src/libvisio/libvisio-0.1.7.tar.xz'
+  source_sha256 '8faf8df870cb27b09a787a1959d6c646faa44d0d8ab151883df408b7166bea4c'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libvisio/0.1.7_armv7l/libvisio-0.1.7-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libvisio/0.1.7_armv7l/libvisio-0.1.7-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libvisio/0.1.7_i686/libvisio-0.1.7-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libvisio/0.1.7_x86_64/libvisio-0.1.7-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: 'a4e6112399cff50add9d00883d8c6b2a49ded05b48c310a96c249717b33ceca9',
+     armv7l: 'a4e6112399cff50add9d00883d8c6b2a49ded05b48c310a96c249717b33ceca9',
+       i686: 'bcc39f2b1b311d1064f39c0faf0d0025d6733afc99aeb02efe16c3302430959f',
+     x86_64: '9c2392e62054330b7768401880a52635875714ba84dcd7add9af5fe8e14c5505'
+  })
+
+  depends_on 'boost' => :build
+  depends_on 'cppunit' => :build
+  depends_on 'doxygen' => :build
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  depends_on 'gperf' => :build
+  depends_on 'icu4c' # R
+  depends_on 'lcms' # R
+  depends_on 'librevenge' # R
+  depends_on 'libwpd' => :build
+  depends_on 'libwpg' => :build
+  depends_on 'libxml2' # R
+  depends_on 'zlibpkg' # R
+
+  def self.build
+    system "./configure #{CREW_OPTIONS}"
+    system 'make'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end

--- a/packages/libwpd.rb
+++ b/packages/libwpd.rb
@@ -1,0 +1,48 @@
+# Adapted from Arch Linux libwpd PKGBUILD at:
+# https://github.com/archlinux/svntogit-packages/raw/packages/libwpd/trunk/PKGBUILD
+
+require 'package'
+
+class Libwpd < Package
+  description 'Library for importing WordPerfect tm documents'
+  homepage 'https://libwpd.sourceforge.net/'
+  version '0.10.3'
+  license 'LGPL'
+  compatibility 'all'
+  source_url 'https://downloads.sourceforge.net/sourceforge/libwpd/libwpd-0.10.3.tar.xz'
+  source_sha256 '2465b0b662fdc5d4e3bebcdc9a79027713fb629ca2bff04a3c9251fdec42dd09'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libwpd/0.10.3_armv7l/libwpd-0.10.3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libwpd/0.10.3_armv7l/libwpd-0.10.3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libwpd/0.10.3_i686/libwpd-0.10.3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libwpd/0.10.3_x86_64/libwpd-0.10.3-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '7a4d5834941571f13ad15e7564b2ec780514f086e96620924516cde800fe422c',
+     armv7l: '7a4d5834941571f13ad15e7564b2ec780514f086e96620924516cde800fe422c',
+       i686: '1d0aacfcb3db543c644fef06b3d04c4431686826b1578f619c0f1d4059a7c7a1',
+     x86_64: '94f5db8b8e15651c00a01020db0412d6a837c203952f083dbb21ce4138cb698a'
+  })
+
+  depends_on 'libgsf' => :build
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  depends_on 'librevenge' # R
+  depends_on 'zlibpkg' # R
+
+  def self.patch
+    downloader 'https://raw.githubusercontent.com/archlinux/svntogit-packages/packages/libwpd/trunk/libwpd-gcc11.patch',
+'7612c36e5e16df2b786fc4c905f096a6e7d600aade292e91950607bfbfba6c32'
+    system 'patch -Np1 -i libwpd-gcc11.patch'
+  end
+
+  def self.build
+    system "./configure #{CREW_OPTIONS} --disable-static"
+    system 'make'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end

--- a/packages/libwpd.rb
+++ b/packages/libwpd.rb
@@ -33,7 +33,7 @@ class Libwpd < Package
 
   def self.patch
     downloader 'https://raw.githubusercontent.com/archlinux/svntogit-packages/packages/libwpd/trunk/libwpd-gcc11.patch',
-'7612c36e5e16df2b786fc4c905f096a6e7d600aade292e91950607bfbfba6c32'
+               '7612c36e5e16df2b786fc4c905f096a6e7d600aade292e91950607bfbfba6c32'
     system 'patch -Np1 -i libwpd-gcc11.patch'
   end
 

--- a/packages/libwpg.rb
+++ b/packages/libwpg.rb
@@ -25,12 +25,12 @@ class Libwpg < Package
      x86_64: '9b7f4b5b3e31bd451a7c80d895490c784517f29d2b5f3126e7abf332e4ab4a21'
   })
 
-  depends_on 'libwpd'
-  depends_on 'perl'
-  depends_on 'librevenge'
   depends_on 'doxygen' => :build
   depends_on 'gcc' # R
   depends_on 'glibc' # R
+  depends_on 'librevenge' # R
+  depends_on 'libwpd' # R
+  depends_on 'perl' => :build
   depends_on 'zlibpkg' # R
 
   def self.build

--- a/packages/libwpg.rb
+++ b/packages/libwpg.rb
@@ -1,0 +1,44 @@
+# Adapted from Arch Linux libwpg PKGBUILD at:
+# https://github.com/archlinux/svntogit-packages/raw/packages/libwpg/trunk/PKGBUILD
+
+require 'package'
+
+class Libwpg < Package
+  description 'Library for importing and converting Corel WordPerfecttm Graphics images.'
+  homepage 'https://libwpg.sourceforge.net/'
+  version '0.3.3'
+  license 'LGPL'
+  compatibility 'all'
+  source_url 'https://downloads.sourceforge.net/libwpg/libwpg-0.3.3.tar.xz'
+  source_sha256 '99b3f7f8832385748582ab8130fbb9e5607bd5179bebf9751ac1d51a53099d1c'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libwpg/0.3.3_armv7l/libwpg-0.3.3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libwpg/0.3.3_armv7l/libwpg-0.3.3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libwpg/0.3.3_i686/libwpg-0.3.3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libwpg/0.3.3_x86_64/libwpg-0.3.3-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '645138bbef5bc5d36a2f5f91c59f9163078ef9044d127a27fe257449eec45f5e',
+     armv7l: '645138bbef5bc5d36a2f5f91c59f9163078ef9044d127a27fe257449eec45f5e',
+       i686: 'b187f519dc386f57aad39c01947be79e64c6ff8b3d7d4aaea7956b7f4ec125a0',
+     x86_64: '9b7f4b5b3e31bd451a7c80d895490c784517f29d2b5f3126e7abf332e4ab4a21'
+  })
+
+  depends_on 'libwpd'
+  depends_on 'perl'
+  depends_on 'librevenge'
+  depends_on 'doxygen' => :build
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  depends_on 'zlibpkg' # R
+
+  def self.build
+    system "./configure #{CREW_OPTIONS}"
+    system 'make'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+end

--- a/packages/potrace.rb
+++ b/packages/potrace.rb
@@ -3,27 +3,30 @@ require 'package'
 class Potrace < Package
   description 'Potrace(TM) is a tool for tracing a bitmap, which means, transforming a bitmap into a smooth, scalable image.'
   homepage 'http://potrace.sourceforge.net/'
-  version '1.15'
+  version '1.16'
   license 'GPL-2'
   compatibility 'all'
-  source_url 'http://potrace.sourceforge.net/download/1.15/potrace-1.15.tar.gz'
-  source_sha256 'a9b33904ace328340c850a01458199e0064e03ccaaa731bc869a842b1b8d529d'
+  source_url 'https://potrace.sourceforge.net/download/1.16/potrace-1.16.tar.gz'
+  source_sha256 'be8248a17dedd6ccbaab2fcc45835bb0502d062e40fbded3bc56028ce5eb7acc'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/potrace/1.15_armv7l/potrace-1.15-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/potrace/1.15_armv7l/potrace-1.15-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/potrace/1.15_i686/potrace-1.15-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/potrace/1.15_x86_64/potrace-1.15-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/potrace/1.16_armv7l/potrace-1.16-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/potrace/1.16_armv7l/potrace-1.16-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/potrace/1.16_i686/potrace-1.16-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/potrace/1.16_x86_64/potrace-1.16-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '8429fae5e3917cb36772db6e14a5245cbf2c1fab7c4798319aace9f037285aed',
-     armv7l: '8429fae5e3917cb36772db6e14a5245cbf2c1fab7c4798319aace9f037285aed',
-       i686: '24bdf26db8e31189bd7440707bc5372952e6e3d37e3a1cac7220e7c75bde5eaa',
-     x86_64: '3afcffc9b2d9db5e880ce55119de7e67295d599ef8fc7837a446f18c67f5ca31'
+    aarch64: '9b3c98c199a622153c6fc35ee284edab1dc872b6ab950983f26adee74f73dcb8',
+     armv7l: '9b3c98c199a622153c6fc35ee284edab1dc872b6ab950983f26adee74f73dcb8',
+       i686: 'd4b063df7f8db9488137a0e2c395bb10f249134c99e20fed86b094973825f0a4',
+     x86_64: 'f740ee5ec834c0c43c58f4eee3015c286440368fd52e96c0cb6cafb8aeb5a77a'
   })
 
+  depends_on 'glibc' # R
+  depends_on 'zlibpkg' # R
+
   def self.build
-    system './configure'
+    system "./configure #{CREW_OPTIONS} --with-libpotrace"
     system 'make'
   end
 

--- a/packages/source_highlight.rb
+++ b/packages/source_highlight.rb
@@ -6,34 +6,36 @@ require 'package'
 class Source_highlight < Package
   description 'Convert source code to syntax highlighted document'
   homepage 'https://www.gnu.org/software/src-highlite/'
-  version '3.1.9-9049-1'
+  version '3.1.9-e4cf32d'
   license 'GPL'
   compatibility 'all'
-  source_url 'https://git.savannah.gnu.org/git/src-highlite.git'
-  git_hashtag '904949c9026cb772dc93fbe0947a252ef47127f4'
+  source_url 'http://git.savannah.gnu.org/cgit/src-highlite.git/snapshot/src-highlite-e4cf32db1ce3f0a7edb32caf131b2f45753cdf58.tar.gz'
+  source_sha256 '98bcd3f8dceed4e4cf24dd9694163dce2b5bfc805e0ba7eb0b7b8d5a01f9154f'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/source_highlight/3.1.9-9049-1_armv7l/source_highlight-3.1.9-9049-1-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/source_highlight/3.1.9-9049-1_armv7l/source_highlight-3.1.9-9049-1-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/source_highlight/3.1.9-9049-1_i686/source_highlight-3.1.9-9049-1-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/source_highlight/3.1.9-9049-1_x86_64/source_highlight-3.1.9-9049-1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/source_highlight/3.1.9-e4cf32d_armv7l/source_highlight-3.1.9-e4cf32d-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/source_highlight/3.1.9-e4cf32d_armv7l/source_highlight-3.1.9-e4cf32d-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/source_highlight/3.1.9-e4cf32d_i686/source_highlight-3.1.9-e4cf32d-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/source_highlight/3.1.9-e4cf32d_x86_64/source_highlight-3.1.9-e4cf32d-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '5c5660558f3a902622714f0c5562aa49b4e2c4ebcf54867b25205656c23d3251',
-     armv7l: '5c5660558f3a902622714f0c5562aa49b4e2c4ebcf54867b25205656c23d3251',
-       i686: '1032b43c246c0e8d95392437112d49f48ce2d5d52f0be5d42944459b0067506b',
-     x86_64: '89797072609793b821f66c9069e96bdb8c02db74545968728a681de6c59d16ed'
+    aarch64: '0e051a4e57afc918238ca62c194270bc5d6ba74461ea45965f2f2e561fbc3413',
+     armv7l: '0e051a4e57afc918238ca62c194270bc5d6ba74461ea45965f2f2e561fbc3413',
+       i686: '81cd2ef95f8a19d3d2e5c6ccf1ddc619bf7d9eedb4f37877988817927c1894d8',
+     x86_64: '0b627edbed9d0c8d1dce51f30f2e4963d5610740941a18fdb977fe40a6573dc1'
   })
 
   depends_on 'boost' # R
   depends_on 'ctags' => :build
   depends_on 'texinfo' => :build
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
 
   def self.build
-    system 'NOCONFIGURE=1 autoreconf -fiv'
+    system 'autoupdate'
+    system 'NOCONFIGURE=1 autoreconf -iv'
     system 'filefix'
-    system "env #{CREW_ENV_OPTIONS} \
-      ./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_OPTIONS} \
       --sysconfdir=#{CREW_PREFIX}/etc \
       --with-bash-completion=#{CREW_PREFIX}/share/bash-completion/completions"
     system 'make'

--- a/packages/swig.rb
+++ b/packages/swig.rb
@@ -3,28 +3,31 @@ require 'package'
 class Swig < Package
   description 'Simplified Wrapper and Interface Generator'
   homepage 'http://www.swig.org'
-  version '4.0.2'
+  version '4.1.1'
   license 'GPL-3, BSD and BSD-2'
   compatibility 'all'
-  source_url 'https://downloads.sourceforge.net/project/swig/swig/swig-4.0.2/swig-4.0.2.tar.gz'
-  source_sha256 'd53be9730d8d58a16bf0cbd1f8ac0c0c3e1090573168bfa151b01eb47fa906fc'
+  source_url 'https://downloads.sourceforge.net/project/swig/swig/swig-4.1.1/swig-4.1.1.tar.gz'
+  source_sha256 '2af08aced8fcd65cdb5cc62426768914bedc735b1c250325203716f78e39ac9b'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/swig/4.0.2_armv7l/swig-4.0.2-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/swig/4.0.2_armv7l/swig-4.0.2-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/swig/4.0.2_i686/swig-4.0.2-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/swig/4.0.2_x86_64/swig-4.0.2-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/swig/4.1.1_armv7l/swig-4.1.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/swig/4.1.1_armv7l/swig-4.1.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/swig/4.1.1_i686/swig-4.1.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/swig/4.1.1_x86_64/swig-4.1.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '12f62e4758ab51ee5284a6124a633f416e16eeb35052ba7a34d208e6c75c37a0',
-     armv7l: '12f62e4758ab51ee5284a6124a633f416e16eeb35052ba7a34d208e6c75c37a0',
-       i686: '3a2745de14603c0c998e3c9219a6ac76e0129068d8a7dae6b53a17f644f8f4b4',
-     x86_64: 'b2c9aff000d7e96df6c4a3ae98c0ca80ccdec8f03b2cec253f1991df189d47a8'
+    aarch64: 'b5837e879e54df39836c0ba11705c4bf9e6d0cba1a9517766a0ce65ce3b189a1',
+     armv7l: 'b5837e879e54df39836c0ba11705c4bf9e6d0cba1a9517766a0ce65ce3b189a1',
+       i686: '6cf56f60437498ef3b08ef4939680d9592a005cc75b868972af9affd8f13d842',
+     x86_64: '382bbf4c71d2508667b628a94f386db95cdbc0a36458dd9c83de6a28f8628975'
   })
 
-  depends_on 'boost'
-  depends_on 'pcre'
-  depends_on 'zlibpkg'
+  depends_on 'boost' => :build
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  depends_on 'pcre' => :build
+  depends_on 'pcre2' # R
+  depends_on 'zlibpkg' # R
 
   def self.build
     system "./configure #{CREW_OPTIONS}"

--- a/packages/taglib.rb
+++ b/packages/taglib.rb
@@ -3,42 +3,35 @@ require 'package'
 class Taglib < Package
   description 'TagLib is a library for reading and editing the meta-data of several popular audio formats.'
   homepage 'https://taglib.org'
-  version '1.11.1'
+  version '1.13'
   license 'LGPL-2.1 and MPL-1.1'
   compatibility 'all'
-  source_url 'https://taglib.org/releases/taglib-1.11.1.tar.gz'
-  source_sha256 'b6d1a5a610aae6ff39d93de5efd0fdc787aa9e9dc1e7026fa4c961b26563526b'
+  source_url 'https://taglib.org/releases/taglib-1.13.tar.gz'
+  source_sha256 '58f08b4db3dc31ed152c04896ee9172d22052bc7ef12888028c01d8b1d60ade0'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/taglib/1.11.1_armv7l/taglib-1.11.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/taglib/1.11.1_armv7l/taglib-1.11.1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/taglib/1.11.1_i686/taglib-1.11.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/taglib/1.11.1_x86_64/taglib-1.11.1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/taglib/1.13_armv7l/taglib-1.13-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/taglib/1.13_armv7l/taglib-1.13-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/taglib/1.13_i686/taglib-1.13-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/taglib/1.13_x86_64/taglib-1.13-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '2bb4922da1de20136cdbc0375a716975aed496ccb3e26a08d7585c80f5364de7',
-     armv7l: '2bb4922da1de20136cdbc0375a716975aed496ccb3e26a08d7585c80f5364de7',
-       i686: 'b7e4b512b4772cdee6f94d61281a36b225af1d0a801867578808ae51f045479b',
-     x86_64: '685aa57d3822a4b92310a839cb76dee74b507991a5053dd976108f718c108698'
+    aarch64: '551c4a220b3986ecaaedf9465aa24b210726ed716574af83d903c46764fa756b',
+     armv7l: '551c4a220b3986ecaaedf9465aa24b210726ed716574af83d903c46764fa756b',
+       i686: 'e7b54f8f92fb9cd7eb797a4eb7717157a9734894f0e85aef808fcbf73ee4a38a',
+     x86_64: 'b91534c1c2edac5560ac303cb4cf8c0c12257dad4c7a44a8e54fbbfd33bffcae'
   })
 
-  depends_on 'boost'
+  depends_on 'boost' => :build
+  depends_on 'cppunit' => :build
 
   def self.build
-    suffix = ''
-    suffix = '64' if ARCH == 'x86_64'
-    system 'cmake',
-           "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
-           "-DEXEC_INSTALL_PREFIX=#{CREW_PREFIX}",
-           "-DLIB_INSTALL_DIR=#{CREW_LIB_PREFIX}",
-           '-DCMAKE_BUILD_TYPE=Release',
-           '-DBUILD_SHARED_LIBS=ON',
-           "-DLIB_SUFFIX=#{suffix}",
-           '.'
-    system 'make'
+    system "cmake -B builddir #{CREW_CMAKE_OPTIONS} \
+            -G Ninja"
+    system 'samu -C builddir'
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
   end
 end

--- a/packages/tcpflow.rb
+++ b/packages/tcpflow.rb
@@ -3,35 +3,48 @@ require 'package'
 class Tcpflow < Package
   description 'TCP/IP packet demultiplexer'
   homepage 'https://github.com/simsong/tcpflow'
-  version '1.5.0'
+  version '1.6.1'
   license 'GPL-3'
-  compatibility 'aarch64,armv7l,x86_64'
-  source_url 'https://github.com/simsong/tcpflow/releases/download/tcpflow-1.5.0/tcpflow-1.5.0.tar.gz'
-  source_sha256 '20abe3353a49a13dcde17ad318d839df6312aa6e958203ea710b37bede33d988'
-
-  depends_on 'boost'
-  depends_on 'cairo'
-  depends_on 'libpcap'
+  compatibility 'all'
+  source_url 'https://github.com/simsong/tcpflow.git'
+  git_hashtag "tcpflow-#{version}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tcpflow/1.5.0_armv7l/tcpflow-1.5.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tcpflow/1.5.0_armv7l/tcpflow-1.5.0-chromeos-armv7l.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tcpflow/1.5.0_x86_64/tcpflow-1.5.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tcpflow/1.6.1_armv7l/tcpflow-1.6.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tcpflow/1.6.1_armv7l/tcpflow-1.6.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tcpflow/1.6.1_i686/tcpflow-1.6.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tcpflow/1.6.1_x86_64/tcpflow-1.6.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '080ce34873a9d15239a61117c58124946187278d39f0c432928e5dd70a919d59',
-     armv7l: '080ce34873a9d15239a61117c58124946187278d39f0c432928e5dd70a919d59',
-     x86_64: 'c30c853d77b7111d2f03af13b605e430d24f16fa4ea4349288ebe63488fd4fc6'
+    aarch64: '46718d8c909cae4a175ec7fc95e04e560407d615c66134ff1f903427712a03c9',
+     armv7l: '46718d8c909cae4a175ec7fc95e04e560407d615c66134ff1f903427712a03c9',
+       i686: '747f148abc6a655671ab6e24503572e03c5ed0d53e702cb2b2abbeb4b7170aa2',
+     x86_64: '4ad32e11746afa35888f1878c503694349b7ff9979b485922b26037f88f3bd65'
   })
 
+  depends_on 'boost' => :build
+  depends_on 'bz2' # R
+  depends_on 'cairo' => :build
+  depends_on 'expat' # R
+  depends_on 'freetype' # R
+  depends_on 'gcc' # R
+  depends_on 'glibc' # R
+  depends_on 'harfbuzz' # R
+  depends_on 'libcap_ng' # R
+  depends_on 'libmd' # R
+  depends_on 'libpcap' # R
+  depends_on 'openssl' # R
+  depends_on 'pixman' # R
+  depends_on 'sqlite' # R
+  depends_on 'zlibpkg' # R
+
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}"
+    system 'bash bootstrap.sh'
+    system "./configure #{CREW_OPTIONS}"
     system 'make'
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system "DESTDIR=#{CREW_DEST_DIR} make install"
   end
 end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -3636,6 +3636,11 @@ url: https://github.com/rocky/libcdio-paranoia/releases
 activity: none
 ---
 kind: url
+name: libcdr
+url: https://dev-www.libreoffice.org/src/libcdr/
+activity: low
+---
+kind: url
 name: libcec
 url: https://github.com/Pulse-Eight/libcec/releases
 activity: low
@@ -4441,6 +4446,11 @@ url: https://github.com/librespot-org/librespot/releases
 activity: high
 ---
 kind: url
+name: librevenge
+url: https://sourceforge.net/projects/libwpd/files/librevenge
+activity: low
+---
+kind: url
 name: librhash
 url: https://github.com/rhash/RHash/releases
 activity: low
@@ -4736,6 +4746,11 @@ url: https://github.com/libvips/libvips/releases
 activity: medium
 ---
 kind: url
+name: libvisio
+url: https://dev-www.libreoffice.org/src/libvisio
+activity: low
+---
+kind: url
 name: libvisual
 url: https://github.com/Libvisual/libvisual/releases
 activity: none
@@ -4796,9 +4811,19 @@ url: https://ftp.gnome.org/pub/GNOME/sources/libwnck/
 activity: low
 ---
 kind: url
+name: libwpd
+url: https://sourceforge.net/projects/libwpd/files/
+activity: low
+---
+kind: url
 name: libwpe
 url: https://github.com/WebPlatformForEmbedded/libwpe/releases/
 activity: medium
+---
+kind: url
+name: libwpg
+url: https://sourceforge.net/projects/libwpg/files/
+activity: low
 ---
 kind: url
 name: libx11


### PR DESCRIPTION
**Packages with boost dependencies updated:**
- [x] eigen
- [x] exempi
- [x] gdb
- [x] grive
- [x] inkscape
- [x] ledger
- [x] potrace
- [x] source_highlight
- [x] swig
- [x] taglib
- [x] tcpflow
- Also adds i686 binaries for `gtksourceview_3`.

Builds properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

![image](https://user-images.githubusercontent.com/1096701/219503424-cfda957f-8fe8-45e0-872a-bdd5d4e12cd9.png)

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=boost_1810  CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
