### PR TITLE
Some rebuilds for updated libtiff

### DIFF
--- a/packages/evince.rb
+++ b/packages/evince.rb
@@ -6,60 +6,66 @@ require 'package'
 class Evince < Package
   description 'Document viewer PDF, PostScript, XPS, djvu, dvi, tiff, cbr, cbz, cb7, cbt'
   homepage 'https://wiki.gnome.org/Apps/Evince'
-  version '43.0'
+  version '44.rc'
   license 'GPL'
-  compatibility 'all'
+  compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.gnome.org/GNOME/evince.git'
   git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evince/43.0_armv7l/evince-43.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evince/43.0_armv7l/evince-43.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evince/43.0_i686/evince-43.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evince/43.0_x86_64/evince-43.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evince/44.rc_armv7l/evince-44.rc-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evince/44.rc_armv7l/evince-44.rc-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evince/44.rc_x86_64/evince-44.rc-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '7a9a9a562931d0df03ae78badadb3e87a34c6810cbc848066bfae27d33695587',
-     armv7l: '7a9a9a562931d0df03ae78badadb3e87a34c6810cbc848066bfae27d33695587',
-       i686: '951637e6b83cf9682b7779d5394e403df80d3e9e291458ff8cd08589c9f4e104',
-     x86_64: 'dc46b37780ac1b9f5c400a3bd8b4c8f01a0752b287747ced776e62b7be053cf5'
+    aarch64: 'a7817e8a1cea35f9c82bbf282cfe108354161ec37a709d03007bae083dbebd61',
+     armv7l: 'a7817e8a1cea35f9c82bbf282cfe108354161ec37a709d03007bae083dbebd61',
+     x86_64: 'a790320dfaf80b7b55caf2aad5f2fc757d59abe379776ec7f771e8fd7c85b298'
   })
 
   depends_on 'at_spi2_core' # R
   depends_on 'cairo' # R
   depends_on 'djvulibre' # R
   depends_on 'docbook_xsl' => :build
+  depends_on 'gcc' # R
   depends_on 'gdk_pixbuf' # R
+  depends_on 'glibc' # R
   depends_on 'glib' # R
   depends_on 'gnome_desktop' # R
   depends_on 'gobject_introspection' => :build
   depends_on 'gstreamer' # R
   depends_on 'gtk3' # R
   depends_on 'gtk_doc' => :build
+  depends_on 'harfbuzz' # R
+  depends_on 'libarchive' # R
   depends_on 'libgxps' # R
   depends_on 'libhandy' # R
   depends_on 'libsecret' # R
   depends_on 'libspectre' # R
   depends_on 'libtiff' # R
+  depends_on 'libxml2' # R
   depends_on 'nautilus' # R
   depends_on 'pango' # R
   depends_on 'poppler' # R
+  depends_on 'py3_gi_docgen' => :build
   depends_on 'valgrind' => :build
+  depends_on 'zlibpkg' # R
+
   gnome
 
   def self.build
-    system "meson setup #{CREW_MESON_OPTIONS} \
+    system "mold -run meson setup #{CREW_MESON_OPTIONS} \
       -Dgtk_doc=false \
       -Dnautilus=false \
       -Dps=enabled \
       -Dsystemduserunitdir=no \
       builddir"
     system 'meson configure builddir'
-    system 'ninja -C builddir'
+    system "mold -run #{CREW_NINJA} -C builddir"
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
   end
 
   def self.postinstall

--- a/packages/gdal.rb
+++ b/packages/gdal.rb
@@ -3,63 +3,61 @@ require 'package'
 class Gdal < Package
   description 'The Geospatial Data Abstraction Library is a translator for raster and vector geospatial data formats.'
   homepage 'http://www.gdal.org/'
-  version '3.5.2'
+  version '3.6.3'
   license 'BSD, Info-ZIP and MIT'
   compatibility 'all'
