### PR TITLE
wayland => 1.22

### DIFF
--- a/packages/wayland.rb
+++ b/packages/wayland.rb
@@ -3,36 +3,34 @@ require 'package'
 class Wayland < Package
   description 'Wayland is intended as a simpler replacement for X, easier to develop and maintain.'
   homepage 'https://wayland.freedesktop.org'
-  @_ver = '1.21.0'
-  version "#{@_ver}-1"
+  @_ver = '1.22.0'
+  version @_ver
   license 'MIT'
-  compatibility 'all'
+  compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.freedesktop.org/wayland/wayland.git'
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland/1.21.0-1_armv7l/wayland-1.21.0-1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland/1.21.0-1_armv7l/wayland-1.21.0-1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland/1.21.0-1_i686/wayland-1.21.0-1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland/1.21.0-1_x86_64/wayland-1.21.0-1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland/1.22.0_armv7l/wayland-1.22.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland/1.22.0_armv7l/wayland-1.22.0-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland/1.22.0_x86_64/wayland-1.22.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '4a655aa1bab807fc82eaabc6c62489c0e0d576d1e16d01cebd536ba203d81832',
-     armv7l: '4a655aa1bab807fc82eaabc6c62489c0e0d576d1e16d01cebd536ba203d81832',
-       i686: 'b0c830aa7f4b7970b45b48b57b47ed4d765b2af6908ebf71e72f1814719bdd0e',
-     x86_64: '27ef241ce34cc01b8a36ccd4ae4b7dc83e080d9e6c3fdb12a1d99a5303fddf15'
+    aarch64: '78e0b1c7e54a4af3caa20151692bc1370e8925106c1673455bd7e8f12eb380ca',
+     armv7l: '78e0b1c7e54a4af3caa20151692bc1370e8925106c1673455bd7e8f12eb380ca',
+     x86_64: '757e55aabee653519af9d4b01888ddbb6a4bbb024be79749322f36b2dfbcf636'
   })
 
-  depends_on 'expat'
-  depends_on 'libxml2'
-  depends_on 'gcc'
-  depends_on 'icu4c'
-  depends_on 'zlibpkg'
-  depends_on 'libffi'
+  depends_on 'expat' # R
+  depends_on 'gcc' # R
   depends_on 'glibc' # R
+  depends_on 'icu4c' => :build
+  depends_on 'libffi' # R
+  depends_on 'libxml2' # R
+  depends_on 'zlibpkg' => :build
 
   def self.build
-    @wayland_env = <<~WAYLAND_ENV_EOF
+    File.write 'waylandenv', <<~WAYLAND_ENV_EOF
       # environment set-up for Chrome OS built-in Wayland server
       set -a
 
@@ -43,7 +41,6 @@ class Wayland < Package
       : "${GDK_BACKEND:=wayland}"
       set +a
     WAYLAND_ENV_EOF
-
     system "meson setup #{CREW_MESON_OPTIONS} -Ddocumentation=false builddir"
     system 'meson configure builddir'
     system 'ninja -C builddir'
@@ -51,7 +48,6 @@ class Wayland < Package
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-    FileUtils.mkdir_p("#{CREW_DEST_PREFIX}/etc/env.d/")
-    File.write("#{CREW_DEST_PREFIX}/etc/env.d/wayland", @wayland_env)
+    FileUtils.install 'waylandenv', "#{CREW_DEST_PREFIX}/etc/env.d/wayland", mode: 0o644
   end
 end

--- a/packages/wayland.rb
+++ b/packages/wayland.rb
@@ -16,9 +16,9 @@ class Wayland < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland/1.22.0_x86_64/wayland-1.22.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '78e0b1c7e54a4af3caa20151692bc1370e8925106c1673455bd7e8f12eb380ca',
-     armv7l: '78e0b1c7e54a4af3caa20151692bc1370e8925106c1673455bd7e8f12eb380ca',
-     x86_64: '757e55aabee653519af9d4b01888ddbb6a4bbb024be79749322f36b2dfbcf636'
+    aarch64: '72e4522abfc219a7f20f7894dcbeb3efe1f630ddda000131df9ba827e5547d13',
+     armv7l: '72e4522abfc219a7f20f7894dcbeb3efe1f630ddda000131df9ba827e5547d13',
+     x86_64: '1fc209aa34fa165f41a6100dad83c352c5bfb5662bc37b279ce6091052edc90b'
   })
 
   depends_on 'expat' # R
@@ -32,14 +32,11 @@ class Wayland < Package
   def self.build
     File.write 'waylandenv', <<~WAYLAND_ENV_EOF
       # environment set-up for Chrome OS built-in Wayland server
-      set -a
-
       : "${XDG_RUNTIME_DIR:=/var/run/chrome}"
       : "${XDG_SESSION_TYPE:=wayland}"
       : "${WAYLAND_DISPLAY:=wayland-0}"
       : "${CLUTTER_BACKEND:=wayland}"
       : "${GDK_BACKEND:=wayland}"
-      set +a
     WAYLAND_ENV_EOF
     system "meson setup #{CREW_MESON_OPTIONS} -Ddocumentation=false builddir"
     system 'meson configure builddir'


### PR DESCRIPTION
- Removes `i686` too...

Builds properly:
- [x] `x86_64`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=wayland122 CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
