### PR TITLE
Change fake packages to use properties of the dependency package(s).

### DIFF
--- a/packages/a52.rb
+++ b/packages/a52.rb
@@ -1,12 +1,12 @@
 require 'package'
+require_relative 'liba52'
 
 class A52 < Package
-  description 'Legacy compatibility package for liba52'
-  homepage 'http://liba52.sourceforge.net/'
-  @_ver = '0.7.4-1'
-  version @_ver
-  license 'public-domain'
-  compatibility 'all'
+  description Liba52.description.to_s
+  homepage Liba52.homepage.to_s
+  version Liba52.version.to_s
+  license Liba52.license.to_s
+  compatibility Liba52.compatibility.to_s
 
   is_fake
 

--- a/packages/asciidoctor.rb
+++ b/packages/asciidoctor.rb
@@ -1,15 +1,14 @@
 require 'package'
+require_relative 'ruby_asciidoctor'
 
 class Asciidoctor < Package
-  description 'A fast text processor & publishing toolchain for converting AsciiDoc to HTML5, DocBook & more.'
-  homepage 'https://asciidoctor.org/'
-  version '2.0.18'
-  license 'MIT'
-  compatibility 'all'
-  source_url 'SKIP'
+  description Ruby_asciidoctor.description.to_s
+  homepage Ruby_asciidoctor.homepage.to_s
+  version Ruby_asciidoctor.version.to_s
+  license Ruby_asciidoctor.license.to_s
+  compatibility Ruby_asciidoctor.compatibility.to_s
 
   is_fake
 
   depends_on 'ruby_asciidoctor'
-
 end

--- a/packages/at_spi2_atk.rb
+++ b/packages/at_spi2_atk.rb
@@ -2,12 +2,11 @@ require 'package'
 require_relative 'at_spi2_core'
 
 class At_spi2_atk < Package
-  description 'D-Bus AT-SPI'
-  homepage 'http://www.freedesktop.org/'
-  @atkversion = At_spi2_core.version
-  version @atkversion
-  license 'LGPL-2.1+'
-  compatibility 'all'
+  description At_spi2_core.description.to_s
+  homepage At_spi2_core.homepage.to_s
+  version At_spi2_core.version.to_s
+  license At_spi2_core.license.to_s
+  compatibility At_spi2_core.compatibility.to_s
 
   depends_on 'at_spi2_core'
 

--- a/packages/at_spi2_core.rb
+++ b/packages/at_spi2_core.rb
@@ -4,6 +4,7 @@ class At_spi2_core < Package
   description 'This is over DBus, tookit widgets provide their content to screen readers such as Orca'
   homepage 'http://www.freedesktop.org/'
   version '2.47.90'
+  license 'LGPL-2.1+'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/at-spi2-core.git'
   git_hashtag "AT_SPI2_CORE_#{version.gsub('.', '_')}"

--- a/packages/atk.rb
+++ b/packages/atk.rb
@@ -2,14 +2,13 @@ require 'package'
 require_relative 'at_spi2_core'
 
 class Atk < Package
-  description 'ATK provides the set of accessibility interfaces that are implemented by other toolkits and applications'
-  homepage 'https://developer.gnome.org/atk'
-  @atkversion = At_spi2_core.version
-  version @atkversion
-  compatibility 'all'
-  license 'LGPL-2+'
-
-  depends_on 'at_spi2_core'
+  description At_spi2_core.description.to_s
+  homepage At_spi2_core.homepage.to_s
+  version At_spi2_core.version.to_s
+  license At_spi2_core.license.to_s
+  compatibility At_spi2_core.compatibility.to_s
 
   is_fake
+
+  depends_on 'at_spi2_core'
 end

--- a/packages/avocado.rb
+++ b/packages/avocado.rb
@@ -1,12 +1,13 @@
 require 'package'
+require_relative 'avocado_framework'
 
 class Avocado < Package
-  description 'A dummy package for avocado_framework.'
-  homepage 'https://avocado-framework.github.io/'
-  @_ver = '94.0'
-  version @_ver
-  license 'GPL-2 and GPL-2+'
-  compatibility 'all'
+  description Avocado_framework.description.to_s
+  homepage Avocado_framework.homepage.to_s
+  version Avocado_framework.version.to_s
+  license Avocado_framework.license.to_s
+  compatibility Avocado_framework.compatibility.to_s
+
   is_fake
 
   depends_on 'avocado_framework'

