### PR TITLE
rust => 1.68.2, rustup => 1.25.2

### DIFF
--- a/packages/rust.rb
+++ b/packages/rust.rb
@@ -3,24 +3,24 @@ require 'package'
 class Rust < Package
   description 'Rust is a systems programming language that runs blazingly fast, prevents segfaults, and guarantees thread safety.'
   homepage 'https://www.rust-lang.org/'
-  @_ver = '1.68.1'
+  @_ver = '1.68.2'
   version @_ver
   license 'Apache-2.0 and MIT'
   compatibility 'all'
   source_url 'https://github.com/rust-lang/rustup.git'
-  git_hashtag '1.25.1'
+  git_hashtag '1.25.2'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.68.1_armv7l/rust-1.68.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.68.1_armv7l/rust-1.68.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.68.1_i686/rust-1.68.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.68.1_x86_64/rust-1.68.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.68.2_armv7l/rust-1.68.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.68.2_armv7l/rust-1.68.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.68.2_i686/rust-1.68.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/rust/1.68.2_x86_64/rust-1.68.2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'ac84bcd6d923dfdf03b5c4b1924623d8c97fd7fff032bd3c372028ebfb1a9903',
-     armv7l: 'ac84bcd6d923dfdf03b5c4b1924623d8c97fd7fff032bd3c372028ebfb1a9903',
-       i686: '48bde8aa6c7495c602784aa525e3e59a4d599390f590a807a2bc5a07c1862be0',
-     x86_64: 'be7d05ba1bbf086baf80a22ee49525ee04441d3e45892f5da89b6167e37ad586'
+    aarch64: '19be13cdf4fcdce8f8914e812b7d44a78dfb2b61d725ec47c1bdec08e478a3cf',
+     armv7l: '19be13cdf4fcdce8f8914e812b7d44a78dfb2b61d725ec47c1bdec08e478a3cf',
+       i686: '9a16b72439b234c7ee11d5718ae3ccd497335af64ce4143ac8d1743bbd645420',
+     x86_64: 'd8918ff1dc0b2eee85f34c047e0fc5b00e4db15953ddb7137eb38dcf300a5438'
   })
 
   depends_on 'gcc' # R
@@ -28,6 +28,8 @@ class Rust < Package
   depends_on 'zlibpkg' # R
 
   def self.install
+    ENV['RUSTUP_PERMIT_COPY_RENAME'] = 'unstable'
+    ENV['RUSTUP_INIT_SKIP_PATH_CHECK'] = 'yes'
     ENV['RUST_BACKTRACE'] = 'full'
     ENV['CARGO_HOME'] = "#{CREW_DEST_PREFIX}/share/cargo"
     ENV['RUSTUP_HOME'] = "#{CREW_DEST_PREFIX}/share/rustup"
@@ -75,6 +77,10 @@ class Rust < Package
         FileUtils.ln_sf "../share/cargo/bin/#{f}", f
       end
     end
+  end
+
+  def self.postinstall
+    system "rustup default #{@_ver}"
   end
 
   def self.remove


### PR DESCRIPTION
- Updates rust and rustup.
- Adds postinstall to address this issue:

Before:
```
rustup default
error: no default toolchain configured
```
After:
```
rustup default
1.68.2-x86_64-unknown-linux-gnu (default)
```
<!-- (let GitHub automatically close an issue when this pull request gets merged) -->

<!--
## Before you submit a pull request

This template is not necessary when you do simple things like updating packages to the latest version. But in doubt, it's always better so provide some information.
-->

## Additional information
<!-- Mention things we might need to know. Like: -->

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=rust1682 CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
