### PR TITLE
Update logic to handle aarch64 userspace install attempts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -102,11 +102,19 @@ function curl () {
 case "${ARCH}" in
 "i686"|"x86_64"|"armv7l"|"aarch64")
   LIB_SUFFIX=
-  [ "${ARCH}" == "x86_64" ] && LIB_SUFFIX='64'
+  # See https://superuser.com/a/1369875
+  # If /bin/bash is 64-bit, then set LIB_SUFFIX, as this is true on both
+  # x86_64 and aarch64 userspace
+  [ $(od -An -t x1 -j 4 -N 1  /bin/bash) == "02" ] && LIB_SUFFIX='64'
+  if [[ $LIB_SUFFIX == '64' ]] && [[ $ARCH == 'aarch64' ]]; then
+    echo_error "Your device is not supported by Chromebrew yet :/"
+    exit 1
+  fi
   ;;
 *)
   echo_error "Your device is not supported by Chromebrew yet :/"
-  exit 1;;
+  exit 1
+  ;;
 esac
 
 echo_info "\n\nDoing initial setup for install in ${CREW_PREFIX}."


### PR DESCRIPTION
Fixes #8090

- Disallows installs on `aarch64` userspace since we are not compatible yet.

Tested in these containers:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
- [x] aarch64

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=aarch64_install_warning CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
