### PR TITLE
Disable patchelf during builds

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1105,6 +1105,9 @@ def prepare_package(destdir)
 end
 
 def patchelf_set_need_paths(dir)
+  # Patchelf currently disabled for security reasons
+  puts "Patchelf is currently disabled during builds due to problems with upx."
+  return
   return if @pkg.no_patchelf? || @pkg.no_compile_needed?
 
   Dir.chdir dir do

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.31.9'
+CREW_VERSION = '1.32.0'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
Patchelf is causing problems with upx: https://github.com/upx/upx/issues/655#issuecomment-1457434081

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=no_patchelf CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