--- a/packages/cairomm.rb
+++ b/packages/cairomm.rb
@@ -1,11 +1,13 @@
 require 'package'
+require_relative 'cairomm_1_0'
+require_relative 'cairomm_1_16'
 
 class Cairomm < Package
-  description 'The Cairomm package provides a C++ interface to Cairo.'
-  homepage 'https://www.cairographics.org/'
-  version '1.0'
-  license 'LGPL-2+'
-  compatibility 'all'
+  description Cairomm_1_0.description.to_s
+  homepage Cairomm_1_0.homepage.to_s
+  version "#{Cairomm_1_0.version}+#{Cairomm_1_16.version}"
+  license Cairomm_1_0.license.to_s
+  compatibility Cairomm_1_0.compatibility.to_s
 
   is_fake
 

--- a/packages/desktop_file_utilities.rb
+++ b/packages/desktop_file_utilities.rb
@@ -1,11 +1,12 @@
 require 'package'
+require_relative 'desktop_file_utils'
 
 class Desktop_file_utilities < Package
-  description 'A package file for legacy compatibility'
-  homepage ''
-  version '1.0'
-  license 'GPL-3+'
-  compatibility 'all'
+  description Desktop_file_utils.descripton.to_s
+  homepage Desktop_file_utils.homepage.to_s
+  version Desktop_file_utils.version.to_s
+  license Desktop_file_utils.license.to_s
+  compatibility Desktop_file_utils.compatibility.to_s
 
   is_fake
 

--- a/packages/gcr.rb
+++ b/packages/gcr.rb
@@ -1,11 +1,13 @@
 require 'package'
+require_relative 'gcr_3'
+require_relative 'gcr_4'
 
 class Gcr < Package
-  description 'GNOME crypto package'
-  homepage 'https://www.gnome.org'
-  version '4.0.0'
-  license 'GPL-2+ and LGPL-2+'
-  compatibility 'all'
+  description Gcr_3.description.to_s
+  homepage Gcr_3.homepage.to_s
+  version "#{Gcr_3.version}+#{Gcr_4.version}"
+  license Gcr_3.license.to_s
+  compatibility Gcr_3.compatibility.to_s
 
   is_fake
 

--- a/packages/glibmm.rb
+++ b/packages/glibmm.rb
@@ -1,11 +1,13 @@
 require 'package'
+require_relative 'glibmm_2_4'
+require_relative 'glibmm_2_68'
 
 class Glibmm < Package
-  description 'C++ bindings for GLib'
-  homepage 'https://www.gtkmm.org'
-  version '1.0'
-  license 'LGPL-2.1+'
-  compatibility 'all'
+  description Glibmm_2_4.description.to_s
+  homepage Glibmm_2_4.homepage.to_s
+  version "#{Glibmm_2_4.version}+#{Glibmm_2_68.version}"
+  license Glibmm_2_4.license.to_s
+  compatibility Glibmm_2_4.compatibility.to_s
 
   is_fake
 

--- a/packages/google_cloud_sdk.rb
+++ b/packages/google_cloud_sdk.rb
@@ -1,13 +1,14 @@
 require 'package'
+require_relative 'gcloud'
 
 class Google_cloud_sdk < Package
-  description 'Command-line interface for Google Cloud Platform products and services'
-  homepage 'https://cloud.google.com/sdk/gcloud/'
-  version '370.0.0'
-  license 'Apache-2.0'
-  compatibility 'i686,x86_64'
-
-  depends_on 'gcloud'
+  description Gcloud.description.to_s
+  homepage Gcloud.homepage.to_s
+  version Gcloud.version.to_s
+  license Gcloud.license.to_s
+  compatibility Gcloud.compatibility.to_s
 
   is_fake
+
+  depends_on 'gcloud'
 end

--- a/packages/gst_plugins_bad.rb
+++ b/packages/gst_plugins_bad.rb
@@ -1,12 +1,12 @@
 require 'package'
+require_relative 'gstreamer'
 
 class Gst_plugins_bad < Package
   description 'Multimedia graph framework - bad plugins'
-  homepage 'https://gstreamer.freedesktop.org/'
-  @_ver = '1.20.0'
-  version @_ver
-  license 'LGPL-2'
-  compatibility 'all'
+  homepage Gstreamer.homepage.to_s
+  version Gstreamer.version.to_s
+  license Gstreamer.license.to_s
+  compatibility Gstreamer.compatibility.to_s
 
   is_fake
 

