### PR TITLE
Maven 3.8.6 => 3.9.0

### DIFF
--- a/packages/maven.rb
+++ b/packages/maven.rb
@@ -3,13 +3,13 @@ require 'package'
 class Maven < Package
   description 'Apache Maven is a software project management and comprehension tool.'
   homepage 'https://maven.apache.org/'
-  version '3.8.6'
+  version '3.9.0'
   license 'Apache-2.0'
   compatibility 'all'
-  source_url 'https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.tar.gz'
-  source_sha256 'c7047a48deb626abf26f71ab3643d296db9b1e67f1faa7d988637deac876b5a9'
+  source_url 'https://dlcdn.apache.org/maven/maven-3/3.9.0/binaries/apache-maven-3.9.0-bin.tar.gz'
+  source_sha256 'b118e624ec6f7abd8fc49e6cb23f134dbbab1119d88718fc09d798d33756dd72'
 
-  depends_on 'openjdk8'
+  depends_on 'openjdk8' unless File.exist? "#{CREW_PREFIX}/bin/java"
 
   no_compile_needed
 


### PR DESCRIPTION
Also works with openjdk11 so no need to depend on a specific java version.