### PR TITLE
update upx, rebuild git

### DIFF
--- a/packages/git.rb
+++ b/packages/git.rb
@@ -3,23 +3,23 @@ require 'package'
 class Git < Package
   description 'Git is a free and open source distributed version control system designed to handle everything from small to very large projects with speed and efficiency.'
   homepage 'https://git-scm.com/'
-  version '2.39.1' # Do not use @_ver here, it will break the installer.
+  version '2.39.2-1' # Do not use @_ver here, it will break the installer.
   license 'GPL-2'
   compatibility 'all'
-  source_url 'https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.39.1.tar.xz'
-  source_sha256 '40a38a0847b30c371b35873b3afcf123885dd41ea3ecbbf510efa97f3ce5c161'
+  source_url 'https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.39.2.tar.xz'
+  source_sha256 '475f75f1373b2cd4e438706185175966d5c11f68c4db1e48c26257c43ddcf2d6'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.39.1_armv7l/git-2.39.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.39.1_armv7l/git-2.39.1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.39.1_i686/git-2.39.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.39.1_x86_64/git-2.39.1-chromeos-x86_64.tar.xz'
+     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.39.2-1_armv7l/git-2.39.2-1-chromeos-armv7l.tar.xz',
+      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.39.2-1_armv7l/git-2.39.2-1-chromeos-armv7l.tar.xz',
+        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.39.2-1_i686/git-2.39.2-1-chromeos-i686.tar.xz',
+      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.39.2-1_x86_64/git-2.39.2-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-    aarch64: '31020a59a0d4f164b926adaff2c188edb1cc02cff0f6a6126fd0053958912309',
-     armv7l: '31020a59a0d4f164b926adaff2c188edb1cc02cff0f6a6126fd0053958912309',
-       i686: '428f5d688660e564575d2c5d65375be981bba728184b5b7b8b6546e28ed88fa3',
-     x86_64: '5bc031d6f6c9b297665e89faba78ecd823364bef8a9fd25bb40d61fa195fe86c'
+     aarch64: 'e1baf1147f0387ba5f6e3ec69f907de48dcfb0384a8dbed47d65af818e206f9b',
+      armv7l: 'e1baf1147f0387ba5f6e3ec69f907de48dcfb0384a8dbed47d65af818e206f9b',
+        i686: 'b8d4ac0df63ab8990c8178b5cc464ff402cc9bd3d5ed9cf6ec0d27987c4289c1',
+      x86_64: 'e5a5ea385c6d95be6a2f1bc4e3f40bb0308e323a711408c5ec46c6fd9fa17c6e'
   })
 
   depends_on 'ca_certificates' => :build

--- a/packages/git.rb
+++ b/packages/git.rb
@@ -10,16 +10,16 @@ class Git < Package
   source_sha256 '475f75f1373b2cd4e438706185175966d5c11f68c4db1e48c26257c43ddcf2d6'
 
   binary_url({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.39.2-1_armv7l/git-2.39.2-1-chromeos-armv7l.tar.xz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.39.2-1_armv7l/git-2.39.2-1-chromeos-armv7l.tar.xz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.39.2-1_i686/git-2.39.2-1-chromeos-i686.tar.xz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.39.2-1_x86_64/git-2.39.2-1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.39.2-1_armv7l/git-2.39.2-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.39.2-1_armv7l/git-2.39.2-1-chromeos-armv7l.tar.xz',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.39.2-1_i686/git-2.39.2-1-chromeos-i686.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/git/2.39.2-1_x86_64/git-2.39.2-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
-     aarch64: 'e1baf1147f0387ba5f6e3ec69f907de48dcfb0384a8dbed47d65af818e206f9b',
-      armv7l: 'e1baf1147f0387ba5f6e3ec69f907de48dcfb0384a8dbed47d65af818e206f9b',
-        i686: 'b8d4ac0df63ab8990c8178b5cc464ff402cc9bd3d5ed9cf6ec0d27987c4289c1',
-      x86_64: 'e5a5ea385c6d95be6a2f1bc4e3f40bb0308e323a711408c5ec46c6fd9fa17c6e'
+    aarch64: 'e1baf1147f0387ba5f6e3ec69f907de48dcfb0384a8dbed47d65af818e206f9b',
+     armv7l: 'e1baf1147f0387ba5f6e3ec69f907de48dcfb0384a8dbed47d65af818e206f9b',
+       i686: 'b8d4ac0df63ab8990c8178b5cc464ff402cc9bd3d5ed9cf6ec0d27987c4289c1',
+     x86_64: 'e5a5ea385c6d95be6a2f1bc4e3f40bb0308e323a711408c5ec46c6fd9fa17c6e'
   })
 
   depends_on 'ca_certificates' => :build

