### PR TITLE
Liba52 0.7.4-1 => 0.7.4-2

### DIFF
--- a/packages/liba52.rb
+++ b/packages/liba52.rb
@@ -4,23 +4,23 @@ class Liba52 < Package
   description 'liba52 is a free library for decoding ATSC A/52 streams.'
   homepage 'http://liba52.sourceforge.net/'
   @_ver = '0.7.4'
-  version "#{@_ver}-1"
+  version "#{@_ver}-2"
   compatibility 'all'
   license 'GPL-2+'
   source_url 'https://salsa.debian.org/multimedia-team/a52dec.git'
   git_hashtag "debian/#{@_ver}-20"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/liba52/0.7.4-1_armv7l/liba52-0.7.4-1-chromeos-armv7l.tpxz',
-      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/liba52/0.7.4-1_armv7l/liba52-0.7.4-1-chromeos-armv7l.tpxz',
-        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/liba52/0.7.4-1_i686/liba52-0.7.4-1-chromeos-i686.tpxz',
-      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/liba52/0.7.4-1_x86_64/liba52-0.7.4-1-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/liba52/0.7.4-2_armv7l/liba52-0.7.4-2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/liba52/0.7.4-2_armv7l/liba52-0.7.4-2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/liba52/0.7.4-2_i686/liba52-0.7.4-2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/liba52/0.7.4-2_x86_64/liba52-0.7.4-2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '106c1cfcb9b7eb7a0dcc891d7586abacddc422f667da68dbd8260f13c7c0d6f3',
-      armv7l: '106c1cfcb9b7eb7a0dcc891d7586abacddc422f667da68dbd8260f13c7c0d6f3',
-        i686: '5d8f45e6a52ee96c54330c624fd66c64b75efd58d20049fdaf7fbe317b6d1bc6',
-      x86_64: '8473516c95e4e2356bf3311ea689b430117b0324b30b4aa06785eb17497136ef'
+    aarch64: '844f79a23cd1dde50dee917211786abdef130f7e952ec6b1c9c8208f8ac69abc',
+     armv7l: '844f79a23cd1dde50dee917211786abdef130f7e952ec6b1c9c8208f8ac69abc',
+       i686: '8fb90edfa222ac82c6b357152f5416a8e5e5d2faa9a904e0b7c531c5e8f7d04a',
+     x86_64: '01c64a8b207833ee58dc4482d4d96f5dff1261071ef6573e5817ce43e76a0789'
   })
 
   def self.patch
@@ -29,15 +29,15 @@ class Liba52 < Package
 
   def self.build
     system './bootstrap'
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_OPTIONS}"
     system 'make'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 
   def self.check
     system 'make', 'check'
+  end
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end


### PR DESCRIPTION
Fixes:
```
lto1: fatal error: bytecode stream in file '/usr/local/lib64/liba52.a' generated with LTO version 11.0 instead of the expected 12.0
```