--- a/packages/gst_plugins_base.rb
+++ b/packages/gst_plugins_base.rb
@@ -1,12 +1,12 @@
 require 'package'
+require_relative 'gstreamer'
 
 class Gst_plugins_base < Package
   description 'An essential, exemplary set of elements for GStreamer'
   homepage 'https://gstreamer.freedesktop.org/modules/gst-plugins-base.html'
-  @_ver = '1.20.0'
-  version @_ver
-  license 'GPL-2+ and LGPL-2+'
-  compatibility 'all'
+  version Gstreamer.version.to_s
+  license Gstreamer.license.to_s
+  compatibility Gstreamer.compatibility.to_s
 
   is_fake
 

--- a/packages/gst_plugins_good.rb
+++ b/packages/gst_plugins_good.rb
@@ -1,12 +1,14 @@
 require 'package'
+require_relative 'gstreamer'
 
 class Gst_plugins_good < Package
   description 'Multimedia graph framework - good plugins'
-  homepage 'https://gstreamer.freedesktop.org/'
-  @_ver = '1.20.0'
-  version @_ver
-  license 'LGPL-2'
-  compatibility 'all'
+  homepage Gstreamer.homepage.to_s
+  version Gstreamer.version.to_s
+  license Gstreamer.license.to_s
+  compatibility Gstreamer.compatibility.to_s
 
   is_fake
+
+  depends_on 'gstreamer'
 end

--- a/packages/gtksourceview.rb
+++ b/packages/gtksourceview.rb
@@ -1,11 +1,14 @@
 require 'package'
+require_relative 'gtksourceview_3'
+require_relative 'gtksourceview_4'
+require_relative 'gtksourceview_5'
 
 class Gtksourceview < Package
-  description 'Source code editing widget'
-  homepage 'https://wiki.gnome.org/Projects/GtkSourceView'
-  version '1.1'
-  license 'GPL-2 and LGPL-2.1+'
-  compatibility 'all'
+  description Gtksourceview_3.description.to_s
+  homepage Gtksourceview_3.homepage.to_s
+  version "#{Gtksourceview_3.version}+#{Gtksourceview_4.version}+#{Gtksourceview_5.version}"
+  license Gtksourceview_3.license.to_s
+  compatibility Gtksourceview_3.compatibility.to_s
 
   is_fake
 

--- a/packages/hunspell.rb
+++ b/packages/hunspell.rb
@@ -1,9 +1,10 @@
 require 'package'
+require_relative 'hunspell_en_us'
 
 class Hunspell < Package
   description 'Hunspell is a spell checker and morphological analyzer library'
   homepage 'https://hunspell.github.io/'
-  version '1.x'
+  version Hunspell_en_us.version.to_s
   license 'MPL-1.1, GPL-2 and LGPL-2.1'
   compatibility 'all'
 

--- a/packages/imagemagick.rb
+++ b/packages/imagemagick.rb
@@ -1,36 +1,39 @@
 require 'package'
+require_relative 'imagemagick6'
+require_relative 'imagemagick7'
 
 class Imagemagick < Package
-  description 'Use ImageMagick to create, edit, compose, or convert bitmap images.'
-  homepage 'http://www.imagemagick.org/script/index.php'
-  version '6.9.11-29-7.0.11-2'
-  license 'imagemagick'
-  compatibility 'all'
+  description Imagemagick7.description.to_s
+  homepage Imagemagick7.homepage.to_s
+  version "#{Imagemagick6.version}-#{Imagemagick7.version}"
+  license Imagemagick7.license.to_s
+  compatibility Imagemagick7.compatibility.to_s
 
   is_fake
 
-  if ARGV[0] == 'install'
-    imver = `stream -version 2> /dev/null | head -1 | cut -d' ' -f3`.chomp
-    abort "ImageMagick version #{imver} already installed.".lightgreen unless imver.to_s == ''
-    puts
-    puts '  Select the version to install:'
-    puts '  6 = ImageMagick 6.9.11-29'
-    puts '  7 = ImageMagick 7.0.11-2'
-    puts '  0 = Cancel'
+  def self.preflight
+    if ARGV.include?('install')
+      imver = `stream -version 2> /dev/null | head -1 | cut -d' ' -f3`.chomp
+      abort "ImageMagick version #{imver} already installed.".lightgreen unless imver.to_s == ''
+      puts "\n  Select the version to install:"
+      puts "  6 = ImageMagick #{Imagemagick6.version}"
+      puts "  7 = ImageMagick #{Imagemagick7.version}"
+      puts '  0 = Cancel'
 
