### PR TITLE
xml package cleanup

### DIFF
--- a/packages/docbook_xml42.rb
+++ b/packages/docbook_xml42.rb
@@ -38,17 +38,17 @@ class Docbook_xml42 < Package
     FileUtils.mkdir_p "#{CREW_PREFIX}/etc/xml"
 
     if File.exist?("#{CREW_PREFIX}/etc/xml/catalog") && !File.zero?("#{CREW_PREFIX}/etc/xml/catalog")
-      puts "#{CREW_PREFIX}/etc/xml/catalog exists"
+      puts "#{CREW_PREFIX}/etc/xml/catalog exists" if @opt_verbose
     else
-      puts "Creating #{CREW_PREFIX}/etc/xml/catalog"
+      puts "Creating #{CREW_PREFIX}/etc/xml/catalog" if @opt_verbose
       FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/catalog"
       system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/catalog"
     end
 
     if File.exist?("#{CREW_PREFIX}/etc/xml/docbook-xml") && !File.zero?("#{CREW_PREFIX}/etc/xml/docbook-xml")
-      puts "#{CREW_PREFIX}/etc/xml/docbook-xml not empty"
+      puts "#{CREW_PREFIX}/etc/xml/docbook-xml not empty" if @opt_verbose
     else
-      puts "Creating #{CREW_PREFIX}/etc/xml/docbook-xml"
+      puts "Creating #{CREW_PREFIX}/etc/xml/docbook-xml" if @opt_verbose
       FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/docbook-xml"
       system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/docbook-xml"
     end

--- a/packages/docbook_xml43.rb
+++ b/packages/docbook_xml43.rb
@@ -38,17 +38,17 @@ class Docbook_xml43 < Package
     FileUtils.mkdir_p "#{CREW_PREFIX}/etc/xml"
 
     if File.exist?("#{CREW_PREFIX}/etc/xml/catalog") && !File.zero?("#{CREW_PREFIX}/etc/xml/catalog")
-      puts "#{CREW_PREFIX}/etc/xml/catalog exists"
+      puts "#{CREW_PREFIX}/etc/xml/catalog exists" if @opt_verbose
     else
-      puts "Creating #{CREW_PREFIX}/etc/xml/catalog"
+      puts "Creating #{CREW_PREFIX}/etc/xml/catalog" if @opt_verbose
       FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/catalog"
       system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/catalog"
     end
 
     if File.exist?("#{CREW_PREFIX}/etc/xml/docbook-xml") && !File.zero?("#{CREW_PREFIX}/etc/xml/docbook-xml")
-      puts "#{CREW_PREFIX}/etc/xml/docbook-xml not empty"
+      puts "#{CREW_PREFIX}/etc/xml/docbook-xml not empty" if @opt_verbose
     else
-      puts "Creating #{CREW_PREFIX}/etc/xml/docbook-xml"
+      puts "Creating #{CREW_PREFIX}/etc/xml/docbook-xml" if @opt_verbose
       FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/docbook-xml"
       system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/docbook-xml"
     end

--- a/packages/docbook_xml44.rb
+++ b/packages/docbook_xml44.rb
@@ -38,17 +38,17 @@ class Docbook_xml44 < Package
     FileUtils.mkdir_p "#{CREW_PREFIX}/etc/xml"
 
     if File.exist?("#{CREW_PREFIX}/etc/xml/catalog") && !File.zero?("#{CREW_PREFIX}/etc/xml/catalog")
-      puts "#{CREW_PREFIX}/etc/xml/catalog exists"
+      puts "#{CREW_PREFIX}/etc/xml/catalog exists" if @opt_verbose
     else
-      puts "Creating #{CREW_PREFIX}/etc/xml/catalog"
+      puts "Creating #{CREW_PREFIX}/etc/xml/catalog" if @opt_verbose
       FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/catalog"
       system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/catalog"
     end
 
     if File.exist?("#{CREW_PREFIX}/etc/xml/docbook-xml") && !File.zero?("#{CREW_PREFIX}/etc/xml/docbook-xml")
-      puts "#{CREW_PREFIX}/etc/xml/docbook-xml not empty"
+      puts "#{CREW_PREFIX}/etc/xml/docbook-xml not empty" if @opt_verbose
     else
-      puts "Creating #{CREW_PREFIX}/etc/xml/docbook-xml"
+      puts "Creating #{CREW_PREFIX}/etc/xml/docbook-xml" if @opt_verbose
       FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/docbook-xml"
       system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/docbook-xml"
     end

--- a/packages/docbook_xml45.rb
+++ b/packages/docbook_xml45.rb
@@ -38,17 +38,17 @@ class Docbook_xml45 < Package
     FileUtils.mkdir_p "#{CREW_PREFIX}/etc/xml"
 
     if File.exist?("#{CREW_PREFIX}/etc/xml/catalog") && !File.zero?("#{CREW_PREFIX}/etc/xml/catalog")
-      puts "#{CREW_PREFIX}/etc/xml/catalog exists"
+      puts "#{CREW_PREFIX}/etc/xml/catalog exists" if @opt_verbose
     else
-      puts "Creating #{CREW_PREFIX}/etc/xml/catalog"
+      puts "Creating #{CREW_PREFIX}/etc/xml/catalog" if @opt_verbose
       FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/catalog"
       system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/catalog"
     end
 
     if File.exist?("#{CREW_PREFIX}/etc/xml/docbook-xml") && !File.zero?("#{CREW_PREFIX}/etc/xml/docbook-xml")
-      puts "#{CREW_PREFIX}/etc/xml/docbook-xml not empty"
+      puts "#{CREW_PREFIX}/etc/xml/docbook-xml not empty" if @opt_verbose
     else
-      puts "Creating #{CREW_PREFIX}/etc/xml/docbook-xml"
+      puts "Creating #{CREW_PREFIX}/etc/xml/docbook-xml" if @opt_verbose
       FileUtils.rm_f "#{CREW_PREFIX}/etc/xml/docbook-xml"
       system "xmlcatalog --noout --create #{CREW_PREFIX}/etc/xml/docbook-xml"
     end


### PR DESCRIPTION
- This has been annoying me for a while. Hide debug messages I added a while ago behind the verbose flag.
Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=xmlcleanup CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
