### PR TITLE
sommelier: Re-add `xdg_shell_v6` patch for <= R84, cleanup

### DIFF
--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -15,9 +15,9 @@ class Sommelier < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20230217-1_x86_64/sommelier-20230217-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '2d5dda093b6d06cdc2811e83293a62bdcf91953fdbe698070f668bfc672f292b',
-     armv7l: '2d5dda093b6d06cdc2811e83293a62bdcf91953fdbe698070f668bfc672f292b',
-     x86_64: 'd4164dab7286bf09f38545ff4178a0d04239762f78b8cac0be5d940fcd01fba7'
+    aarch64: 'cfad8fcc1334545af6184dc05ab4f65446a0439b7d7f69f26b1489494e51cb77',
+     armv7l: 'cfad8fcc1334545af6184dc05ab4f65446a0439b7d7f69f26b1489494e51cb77',
+     x86_64: '5a900c0056f78519c7c96b9e758d51385fcecdd2cbf0416dd79b872c0e8228ad'
   })
 
   depends_on 'gcc' # R
@@ -450,16 +450,17 @@ class Sommelier < Package
 
   def self.postinstall
     # all tasks are done by sommelier.env now
-    FileUtils.cp "#{HOME}/.bashrc", "#{HOME}/.bashrc.bak"
+    @now = Time.now.strftime('%Y%m%d%H%M')
+    FileUtils.cp "#{HOME}/.bashrc", "#{HOME}/.bashrc.#{@now}"
     system "sed -i '/[sS]ommelier/d' #{HOME}/.bashrc"
 
-    if FileUtils.identical?("#{HOME}/.bashrc", "#{HOME}/.bashrc.bak")
-      FileUtils.rm "#{HOME}/.bashrc.bak"
+    if FileUtils.identical?("#{HOME}/.bashrc", "#{HOME}/.bashrc.#{@now}")
+      FileUtils.rm "#{HOME}/.bashrc.#{@now}"
     else
       puts <<~EOT0.lightblue
 
         Removed old sommelier environment variables in ~/.bashrc.
-        A backup of the original is stored in ~/.bashrc.bak.
+        A backup of the original is stored in ~/.bashrc.#{@now}
         To complete the installation, execute the following:
         source ~/.bashrc
       EOT0

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -15,9 +15,9 @@ class Sommelier < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20230217-1_x86_64/sommelier-20230217-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '04f8f3acdadc9061b6759b75af949c4994c6f45e52093f88a9e4684c57244954',
-     armv7l: '04f8f3acdadc9061b6759b75af949c4994c6f45e52093f88a9e4684c57244954',
-     x86_64: '7e284e4cd610a2a275e78242ec3ad6cebebac58873305a98cb1e2ec4b47074e0'
+    aarch64: 'a7f6c1447c93bf6eaa74b395d93a3c79ca3e7e14ac72864b6247be141aa9be85',
+     armv7l: 'a7f6c1447c93bf6eaa74b395d93a3c79ca3e7e14ac72864b6247be141aa9be85',
+     x86_64: '2c128067ce998c69f693c3d5baf1706e603a1a342ae310f5d1e950b9d2f71d65'
   })
 
   depends_on 'gcc' # R
@@ -32,10 +32,10 @@ class Sommelier < Package
   depends_on 'mesa' # R
   depends_on 'pixman' # R
   depends_on 'procps' # for pgrep in wrapper script
-  depends_on 'psmisc'
+  depends_on 'psmisc' # L
   depends_on 'wayland' # R
   depends_on 'wayland_info' # L
-  depends_on 'xauth'
+  depends_on 'xauth' # L
   depends_on 'xhost' # for xhost in sommelierd script
   depends_on 'xkbcomp' # The sommelier log complains if this isn't installed.
   depends_on 'xorg_xset' # for xset in wrapper script
@@ -393,7 +393,7 @@ class Sommelier < Package
         File.write 'stopsommelier', <<~STOPSOMMELIEREOF
           #!/bin/bash
           # Quickest way is to use killall on Xwayland
