### PR TITLE
Add bazelisk package

### DIFF
--- a/packages/bazelisk.rb
+++ b/packages/bazelisk.rb
@@ -1,0 +1,18 @@
+require 'package'
+
+class Bazelisk < Package
+  description 'A user-friendly launcher for Bazel.'
+  homepage 'https://github.com/bazelbuild/bazelisk'
+  version '1.16.0'
+  license 'Apache-2.0'
+  compatibility 'x86_64'
+  source_url 'https://github.com/bazelbuild/bazelisk/releases/download/v1.16.0/bazelisk-linux-amd64'
+  source_sha256 '168851e70cf5f95c0e215e7f3aaca5132ffc3c8dd8f585a4157b0be2b53cfe32'
+
+  no_compile_needed
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    FileUtils.install 'bazelisk-linux-amd64', "#{CREW_DEST_PREFIX}/bin/bazelisk", mode: 0o755
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -515,6 +515,11 @@ url: https://github.com/bazelbuild/bazel/releases
 activity: medium
 ---
 kind: url
+name: bazelisk
+url: https://github.com/bazelbuild/bazelisk/releases
+activity: low
+---
+kind: url
 name: bc
 url: https://ftp.gnu.org/gnu/bc
 activity: low


### PR DESCRIPTION
Bazelisk is a wrapper for Bazel written in Go. It automatically picks a good version of Bazel given your current working directory, downloads it from the official server (if required) and then transparently passes through all command-line arguments to the real Bazel binary. You can call it just like you would call Bazel.  See https://github.com/bazelbuild/bazelisk.  Tested on x86_64.