### PR TITLE
crew_mvdir workaround until it gets fixed

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1274,11 +1274,10 @@ end
 
 def install_files(src, dst = File.join( CREW_PREFIX, src.delete_prefix('./usr/local') ))
   if Dir.exist?(src)
-    CREW_DISABLE_MVDIR = 1 unless CREW_ENABLE_MVDIR
-    if File.executable?("#{CREW_PREFIX}/bin/crew-mvdir") && !CREW_DISABLE_MVDIR
+    if File.executable?("#{CREW_PREFIX}/bin/crew-mvdir") && !CREW_DISABLE_MVDIR && CREW_ENABLE_MVDIR
       system "crew-mvdir #{@short_verbose} #{src} #{dst}", exception: true
     else
-      warn 'crew-mvdir is not installed. Please install it with \'crew install crew_mvdir\' for improved installation performance'.yellow unless @pkg.name == 'crew_mvdir' or CREW_DISABLE_MVDIR
+      warn 'crew-mvdir is not installed. Please install it with \'crew install crew_mvdir\' for improved installation performance'.yellow unless @pkg.name == 'crew_mvdir' or !CREW_ENABLE_MVDIR
 
       if File.executable?("#{CREW_PREFIX}/bin/rsync") && system("#{CREW_PREFIX}/bin/rsync --version > /dev/null")
         # rsync src path needs a trailing slash

--- a/bin/crew
+++ b/bin/crew
@@ -1275,10 +1275,10 @@ end
 
 def install_files(src, dst = File.join( CREW_PREFIX, src.delete_prefix('./usr/local') ))
   if Dir.exist?(src)
-    if File.executable?("#{CREW_PREFIX}/bin/crew-mvdir") && !CREW_DISABLE_MVDIR && CREW_ENABLE_MVDIR
+    if File.executable?("#{CREW_PREFIX}/bin/crew-mvdir") && !CREW_DISABLE_MVDIR
       system "crew-mvdir #{@short_verbose} #{src} #{dst}", exception: true
     else
-      warn 'crew-mvdir is not installed. Please install it with \'crew install crew_mvdir\' for improved installation performance'.yellow unless (@pkg.name == 'crew_mvdir') || !CREW_ENABLE_MVDIR
+      warn 'crew-mvdir is not installed. Please install it with \'crew install crew_mvdir\' for improved installation performance'.yellow unless (@pkg.name == 'crew_mvdir') || CREW_DISABLE_MVDIR
 
       if File.executable?("#{CREW_PREFIX}/bin/rsync") && system("#{CREW_PREFIX}/bin/rsync --version > /dev/null")
         # rsync src path needs a trailing slash

--- a/bin/crew
+++ b/bin/crew
@@ -1274,10 +1274,11 @@ end
 
 def install_files(src, dst = File.join( CREW_PREFIX, src.delete_prefix('./usr/local') ))
   if Dir.exist?(src)
+    CREW_DISABLE_MVDIR = 1 unless CREW_ENABLE_MVDIR
     if File.executable?("#{CREW_PREFIX}/bin/crew-mvdir") && !CREW_DISABLE_MVDIR
       system "crew-mvdir #{@short_verbose} #{src} #{dst}", exception: true
     else
-      warn 'crew-mvdir is not installed. Please install it with \'crew install crew_mvdir\' for improved installation performance'.yellow unless @pkg.name == 'crew_mvdir'
+      warn 'crew-mvdir is not installed. Please install it with \'crew install crew_mvdir\' for improved installation performance'.yellow unless @pkg.name == 'crew_mvdir' or CREW_DISABLE_MVDIR
 
       if File.executable?("#{CREW_PREFIX}/bin/rsync") && system("#{CREW_PREFIX}/bin/rsync --version > /dev/null")
         # rsync src path needs a trailing slash

--- a/bin/crew
+++ b/bin/crew
@@ -1108,6 +1108,7 @@ end
 
 def patchelf_set_need_paths(dir)
   return if @pkg.no_patchelf? || @pkg.no_compile_needed?
+
   puts 'Patchelf is currently disabled during builds due to problems with upx.'.yellow
   return
 