-  source_url 'https://download.osgeo.org/gdal/3.5.2/gdal-3.5.2.tar.xz'
-  source_sha256 '0874dfdeb9ac42e53c37be4184b19350be76f0530e1f4fa8004361635b9030c2'
+  source_url 'https://download.osgeo.org/gdal/3.6.3/gdal-3.6.3.tar.xz'
+  source_sha256 '3cccbed883b1fb99b913966aa3a650ad930e7c3afc714f5823f9754176ee49ea'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdal/3.5.2_armv7l/gdal-3.5.2-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdal/3.5.2_armv7l/gdal-3.5.2-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdal/3.5.2_i686/gdal-3.5.2-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdal/3.5.2_x86_64/gdal-3.5.2-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdal/3.6.3_armv7l/gdal-3.6.3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdal/3.6.3_armv7l/gdal-3.6.3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdal/3.6.3_i686/gdal-3.6.3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdal/3.6.3_x86_64/gdal-3.6.3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '97817ef4a8c5a4f006a327d9c4cf5fedaf9bda63b0fe6133357ffdb6c51f2969',
-     armv7l: '97817ef4a8c5a4f006a327d9c4cf5fedaf9bda63b0fe6133357ffdb6c51f2969',
-       i686: '3d64d3e78e9d8a16941f052a5a574a147337091229f0c6ef1c6fddfe45b0f15b',
-     x86_64: '4f75750a53750a78ff43625ab073afe457045387106074537cb294ee38d51bac'
+    aarch64: '07803c1d895f07923b3a4de611aae93302d5fcbb772db4209be19d8bd654b582',
+     armv7l: '07803c1d895f07923b3a4de611aae93302d5fcbb772db4209be19d8bd654b582',
+       i686: '6816f286833651fc1201dfe25d571355ff728f0eae15e7f23097b53c4f6f149c',
+     x86_64: '3b5505ae58c8d72eeb7c58125cac5ad340543ec5c6caba62454effeea17fee73'
   })
 
-  depends_on 'openjpeg'
-  depends_on 'libcurl'
-  depends_on 'geos'
-  depends_on 'hdf5'
-  depends_on 'proj4'
-  depends_on 'qhull'
-  depends_on 'libgeotiff'
-  depends_on 'libxml2'
-  depends_on 'xercesc'
   depends_on 'expat' # R
   depends_on 'gcc' # R
+  depends_on 'geos' # R
   depends_on 'giflib' # R
   depends_on 'glibc' # R
+  depends_on 'hdf5' => :build
   depends_on 'jsonc' # R
+  depends_on 'libcurl' # R
   depends_on 'libdeflate' # R
+  depends_on 'libgeotiff' # R
   depends_on 'libjpeg' # R
   depends_on 'libpng' # R
   depends_on 'libtiff' # R
   depends_on 'libwebp' # R
+  depends_on 'libxml2' # R
   depends_on 'lz4' # R
+  depends_on 'openjpeg' # R
   depends_on 'openssl' # R
   depends_on 'pcre2' # R
+  depends_on 'proj4' # R
+  depends_on 'qhull' # R
   depends_on 'sqlite' # R
   depends_on 'unixodbc' # R
+  depends_on 'xercesc' # R
+  depends_on 'xzutils' # R
   depends_on 'zlibpkg' # R
   depends_on 'zstd' # R
 
   def self.build
-    system 'filefix'
-    system "./configure \
-      --with-curl=#{CREW_PREFIX}/bin/curl-config \
-      --with-geos=#{CREW_PREFIX}/bin/geos-config \
-      --with-python \
-      --with-proj"
-    system 'make'
+    system "mold -run cmake -B builddir #{CREW_CMAKE_OPTIONS} \
+        -Wno-dev \
+        -G Ninja"
+    system "mold -run #{CREW_NINJA} -C builddir"
   end
 
   def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
   end
 end

--- a/packages/gdk_pixbuf.rb
+++ b/packages/gdk_pixbuf.rb
@@ -4,31 +4,31 @@ class Gdk_pixbuf < Package
   description 'GdkPixbuf is a library for image loading and manipulation.'
   homepage 'https://developer.gnome.org/gdk-pixbuf'
   @_ver = '2.42.10'
-  version @_ver
+  version "#{@_ver}-1"
   license 'LGPL-2.1+'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/gdk-pixbuf.git'