-          pgrep Xwayland 2>> #{CREW_PREFIX}/var/log/sommelier.log && killall Xwayland
+          pgrep Xwayland &>> #{CREW_PREFIX}/var/log/sommelier.log && killall Xwayland
           SOMM="$(pgrep -fc sommelier.elf 2> /dev/null)"
           if [[ "${SOMM}" -gt "0" ]]; then
             pkill -f sommelier.elf &>/dev/null
@@ -421,7 +421,7 @@ class Sommelier < Package
         # start sommelier from bash.d, which loads after all of env.d via #{CREW_PREFIX}/etc/profile
         File.write 'bash.d_sommelier', <<~BASHDSOMMELIEREOF
           source #{CREW_PREFIX}/bin/startsommelier
-          pgrep Xwayland 2>> #{CREW_PREFIX}/var/log/sommelier.log && source #{CREW_PREFIX}/etc/sommelierrc
+          pgrep Xwayland &>> #{CREW_PREFIX}/var/log/sommelier.log && source #{CREW_PREFIX}/etc/sommelierrc
         BASHDSOMMELIEREOF
       end
     end

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -1,3 +1,4 @@
+require 'popen'
 require 'package'
 
 class Sommelier < Package
@@ -90,8 +91,10 @@ class Sommelier < Package
          APPLICATION_ID_FORMAT_PREFIX ".wayland.%s"
     EOF
 
-    File.write('patch', patch)
-    system 'patch -p1 < patch'
+    Dir.chdir 'vm_tools/sommelier' do
+      File.write('patch', patch)
+      system 'patch -p1 < patch'
+    end
   end
 
   def self.build

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -15,9 +15,9 @@ class Sommelier < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20230217-1_x86_64/sommelier-20230217-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'cfad8fcc1334545af6184dc05ab4f65446a0439b7d7f69f26b1489494e51cb77',
-     armv7l: 'cfad8fcc1334545af6184dc05ab4f65446a0439b7d7f69f26b1489494e51cb77',
-     x86_64: '5a900c0056f78519c7c96b9e758d51385fcecdd2cbf0416dd79b872c0e8228ad'
+    aarch64: 'bd3b72361e569654ba9d79b1d6f2c779e97ab4a1d51d4244ecc620e3813967a8',
+     armv7l: 'bd3b72361e569654ba9d79b1d6f2c779e97ab4a1d51d4244ecc620e3813967a8',
+     x86_64: 'f952d03857683b2a89537fca6469798a41a2deb24bd50e46fb903ed5c875daa2'
   })
 
   depends_on 'gcc' # R
@@ -365,8 +365,7 @@ class Sommelier < Package
             set +a
             echo -e "\e[1;33m""Sommelier SCALE is set to \e[1;32m"${SCALE}"\e[1;33m"."\e[0m"
             echo -e "\e[1;33m""SCALE may be manually set in ~/.sommelier.env .""\e[0m"
-            #{CREW_PREFIX}/sbin/sommelierd &>/dev/null &
-            # source #{CREW_PREFIX}/sbin/sommelierd
+            #{CREW_PREFIX}/sbin/sommelierd &>> #{CREW_PREFIX}/var/log/sommelier.log &
           fi
           wait=3
           until checksommelierwayland && checksommelierxwayland; do
@@ -394,7 +393,7 @@ class Sommelier < Package
         File.write 'stopsommelier', <<~STOPSOMMELIEREOF
           #!/bin/bash
           # Quickest way is to use killall on Xwayland
-          pgrep Xwayland &>/dev/null && killall Xwayland
+          pgrep Xwayland 2>> #{CREW_PREFIX}/var/log/sommelier.log && killall Xwayland
           SOMM="$(pgrep -fc sommelier.elf 2> /dev/null)"
           if [[ "${SOMM}" -gt "0" ]]; then
             pkill -f sommelier.elf &>/dev/null
@@ -422,7 +421,7 @@ class Sommelier < Package
         # start sommelier from bash.d, which loads after all of env.d via #{CREW_PREFIX}/etc/profile
         File.write 'bash.d_sommelier', <<~BASHDSOMMELIEREOF
           source #{CREW_PREFIX}/bin/startsommelier
