### PR TITLE
[install.sh]: Fix SSL warning in curl

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -90,7 +90,7 @@ function curl () {
   # here.
   for (( i = 0; i < 4; i++ )); do
     # force TLS as we know GitLab supports it
-    env -u LD_LIBRARY_PATH ${CURL} --ssl-reqd --tlsv1 -C - "${@}" && return 0
+    env -u LD_LIBRARY_PATH ${CURL} --ssl-reqd --tlsv1.2 -C - "${@}" && return 0
     echo_info "Retrying, $((3-i)) retries left."
   done
   # The download failed if we're still here.

--- a/install.sh
+++ b/install.sh
@@ -89,7 +89,8 @@ function curl () {
   # the 'curl: (7) Couldn't connect to server' error, a for loop is used
   # here.
   for (( i = 0; i < 4; i++ )); do
-    env LD_LIBRARY_PATH='' ${CURL} --ssl -C - "${@}" && return 0
+    # force TLSv1.3 as we know GitLab supports it
+    env -u LD_LIBRARY_PATH ${CURL} --ssl-reqd --tlsv3 -C - "${@}" && return 0
     echo_info "Retrying, $((3-i)) retries left."
   done
   # The download failed if we're still here.

--- a/install.sh
+++ b/install.sh
@@ -90,7 +90,7 @@ function curl () {
   # here.
   for (( i = 0; i < 4; i++ )); do
     # force TLSv1.3 as we know GitLab supports it
-    env -u LD_LIBRARY_PATH ${CURL} --ssl-reqd --tlsv1.3 -C - "${@}" && return 0
+    env -u LD_LIBRARY_PATH ${CURL} --ssl-reqd -C - "${@}" && return 0
     echo_info "Retrying, $((3-i)) retries left."
   done
   # The download failed if we're still here.

--- a/install.sh
+++ b/install.sh
@@ -89,8 +89,8 @@ function curl () {
   # the 'curl: (7) Couldn't connect to server' error, a for loop is used
   # here.
   for (( i = 0; i < 4; i++ )); do
-    # force TLSv1.3 as we know GitLab supports it
-    env -u LD_LIBRARY_PATH ${CURL} --ssl-reqd -C - "${@}" && return 0
+    # force TLS as we know GitLab supports it
+    env -u LD_LIBRARY_PATH ${CURL} --ssl-reqd --tlsv1 -C - "${@}" && return 0
     echo_info "Retrying, $((3-i)) retries left."
   done
   # The download failed if we're still here.

--- a/install.sh
+++ b/install.sh
@@ -90,7 +90,7 @@ function curl () {
   # here.
   for (( i = 0; i < 4; i++ )); do
     # force TLSv1.3 as we know GitLab supports it
-    env -u LD_LIBRARY_PATH ${CURL} --ssl-reqd --tlsv3 -C - "${@}" && return 0
+    env -u LD_LIBRARY_PATH ${CURL} --ssl-reqd --tlsv1.3 -C - "${@}" && return 0
     echo_info "Retrying, $((3-i)) retries left."
   done
   # The download failed if we're still here.

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -66,7 +66,9 @@ def downloader(url, sha256sum, filename = File.basename(url), verbose = false)
 
     exit 2
   end
-rescue
+rescue StandardError => e
+  warn e.full_message
+
   # fallback to curl if error occurred
   external_downloader(uri, filename, verbose)
 end
@@ -79,7 +81,7 @@ def http_downloader(uri, filename = File.basename(url), verbose = false)
   Net::HTTP.start(uri.host, uri.port, {
     max_retries: CREW_DOWNLOADER_RETRY,
         use_ssl: uri.scheme.eql?('https'),
-    min_version: :TLSv1,
+    min_version: :TLS1,
         ca_file: SSL_CERT_FILE,
         ca_path: SSL_CERT_DIR
   }) do |http|

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -161,7 +161,7 @@ def external_downloader(uri, filename = File.basename(url), verbose = false)
   #      %<retry>: Will be substitute to #{CREW_DOWNLOADER_RETRY}
   #       %<url>s: Will be substitute to #{url}
   #    %<output>s: Will be substitute to #{filename}
-  curl_cmdline = 'curl %<verbose>s -L -# --tlsv1 --retry %<retry>s %<url>s -o %<output>s'
+  curl_cmdline = 'curl %<verbose>s -L -# --retry %<retry>s %<url>s -o %<output>s'
 
   # use CREW_DOWNLOADER if specified, use curl by default
   downloader_cmdline = CREW_DOWNLOADER || curl_cmdline

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -161,7 +161,7 @@ def external_downloader(uri, filename = File.basename(url), verbose = false)
   #      %<retry>: Will be substitute to #{CREW_DOWNLOADER_RETRY}
   #       %<url>s: Will be substitute to #{url}
   #    %<output>s: Will be substitute to #{filename}
-  curl_cmdline = 'curl %<verbose>s -L -# --retry %<retry>s %<url>s -o %<output>s'
+  curl_cmdline = 'curl %<verbose>s -L -# --tlsv1 --retry %<retry>s %<url>s -o %<output>s'
 
   # use CREW_DOWNLOADER if specified, use curl by default
   downloader_cmdline = CREW_DOWNLOADER || curl_cmdline

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -81,7 +81,7 @@ def http_downloader(uri, filename = File.basename(url), verbose = false)
   Net::HTTP.start(uri.host, uri.port, {
     max_retries: CREW_DOWNLOADER_RETRY,
         use_ssl: uri.scheme.eql?('https'),
-    min_version: :TLS1,
+    min_version: :TLS1_2,
         ca_file: SSL_CERT_FILE,
         ca_path: SSL_CERT_DIR
   }) do |http|


### PR DESCRIPTION
### Changes
- Fix `Warning: --ssl is an insecure option, consider --ssl-reqd instead` by replacing `--ssl` flag to `--ssl-reqd`
- Handle SSL errors (`lib/downloader`)

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/supechicken/chromebrew.git CREW_TESTING_BRANCH=force_tls3 CREW_TESTING=1 crew update
```
