### PR TITLE
Revert "git => 2.39.2"

### DIFF
--- a/packages/git.rb
+++ b/packages/git.rb
@@ -3,23 +3,23 @@ require 'package'
 class Git < Package
   description 'Git is a free and open source distributed version control system designed to handle everything from small to very large projects with speed and efficiency.'
   homepage 'https://git-scm.com/'
-  version '2.39.2' # Do not use @_ver here, it will break the installer.
+  version '2.39.1' # Do not use @_ver here, it will break the installer.
   license 'GPL-2'
   compatibility 'all'
-  source_url 'https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.39.2.tar.xz'
-  source_sha256 '475f75f1373b2cd4e438706185175966d5c11f68c4db1e48c26257c43ddcf2d6'
+  source_url 'https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.39.1.tar.xz'
+  source_sha256 '40a38a0847b30c371b35873b3afcf123885dd41ea3ecbbf510efa97f3ce5c161'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.39.2_armv7l/git-2.39.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.39.2_armv7l/git-2.39.2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.39.2_i686/git-2.39.2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.39.2_x86_64/git-2.39.2-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.39.1_armv7l/git-2.39.1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.39.1_armv7l/git-2.39.1-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.39.1_i686/git-2.39.1-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.39.1_x86_64/git-2.39.1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '36c15e0db8fe5cb2e20b9b1993cdbfb3f6b3ff81330b7150b2fa75bee5c12346',
-     armv7l: '36c15e0db8fe5cb2e20b9b1993cdbfb3f6b3ff81330b7150b2fa75bee5c12346',
-       i686: '30436a9ec1c43a4d86780ef919a008db9ac0cb9b9370ec12b3d01dda9cf0191a',
-     x86_64: 'b81daa55b5ef25f00b2684f17a111639071f75b4c7a1fe795990aa8054ae575c'
+    aarch64: '31020a59a0d4f164b926adaff2c188edb1cc02cff0f6a6126fd0053958912309',
+     armv7l: '31020a59a0d4f164b926adaff2c188edb1cc02cff0f6a6126fd0053958912309',
+       i686: '428f5d688660e564575d2c5d65375be981bba728184b5b7b8b6546e28ed88fa3',
+     x86_64: '5bc031d6f6c9b297665e89faba78ecd823364bef8a9fd25bb40d61fa195fe86c'
   })
 
   depends_on 'ca_certificates' => :build


### PR DESCRIPTION
Reverts chromebrew/chromebrew#8026

Git on armv7l is segfaulting. See https://github.com/upx/upx/issues/654

(i686 and x86_64 are not having problems.)