-          pgrep Xwayland &>/dev/null && source #{CREW_PREFIX}/etc/sommelierrc
+          pgrep Xwayland 2>> #{CREW_PREFIX}/var/log/sommelier.log && source #{CREW_PREFIX}/etc/sommelierrc
         BASHDSOMMELIEREOF
       end
     end

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -15,9 +15,9 @@ class Sommelier < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20230217-1_x86_64/sommelier-20230217-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'c11272f483b99d62e4d05392303be25c65d36be6a1d301823fee918eacf7d681',
-     armv7l: 'c11272f483b99d62e4d05392303be25c65d36be6a1d301823fee918eacf7d681',
-     x86_64: 'b60d7d0ccc260edf646bb930f6a8d81dfdbaf05ba435bcef5bc781417b4d17c6'
+    aarch64: '6beeb6b20ce771cbf999b4e73fff26875fef475daedac6765c6db69c2745d075',
+     armv7l: '6beeb6b20ce771cbf999b4e73fff26875fef475daedac6765c6db69c2745d075',
+     x86_64: 'c8effd129481e73940ed03f7d350d040ac61e5e22dce9fd142df8c6a105bd002'
   })
 
   depends_on 'gcc' # R
@@ -255,7 +255,7 @@ class Sommelier < Package
             xdg_shell_v6=''
 
             # check if exo support xdg_wm_base
-            if [[ -z "$(wayland-info -i xdg_wm_base)" ]]; then
+            if [[ -z "$(WAYLAND_DISPLAY=wayland-0 wayland-info -i xdg_wm_base)" ]]; then
               xdg_shell_v6='--xdg-shell-v6'
             fi
 
@@ -332,8 +332,8 @@ class Sommelier < Package
           function roundhalves {
                   echo "$1 * 2" | bc | xargs -I@ printf "%1.f" @ | xargs -I% echo "% * .5" | bc
           }
-          pxwidth=$(wayland-info -i wl_output | grep width: | grep px | head -n 1 | awk '{print $2}')
-          lwidth=$(wayland-info -i zxdg_output_manager_v1 | grep logical_width:  | sed 's/,//' | awk '{print $2}')
+          pxwidth=$(WAYLAND_DISPLAY=wayland-0 wayland-info -i wl_output | grep width: | grep px | head -n 1 | awk '{print $2}')
+          lwidth=$(WAYLAND_DISPLAY=wayland-0 wayland-info -i zxdg_output_manager_v1 | grep logical_width:  | sed 's/,//' | awk '{print $2}')
           # echo "pxwidth: $pxwidth, lwidth: $lwidth"
           # SCALE needs to be rounded to the nearest 0.5
           SCALE=$(roundhalves $(echo "scale=2 ;$lwidth / $pxwidth" | bc))

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -15,9 +15,9 @@ class Sommelier < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20230217-1_x86_64/sommelier-20230217-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '0e60851e94db618826f02254fae426d451bb04997d78916c7d0dfeed97bae540',
-     armv7l: '0e60851e94db618826f02254fae426d451bb04997d78916c7d0dfeed97bae540',
-     x86_64: '9fd40cb244aaab9f25496fba779334ca377ac375e658d0b3899920ee3a16cd02'
+    aarch64: 'df91be068c3ba691d57f740b8fa99158446940488204a4582dada0015d6b0e76',
+     armv7l: 'df91be068c3ba691d57f740b8fa99158446940488204a4582dada0015d6b0e76',
+     x86_64: '52838d797529f72d300124f6cf1080d695add9c897ef6142ef04167a850a1a4c'
   })
 
   depends_on 'gcc' # R
@@ -136,8 +136,6 @@ class Sommelier < Package
       Dir.chdir('builddir') do
         system 'curl -L "https://chromium.googlesource.com/chromiumos/containers/sommelier/+/fbdefff6230026ac333eac0924d71cf824e6ecd8/sommelierrc?format=TEXT" | base64 --decode > sommelierrc'
         system "sed -i '/exit 0/d' sommelierrc"