-    while version = $stdin.gets.chomp.downcase
-      case version
-      when '6'
-        depends_on 'imagemagick6'
-        break
-      when '7'
-        depends_on 'imagemagick7'
-        break
-      when '0'
-        abort
-        break
-      else
-        puts '  Please select from one of the options or enter 0 to cancel.'
+      while version = $stdin.gets.chomp.downcase
+        case version
+        when '6'
+          depends_on 'imagemagick6'
+          break
+        when '7'
+          depends_on 'imagemagick7'
+          break
+        when '0'
+          abort
+          break
+        else
+          puts '  Please select from one of the options or enter 0 to cancel.'
+        end
       end
     end
   end

--- a/packages/libcurl.rb
+++ b/packages/libcurl.rb
@@ -2,11 +2,12 @@ require 'package'
 require_relative 'curl'
 
 class Libcurl < Package
-  description 'Command line tool and library for transferring data with URLs.'
-  homepage 'https://curl.se/'
+  description Curl.description.to_s
+  homepage Curl.homepage.to_s
   version Curl.version.to_s
-  license 'curl'
-  compatibility 'all'
+  license Curl.license.to_s
+  compatibility Curl.compatibility.to_s
+
   is_fake
 
   depends_on 'curl'

--- a/packages/libressl.rb
+++ b/packages/libressl.rb
@@ -1,19 +1,18 @@
 require 'package'
+require_relative 'openssl'
 
 class Libressl < Package
   description 'LibreSSL is a version of the TLS/crypto stack forked from OpenSSL in 2014, with goals of modernizing the codebase, improving security, and applying best practice development processes.'
   homepage 'https://www.libressl.org/'
-  version '1.1.1i'
-  license 'ISC and openssl' # This is the actual libressl package license.
-  compatibility 'all'
+  version Openssl.version.to_s
+  license Openssl.license.to_s
+  compatibility Openssl.compatibility.to_s
 
   is_fake
 
   depends_on 'openssl'
 
-  def self.preflight
-    puts
-    puts 'Chromebrew\'s libressl is a fake package pointing to openssl.'.lightblue
-    puts
+  def self.postinstall
+    puts "\nLibressl is a fake package pointing to openssl.\n".lightblue
   end
 end

--- a/packages/libuuid.rb
+++ b/packages/libuuid.rb
@@ -1,11 +1,12 @@
 require 'package'
+require_relative 'util_linux'
 
 class Libuuid < Package
-  description 'Portable UUID C library'
+  description 'Portable UUID C library. Bundled with util_linux.'
   homepage 'https://sourceforge.net/projects/libuuid/'
-  version '1.3.0'
-  license 'BSD' # The actual libuuid library
-  compatibility 'all'
+  version Util_linux.version.to_s
+  license Util_linux.license.to_s
+  compatibility Util_linux.compatibility.to_s
 
   is_fake
 

--- a/packages/libxml2_python.rb
+++ b/packages/libxml2_python.rb
@@ -1,11 +1,12 @@
 require 'package'
+require_relative 'py3_libxml2'
 
 class Libxml2_python < Package
-  description 'Dummy package for py3_libxml2'
-  homepage 'https://gitlab.gnome.org/GNOME/libxml2/'
-  version '1'
-  license 'MIT'
-  compatibility 'all'
+  description Py3_libxml2.description.to_s
+  homepage Py3_libxml2.homepage.to_s
+  version Py3_libxml2.version.to_s
+  license Py3_libxml2.license.to_s
+  compatibility Py3_libxml2.compatibility.to_s
 
   is_fake
 

--- a/packages/libxscrnsaver.rb
+++ b/packages/libxscrnsaver.rb
@@ -1,11 +1,12 @@
 require 'package'
+require_relative 'libxss'
 
 class Libxscrnsaver < Package
-  description 'X11 Screen Saver extension library'
-  homepage 'https://gitlab.freedesktop.org/xorg/lib/libxscrnsaver'
-  version '1.2.3'
-  license 'MIT'
-  compatibility 'all'
+  description Libxss.description.to_s
+  homepage Libxss.homepage.to_s
+  version Libxss.version.to_s
+  license Libxss.license.to_s
+  compatibility Libxss.compatibility.to_s
 
   is_fake
 

