### PR TITLE
fix line continuation issue

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -176,6 +176,9 @@ Style/NumericLiterals:
 Style/RedundantCapitalW:
   Enabled: false
 
+Style/RedundantLineContinuation:
+  Enabled: false
+
 Naming/AccessorMethodName:
   Enabled: false
 


### PR DESCRIPTION
- This behavior is wrong:
```
packages/geany.rb:[39](https://github.com/chromebrew/chromebrew/actions/runs/4631594401/jobs/8194640260?pr=8159#step:8:40):35: C: [Correctable] Style/RedundantLineContinuation: Redundant line continuation.
    system "mold -run meson setup \ ...
                                  ^
packages/geany.rb:48:18: C: [Correctable] Style/RedundantLineContinuation: Redundant line continuation.
      -Dvte=true \ ...
```
