### PR TITLE
Glib => 2.76.0, gtk => 4.10.1, libadwaita => 1.3.rc

### DIFF
--- a/packages/glib.rb
+++ b/packages/glib.rb
@@ -3,8 +3,7 @@ require 'package'
 class Glib < Package
   description 'GLib provides the core application building blocks for libraries and applications written in C.'
   homepage 'https://developer.gnome.org/glib'
-  @_ver = '2.75.3'
-  @_ver_prelastdot = @_ver.rpartition('.')[0]
+  @_ver = '2.76.0'
   version @_ver
   license 'LGPL-2.1'
   compatibility 'all'
@@ -12,16 +11,16 @@ class Glib < Package
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.75.3_armv7l/glib-2.75.3-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.75.3_armv7l/glib-2.75.3-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.75.3_i686/glib-2.75.3-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.75.3_x86_64/glib-2.75.3-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.76.0_armv7l/glib-2.76.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.76.0_armv7l/glib-2.76.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.76.0_i686/glib-2.76.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.76.0_x86_64/glib-2.76.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '318b638dd61f2eec057c4f7d9c552d877587668223321eaaabd7b757ff22b22f',
-     armv7l: '318b638dd61f2eec057c4f7d9c552d877587668223321eaaabd7b757ff22b22f',
-       i686: 'a78f2a79fe85a0fa2a7680582dd3613a53e5af415395c11d77855a6f0f2d74e7',
-     x86_64: '20e505f49f2bc3f924adb7f3290305da0a8f1949b8bd1d612de8d8cb967aa033'
+    aarch64: '4cf42a0a1cafa5e90770767b47ae1c017b2d5263e843cf2b764f1c62140f308a',
+     armv7l: '4cf42a0a1cafa5e90770767b47ae1c017b2d5263e843cf2b764f1c62140f308a',
+       i686: '98ac44357d9dc5e09dac89451de90e5abb18e3a33d7a6474f7cb926b974b1bbc',
+     x86_64: 'dec2b47aa6487b723e87859a58d77e8c7242a96e56a3d3b597d2b53f2f62b131'
   })
 
   depends_on 'elfutils' # R

--- a/packages/glib.rb
+++ b/packages/glib.rb
@@ -36,18 +36,18 @@ class Glib < Package
   gnome
 
   def self.build
-    system "meson setup #{CREW_MESON_OPTIONS.gsub('strip=true', 'strip=false')} \
+    system "mold -run meson setup #{CREW_MESON_OPTIONS.gsub('strip=true', 'strip=false')} \
     -Dselinux=disabled \
     -Dsysprof=disabled \
     -Dman=false \
     -Dtests=false \
     builddir"
     system 'meson configure builddir'
-    system 'mold -run ninja -C builddir'
+    system "mold -run #{CREW_NINJA} -C builddir"
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
     # Create libtool file. Needed by handbrake build.
     return if File.file?("#{CREW_DEST_LIB_PREFIX}/#{@libname}.la")
 

--- a/packages/gnome_console.rb
+++ b/packages/gnome_console.rb
@@ -6,53 +6,53 @@ require 'package'
 class Gnome_console < Package
   description 'A simple user-friendly terminal emulator for the GNOME desktop'
   homepage 'https://gitlab.gnome.org/GNOME/console'
-  version '44.beta'
+  @_ver = '44.beta'
+  version "#{@_ver}-1"
   license 'GPL3'
-  compatibility 'all'
+  compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.gnome.org/GNOME/console.git'
-  git_hashtag version
+  git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_console/44.beta_armv7l/gnome_console-44.beta-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_console/44.beta_armv7l/gnome_console-44.beta-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_console/44.beta_i686/gnome_console-44.beta-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_console/44.beta_x86_64/gnome_console-44.beta-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_console/44.beta-1_armv7l/gnome_console-44.beta-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_console/44.beta-1_armv7l/gnome_console-44.beta-1-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_console/44.beta-1_x86_64/gnome_console-44.beta-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'dbc14ab6922e47d06f754ce71bc56c9a92b5f6327dbf68a70e71a847415a3a1e',
-     armv7l: 'dbc14ab6922e47d06f754ce71bc56c9a92b5f6327dbf68a70e71a847415a3a1e',
-       i686: 'ba4c9c384b6d4ef0d8e25388fe17b133bf336f7101c9791ad16935bc901deb60',
-     x86_64: '406c3d4f67aacc9824f5fe69a62bd356ee8230b4eb5c55e41fdd2c1ac6ee6d0f'
+    aarch64: '93d882c703a0f53035783ce30ce5cb0db6fd553eebd1fc18bb69bcd88399f8bc',
+     armv7l: '93d882c703a0f53035783ce30ce5cb0db6fd553eebd1fc18bb69bcd88399f8bc',
+     x86_64: '13cdea3dc6b049f7defc8aed6735e16c66eb74c08688b47aad6504dafd4cb190'
   })
 
