### PR TITLE
Fix errors in fake packages

### DIFF
--- a/packages/desktop_file_utilities.rb
+++ b/packages/desktop_file_utilities.rb
@@ -2,7 +2,7 @@ require 'package'
 require_relative 'desktop_file_utils'
 
 class Desktop_file_utilities < Package
-  description Desktop_file_utils.descripton.to_s
+  description Desktop_file_utils.description.to_s
   homepage Desktop_file_utils.homepage.to_s
   version Desktop_file_utils.version.to_s
   license Desktop_file_utils.license.to_s

--- a/packages/orc.rb
+++ b/packages/orc.rb
@@ -6,7 +6,7 @@ class Orc < Package
   homepage 'https://gitlab.freedesktop.org/gstreamer/orc'
   version Gstreamer.version.to_s
   license Gstreamer.license.to_s
-  compatibility Gstreamer.compatibilty.to_s
+  compatibility Gstreamer.compatibility.to_s
 
   is_fake
 


### PR DESCRIPTION
- Error with desktop_file_utilities.rb: undefined method `descripton' for Desktop_file_utils:Class
- Error with orc.rb: undefined method `compatibilty' for gstreamer:Class