--- a/packages/lzma.rb
+++ b/packages/lzma.rb
@@ -1,11 +1,12 @@
 require 'package'
+require_relative 'xzutils'
 
 class Lzma < Package
-  description 'LZMA Utils are legacy data compression software with high compression ratio.'
+  description 'LZMA Utils are legacy data compression software with high compression ratio. Bundled with xzutils.'
   homepage 'https://tukaani.org/lzma/'
-  version '4.98'
-  license 'public-domain'
-  compatibility 'all'
+  version Xzutils.version.to_s
+  license Xzutils.license.to_s
+  compatibility Xzutils.compatibility.to_s
 
   is_fake
 

--- a/packages/musl_toolchain.rb
+++ b/packages/musl_toolchain.rb
@@ -1,11 +1,12 @@
 require 'package'
+require_relative 'musl_cc_toolchain'
 
 class Musl_toolchain < Package
-  description 'A modern, simple, and fast C library implementation that strives to be lightweight, fast, simple, free, and correct in the sense of standards-conformance and safety.'
-  homepage 'https://musl.cc/'
-  version '1.2.2-b76f37fd'
-  compatibility 'all'
-  license 'MIT, LGPL-2 and GPL-2'
+  description Musl_cc_toolchain.description.to_s
+  homepage Musl_cc_toolchain.homepage.to_s
+  version Musl_cc_toolchain.version.to_s
+  license Musl_cc_toolchain.license.to_s
+  compatibility Musl_cc_toolchain.compatibility.to_s
 
   is_fake
 

--- a/packages/node.rb
+++ b/packages/node.rb
@@ -1,9 +1,10 @@
 require 'package'
+require_relative 'nodebrew'
 
 class Node < Package
   description 'As an asynchronous event driven JavaScript runtime, Node is designed to build scalable network applications.'
   homepage 'https://nodejs.org/en/'
-  version '8.9.1'
+  version Nodebrew.version.to_s
   license 'Apache-1.1, Apache-2.0, BSD, BSD-2 and MIT'
   compatibility 'all'
 

--- a/packages/nspr.rb
+++ b/packages/nspr.rb
@@ -1,9 +1,10 @@
 require 'package'
+require_relative 'nss'
 
 class Nspr < Package
   description 'Netscape Portable Runtime (NSPR) provides a platform-neutral API for system level and libc-like functions.'
   homepage 'https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR'
-  version '4.32'
+  version Nss.version.to_s
   license 'MPL-2.0, GPL-2 or LGPL-2.1'
   compatibility 'all'
 

--- a/packages/orc.rb
+++ b/packages/orc.rb
@@ -1,12 +1,12 @@
 require 'package'
+require_relative 'gstreamer'
 
 class Orc < Package
-  description 'Optimized Inner Loop Runtime Compiler'
+  description 'Optimized Inner Loop Runtime Compiler. Bundled with gstreamer.'
   homepage 'https://gitlab.freedesktop.org/gstreamer/orc'
-  @_ver = '0.4.32'
-  version @_ver
-  license 'BSD and BSD-2'
-  compatibility 'all'
+  version Gstreamer.version.to_s
+  license Gstreamer.license.to_s
+  compatibility Gstreamer.compatibilty.to_s
 
   is_fake
 

--- a/packages/p7zip.rb
+++ b/packages/p7zip.rb
@@ -1,11 +1,12 @@
 require 'package'
+require_relative 'pkg_7_zip'
 
 class P7zip < Package
-  description 'Dummy package that points to the official 7-zip package.'
-  homepage 'http://p7zip.sourceforge.net/'
-  version '21.07'
-  license 'LGPL-2.1 and unRAR'
-  compatibility 'all'
+  description Pkg_7_zip.description.to_s
+  homepage Pkg_7_zip.homepage.to_s
+  version Pkg_7_zip.version.to_s
+  license Pkg_7_zip.license.to_s
+  compatibility Pkg_7_zip.compatibility.to_s
 
   is_fake
 

--- a/packages/pangomm.rb
+++ b/packages/pangomm.rb
@@ -1,11 +1,13 @@
 require 'package'