-        system "echo '# Return or exit depending upon whether script was sourced.' >> sommelierrc"
-        system "echo '(return 0 2>/dev/null) && return 0 || exit 0' >> sommelierrc"
 
         File.write 'sommelierenv', <<~SOMMELIERENVEOF
           set -a
@@ -422,7 +420,7 @@ class Sommelier < Package
         # start sommelier from bash.d, which loads after all of env.d via #{CREW_PREFIX}/etc/profile
         File.write 'bash.d_sommelier', <<~BASHDSOMMELIEREOF
           source #{CREW_PREFIX}/bin/startsommelier
-          pgrep Xwayland &>> #{CREW_PREFIX}/var/log/sommelier.log && source #{CREW_PREFIX}/etc/sommelierrc
+          pgrep Xwayland &>> #{CREW_PREFIX}/var/log/sommelier.log && #{CREW_PREFIX}/etc/sommelierrc &>> #{CREW_PREFIX}/var/log/sommelier.log
         BASHDSOMMELIEREOF
       end
     end
@@ -441,7 +439,7 @@ class Sommelier < Package
         FileUtils.ln_sf 'startsommelier', "#{CREW_DEST_PREFIX}/bin/initsommelier"
         FileUtils.install 'stopsommelier', "#{CREW_DEST_PREFIX}/bin/stopsommelier", mode: 0o755
         FileUtils.install 'restartsommelier', "#{CREW_DEST_PREFIX}/bin/restartsommelier", mode: 0o755
-        FileUtils.install 'sommelierrc', "#{CREW_DEST_PREFIX}/etc/sommelierrc", mode: 0o644
+        FileUtils.install 'sommelierrc', "#{CREW_DEST_PREFIX}/etc/sommelierrc", mode: 0o755
         FileUtils.install 'sommelierenv', "#{CREW_DEST_PREFIX}/etc/env.d/sommelier", mode: 0o644
         FileUtils.install 'bash.d_sommelier', "#{CREW_DEST_PREFIX}/etc/bash.d/sommelier", mode: 0o644
       end

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -1,4 +1,3 @@
-require 'popen'
 require 'package'
 
 class Sommelier < Package

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -15,9 +15,9 @@ class Sommelier < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20230217-1_x86_64/sommelier-20230217-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'bd3b72361e569654ba9d79b1d6f2c779e97ab4a1d51d4244ecc620e3813967a8',
-     armv7l: 'bd3b72361e569654ba9d79b1d6f2c779e97ab4a1d51d4244ecc620e3813967a8',
-     x86_64: 'f952d03857683b2a89537fca6469798a41a2deb24bd50e46fb903ed5c875daa2'
+    aarch64: '04f8f3acdadc9061b6759b75af949c4994c6f45e52093f88a9e4684c57244954',
+     armv7l: '04f8f3acdadc9061b6759b75af949c4994c6f45e52093f88a9e4684c57244954',
+     x86_64: '7e284e4cd610a2a275e78242ec3ad6cebebac58873305a98cb1e2ec4b47074e0'
   })
 
   depends_on 'gcc' # R
@@ -258,7 +258,7 @@ class Sommelier < Package
               xdg_shell_v6='--xdg-shell-v6'
             fi
 
-            xauth_cmd="xauth generate ${DISPLAY} . trusted"
+            xauth_cmd="touch ~/.Xauthority ; xauth generate ${DISPLAY} . trusted"
             # --enable-xshape Appears to be broken as of Feb 17, 2023.
             sommelier_cmd="sommelier -X \
               --x-display=${DISPLAY} \
@@ -361,7 +361,7 @@ class Sommelier < Package
               SCALE=$(roundhalves $(echo "scale=2 ;$lwidth / $pxwidth" | bc))
             fi
             # Allow overriding environment variables before starting sommelier daemon.