-  depends_on 'libgtop'
-  depends_on 'libhandy'
-  depends_on 'vte'
-  depends_on 'sassc' => :build
-  depends_on 'nautilus' => :build
   depends_on 'gcc' # R
-  depends_on 'gdk_pixbuf' # R
-  depends_on 'glib' # R
+  depends_on 'gdk_pixbuf' # L
   depends_on 'glibc' # R
-  depends_on 'graphene' # R
+  depends_on 'glib' # R
+  depends_on 'graphene' => :build
   depends_on 'gtk4' # R
-  depends_on 'harfbuzz' # R
+  depends_on 'harfbuzz' => :build
   depends_on 'libadwaita' # R
+  depends_on 'libgtop' # R
+  depends_on 'libhandy' => :build
+  depends_on 'nautilus' => :build
   depends_on 'pango' # R
-  depends_on 'pcre2' # R
-  depends_on 'vulkan_icd_loader' # R
+  depends_on 'pcre2' => :build
+  depends_on 'sassc' => :build
+  depends_on 'vte' # R
+  depends_on 'vulkan_headers' => :build
+  depends_on 'vulkan_icd_loader' # L
 
   gnome
 
   def self.build
-    system "meson setup #{CREW_MESON_OPTIONS} \
+    system "mold -run meson setup #{CREW_MESON_OPTIONS} \
     builddir"
     system 'meson configure builddir'
-    system 'mold -run samu -C builddir'
+    system "mold -run #{CREW_NINJA} -C builddir"
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
+    system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
   end
 
   def self.postinstall

--- a/packages/gtk4.rb
+++ b/packages/gtk4.rb
@@ -3,21 +3,21 @@ require 'package'
 class Gtk4 < Package
   description 'GTK+ is a multi-platform toolkit for creating graphical user interfaces.'
   homepage 'https://developer.gnome.org/gtk4/'
-  version '4.10.0'
+  version '4.10.1'
   license 'LGPL-2.1'
-  compatibility 'aarch64,armv7l,x86_64'
+  compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.gnome.org/GNOME/gtk.git'
   git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk4/4.10.0_armv7l/gtk4-4.10.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk4/4.10.0_armv7l/gtk4-4.10.0-chromeos-armv7l.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk4/4.10.0_x86_64/gtk4-4.10.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk4/4.10.1_armv7l/gtk4-4.10.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk4/4.10.1_armv7l/gtk4-4.10.1-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk4/4.10.1_x86_64/gtk4-4.10.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'dcc5e63215b1e7185ab366f4f26b3c9674c459d4e8bf310f61437118b03071aa',
-     armv7l: 'dcc5e63215b1e7185ab366f4f26b3c9674c459d4e8bf310f61437118b03071aa',
-     x86_64: 'bcd655a3a40d18c55cfb5ae579b408b6ecd5a9656ccda339dff0dd5a5883688a'
+    aarch64: '8a33562692300a3600fba6caf29326b1effd6e1c458a3f30ffb49fc05d3306df',
+     armv7l: '8a33562692300a3600fba6caf29326b1effd6e1c458a3f30ffb49fc05d3306df',
+     x86_64: 'b9840269788ae21b6b0649762cfbd0ca56a352348fa5bc50d264e654b486f90e'
   })
 
   # L = Logical Dependency, R = Runtime Dependency

--- a/packages/gtk4.rb
+++ b/packages/gtk4.rb
@@ -85,7 +85,7 @@ class Gtk4 < Package
   end
 
   def self.build
-    system "meson setup #{CREW_MESON_OPTIONS} \
+    system "mold -run meson setup #{CREW_MESON_OPTIONS} \
       -Dbroadway-backend=true \
       -Dbuild-examples=false \
       -Dbuild-tests=false \
@@ -99,8 +99,8 @@ class Gtk4 < Package
       -Dvulkan=enabled \
       -Dprint-cups=auto \
       build"
-    system 'meson configure build'
-    system 'ninja -C build'
+    system 'meson configure builddir'
+    system "mold -run #{CREW_NINJA} -C builddir"
     @gtk4settings = <<~GTK4_CONFIG_HEREDOC
       [Settings]
       gtk-icon-theme-name = Adwaita
@@ -110,7 +110,7 @@ class Gtk4 < Package
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C build install"
+    system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
     @xdg_config_dest_home = "#{CREW_DEST_PREFIX}/.config"
     FileUtils.mkdir_p "#{@xdg_config_dest_home}/gtk-4.0"
     File.write("#{@xdg_config_dest_home}/gtk-4.0/settings.ini", @gtk4settings)

--- a/packages/libadwaita.rb
+++ b/packages/libadwaita.rb
@@ -3,24 +3,22 @@ require 'package'
 class Libadwaita < Package
   description 'Library of GNOME-specific UI patterns, replacing libhandy for GTK4'
   homepage 'https://gitlab.gnome.org/GNOME/libadwaita/'
-  @_ver = '1.3.beta'
+  @_ver = '1.3.rc'
   version @_ver
   license 'LGPL-2.1+'