+require_relative 'pangomm_1_4'
+require_relative 'pangomm_2_48'
 
 class Pangomm < Package
-  description 'pangomm is the official C++ interface for the Pango font layout library.'
-  homepage 'https://developer.gnome.org/pangomm/stable/'
-  version '1.0'
-  license 'LGPL-2.1+'
-  compatibility 'all'
+  description Pangomm_1_4.description.to_s
+  homepage Pangomm_1_4.homepage.to_s
+  version "#{Pangomm_1_4.version}+#{Pangomm_2_48.version}"
+  license Pangomm_1_4.license.to_s
+  compatibility Pangomm_1_4.compatibility.to_s
 
   is_fake
 

--- a/packages/parallel.rb
+++ b/packages/parallel.rb
@@ -1,11 +1,12 @@
 require 'package'
+require_relative 'moreutils'
 
 class Parallel < Package
-  description 'Run multiple programs simultaneously.'
-  homepage 'https://joeyh.name/code/moreutils/'
-  version '0.60'
-  license 'GPL-2'
-  compatibility 'all'
+  description 'Run multiple programs simultaneously. Bundled with moreutils.'
+  homepage Moreutils.homepage.to_s
+  version Moreutils.version.to_s
+  license Moreutils.license.to_s
+  compatibility Moreutils.compatibility.to_s
 
   is_fake
 

--- a/packages/pycairo.rb
+++ b/packages/pycairo.rb
@@ -1,11 +1,13 @@
 require 'package'
+require_relative 'py3_pycairo'
 
 class Pycairo < Package
-  description 'Dummy package for py3_pycairo.'
-  homepage 'https://cairographics.org/pycairo/'
-  version '1'
-  license 'LGPL-2.1 or MPL-1.1'
-  compatibility 'all'
+  description Py3_pycairo.description.to_s
+  homepage Py3_pycairo.homepage.to_s
+  version Py3_pycairo.version.to_s
+  license Py3_pycairo.license.to_s
+  compatibility Py3_pycairo.compatibility.to_s
+
   is_fake
 
   depends_on 'py3_pycairo'

--- a/packages/python27.rb
+++ b/packages/python27.rb
@@ -1,10 +1,11 @@
 require 'package'
+require_relative 'python2'
 
 class Python27 < Package
   description 'A compatibility package for python2.'
-  homepage 'https://www.python.org/'
-  version '2.7.18-1'
-  compatibility 'all'
+  homepage Python2.homepage.to_s
+  version Python2.version.to_s
+  compatibility Python2.compatibility.to_s
 
   is_fake
 

--- a/packages/ragel.rb
+++ b/packages/ragel.rb
@@ -1,12 +1,14 @@
 require 'package'
+require_relative 'harfbuzz'
 
 class Ragel < Package
   description 'Ragel compiles executable finite state machines from regular languages. Now bundled with harfbuzz.'
   homepage 'https://www.colm.net/open-source/ragel/'
-  version '1.0'
+  version Harfbuzz.version.to_s
   license 'MIT' # Previously was GPL-2
   compatibility 'all'
 
-  depends_on 'harfbuzz'
   is_fake
+
+  depends_on 'harfbuzz'
 end

--- a/packages/six.rb
+++ b/packages/six.rb
@@ -1,11 +1,12 @@
 require 'package'
+require_relative 'py3_six'
 
 class Six < Package
-  description 'Dummy package for py3_six'
-  homepage 'https://six.readthedocs.io/'
-  version '1'
-  license 'MIT'
-  compatibility 'all'
+  description Py3_six.description.to_s
+  homepage Py3_six.homepage.to_s
+  version Py3_six.version.to_s
+  license Py3_six.license.to_s
+  compatibility Py3_six.compatibility.to_s
 
   is_fake
 

--- a/packages/snap.rb
+++ b/packages/snap.rb
@@ -3,7 +3,7 @@ require 'package'
 class Snap < Package
   description 'Server stack which includes sqlite, nginx and php. Not to be confused with snapd.'
   homepage ''
-  version '1.0'
+  version '1.1'
   license 'GPL-3+'
   compatibility 'all'
 
@@ -11,5 +11,5 @@ class Snap < Package
 
   depends_on 'nginx'
   depends_on 'sqlite'
-  depends_on 'php74' unless File.exist? "#{CREW_PREFIX}/bin/php"
+  depends_on 'php81' unless File.exist? "#{CREW_PREFIX}/bin/php"
 end