-  git_hashtag version
+  git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.10_armv7l/gdk_pixbuf-2.42.10-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.10_armv7l/gdk_pixbuf-2.42.10-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.10_i686/gdk_pixbuf-2.42.10-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.10_x86_64/gdk_pixbuf-2.42.10-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.10-1_armv7l/gdk_pixbuf-2.42.10-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.10-1_armv7l/gdk_pixbuf-2.42.10-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.10-1_i686/gdk_pixbuf-2.42.10-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gdk_pixbuf/2.42.10-1_x86_64/gdk_pixbuf-2.42.10-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '4c4a3256bd6d71d843fdb61eaaa4747ad593794ef6e0d13e098da0113734c6a2',
-     armv7l: '4c4a3256bd6d71d843fdb61eaaa4747ad593794ef6e0d13e098da0113734c6a2',
-       i686: '21e9221b750b29249859be3459783bd7ef374edca8cf44cc6854a909369d44e8',
-     x86_64: '2f374ebec8d94d8856d577e3046c889c45e77787115acf471bf853db13b05301'
+    aarch64: '8d79852a5069b1c1e5a6834648c32f346ad407e894be2ecc75a66f69cf42160c',
+     armv7l: '8d79852a5069b1c1e5a6834648c32f346ad407e894be2ecc75a66f69cf42160c',
+       i686: '948434f4e7e58091e04a9a7918f08fe52db255bc1dc5dbacb8a59c58cf99cd93',
+     x86_64: '65eb125c9b4a15ba85b5f3d95f7e5a66d1024154ed34cf807d8fa651800e259d'
   })
 
   depends_on 'glib' # R
   depends_on 'gobject_introspection' => :build
   depends_on 'harfbuzz' # R
   depends_on 'libjpeg' # R
-  # depends_on 'libtiff' # R This drags gtk3 into the deps via libwebp
-  # depends_on 'libwebp' => :build This drags gtk3 into the deps.
+  depends_on 'libtiff' # R
+  depends_on 'libwebp' # R
   depends_on 'pango' => :build
   depends_on 'py3_docutils' => :build
   depends_on 'py3_gi_docgen' => :build
@@ -45,13 +45,14 @@ class Gdk_pixbuf < Package
   gnome
 
   def self.build
-    system "meson setup #{CREW_MESON_OPTIONS} \
+    system "mold -run meson setup #{CREW_MESON_OPTIONS} \
       -Dinstalled_tests=false \
       -Dbuiltin_loaders=all \
       -Drelocatable=true \
       -Ddebug=false \
       -Dgtk_doc=false \
       -Dman=true \
+      -Dtests=false \
       builddir"
     system 'mold -run samu -C builddir'
   end

--- a/packages/gegl.rb
+++ b/packages/gegl.rb
@@ -3,23 +3,21 @@ require 'package'
 class Gegl < Package
   description 'GEGL (Generic Graphics Library) is a data flow based image processing framework, providing floating point processing and non-destructive image processing capabilities to GNU Image Manipulation Program and other projects.'
   homepage 'http://gegl.org/'
-  version '0.4.40'
+  version '0.4.42'
   license 'GPL-3+ and LGPL-3'
-  compatibility 'all'
-  source_url 'https://download.gimp.org/pub/gegl/0.4/gegl-0.4.40.tar.xz'
-  source_sha256 'cdde80d15a49dab9a614ef98f804c8ce6e4cfe1339a3c240c34f3fb45436b85d'
+  compatibility 'x86_64 aarch64 armv7l'
+  source_url 'https://download.gimp.org/pub/gegl/0.4/gegl-0.4.42.tar.xz'
+  source_sha256 'aba83a0cbaa6c56edc29ea22f2e8172950a53b96daa51592083d59222bdde02d'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gegl/0.4.40_armv7l/gegl-0.4.40-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gegl/0.4.40_armv7l/gegl-0.4.40-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gegl/0.4.40_i686/gegl-0.4.40-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gegl/0.4.40_x86_64/gegl-0.4.40-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gegl/0.4.42_armv7l/gegl-0.4.42-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gegl/0.4.42_armv7l/gegl-0.4.42-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gegl/0.4.42_x86_64/gegl-0.4.42-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '44e1852b0f8a9534bca83213b19caa7d8c21dd0e2cb6d70f543db283c501a1f7',
-     armv7l: '44e1852b0f8a9534bca83213b19caa7d8c21dd0e2cb6d70f543db283c501a1f7',
-       i686: '58ee62cb95cc60a75ecf91afe463b5896049f0206f112ec82e9abf5e24c4621f',
-     x86_64: 'c874a01a85b80451716fdd6898ab3e1e2e2df6ef6296217aea1d444e58196b69'
+    aarch64: 'b0aba71d5f37ffc560c39786b193d7a32f122d62fe612a88539d3ed6e13102ae',
+     armv7l: 'b0aba71d5f37ffc560c39786b193d7a32f122d62fe612a88539d3ed6e13102ae',
+     x86_64: '17e36b43e2d5217b7df42f83c013a91c32df492d5b719665e9aada083e9a9173'
   })
 
   depends_on 'asciidoc' => :build
