### PR TITLE
set LC_ALL=C when running grep.

### DIFF
--- a/tools/getrealdeps.sh
+++ b/tools/getrealdeps.sh
@@ -103,6 +103,7 @@ read -r -n 4 exec_header_bytes < "${i}"
 # since otherwise we cannot figure out their dependencies.
 [[ -f "/.dockerenv" ]] &&  upx -d "${i}" &> /dev/null
 mkdir -p /tmp/deps/"${pkg}"/
+# shellcheck disable=SC2030,SC2046
 lines+=$(echo ; readelf -d "$i" 2>/dev/null | $GREP NEEDED | awk '{print $5}' \
 | sed 's/\[//g' | sed 's/\]//g' | awk '!x[$0]++' | tee /tmp/deps/"${pkg}"/$(basename "$i") ; echo ) ; \
 done ; \
@@ -113,6 +114,7 @@ echo "$lines" | tr " " "\n" \
 pkgdeps="$(awk 'NF' <<< "${pkgdeps}" | awk '!x[$0]++')"
 
 # Figure out which Chromebrew packages provide the relevant deps.
+# shellcheck disable=SC2031
 pkgdeps=$(unset lines; for j in $pkgdeps ; \
 do lines+=$(echo ; whatprovidesfxn "$j"); done ; \
 echo "$lines" | tr " " "\n" | awk '!x[$0]++')

--- a/tools/getrealdeps.sh
+++ b/tools/getrealdeps.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# getrealdeps for Chromebrew
+# getrealdeps for Chromebrew version 1.1
 # Author: Satadru Pramanik (satmandu) satadru at gmail dot com
 # set -x
 pkg="${1%.rb}"
@@ -50,6 +50,9 @@ if ! [[ -f "${CREW_PREFIX}/etc/crew/meta/${pkg}.filelist" ]]; then
   echo_error "Package $pkg either does not exist or does not contain any libraries."
   exit 1
 fi
+
+# Speed up grep
+LC_ALL=C
 
 # Install grep if a functional local copy does not exist.
 if grep --version &> /dev/null; then


### PR DESCRIPTION
 - Using `LC_ALL=C` [speeds up grep](https://www.inmotionhosting.com/support/website/speed-up-grep-searches-with-lc-all/).

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=getrealdeps CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