-            [ -f "$HOME/.sommelier.env" ] && source ~/.sommelier.env 2>> /usr/local/var/log/sommelier.log
+            [ -f "$HOME/.sommelier.env" ] && source ~/.sommelier.env 2>> #{CREW_PREFIX}/var/log/sommelier.log
             set +a
             echo -e "\e[1;33m""Sommelier SCALE is set to \e[1;32m"${SCALE}"\e[1;33m"."\e[0m"
             echo -e "\e[1;33m""SCALE may be manually set in ~/.sommelier.env .""\e[0m"

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -15,9 +15,9 @@ class Sommelier < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20230217-1_x86_64/sommelier-20230217-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'b5e64142b9c4f74c219dd928f15f7df233e4964f476a42229b7626e78bb1615c',
-     armv7l: 'b5e64142b9c4f74c219dd928f15f7df233e4964f476a42229b7626e78bb1615c',
-     x86_64: 'f28a1b463037ec0093d38edd61e3a9f76e2b75f61b4915f7a796e1eab280d9d1'
+    aarch64: '0e60851e94db618826f02254fae426d451bb04997d78916c7d0dfeed97bae540',
+     armv7l: '0e60851e94db618826f02254fae426d451bb04997d78916c7d0dfeed97bae540',
+     x86_64: '9fd40cb244aaab9f25496fba779334ca377ac375e658d0b3899920ee3a16cd02'
   })
 
   depends_on 'gcc' # R
@@ -258,7 +258,8 @@ class Sommelier < Package
               xdg_shell_v6='--xdg-shell-v6'
             fi
 
-            xauth_cmd="touch ~/.Xauthority ; xauth generate ${DISPLAY} . trusted"
+            touch ~/.Xauthority
+            xauth_cmd="xauth generate ${DISPLAY} . trusted"
             # --enable-xshape Appears to be broken as of Feb 17, 2023.
             sommelier_cmd="sommelier -X \
               --x-display=${DISPLAY} \
@@ -365,7 +366,7 @@ class Sommelier < Package
             set +a
             echo -e "\e[1;33m""Sommelier SCALE is set to \e[1;32m"${SCALE}"\e[1;33m"."\e[0m"
             echo -e "\e[1;33m""SCALE may be manually set in ~/.sommelier.env .""\e[0m"
-            #{CREW_PREFIX}/sbin/sommelierd &>> #{CREW_PREFIX}/var/log/sommelierd.log &
+            #{CREW_PREFIX}/sbin/sommelierd &>/dev/null &
           fi
           wait=3
           until checksommelierwayland && checksommelierxwayland; do

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -86,7 +86,7 @@ class Sommelier < Package
       -#define APPLICATION_ID_FORMAT_PREFIX "org.chromium.guest_os.%s"
       +#define XDG_SHELL_VERSION 1u
       +#define APPLICATION_ID_FORMAT_PREFIX "org.chromebrew.%s"
-       #define NATIVE_WAYLAND_APPLICATION_ID_FORMAT \
+       #define NATIVE_WAYLAND_APPLICATION_ID_FORMAT \\
          APPLICATION_ID_FORMAT_PREFIX ".wayland.%s"
     EOF
 

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -15,9 +15,9 @@ class Sommelier < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20230217-1_x86_64/sommelier-20230217-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'a7f6c1447c93bf6eaa74b395d93a3c79ca3e7e14ac72864b6247be141aa9be85',
-     armv7l: 'a7f6c1447c93bf6eaa74b395d93a3c79ca3e7e14ac72864b6247be141aa9be85',
-     x86_64: '2c128067ce998c69f693c3d5baf1706e603a1a342ae310f5d1e950b9d2f71d65'
+    aarch64: 'b5e64142b9c4f74c219dd928f15f7df233e4964f476a42229b7626e78bb1615c',
+     armv7l: 'b5e64142b9c4f74c219dd928f15f7df233e4964f476a42229b7626e78bb1615c',
+     x86_64: 'f28a1b463037ec0093d38edd61e3a9f76e2b75f61b4915f7a796e1eab280d9d1'
   })
 
   depends_on 'gcc' # R
@@ -290,7 +290,7 @@ class Sommelier < Package
             # Return or exit depending upon whether script was sourced.
             (return 0 2>/dev/null) && return 0 || exit 0
           fi