@@ -34,6 +32,7 @@ class Gegl < Package
   depends_on 'glib' # R
   depends_on 'graphviz' => :build # for dot
   depends_on 'harfbuzz' # R
+  depends_on 'ilmbase' # R
   depends_on 'jasper' # R
   depends_on 'json_glib' # R
   depends_on 'lcms' # R
@@ -48,6 +47,7 @@ class Gegl < Package
   depends_on 'pango' # R
   depends_on 'poppler' # R
   depends_on 'vala' => :build
+  depends_on 'zlibpkg' # R
 
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
@@ -55,10 +55,10 @@ class Gegl < Package
       -Dlibpng=enabled \
     builddir"
     system 'meson configure builddir'
-    system 'ninja -C builddir'
+    system "mold -run #{CREW_NINJA} -C builddir"
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
+    system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
   end
 end

--- a/packages/ghostscript.rb
+++ b/packages/ghostscript.rb
@@ -3,23 +3,23 @@ require 'package'
 class Ghostscript < Package
   description 'Interpreter for the PostScript language'
   homepage 'https://www.ghostscript.com/'
-  version '10.0.0'
+  version '10.0.0-1'
   license 'AGPL-3+'
   compatibility 'all'
   source_url 'https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs1000/ghostpdl-10.0.0.tar.xz'
   source_sha256 '8f2b7941f60df694b4f5c029b739007f7c4e0d43858471ae481e319a967d5d8b'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ghostscript/10.0.0_armv7l/ghostscript-10.0.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ghostscript/10.0.0_armv7l/ghostscript-10.0.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ghostscript/10.0.0_i686/ghostscript-10.0.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ghostscript/10.0.0_x86_64/ghostscript-10.0.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ghostscript/10.0.0-1_armv7l/ghostscript-10.0.0-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ghostscript/10.0.0-1_armv7l/ghostscript-10.0.0-1-chromeos-armv7l.tar.zst',
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ghostscript/10.0.0-1_i686/ghostscript-10.0.0-1-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ghostscript/10.0.0-1_x86_64/ghostscript-10.0.0-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '82c15db8a46f73fcf467fd36bdc1d9713bfe35e1fd269408a75232967400ebf4',
-     armv7l: '82c15db8a46f73fcf467fd36bdc1d9713bfe35e1fd269408a75232967400ebf4',
-       i686: '91dfb5bab16d31c3418c57cae464f0b2377f0e19d0057cec751ef8b14f50b9aa',
-     x86_64: 'c3c1f1ac1c31ea6a465367504156c18d47bae8b1ecbaee3b118e3bbc3b25a5a9'
+    aarch64: 'b238eae744d34ddb16c3b8d460bf6012021deadf690ce23a08449c8c0d5c583f',
+     armv7l: 'b238eae744d34ddb16c3b8d460bf6012021deadf690ce23a08449c8c0d5c583f',
+    i686: '858a1f11a7c3977e3e42bb0179b1964a8671196270f9cd1f3a02b3dee735aed9',
+  x86_64: '384a4c40c58a46bc7c7610fbd883bb532d0da7c83ff2cf9858aa51f989e4525d'
   })
 
   depends_on 'at_spi2_core' # R
