### PR TITLE
add required dep to jellyfin

### DIFF
--- a/packages/jellyfin_media_player.rb
+++ b/packages/jellyfin_media_player.rb
@@ -35,7 +35,7 @@ class Jellyfin_media_player < Package
   depends_on 'qtbase' # R
   depends_on 'qtdeclarative' # R
   depends_on 'qtlocation' # R
-  depends_on 'qtquickcontrols' => :build
+  depends_on 'qtquickcontrols' # L
   depends_on 'qtwayland' # R
   depends_on 'qtwebchannel' # R
   depends_on 'qtwebengine' # R


### PR DESCRIPTION

Works properly:
- [x] `x86_64`
