### PR TITLE
terraform => 1.3.9

### DIFF
--- a/packages/terraform.rb
+++ b/packages/terraform.rb
@@ -3,20 +3,20 @@ require 'package'
 class Terraform < Package
   description 'Terraform is a tool for building, changing, and combining infrastructure safely and efficiently.'
   homepage 'https://www.terraform.io/'
-  version '1.3.8'
+  version '1.3.9'
   license 'Apache-2.0, BSD-2, BSD-4, ECL-2.0, imagemagick, ISC, JSON, MIT, MIT-with-advertising, MPL-2.0 and unicode'
   compatibility 'all'
   source_url({
-    aarch64: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_arm.zip",
+    aarch64: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_arm64.zip",
      armv7l: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_arm.zip",
        i686: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_386.zip",
      x86_64: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_amd64.zip"
   })
   source_sha256({
-    aarch64: 'a42bf3c7d6327f45d2b212b692ab4229285fb44dbb8adb7c39e18be2b26167c8',
-     armv7l: 'a42bf3c7d6327f45d2b212b692ab4229285fb44dbb8adb7c39e18be2b26167c8',
-       i686: '7497a13307b9f3e1e8d163f8cd3f6b31800bd71af54ca03d795ac20d9caafbf0',
-     x86_64: '9d9e7d6a9b41cef8b837af688441d4fbbd84b503d24061d078ad662441c70240'
+    aarch64: 'da571087268c5faf884912c4239c6b9c8e1ed8e8401ab1dcb45712df70f42f1b',
+     armv7l: '58203da8e5468ab5c22d26d242bf64e305c038d99717199f6783a3686130b60e',
+       i686: 'd321b0ef810a3f972b031176e329006644c8915b83ecfcf506099952c5fbaccc',
+     x86_64: '53048fa573effdd8f2a59b726234c6f450491fe0ded6931e9f4c6e3df6eece56'
   })
 
   def self.install

--- a/packages/terraform.rb
+++ b/packages/terraform.rb
@@ -7,13 +7,13 @@ class Terraform < Package
   license 'Apache-2.0, BSD-2, BSD-4, ECL-2.0, imagemagick, ISC, JSON, MIT, MIT-with-advertising, MPL-2.0 and unicode'
   compatibility 'all'
   source_url({
-    aarch64: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_arm64.zip",
+    aarch64: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_arm.zip",
      armv7l: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_arm.zip",
        i686: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_386.zip",
      x86_64: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_amd64.zip"
   })
   source_sha256({
-    aarch64: 'da571087268c5faf884912c4239c6b9c8e1ed8e8401ab1dcb45712df70f42f1b',
+    aarch64: '58203da8e5468ab5c22d26d242bf64e305c038d99717199f6783a3686130b60e',
      armv7l: '58203da8e5468ab5c22d26d242bf64e305c038d99717199f6783a3686130b60e',
        i686: 'd321b0ef810a3f972b031176e329006644c8915b83ecfcf506099952c5fbaccc',
      x86_64: '53048fa573effdd8f2a59b726234c6f450491fe0ded6931e9f4c6e3df6eece56'


### PR DESCRIPTION
Updating the Terraform CLI to 1.3.9, and also adding some differentiation between aarch64 and armv7l since the vendor provides a suitable binary for all of Chromebrew's supported platforms.

## Additional information

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/JasonPratt/chromebrew.git CREW_TESTING_BRANCH=patch-1 CREW_TESTING=1 crew update
```