### PR TITLE
libarchive rebuild

### DIFF
--- a/packages/libarchive.rb
+++ b/packages/libarchive.rb
@@ -4,23 +4,23 @@ class Libarchive < Package
   description 'Multi-format archive and compression library.'
   homepage 'https://www.libarchive.org/'
   @_ver = '3.6.2'
-  version @_ver
+  version "#{@_ver}-1"
   license 'BSD, BSD-2, BSD-4 and public-domain'
   compatibility 'all'
   source_url "https://www.libarchive.org/downloads/libarchive-#{@_ver}.tar.xz"
   source_sha256 '9e2c1b80d5fbe59b61308fdfab6c79b5021d7ff4ff2489fb12daf0a96a83551d'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libarchive/3.6.2_armv7l/libarchive-3.6.2-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libarchive/3.6.2_armv7l/libarchive-3.6.2-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libarchive/3.6.2_i686/libarchive-3.6.2-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libarchive/3.6.2_x86_64/libarchive-3.6.2-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libarchive/3.6.2-1_armv7l/libarchive-3.6.2-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libarchive/3.6.2-1_armv7l/libarchive-3.6.2-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libarchive/3.6.2-1_i686/libarchive-3.6.2-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libarchive/3.6.2-1_x86_64/libarchive-3.6.2-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'ea79c0fb02a8fcedaecb62560c31229a9e75d2c9c610d098a5b8f6edb6259b53',
-     armv7l: 'ea79c0fb02a8fcedaecb62560c31229a9e75d2c9c610d098a5b8f6edb6259b53',
-       i686: 'facc3060ac2b1fbc32adfca9c4603261d54044788d48dcb91521ca12c6c37192',
-     x86_64: 'b47fba0e0591e1e05c38d3cf74c44d49ba9ff8a4bb2bd6a02bdfa61d9c098802'
+    aarch64: '79d1a1b9dd755eca23827575de2a5337675f50ae90ba39c7821947eaf0ca66f7',
+     armv7l: '79d1a1b9dd755eca23827575de2a5337675f50ae90ba39c7821947eaf0ca66f7',
+       i686: '9367d373e29a70798e4beb787551bc603fd31c5391f1b531cdd3c614e79d463a',
+     x86_64: '24980bda1ab951b1b68b7f4270dd0ba356969d0a203e7810c14614b4735ad517'
   })
 
   depends_on 'acl' # R
@@ -48,5 +48,7 @@ class Libarchive < Package
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    # As per Arch pkgbuild. This fixes epiphany builds.
+    system "sed -i 's/iconv//g' #{CREW_DEST_LIB_PREFIX}/pkgconfig/libarchive.pc"
   end
 end


### PR DESCRIPTION
- Fixes epiphany build.

Builds properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=libarchive CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
