### PR TITLE
[downloader]: Fix broken progress bar when `content-length` not provided

### DIFF
--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -127,19 +127,18 @@ def http_downloader(uri, filename = File.basename(url), verbose = false)
 
       # read file chunks from server, write it to filesystem
       File.open(filename, 'wb') do |io|
-        progress_bar_thread = progress_bar.show # print progress bar
-
         response.read_body do |chunk|
-          downloaded_size += chunk.size # record downloaded size, used for showing progress bar
+          progress_bar_thread = progress_bar.show # print progress bar
+          downloaded_size    += chunk.size        # record downloaded size, used for showing progress bar
           progress_bar.set_downloaded_size(downloaded_size, invalid_size_error: false) if file_size.positive?
 
           io.write(chunk) # write to file
+        ensure
+          # stop progress bar, wait for it to terminate
+          progress_bar.progress_bar_showing = false
+          progress_bar_thread.join
         end
       end
-    ensure
-      # stop progress bar, wait for it to terminate
-      progress_bar.progress_bar_showing = false
-      progress_bar_thread.join
     end
   end
 rescue OpenSSL::SSL::SSLError

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -130,7 +130,7 @@ def http_downloader(uri, filename = File.basename(url), verbose = false)
       # read file chunks from server, write it to filesystem
       File.open(filename, 'wb') do |io|
         response.read_body do |chunk|
-          downloaded_size += chunk.size        # record downloaded size, used for showing progress bar
+          downloaded_size += chunk.size # record downloaded size, used for showing progress bar
           progress_bar.set_downloaded_size(downloaded_size, invalid_size_error: false) if file_size.positive?
 
           io.write(chunk) # write to file

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -135,22 +135,17 @@ def http_downloader(uri, filename = File.basename(url), verbose = false)
 
           io.write(chunk) # write to file
         end
-      ensure
-        # stop progress bar, wait for it to terminate
-        progress_bar.progress_bar_showing = false
-        progress_bar_thread.join
       end
+    ensure
+      # stop progress bar, wait for it to terminate
+      progress_bar.progress_bar_showing = false
+      progress_bar_thread.join
     end
   end
 rescue OpenSSL::SSL::SSLError
   # handle SSL errors
   ssl_error_retry += 1
-
-  if ssl_error_retry <= 3
-    retry
-  else
-    raise
-  end
+  ssl_error_retry <= 3 ? retry : raise
 end
 
 def external_downloader(uri, filename = File.basename(url), verbose = false)

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -125,20 +125,21 @@ def http_downloader(uri, filename = File.basename(url), verbose = false)
         warn "\n"
       end
 
+      progress_bar_thread = progress_bar.show # print progress bar
+
       # read file chunks from server, write it to filesystem
       File.open(filename, 'wb') do |io|
         response.read_body do |chunk|
-          progress_bar_thread = progress_bar.show # print progress bar
-          downloaded_size    += chunk.size        # record downloaded size, used for showing progress bar
+          downloaded_size += chunk.size        # record downloaded size, used for showing progress bar
           progress_bar.set_downloaded_size(downloaded_size, invalid_size_error: false) if file_size.positive?
 
           io.write(chunk) # write to file
-        ensure
-          # stop progress bar, wait for it to terminate
-          progress_bar.progress_bar_showing = false
-          progress_bar_thread.join
         end
       end
+    ensure
+      # stop progress bar, wait for it to terminate
+      progress_bar.progress_bar_showing = false
+      progress_bar_thread.join
     end
   end
 rescue OpenSSL::SSL::SSLError

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -102,7 +102,7 @@ class ProgressBar
         end
 
         # stop when 100%
-        @percentage >= 100 ? break : print "\r"
+        @percentage >= 100 ? break : print("\r")
       end
     ensure
       print "\e[2K\r\e[?25h" # clear line and restore cursor mode

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -102,15 +102,10 @@ class ProgressBar
         end
 
         # stop when 100%
-        if @percentage >= 100
-          print "\e[2K\r" # clear previous line (progress bar)
-          break
-        else
-          print "\r"
-        end
+        @percentage >= 100 ? break : print "\r"
       end
     ensure
-      print "\e[?25h" # restore cursor mode since we hide it before
+      print "\e[2K\r\e[?25h" # clear line and restore cursor mode
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/chromebrew/chromebrew/issues/7932#issuecomment-1430272721

When the size of file is not provided by the remote server, the progress bar will not exit (as it doesn't know if the file is fully downloaded) properly. This PR fixes it.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/supechicken/chromebrew.git CREW_TESTING_BRANCH=fix_progbar CREW_TESTING=1 crew update
```