@@ -1277,7 +1278,7 @@ def install_files(src, dst = File.join( CREW_PREFIX, src.delete_prefix('./usr/lo
     if File.executable?("#{CREW_PREFIX}/bin/crew-mvdir") && !CREW_DISABLE_MVDIR && CREW_ENABLE_MVDIR
       system "crew-mvdir #{@short_verbose} #{src} #{dst}", exception: true
     else
-      warn 'crew-mvdir is not installed. Please install it with \'crew install crew_mvdir\' for improved installation performance'.yellow unless @pkg.name == 'crew_mvdir' or !CREW_ENABLE_MVDIR
+      warn 'crew-mvdir is not installed. Please install it with \'crew install crew_mvdir\' for improved installation performance'.yellow unless (@pkg.name == 'crew_mvdir') || !CREW_ENABLE_MVDIR
 
       if File.executable?("#{CREW_PREFIX}/bin/rsync") && system("#{CREW_PREFIX}/bin/rsync --version > /dev/null")
         # rsync src path needs a trailing slash

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -138,12 +138,8 @@ CHROMEOS_RELEASE = if File.exist?('/etc/lsb-release')
                      ENV.fetch('CHROMEOS_RELEASE_CHROME_MILESTONE', nil)
                    end
 
-# If CREW_ENABLE_MVDIR environment variable exists use crew-mvdir in lieu of rsync/tar to install files.
-# This overrides CREW_DISABLE_MVDIR.
-CREW_ENABLE_MVDIR = ENV['CREW_ENABLE_MVDIR'].eql?('1')
-
-# If CREW_DISABLE_MVDIR environment variable exists use rsync/tar to install files in lieu of crew-mvdir.
-CREW_DISABLE_MVDIR = ENV['CREW_DISABLE_MVDIR'].eql?('1')
+# If CREW_DISABLE_MVDIR environment variable exists and is equal to 1 use rsync/tar to install files in lieu of crew-mvdir.
+CREW_DISABLE_MVDIR = ENV['CREW_DISABLE_MVDIR'] != "0" ? true : false
 
 # If CREW_USE_CURL environment variable exists use curl in lieu of net/http.
 CREW_USE_CURL = ENV['CREW_USE_CURL'].eql?('1')

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -139,7 +139,7 @@ CHROMEOS_RELEASE = if File.exist?('/etc/lsb-release')
                    end
 
 # If CREW_DISABLE_MVDIR environment variable exists and is equal to 1 use rsync/tar to install files in lieu of crew-mvdir.
-CREW_DISABLE_MVDIR = ENV['CREW_DISABLE_MVDIR'] != "0" ? true : false
+CREW_DISABLE_MVDIR = ENV['CREW_DISABLE_MVDIR'] != '0'
 
 # If CREW_USE_CURL environment variable exists use curl in lieu of net/http.
 CREW_USE_CURL = ENV['CREW_USE_CURL'].eql?('1')

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.32.0'
+CREW_VERSION = '1.32.1'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp
@@ -137,6 +137,10 @@ CHROMEOS_RELEASE = if File.exist?('/etc/lsb-release')
                      # newer version of Chrome OS exports info to env by default
                      ENV.fetch('CHROMEOS_RELEASE_CHROME_MILESTONE', nil)
                    end
+
+# If CREW_ENABLE_MVDIR environment variable exists use crew-mvdir in lieu of rsync/tar to install files.
+# This overrides CREW_DISABLE_MVDIR.
+CREW_ENABLE_MVDIR = ENV['CREW_ENABLE_MVDIR'].eql?('1')
 
 # If CREW_DISABLE_MVDIR environment variable exists use rsync/tar to install files in lieu of crew-mvdir.
 CREW_DISABLE_MVDIR = ENV['CREW_DISABLE_MVDIR'].eql?('1')


### PR DESCRIPTION
Not a fix but a workaround for https://github.com/chromebrew/chromebrew/issues/8063

(@supechicken You can invoke `crew_mvdir` during an install now with `CREW_DISABLE_MVDIR=0 crew install linter` for instance.)
<!-- (let GitHub automatically close an issue when this pull request gets merged) -->

<!--
## Before you submit a pull request

This template is not necessary when you do simple things like updating packages to the latest version. But in doubt, it's always better so provide some information.
-->

## Description
```
chronos@localhost / $ crew remove linter
Linter removed!
chronos@localhost / $ CREW_DISABLE_MVDIR=0 crew install linter
linter: Comprehensive linter and code analysis for various file types.
https://github.com/chromebrew/chromebrew
Version: 1.4
License: GPL-3
Performing pre-flight checks...
Skipping source download...
Preconfiguring package...
Checking for FHS3 compliance...
Checking for conflicts with files from installed packages...
Using rdfind to convert duplicate files to hard links.
Now scanning ".", found 5 files.
Now have 5 files in total.
Removed 0 files due to nonunique device and inode.
Total size is 1102 bytes or 1 KiB
Removed 5 files due to unique sizes from list. 0 files left.
Now eliminating candidates based on first bytes: removed 0 files from list. 0 files left.
Now eliminating candidates based on last bytes: removed 0 files from list. 0 files left.
Now eliminating candidates based on sha1 checksum: removed 0 files from list. 0 files left.
It seems like you have 0 files that are not unique
Totally, 0 B can be reduced.
Now making hard links.
Making 0 links.
Performing pre-install...
Performing install...
Using rdfind to convert duplicate files to hard links.
Now scanning ".", found 3 files.
Now have 3 files in total.
Removed 0 files due to nonunique device and inode.
Total size is 1065 bytes or 1 KiB
Removed 3 files due to unique sizes from list. 0 files left.
Now eliminating candidates based on first bytes: removed 0 files from list. 0 files left.
Now eliminating candidates based on last bytes: removed 0 files from list. 0 files left.
Now eliminating candidates based on sha1 checksum: removed 0 files from list. 0 files left.
It seems like you have 0 files that are not unique
Totally, 0 B can be reduced.
Now making hard links.
Making 0 links.
./home/chronos/user/.mdl_style.rb: rename() failed: Invalid cross-device link
/usr/local/bin/crew:1279:in `system': Command failed with exit 18: crew-mvdir (RuntimeError)
        from /usr/local/bin/crew:1279:in `install_files'
        from /usr/local/bin/crew:1329:in `block in install_package'
        from /usr/local/bin/crew:1297:in `chdir'
        from /usr/local/bin/crew:1297:in `install_package'
        from /usr/local/bin/crew:1482:in `install'
        from /usr/local/bin/crew:1349:in `resolve_dependencies_and_install'
        from /usr/local/bin/crew:1795:in `block in install_command'
        from /usr/local/bin/crew:1790:in `each'
        from /usr/local/bin/crew:1790:in `install_command'
        from /usr/local/bin/crew:1922:in `<main>'
chronos@localhost / $ crew install linter
linter: Comprehensive linter and code analysis for various file types.
https://github.com/chromebrew/chromebrew
Version: 1.4
License: GPL-3
Performing pre-flight checks...
Skipping source download...
Preconfiguring package...
Checking for FHS3 compliance...
Checking for conflicts with files from installed packages...
Using rdfind to convert duplicate files to hard links.
Now scanning ".", found 5 files.
Now have 5 files in total.
Removed 0 files due to nonunique device and inode.
Total size is 1102 bytes or 1 KiB
Removed 5 files due to unique sizes from list. 0 files left.
Now eliminating candidates based on first bytes: removed 0 files from list. 0 files left.
Now eliminating candidates based on last bytes: removed 0 files from list. 0 files left.
Now eliminating candidates based on sha1 checksum: removed 0 files from list. 0 files left.
It seems like you have 0 files that are not unique
Totally, 0 B can be reduced.
Now making hard links.
Making 0 links.
Performing pre-install...
Performing install...
Using rdfind to convert duplicate files to hard links.
Now scanning ".", found 3 files.
Now have 3 files in total.
Removed 0 files due to nonunique device and inode.
Total size is 1065 bytes or 1 KiB
Removed 3 files due to unique sizes from list. 0 files left.
Now eliminating candidates based on first bytes: removed 0 files from list. 0 files left.
Now eliminating candidates based on last bytes: removed 0 files from list. 0 files left.
Now eliminating candidates based on sha1 checksum: removed 0 files from list. 0 files left.
It seems like you have 0 files that are not unique
Totally, 0 B can be reduced.
Now making hard links.
Making 0 links.
Linter installed!
chronos@localhost / $ 
```

## Additional information
<!-- Mention things we might need to know. Like: -->

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=mvdir_workaround CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