-
+          touch #{CREW_PREFIX}/var/log/sommelier.log
           set -a
           # Set DRM device here so output is visible, but don't run
           # some of these checks in an env.d file since we don't need
@@ -340,7 +340,7 @@ class Sommelier < Package
             (return 0 2>/dev/null) && return 0 || exit 0
           }
           checksommelierxwayland () {
-            DISPLAY="${DISPLAY}" timeout 1s xset q &>/dev/null
+            DISPLAY="${DISPLAY}" timeout 1s xset q &>> #{CREW_PREFIX}/var/log/sommelier.log
           }
           if ! checksommelierwayland || ! checksommelierxwayland ; then
             [ -f  #{CREW_PREFIX}/bin/stopbroadway ] && stopbroadway
@@ -365,7 +365,7 @@ class Sommelier < Package
             set +a
             echo -e "\e[1;33m""Sommelier SCALE is set to \e[1;32m"${SCALE}"\e[1;33m"."\e[0m"
             echo -e "\e[1;33m""SCALE may be manually set in ~/.sommelier.env .""\e[0m"
-            #{CREW_PREFIX}/sbin/sommelierd &>> #{CREW_PREFIX}/var/log/sommelier.log &
+            #{CREW_PREFIX}/sbin/sommelierd &>> #{CREW_PREFIX}/var/log/sommelierd.log &
           fi
           wait=3
           until checksommelierwayland && checksommelierxwayland; do
@@ -396,9 +396,9 @@ class Sommelier < Package
           pgrep Xwayland &>> #{CREW_PREFIX}/var/log/sommelier.log && killall Xwayland
           SOMM="$(pgrep -fc sommelier.elf 2> /dev/null)"
           if [[ "${SOMM}" -gt "0" ]]; then
-            pkill -f sommelier.elf &>/dev/null
-            pkill -F #{CREW_PREFIX}/var/run/sommelier-wayland.pid &>/dev/null
-            pkill -F #{CREW_PREFIX}/var/run/sommelier-xwayland.pid &>/dev/null
+            pkill -f sommelier.elf &>> #{CREW_PREFIX}/var/log/sommelier.log
+            pkill -F #{CREW_PREFIX}/var/run/sommelier-wayland.pid &>> #{CREW_PREFIX}/var/log/sommelier.log
+            pkill -F #{CREW_PREFIX}/var/run/sommelier-xwayland.pid &>> #{CREW_PREFIX}/var/log/sommelier.log
           else
             # Return or exit depending upon whether script was sourced.
             (return 0 2>/dev/null) && return 0 || exit 0

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -15,9 +15,9 @@ class Sommelier < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20230217-1_x86_64/sommelier-20230217-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '6beeb6b20ce771cbf999b4e73fff26875fef475daedac6765c6db69c2745d075',
-     armv7l: '6beeb6b20ce771cbf999b4e73fff26875fef475daedac6765c6db69c2745d075',
-     x86_64: 'c8effd129481e73940ed03f7d350d040ac61e5e22dce9fd142df8c6a105bd002'
+    aarch64: '5071cea7e9e8c892787c386efd9806eeed08c4d4b06c38321b9996505aaf6e86',
+     armv7l: '5071cea7e9e8c892787c386efd9806eeed08c4d4b06c38321b9996505aaf6e86',
+     x86_64: '21183a81b95ed92fa8c83ee502fe7f6caff2e2f145211abe3dc5985c1f7f6178'
   })
 
   depends_on 'gcc' # R
@@ -336,8 +336,12 @@ class Sommelier < Package
           lwidth=$(WAYLAND_DISPLAY=wayland-0 wayland-info -i zxdg_output_manager_v1 | grep logical_width:  | sed 's/,//' | awk '{print $2}')
           # echo "pxwidth: $pxwidth, lwidth: $lwidth"
           # SCALE needs to be rounded to the nearest 0.5