-  compatibility 'all'
+  compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.gnome.org/GNOME/libadwaita.git'
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libadwaita/1.3.beta_armv7l/libadwaita-1.3.beta-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libadwaita/1.3.beta_armv7l/libadwaita-1.3.beta-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libadwaita/1.3.beta_i686/libadwaita-1.3.beta-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libadwaita/1.3.beta_x86_64/libadwaita-1.3.beta-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libadwaita/1.3.rc_armv7l/libadwaita-1.3.rc-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libadwaita/1.3.rc_armv7l/libadwaita-1.3.rc-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libadwaita/1.3.rc_x86_64/libadwaita-1.3.rc-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'e5cd5435b81fd35bc68767f3e5f64984afe5bdf4b12edff8a79ecb595a824f65',
-     armv7l: 'e5cd5435b81fd35bc68767f3e5f64984afe5bdf4b12edff8a79ecb595a824f65',
-       i686: 'f8014d089f29c90e50deb66b1c909d6cf0ea64c11fd0b6874ed2811e938f3648',
-     x86_64: '1fbbb78a8db44da2d889b92966635100e40ab46503f606083fb77370597a94d0'
+    aarch64: '9befd825d6c634327d2b7a2a4445f746a5b0651b77247b02f7a867a77f2b071f',
+     armv7l: '9befd825d6c634327d2b7a2a4445f746a5b0651b77247b02f7a867a77f2b071f',
+     x86_64: '8f1ae1e2195af60a04b962aa5209e101c7945347c1276197f6f63f0fac79bb93'
   })
 
   depends_on 'cairo'

--- a/packages/vte.rb
+++ b/packages/vte.rb
@@ -3,47 +3,47 @@ require 'package'
 class Vte < Package
   description 'Virtual Terminal Emulator widget for use with GTK'
   homepage 'https://wiki.gnome.org/Apps/Terminal/VTE'
-  @_ver = '0.71.92'
+  @_ver = '0.71.99'
   version @_ver
   license 'LGPL-2+ and GPL-3+'
-  compatibility 'all'
+  compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.gnome.org/GNOME/vte.git'
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vte/0.71.92_armv7l/vte-0.71.92-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vte/0.71.92_armv7l/vte-0.71.92-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vte/0.71.92_i686/vte-0.71.92-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vte/0.71.92_x86_64/vte-0.71.92-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vte/0.71.99_armv7l/vte-0.71.99-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vte/0.71.99_armv7l/vte-0.71.99-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vte/0.71.99_x86_64/vte-0.71.99-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '1b34b6cdf4755b9b2701de67bba27207c057e4f3cedab5c1787240f40bf68048',
-     armv7l: '1b34b6cdf4755b9b2701de67bba27207c057e4f3cedab5c1787240f40bf68048',
-       i686: '8f23401336fe44e7d0a921c544cd79efb36ce13d362df6eb420630f6832b38b9',
-     x86_64: '8e05cc8656261e324f8189fb55cb0289696209c7ad49d1b0971bfeff0eab42b8'
+    aarch64: '3dfd68ec60b4d9d9fc778ee7fd1fcb90b55b6e8623edbe0f041c8a3a88216633',
+     armv7l: '3dfd68ec60b4d9d9fc778ee7fd1fcb90b55b6e8623edbe0f041c8a3a88216633',
+     x86_64: '76e0e0f31bcf534809bfd4d34f03aa51edfc621c814e6aaf22679506e2e0d27f'
   })
 
-  depends_on 'gobject_introspection' => :build
-  depends_on 'fribidi'
-  depends_on 'gtk3'
-  depends_on 'gtk4'
   depends_on 'at_spi2_core' # R
+  depends_on 'fribidi' # R
   depends_on 'gcc' # R
   depends_on 'gdk_pixbuf' # R
-  depends_on 'glib' # R
   depends_on 'glibc' # R
+  depends_on 'glib' # R
   depends_on 'gnutls' # R
+  depends_on 'gobject_introspection' => :build
+  depends_on 'gtk3' # R
+  depends_on 'gtk4' # R
   depends_on 'harfbuzz' # R
   depends_on 'icu4c' # R
   depends_on 'pango' # R
   depends_on 'pcre2' # R
+  depends_on 'vulkan_headers' => :build
+  depends_on 'vulkan_icd_loader' => :build
   depends_on 'zlibpkg' # R
 
   gnome
 
   def self.build
     system <<~CONFIGURE
-      meson \
+      mold -run meson \
       #{CREW_MESON_FNO_LTO_OPTIONS.gsub('-fno-lto', '-fno-lto -fno-stack-protector')} \
       -D_systemd=false \
       -Dfribidi=true \
@@ -55,10 +55,10 @@ class Vte < Package
     CONFIGURE
 
     system 'meson configure builddir'
-    system 'ninja -C builddir'
+    system "mold -run #{CREW_NINJA} -C builddir"
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
   end
 end


### PR DESCRIPTION
- removes `i686` for gtk dependent packages.
- also fixes gnome_console & updates `vte`

Works properly:
- [x] `x86_64`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=glib2760 CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