--- a/packages/stow.rb
+++ b/packages/stow.rb
@@ -1,11 +1,12 @@
 require 'package'
+require_relative 'perl_stow'
 
 class Stow < Package
-  description 'Manage installation of multiple softwares in the same directory tree'
-  homepage 'https://www.gnu.org/software/stow/'
-  version '2.3.1'
-  license 'GPL-3+'
-  compatibility 'all'
+  description Perl_stow.description.to_s
+  homepage Perl_stow.homepage.to_s
+  version Perl_stow.version.to_s
+  license Perl_stow.license.to_s
+  compatibility Perl_stow.compatibility.to_s
 
   depends_on 'perl_stow'
 

--- a/packages/tepl.rb
+++ b/packages/tepl.rb
@@ -1,11 +1,13 @@
 require 'package'
+require_relative 'tepl_5'
+require_relative 'tepl_6'
 
 class Tepl < Package
-  description 'Library that eases the development of GtkSourceView-based text editors and IDEs'
-  homepage 'https://wiki.gnome.org/Projects/Tepl'
-  version '1.0'
-  license 'LGPL-2.1+'
-  compatibility 'all'
+  description Tepl_5.description.to_s
+  homepage Tepl_5.homepage.to_s
+  version "#{Tepl_5.version}+#{Tepl_6.version}"
+  license Tepl_5.license.to_s
+  compatibility Tepl_5.compatibility.to_s
 
   is_fake
 

--- a/packages/tilp.rb
+++ b/packages/tilp.rb
@@ -1,11 +1,12 @@
 require 'package'
+require_relative 'tilp2'
 
 class Tilp < Package
-  description 'TiLP is a linking program for Texas Instruments\' graphing calculators.'
-  homepage 'http://lpg.ticalc.org/prj_tilp/'
-  version '1.18'
-  license 'GPL-2'
-  compatibility 'all'
+  description Tilp2.description.to_s
+  homepage Tilp2.homepage.to_s
+  version Tilp2.version.to_s
+  license Tilp2.license.to_s
+  compatibility Tilp2.compatibility.to_s
 
   is_fake
 

--- a/packages/webkit2gtk.rb
+++ b/packages/webkit2gtk.rb
@@ -1,12 +1,12 @@
 require 'package'
+require_relative 'webkit2gtk_4'
 
 class Webkit2gtk < Package
-  description 'Web content engine for GTK'
-  homepage 'https://webkitgtk.org'
-  @_ver = '2.32.0'
-  version @_ver
-  license 'LGPL-2+ and BSD-2'
-  compatibility 'all'
+  description Webkit2gtk_4.description.to_s
+  homepage Webkit2gtk_4.homepage.to_s
+  version Webkit2gtk_4.version.to_s
+  license Webkit2gtk_4.license.to_s
+  compatibility Webkit2gtk_4.compatibility.to_s
 
   is_fake
 

--- a/packages/xorg_lib.rb
+++ b/packages/xorg_lib.rb
@@ -1,11 +1,12 @@
 require 'package'
+require_relative 'libx11'
 
 class Xorg_lib < Package
   description 'A collection of xorg libraries.'
-  homepage ''
-  version '0.1-0'
-  license '' # is_fake
-  compatibility 'all'
+  homepage Libx11.homepage.to_s
+  version Libx11.version.to_s
+  license Libx11.license.to_s
+  compatibility Libx11.compatibility.to_s
 
   is_fake
 

--- a/packages/youtubedl.rb
+++ b/packages/youtubedl.rb
@@ -1,12 +1,12 @@
 require 'package'
+require_relative 'youtube_dl'
 
 class Youtubedl < Package
-  description 'Legacy compatibility package for youtube_dl'
-  homepage 'https://youtube-dl.org/'
-  @_ver = '2021.12.17'
-  version @_ver
-  license 'public-domain'
-  compatibility 'all'
+  description Youtube_dl.description.to_s
+  homepage Youtube_dl.homepage.to_s
+  version Youtube_dl.version.to_s
+  license Youtube_dl.license.to_s
+  compatibility Youtube_dl.compatibility.to_s
 
   is_fake
 


### PR DESCRIPTION
This can probably be simplified further to call a function to set all the properties but there are certain instances where it makes sense to only use certain dependency package properties.  The plus side of doing this is fake versions bump automagically when the dependency package(s) are updated.