-          SCALE=$(roundhalves $(echo "scale=2 ;$lwidth / $pxwidth" | bc))
-          echo -e "\e[1;33m""Sommelier SCALE automatically set to \e[1;32m"${SCALE}"\e[1;33m"."\e[0m"
+          # Check to see if pxwidth and lwidth are integers before calculating SCALE.
+          # wayland-info on armv7l does not show lwidth, but aarch64 does.
+          if [[ $pxwidth == ?(-)+([0-9]) ]] && [[ $lwidth == ?(-)+([0-9]) ]]; then
+            SCALE=$(roundhalves $(echo "scale=2 ;$lwidth / $pxwidth" | bc))
+          fi
+          echo -e "\e[1;33m""Sommelier SCALE was set to \e[1;32m"${SCALE}"\e[1;33m"."\e[0m"
           echo -e "\e[1;33m""SCALE may be manually set in ~/.sommelier.env .""\e[0m"
           set +a
 

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -15,9 +15,9 @@ class Sommelier < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sommelier/20230217-1_x86_64/sommelier-20230217-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '5071cea7e9e8c892787c386efd9806eeed08c4d4b06c38321b9996505aaf6e86',
-     armv7l: '5071cea7e9e8c892787c386efd9806eeed08c4d4b06c38321b9996505aaf6e86',
-     x86_64: '21183a81b95ed92fa8c83ee502fe7f6caff2e2f145211abe3dc5985c1f7f6178'
+    aarch64: '493c066ee3f6250df407e77133ca00a47d3cfb7521d150dc95905c55013ff647',
+     armv7l: '493c066ee3f6250df407e77133ca00a47d3cfb7521d150dc95905c55013ff647',
+     x86_64: '631631d07ad31b3268d25bd0ce9afb4556648980d23c1aff72215b0f852d5108'
   })
 
   depends_on 'gcc' # R
@@ -362,7 +362,7 @@ class Sommelier < Package
           if ! checksommelierwayland || ! checksommelierxwayland ; then
             [ -f  #{CREW_PREFIX}/bin/stopbroadway ] && stopbroadway
             # Allow overriding environment variables before starting sommelier daemon.
-            [ -f "$HOME/.sommelier.env" ] && source ~/.sommelier.env
+            [ -f "$HOME/.sommelier.env" ] && source ~/.sommelier.env 2>> /usr/local/var/log/sommelier.log
             #{CREW_PREFIX}/sbin/sommelierd &>/dev/null &
             # source #{CREW_PREFIX}/sbin/sommelierd
           fi

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -41,7 +41,6 @@ class Sommelier < Package
   depends_on 'xorg_xset' # for xset in wrapper script
   depends_on 'xsetroot' # for xsetroot in /usr/local/etc/sommelierrc script
   depends_on 'xwayland' # L
-  depends_on 'xxd_standalone' # for xxd in wrapper script
 
   no_shrink
 

--- a/packages/wayland_info.rb
+++ b/packages/wayland_info.rb
@@ -36,4 +36,3 @@ class Wayland_info < Package
     system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
   end
 end
-

--- a/packages/wayland_info.rb
+++ b/packages/wayland_info.rb
@@ -36,3 +36,4 @@ class Wayland_info < Package
     system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
   end
 end
+


### PR DESCRIPTION
### Changes
- New package: `wayland-info` (*merged in https://github.com/chromebrew/chromebrew/pull/7971*)
- Update sommelier to `20220217`, with patch addressing the `xdg_wm_base` error
- Now `sommelierd` will use `wayland-info` to determine whatever exo supports `xdg_wm_base`, if not, tell sommelier with a flag called `--xdg-shell-v6` (flag added in patch)
- Removed `i686` support
- Removed gcc patch as it is no longer relevant
- Added patch for `xdg_wm_base (41): have 1, wanted 3` error
- Cleanup, removed `diff` & `xxd` dependencies
- Added automatic setup of SCALE variable in `startsommelier`

Will move all changes to [chromebrew/crew-package-sommelier](https://github.com/chromebrew/crew-package-sommelier) later... (prebuilt binary can be added later)

### Tested on
- `armv7l` with R84
- `x86_64` with acceleration (@satmandu: works with latest mesa)

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/supechicken/chromebrew.git CREW_TESTING_BRANCH=sommelier_update_20220217 CREW_TESTING=1 crew update
```
