### PR TITLE
rsync deps are no longer parts of CREW_ESSENTIAL_FILES

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.31.7'
+CREW_VERSION = '1.31.8'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp
@@ -308,6 +308,5 @@ PY3_BUILD_OPTIONS = '--wheel --no-isolation'
 PY3_INSTALLER_OPTIONS = "--destdir=#{CREW_DEST_DIR} --compile-bytecode 2 dist/*.whl"
 
 CREW_ESSENTIAL_FILES = `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/ruby`.scan(/\t([^ ]+)/).flatten +
-                       `LD_TRACE_LOADED_OBJECTS=1 #{CREW_PREFIX}/bin/rsync`.scan(/\t([^ ]+)/).flatten +
                        %w[libzstd.so.1 libstdc++.so.6]
 CREW_ESSENTIAL_FILES.uniq!


### PR DESCRIPTION
- This prevents `sh: 1: /usr/local/bin/rsync: not found` errors on every crew invocation when `rsync` isn't installed. (This will only be seen on new installs.)
i.e.,
```
chronos@rpi4b-armv7l /usr/local/lib/crew/packages $ crew update
sh: 1: /usr/local/bin/rsync: not found
From https://github.com/chromebrew/chromebrew
 * branch            master     -> FETCH_HEAD
HEAD is now at 52d645b crew: Use `rename()` syscall to install files from destdir for faster speed (#7751)
Package lists, crew, and library updated.
Checking for package updates...
Your software is up to date.
chronos@rpi4b-armv7l /usr/local/lib/crew/packages 
```

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=rsync_const CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