--- a/packages/upx.rb
+++ b/packages/upx.rb
@@ -13,16 +13,16 @@ class Upx < Package
   git_hashtag 'f4c4d5148e4f8c9fc5bfd2c2e836ee2aa27fbaab'
 
   binary_url({
-     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.3-f4c4d51_armv7l/upx-4.0.3-f4c4d51-chromeos-armv7l.tar.zst',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.3-f4c4d51_armv7l/upx-4.0.3-f4c4d51-chromeos-armv7l.tar.zst',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.3-f4c4d51_i686/upx-4.0.3-f4c4d51-chromeos-i686.tar.zst',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.3-f4c4d51_x86_64/upx-4.0.3-f4c4d51-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.3-f4c4d51_armv7l/upx-4.0.3-f4c4d51-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.3-f4c4d51_armv7l/upx-4.0.3-f4c4d51-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.3-f4c4d51_i686/upx-4.0.3-f4c4d51-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.3-f4c4d51_x86_64/upx-4.0.3-f4c4d51-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-     aarch64: 'a6eb586e86e3566185e16873529325bc4828cf1542c02c1347eec9ef06f68309',
-      armv7l: 'a6eb586e86e3566185e16873529325bc4828cf1542c02c1347eec9ef06f68309',
-        i686: '83bf7c39b72055cd7e035d8d70def2c82252151edd3cc0f6f203cac7b35c47dc',
-      x86_64: 'f68d21c492b38e8a7e05cf02ac74455dc60799bd7734f942b188cff8b8992f84'
+    aarch64: 'a6eb586e86e3566185e16873529325bc4828cf1542c02c1347eec9ef06f68309',
+     armv7l: 'a6eb586e86e3566185e16873529325bc4828cf1542c02c1347eec9ef06f68309',
+       i686: '83bf7c39b72055cd7e035d8d70def2c82252151edd3cc0f6f203cac7b35c47dc',
+     x86_64: 'f68d21c492b38e8a7e05cf02ac74455dc60799bd7734f942b188cff8b8992f84'
   })
 
   # depends_on 'ucl'

--- a/packages/upx.rb
+++ b/packages/upx.rb
@@ -6,23 +6,23 @@ require 'package'
 class Upx < Package
   description 'Extendable, high-performance executable packer for several executable formats'
   homepage 'https://github.com/upx/upx'
-  version '4.0.2'
+  version '4.0.3-f4c4d51'
   license 'custom GPL2'
   compatibility 'all'
   source_url 'https://github.com/upx/upx.git'
-  git_hashtag "v#{version}"
+  git_hashtag 'f4c4d5148e4f8c9fc5bfd2c2e836ee2aa27fbaab'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.2_armv7l/upx-4.0.2-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.2_armv7l/upx-4.0.2-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.2_i686/upx-4.0.2-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.2_x86_64/upx-4.0.2-chromeos-x86_64.tar.zst'
+     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.3-f4c4d51_armv7l/upx-4.0.3-f4c4d51-chromeos-armv7l.tar.zst',
+      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.3-f4c4d51_armv7l/upx-4.0.3-f4c4d51-chromeos-armv7l.tar.zst',
+        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.3-f4c4d51_i686/upx-4.0.3-f4c4d51-chromeos-i686.tar.zst',
+      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/upx/4.0.3-f4c4d51_x86_64/upx-4.0.3-f4c4d51-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'dc9823913706ce2e9d31679fb733ebbc947b000b1e70ef80b621f6cf7fcb1efe',
-     armv7l: 'dc9823913706ce2e9d31679fb733ebbc947b000b1e70ef80b621f6cf7fcb1efe',
-       i686: '3944e0d6ad263b5fef6318940f7e2b67f9f236dc71f61cf33c638068e8aa3481',
-     x86_64: '19c01ac6154add7e3376c01ec179230118ea87147ef72874b69a4e466d80617e'
+     aarch64: 'a6eb586e86e3566185e16873529325bc4828cf1542c02c1347eec9ef06f68309',
+      armv7l: 'a6eb586e86e3566185e16873529325bc4828cf1542c02c1347eec9ef06f68309',
+        i686: '83bf7c39b72055cd7e035d8d70def2c82252151edd3cc0f6f203cac7b35c47dc',
+      x86_64: 'f68d21c492b38e8a7e05cf02ac74455dc60799bd7734f942b188cff8b8992f84'
   })
 
   # depends_on 'ucl'
@@ -30,12 +30,9 @@ class Upx < Package
   depends_on 'glibc' # R
 
   def self.build
-    FileUtils.mkdir('builddir')
-    Dir.chdir('builddir') do
-      system "cmake #{CREW_CMAKE_OPTIONS} \
+    system "cmake -B builddir #{CREW_CMAKE_OPTIONS} \
       -DUPX_CONFIG_DISABLE_GITREV=true \
-      ../ -G Ninja"
-    end
+      -G Ninja"
     system 'samu -C builddir'
   end
 


### PR DESCRIPTION
- new version of upx which correctly compresses gcc12 built i686 & armv7l binaries, and also correctly compresses x86_64,i686, armv7l libraries.
- modifying crew to compress libraries will be in a separate PR after more testing.
- rebuilt git, confirmed it works on all architectures.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=upxgit CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