@@ -34,6 +34,7 @@ class Ghostscript < Package
   depends_on 'glib' # R
   depends_on 'gtk3' unless ARCH == 'i686' # R
   depends_on 'harfbuzz' # R
+  depends_on 'jbigkit' => :build
   depends_on 'lcms' # R
   depends_on 'libarchive' # R
   depends_on 'libice' # R
@@ -56,6 +57,7 @@ class Ghostscript < Package
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
     system 'filefix'
+    @x = ARCH == 'i686' ? '--with-x' : ''
     system "./configure #{CREW_OPTIONS} \
       --disable-compile-inits \
       --enable-dynamic \
@@ -67,10 +69,8 @@ class Ghostscript < Package
       --with-ijs \
       --with-jbig2dec \
       --with-libpaper \
-      --with-openprinting \
-      --without-luratech \
       --with-system-libtiff \
-      --with-x"
+      #{@x}"
     system 'make'
     system 'make so' # Make libgs
   end

--- a/packages/libgeotiff.rb
+++ b/packages/libgeotiff.rb
@@ -3,23 +3,23 @@ require 'package'
 class Libgeotiff < Package
   description 'GeoTIFF is based on the TIFF format and is used as an interchange format for georeferenced raster imagery.'
   homepage 'https://github.com/OSGeo/libgeotiff'
-  version '1.7.1'
+  version '1.7.1-1'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://github.com/OSGeo/libgeotiff/releases/download/1.7.1/libgeotiff-1.7.1.tar.gz'
   source_sha256 '05ab1347aaa471fc97347d8d4269ff0c00f30fa666d956baba37948ec87e55d6'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgeotiff/1.7.1_armv7l/libgeotiff-1.7.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgeotiff/1.7.1_armv7l/libgeotiff-1.7.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgeotiff/1.7.1_i686/libgeotiff-1.7.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgeotiff/1.7.1_x86_64/libgeotiff-1.7.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgeotiff/1.7.1-1_armv7l/libgeotiff-1.7.1-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgeotiff/1.7.1-1_armv7l/libgeotiff-1.7.1-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgeotiff/1.7.1-1_i686/libgeotiff-1.7.1-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgeotiff/1.7.1-1_x86_64/libgeotiff-1.7.1-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'ca3b82c76afdc8f1b296ee5db782aceb947b78f6ccfd19093a881291bb7239af',
-     armv7l: 'ca3b82c76afdc8f1b296ee5db782aceb947b78f6ccfd19093a881291bb7239af',
-       i686: '1ba477f5bd5dec79dd0da7be7ce5ab11f09dcb7aa1e4d4f65ebd234a8b744017',
-     x86_64: 'c570d1d56a1255e569be9052135ad46b24e7f68886a8a98c7365a25a1ca664fe'
+    aarch64: '37c527b38436f6313b6be20ed176d7f8be509f2dd2cb9e2fadcba16823b17331',
+     armv7l: '37c527b38436f6313b6be20ed176d7f8be509f2dd2cb9e2fadcba16823b17331',
+       i686: 'dabea0e5c4f43acabdd1de7b6c46f883a2c2734a0fefe502dd13c3bb4ee2d32e',
+     x86_64: '14c3b9e715d8fb79247f8fb17b93a843219f4e064b6b71115a4d57f2ff81ed6b'
   })
 
   depends_on 'gcc' # R
@@ -28,14 +28,11 @@ class Libgeotiff < Package
   depends_on 'proj4' # R
 
   def self.build
-    Dir.mkdir 'builddir'
-    Dir.chdir 'builddir' do
-      system "cmake -G Ninja \
+    system "cmake -B builddir -G Ninja \
         #{CREW_CMAKE_OPTIONS} \
+        -DGEOTIFF_LIB_SUBDIR=#{CREW_LIB_PREFIX} \
         -DCMAKE_INSTALL_DOCDIR=#{CREW_PREFIX}/share/doc \
-        -DBUILD_SHARED_LIBS=true \
-        .."
-    end
+        -DBUILD_SHARED_LIBS=true"
     system 'ninja -C builddir'
   end
 
@@ -43,8 +40,5 @@ class Libgeotiff < Package
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share"
     FileUtils.mv "#{CREW_DEST_PREFIX}/doc", "#{CREW_DEST_PREFIX}/share/"
