### PR TITLE
remove duplicate  depends_on 'at_spi2_core' lines

### DIFF
--- a/packages/asunder.rb
+++ b/packages/asunder.rb
@@ -26,7 +26,6 @@ class Asunder < Package
   })
 
   depends_on 'at_spi2_core' # R
-  depends_on 'at_spi2_core' # R
   depends_on 'cdparanoia' # R
   depends_on 'freetype' # R
   depends_on 'gdk_pixbuf' # R

--- a/packages/codium.rb
+++ b/packages/codium.rb
@@ -19,7 +19,6 @@ class Codium < Package
 
   depends_on 'alsa_lib' # R
   depends_on 'at_spi2_core' # R
-  depends_on 'at_spi2_core' # R
   depends_on 'cups' # R
   depends_on 'dbus' # R
   depends_on 'expat' # R

--- a/packages/epiphany.rb
+++ b/packages/epiphany.rb
@@ -24,7 +24,6 @@ class Epiphany < Package
   })
 
   depends_on 'at_spi2_core' # R
-  depends_on 'at_spi2_core' # R
   depends_on 'docbook_xml' => :build
   depends_on 'freetype' => :build
   depends_on 'gcc' # R

--- a/packages/ettercap_gtk.rb
+++ b/packages/ettercap_gtk.rb
@@ -24,7 +24,6 @@ class Ettercap_gtk < Package
   })
 
   depends_on 'at_spi2_core' # R
-  depends_on 'at_spi2_core' # R
   depends_on 'curl' => :build
   depends_on 'ethtool' => :build
   depends_on 'freetype' # R

--- a/packages/evolution_data_server.rb
+++ b/packages/evolution_data_server.rb
@@ -23,7 +23,6 @@ class Evolution_data_server < Package
   })
 
   depends_on 'at_spi2_core' # R
-  depends_on 'at_spi2_core' # R
   depends_on 'gcc' # R
   depends_on 'gcr_3' # R
   depends_on 'gdk_pixbuf' # R

--- a/packages/gemacs.rb
+++ b/packages/gemacs.rb
@@ -25,7 +25,6 @@ class Gemacs < Package
   depends_on 'acl' # R
   depends_on 'alsa_lib' # R
   depends_on 'at_spi2_core' # R
-  depends_on 'at_spi2_core' # R
   depends_on 'cairo'
   depends_on 'dbus' # R
   depends_on 'freetype' # R

--- a/packages/gnome_terminal.rb
+++ b/packages/gnome_terminal.rb
@@ -25,7 +25,6 @@ class Gnome_terminal < Package
 
   depends_on 'adobe_source_code_pro_fonts' # (Needed for monospace fonts)
   depends_on 'at_spi2_core' # R
-  depends_on 'at_spi2_core' # R
   depends_on 'dconf' => :build
   depends_on 'dbus' # L
   depends_on 'desktop_file_utilities' => :build

--- a/packages/graphviz.rb
+++ b/packages/graphviz.rb
@@ -24,7 +24,6 @@ class Graphviz < Package
   })
 
   depends_on 'at_spi2_core' # R
-  depends_on 'at_spi2_core' # R
   depends_on 'cairo' => :build
   depends_on 'expat' # R
   depends_on 'gcc' # R

--- a/packages/gstreamer.rb
+++ b/packages/gstreamer.rb
@@ -25,7 +25,6 @@ class Gstreamer < Package
 
   depends_on 'alsa_lib' # R
   depends_on 'at_spi2_core' # R
-  depends_on 'at_spi2_core' # R
   depends_on 'bz2' # R
   depends_on 'cairo' # R
   depends_on 'chromaprint' # R

--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -27,7 +27,6 @@ class Gtk3 < Package
   # L = Logical Dependency, R = Runtime Dependency
   depends_on 'adwaita_icon_theme' # L
   depends_on 'at_spi2_core' # R
-  depends_on 'at_spi2_core' # R
   depends_on 'cairo' # R
   depends_on 'cantarell_fonts' # L
   depends_on 'cups' # R

--- a/packages/gtksourceview_3.rb
+++ b/packages/gtksourceview_3.rb
@@ -24,7 +24,6 @@ class Gtksourceview_3 < Package
   })
 
   depends_on 'at_spi2_core' # R
-  depends_on 'at_spi2_core' # R
   depends_on 'cairo' => :build
   depends_on 'fontconfig' => :build
   depends_on 'freetype' => :build

--- a/packages/handbrake.rb
+++ b/packages/handbrake.rb
@@ -17,7 +17,6 @@ class Handbrake < Package
   })
 
   depends_on 'at_spi2_core' # R
-  depends_on 'at_spi2_core' # R
   depends_on 'bz2' # R
   depends_on 'expat' # R
   depends_on 'ffmpeg'

--- a/packages/inkscape.rb
+++ b/packages/inkscape.rb
@@ -24,7 +24,6 @@ class Inkscape < Package
 
   depends_on 'atkmm' # R
   depends_on 'at_spi2_core' # R
-  depends_on 'at_spi2_core' # R
   depends_on 'bdwgc' # R
   depends_on 'boost' # R
   depends_on 'cairo' => :build

--- a/packages/qtbase.rb
+++ b/packages/qtbase.rb
@@ -24,7 +24,6 @@ class Qtbase < Package
 
   depends_on 'alsa_plugins' => :build
   depends_on 'at_spi2_core' # R
-  depends_on 'at_spi2_core' # R
   depends_on 'cairo' => :build
   depends_on 'cups' # R
   depends_on 'dbus' # R

--- a/packages/vte.rb
+++ b/packages/vte.rb
@@ -38,7 +38,6 @@ class Vte < Package
   depends_on 'pango' # R
   depends_on 'pcre2' # R
   depends_on 'zlibpkg' # R
-  depends_on 'at_spi2_core' # R
 
   gnome
 

--- a/packages/webkit2gtk_4.rb
+++ b/packages/webkit2gtk_4.rb
@@ -21,7 +21,6 @@ class Webkit2gtk_4 < Package
   })
 
   depends_on 'at_spi2_core' # R
-  depends_on 'at_spi2_core' # R
   depends_on 'cairo'
   # depends_on 'ccache' => :build
   depends_on 'dav1d'

--- a/packages/webkit2gtk_4_1.rb
+++ b/packages/webkit2gtk_4_1.rb
@@ -21,7 +21,6 @@ class Webkit2gtk_4_1 < Package
   })
 
   depends_on 'at_spi2_core' # R
-  depends_on 'at_spi2_core' # R
   depends_on 'cairo'
   # depends_on 'ccache' => :build
   depends_on 'dav1d'

--- a/packages/webkit2gtk_5.rb
+++ b/packages/webkit2gtk_5.rb
@@ -21,7 +21,6 @@ class Webkit2gtk_5 < Package
   })
 
   depends_on 'at_spi2_core' # R
-  depends_on 'at_spi2_core' # R
   depends_on 'cairo'
   # depends_on 'ccache' => :build
   depends_on 'dav1d'


### PR DESCRIPTION
```
 sed -i "0,/^  depends_on 'at_spi2_core' /b; /^  depends_on 'at_spi2_core' /d" *.rb
```
Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=duplicate-cleanup CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
