### PR TITLE
mold rebuild

### DIFF
--- a/packages/mold.rb
+++ b/packages/mold.rb
@@ -54,4 +54,9 @@ class Mold < Package
     system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
     FileUtils.install 'moldenv', "#{CREW_DEST_PREFIX}/etc/env.d/mold", mode: 0o644
   end
+
+  def self.postinstall
+    puts "\nTo finish the installation, execute the following:".lightblue
+    puts "source ~/.bashrc\n".lightblue
+  end
 end

--- a/packages/mold.rb
+++ b/packages/mold.rb
@@ -6,22 +6,22 @@ require 'package'
 class Mold < Package
   description 'A Modern Linker'
   homepage 'https://github.com/rui314/mold'
-  version '1.11.0'
+  version '1.11.0-4610013'
   compatibility 'all'
-  source_url 'https://github.com/rui314/mold/archive/v1.11.0.tar.gz'
-  source_sha256 '99318eced81b09a77e4c657011076cc8ec3d4b6867bd324b8677974545bc4d6f'
+  source_url 'https://github.com/rui314/mold.git'
+  git_hashtag '461001328bccf3b61709ee4531c6768c5280e289'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.11.0_armv7l/mold-1.11.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.11.0_armv7l/mold-1.11.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.11.0_i686/mold-1.11.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.11.0_x86_64/mold-1.11.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.11.0-4610013_armv7l/mold-1.11.0-4610013-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.11.0-4610013_armv7l/mold-1.11.0-4610013-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.11.0-4610013_i686/mold-1.11.0-4610013-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.11.0-4610013_x86_64/mold-1.11.0-4610013-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '7bd4c1795aa79bb4bc9c9ef47a28e67f9b0d5436ea6bd94f8260fb2742f845d0',
-     armv7l: '7bd4c1795aa79bb4bc9c9ef47a28e67f9b0d5436ea6bd94f8260fb2742f845d0',
-       i686: 'bdb93a3a2b4e2274864cb34dd866a7ef09f49e98606044496781a81eb25c5471',
-     x86_64: '4de15897106e82fdebd436ace4d442f5ed7b959b4b6f752f85dd41e413afef25'
+    aarch64: 'cbe0e18bcd3a58d72342e4369d4cd42a2017f352a96daaebb60c7016cdc98409',
+     armv7l: 'cbe0e18bcd3a58d72342e4369d4cd42a2017f352a96daaebb60c7016cdc98409',
+       i686: 'ef84fd60c77e04d7ba97f171b7a6bd353d4ac23ab0e8912c8d97dd91b403d2b4',
+     x86_64: 'f3bdf8618e34e7aa23ddcfdd94e6576e3e052fc9a467eba50e2afca2a078451c'
   })
 
   depends_on 'zlibpkg' # R
@@ -44,9 +44,14 @@ class Mold < Package
         -Wno-dev \
         -G Ninja"
     system "#{CREW_NINJA} -C builddir"
+    File.write 'moldenv', <<~MOLD_ENV_EOF
+      # See https://github.com/rui314/mold/commit/36fc0655489eb96e1be15b03b3f5e227cd97a22e
+      MOLD_JOBS=1
+    MOLD_ENV_EOF
   end
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
+    FileUtils.install 'moldenv', "#{CREW_DEST_PREFIX}/etc/env.d/mold", mode: 0o644
   end
 end


### PR DESCRIPTION
- This builds correctly with the FileUtils 1.7.1 gem (updatable with `gem update fileutils`), which is included in a forthcoming PR that has ruby 3.2.2...
- Note the env variable  `MOLD_JOBS=1` which is set to help with low memory situations.
- If your system has no memory pressure you can unset the `MOLD_JOBS` variable.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=moldrebuild CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