-    return unless ARCH == 'x86_64'
-
-    FileUtils.mv "#{CREW_DEST_PREFIX}/lib", "#{CREW_DEST_PREFIX}/lib64"
   end
 end

--- a/packages/libwebp.rb
+++ b/packages/libwebp.rb
@@ -3,33 +3,34 @@ require 'package'
 class Libwebp < Package
   description 'WebP is a modern image format that provides superior lossless and lossy compression for images on the web.'
   homepage 'https://developers.google.com/speed/webp/'
-  version '1.2.4'
+  version '1.3.0'
   license 'BSD'
   compatibility 'all'
-  source_url 'http://downloads.webmproject.org/releases/webp/libwebp-1.2.4.tar.gz'
-  source_sha256 '7bf5a8a28cc69bcfa8cb214f2c3095703c6b73ac5fba4d5480c205331d9494df'
+  source_url 'http://downloads.webmproject.org/releases/webp/libwebp-1.3.0.tar.gz'
+  source_sha256 '64ac4614db292ae8c5aa26de0295bf1623dbb3985054cb656c55e67431def17c'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libwebp/1.2.4_armv7l/libwebp-1.2.4-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libwebp/1.2.4_armv7l/libwebp-1.2.4-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libwebp/1.2.4_i686/libwebp-1.2.4-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libwebp/1.2.4_x86_64/libwebp-1.2.4-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libwebp/1.3.0_armv7l/libwebp-1.3.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libwebp/1.3.0_armv7l/libwebp-1.3.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libwebp/1.3.0_i686/libwebp-1.3.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libwebp/1.3.0_x86_64/libwebp-1.3.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'a2e7a4256e82a504e6743fbe60f00392454d372cd7dc49bdb6048d7ad38f295e',
-     armv7l: 'a2e7a4256e82a504e6743fbe60f00392454d372cd7dc49bdb6048d7ad38f295e',
-       i686: 'e7a0d7cdce843ec6fdfb4777cea92c4a86e788db276c323ca2509444411cc064',
-     x86_64: '1abbb91a453ce229b295d6a1383799bc7a1898140d711b866f13a69ea9d318da'
+    aarch64: 'b53467584541660e2868e195e380b4f489a2a1bc3547705ad918dbebda3486e5',
+     armv7l: 'b53467584541660e2868e195e380b4f489a2a1bc3547705ad918dbebda3486e5',
+       i686: '036924f4f26489260fc49d8cbc4656c4a23b8d6c936cc71f96cd59880e650c75',
+     x86_64: '8568b43bcc23bc5686354a67b654cb18c4dfe6560637c43ce8b8f9eef5b76580'
   })
 
   depends_on 'freeglut' # R
   depends_on 'giflib' # R
   depends_on 'glibc' # R
+  depends_on 'jbigkit' => :build
   depends_on 'libdeflate' # R
   depends_on 'libglvnd' # R
   depends_on 'libjpeg' # R
   depends_on 'libpng' # R
-  depends_on 'libsdl' => :build
+  depends_on 'libsdl' => :build unless ARCH == 'i686'
   depends_on 'libtiff' # R
   depends_on 'xzutils' # R
   depends_on 'zlibpkg' # R

--- a/packages/v4l_utils.rb
+++ b/packages/v4l_utils.rb
@@ -27,8 +27,8 @@ class V4l_utils < Package
   depends_on 'eudev'
   depends_on 'libglu'
   depends_on 'libjpeg'
-  depends_on 'mesa'
-  depends_on 'qtbase'
+  depends_on 'mesa' unless ARCH == 'i686'
+  depends_on 'qtbase' unless ARCH == 'i686'
   depends_on 'sdl2_image'
   depends_on 'gcc' # R
   depends_on 'glibc' # R


### PR DESCRIPTION
Fixes #8083
- Also adds more fixes for letting i686 builds succeed w/o sommelier...

Updated:
- [x] evince
- [x] gdk_pixbuf
- [x] gdal
- [x] gegl
- [x] ghostscript
- [x] libgeotiff
- [x] libwebp


Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=libtiff_rebuilds CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
