### PR TITLE
replace asciidoctor with ruby_asciidoctor

### DIFF
--- a/packages/asciidoctor.rb
+++ b/packages/asciidoctor.rb
@@ -3,31 +3,13 @@ require 'package'
 class Asciidoctor < Package
   description 'A fast text processor & publishing toolchain for converting AsciiDoc to HTML5, DocBook & more.'
   homepage 'https://asciidoctor.org/'
-  version '2.0.17'
+  version '2.0.18'
   license 'MIT'
   compatibility 'all'
   source_url 'SKIP'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/asciidoctor/2.0.17_armv7l/asciidoctor-2.0.17-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/asciidoctor/2.0.17_armv7l/asciidoctor-2.0.17-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/asciidoctor/2.0.17_i686/asciidoctor-2.0.17-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/asciidoctor/2.0.17_x86_64/asciidoctor-2.0.17-chromeos-x86_64.tar.zst'
-  })
-  binary_sha256({
-    aarch64: 'b947ceb099358cca321dbdb483e058efd41391c729be866acc40f672b1b82910',
-     armv7l: 'b947ceb099358cca321dbdb483e058efd41391c729be866acc40f672b1b82910',
-       i686: '890a1d900911ad20b4e87808c38ed59d5a88b4bb6343abecca0cb31b85ef8f27',
-     x86_64: '8f6581e50b2ccf4074488575f439caee9e83dcb1dbf24778e2e3ef0b271f1c55'
-  })
+  is_fake
 
-  def self.install
-    system "gem install --ignore-dependencies --no-user-install --verbose \
-        -i #{CREW_DEST_DIR}#{Gem.default_dir} -n #{CREW_DEST_PREFIX}/bin \
-        #{to_s.downcase} -v #{version}"
-    system "install -Dm644 #{CREW_DEST_DIR}#{Gem.default_dir}/gems/#{to_s.downcase}-#{version}/man/#{to_s.downcase}.1 \
-        #{CREW_DEST_MAN_PREFIX}/man1/#{to_s.downcase}.1"
-    FileUtils.rm "#{CREW_DEST_DIR}#{Gem.default_dir}/cache/#{to_s.downcase}-#{version}.gem"
-    FileUtils.rm_rf "#{CREW_DEST_DIR}#{Gem.default_dir}/gems/#{to_s.downcase}-#{version}/man"
-  end
+  depends_on 'ruby_asciidoctor'
+
 end

--- a/packages/ndctl.rb
+++ b/packages/ndctl.rb
@@ -20,7 +20,7 @@ class Ndctl < Package
      x86_64: '6d1a0625c7c26687531cf8d63859bbe4bcdd44c5f1b623657491845c89a2a8bc'
   })
 
-  depends_on 'asciidoctor' => :build
+  depends_on 'ruby_asciidoctor' => :build
   depends_on 'bash_completion' => :build
   depends_on 'iniparser' => :build
   depends_on 'jsonc' => :build

--- a/packages/newsboat.rb
+++ b/packages/newsboat.rb
@@ -29,7 +29,7 @@ class Newsboat < Package
   depends_on 'libstfl'
   depends_on 'jsonc'
   depends_on 'openssl'
-  depends_on 'asciidoctor' => :build
+  depends_on 'ruby_asciidoctor' => :build
   depends_on 'rust' => :build
 
   def self.patch

--- a/packages/ruby_asciidoctor.rb
+++ b/packages/ruby_asciidoctor.rb
@@ -1,0 +1,34 @@
+require 'package'
+
+class Ruby_asciidoctor < Package
+  description 'A fast text processor & publishing toolchain for converting AsciiDoc to HTML5, DocBook & more.'
+  homepage 'https://asciidoctor.org/'
+  version '2.0.18-ruby-3.2'
+  compatibility 'all'
+  source_url 'SKIP'
+
+  no_fhs
+  no_compile_needed
+
+  depends_on 'libyaml'
+  depends_on 'ruby'
+
+  def self.postinstall
+    @gem_name = name.sub('ruby_', '')
+    system "gem uninstall -Dx --force --abort-on-dependent #{@gem_name}", exception: false
+    system "gem install -N #{@gem_name}", exception: false
+  end
+
+  def self.remove
+    @gem_name = name.sub('ruby_', '')
+    @gems_deps = `gem dependency ^#{@gem_name}\$ | awk '{print \$1}'`.chomp
+    # Delete the first line and convert to an array.
+    @gems = @gems_deps.split("\n").drop(1).append(@gem_name)
+    # bundler never gets uninstalled, though gem dependency lists it for
+    # every package, so delete it from the list.
+    @gems.delete('bundler')
+    @gems.each do |gem|
+      system "gem uninstall -Dx --force --abort-on-dependent #{gem}", exception: false
+    end
+  end
+end

--- a/packages/shaderc.rb
+++ b/packages/shaderc.rb
@@ -24,7 +24,7 @@ class Shaderc < Package
      x86_64: '9e32e0db031138d5ead88e9e6a99f1a14d1d07e6c89999f0d336d105462b1306'
   })
 
-  depends_on 'asciidoctor' => :build
+  depends_on 'ruby_asciidoctor' => :build
 
   def self.build
     system './utils/git-sync-deps'

--- a/packages/wireshark.rb
+++ b/packages/wireshark.rb
@@ -24,7 +24,7 @@ class Wireshark < Package
      x86_64: '60eee74f73306e3339da92c28e1e14202ebaaff3046521eab46eb8fa4a091b7c'
   })
 
-  depends_on 'asciidoctor' => :build
+  depends_on 'ruby_asciidoctor' => :build
   depends_on 'c_ares'
   depends_on 'libmaxminddb'
   depends_on 'libcap'

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -275,11 +275,6 @@ url: https://sourceforge.net/projects/asciidoc/files/asciidoc/
 activity: none
 ---
 kind: url
-name: asciidoctor
-url: https://github.com/asciidoctor/asciidoctor/releases
-activity: medium
----
-kind: url
 name: asciinema
 url: https://github.com/asciinema/asciinema/releases
 activity: medium
@@ -7208,6 +7203,11 @@ activity: none
 kind: url
 name: ruby
 url: http://www.ruby-lang.org/en/downloads/
+activity: medium
+---
+kind: url
+name: ruby_asciidoctor
+url: https://github.com/asciidoctor/asciidoctor/releases
 activity: medium
 ---
 kind: url


### PR DESCRIPTION
Fixes #8009

- replaces package with standard ruby_gem package.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=ruby_asciidoctor CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
