### PR TITLE
Add preremove package function

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1586,6 +1586,10 @@ def remove(pkgName)
     return
   end
 
+  # Perform any operations required prior to package removal.
+  search pkgName, true
+  @pkg.preremove
+
   # Preserve CREW_ESSENTIAL_FILES and make sure they are real files
   # and not symlinks, because preserving symlinked libraries does not
   # prevent breakage.

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.31.5'
+CREW_VERSION = '1.31.6'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -22,11 +22,11 @@ class Package
                      :preinstall,  # Function to perform pre-install operations prior to install.
                      :install,     # Function to perform install from source build.
                      :postinstall, # Function to perform post-install for both source build and binary distribution.
+                     :preremove,   # Function to perform prior to package removal.
                      :remove       # Function to perform after package removal.
 
   class << self
-    attr_accessor :name, :cached_build, :in_build, :build_from_source,
-                  :in_upgrade
+    attr_accessor :name, :cached_build, :in_build, :build_from_source, :in_upgrade
   end
 
   def self.load_package(pkgFile, pkgName = File.basename(pkgFile, '.rb'))

--- a/packages/transmission.rb
+++ b/packages/transmission.rb
@@ -115,6 +115,10 @@ class Transmission < Package
     puts "\nConfiguration files are stored in #{HOME}/.config/transmission-daemon\n".lightblue
   end
 
+  def self.preremove
+    system 'stoptransmission'
+  end
+
   def self.remove
     config_dirs_exist = false
     config_dirs = ["#{CREW_PREFIX}/.config/transmission", "#{CREW_PREFIX}/.config/transmission-daemon"]


### PR DESCRIPTION
This function is to be used in cases where the package may require operations prior to package removal.  For instance, to stop currently running processes.  The transmission package has been updated to take advantage of this new function.
```
$ crew remove transmission
transmission-daemon process stopped
Transmission removed!
```