### PR TITLE
Add a new entry for our custom version bump

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -165,7 +165,7 @@ def print_current_package(extra = false)
   if extra
     puts ''
     puts @pkg.homepage if @pkg.homepage
-    puts "Version: #{@pkg.version}"
+    puts "Version: #{@pkg.full_version}"
     print "License: #{@pkg.license}" if @pkg.license
   end
   puts ''
@@ -272,7 +272,7 @@ def generate_compatible
     end
     if @pkg.compatible? && @compatibility
       # add to compatible packages
-      puts "Adding #{pkgName} #{@pkg.version} to compatible packages.".lightgreen if @opt_verbose
+      puts "Adding #{pkgName} #{@pkg.full_version} to compatible packages.".lightgreen if @opt_verbose
       @device[:compatible_packages].push(name: @pkg.name)
     elsif @opt_verbose
       puts "#{pkgName} is not a compatible package.".lightred
@@ -508,7 +508,7 @@ def help(pkgName = nil)
 end
 
 def cache_build
-  @build_cachefile = "#{CREW_CACHE_DIR}#{@pkg.name}-#{@pkg.version}-build-#{@device[:architecture]}.tar.zst"
+  @build_cachefile = "#{CREW_CACHE_DIR}#{@pkg.name}-#{@pkg.full_version}-build-#{@device[:architecture]}.tar.zst"
   if CREW_CACHE_ENABLED && File.writable?(CREW_CACHE_DIR)
     puts 'Caching build dir...'
     @pkg_build_dirname_absolute = File.join(CREW_BREW_DIR, @extract_dir)
@@ -629,9 +629,9 @@ def update
       puts "Package file for #{package[:name]} not found. :(".lightred if @opt_verbose
       next
     end
-    if package[:version] != @pkg.version
+    if package[:version] != @pkg.full_version
       canBeUpdated += 1
-      puts "#{@pkg.name} could be updated from #{package[:version]} to #{@pkg.version}"
+      puts "#{@pkg.name} could be updated from #{package[:version]} to #{@pkg.full_version}"
     end
   end
 
@@ -725,7 +725,7 @@ def download
   sha256sum = @pkg.get_sha256(@device[:architecture])
   @extract_dir = @pkg.get_extract_dir
 
-  @build_cachefile = "#{CREW_CACHE_DIR}#{@pkg.name}-#{@pkg.version}-build-#{@device[:architecture]}.tar.zst"
+  @build_cachefile = "#{CREW_CACHE_DIR}#{@pkg.name}-#{@pkg.full_version}-build-#{@device[:architecture]}.tar.zst"
   return { source:, filename: } if CREW_CACHE_BUILD && File.file?(@build_cachefile)
 
   if !url
@@ -880,7 +880,7 @@ def unpack(meta)
   Dir.chdir CREW_BREW_DIR do
     FileUtils.mkdir_p @extract_dir, verbose: @fileutils_verbose
 
-    @build_cachefile = "#{CREW_CACHE_DIR}#{@pkg.name}-#{@pkg.version}-build-#{@device[:architecture]}.tar.zst"
+    @build_cachefile = "#{CREW_CACHE_DIR}#{@pkg.name}-#{@pkg.full_version}-build-#{@device[:architecture]}.tar.zst"
     if CREW_CACHE_BUILD && File.file?(@build_cachefile) && File.file?("#{@build_cachefile}.sha256") && ( system "cd #{CREW_CACHE_DIR} && sha256sum -c #{@build_cachefile}.sha256" )
       @pkg.cached_build = true
       puts "Extracting cached build directory from #{@build_cachefile}".lightgreen
@@ -1488,7 +1488,7 @@ def install
   end
 
   # add to installed packages
-  @device[:installed_packages].push(name: @pkg.name, version: @pkg.version)
+  @device[:installed_packages].push(name: @pkg.name, version: @pkg.full_version)
   File.open("#{CREW_CONFIG_PATH}device.json.tmp", 'w') do |file|
     output = JSON.parse @device.to_json
     file.write JSON.pretty_generate(output)
@@ -1561,13 +1561,13 @@ def archive_package(pwd)
   end
   if @pkg.no_zstd? || !@crew_prefix_zstd_available
     puts 'Using xz to compress package. This may take some time.'.lightblue
-    pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.tar.xz"
+    pkg_name = "#{@pkg.name}-#{@pkg.full_version}-chromeos-#{@device[:architecture]}.tar.xz"
     Dir.chdir CREW_DEST_DIR do
       system "tar c#{@verbose}Jf #{pwd}/#{pkg_name} *"
     end
   else
     puts 'Using zstd to compress package. This may take some time.'.lightblue
-    pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.tar.zst"
+    pkg_name = "#{@pkg.name}-#{@pkg.full_version}-chromeos-#{@device[:architecture]}.tar.zst"
     Dir.chdir CREW_DEST_DIR do
       # Using same zstd compression options as Arch, which privilege
       # decompression speed over compression speed.

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -5,7 +5,7 @@ require_relative 'package_helpers'
 require_relative 'selector'
 
 class Package
-  property :description, :homepage, :version, :license, :compatibility,
+  property :description, :homepage, :version, :revision, :license, :compatibility,
            :binary_url, :binary_sha256, :source_url, :source_sha256,
            :git_branch, :git_hashtag
 
@@ -216,6 +216,14 @@ class Package
     @dependencies.store(depName, [dep_tags, ver_check])
   end
 
+  def self.full_version
+    if @release && @revision != 0
+      return "#{@version}-#{@revision}"
+    else
+      return @version
+    end
+  end
+
   def self.get_url(architecture)
     if !@build_from_source && @binary_url && @binary_url.key?(architecture)
       return @binary_url[architecture]
@@ -245,23 +253,15 @@ class Package
   end
 
   def self.get_extract_dir
-    "#{name}.#{Time.now.utc.strftime('%Y%m%d%H%M%S')}.dir"
+    return "#{name}.#{Time.now.utc.strftime('%Y%m%d%H%M%S')}.dir"
   end
 
   def self.is_binary?(architecture)
-    if !@build_from_source && @binary_url && @binary_url.key?(architecture)
-      return true
-    else
-      return false
-    end
+    return (!@build_from_source && @binary_url && @binary_url.key?(architecture))
   end
 
   def self.is_source?(architecture)
-    if is_binary?(architecture) || is_fake?
-      return false
-    else
-      return true
-    end
+    return !(is_binary?(architecture) || is_fake?)
   end
 
   def self.system(*args, **opt_args)

--- a/packages/abseil_cpp.rb
+++ b/packages/abseil_cpp.rb
@@ -3,11 +3,10 @@ require 'package'
 class Abseil_cpp < Package
   description 'Abseil Common Libraries C++'
   homepage 'https://abseil.io/'
-  @_ver = '20200923.3'
-  version @_ver
+  version '20200923.3'
   license 'Apache-2.0'
   compatibility 'all'
-  source_url "https://github.com/abseil/abseil-cpp/archive/#{@_ver}.tar.gz"
+  source_url "https://github.com/abseil/abseil-cpp/archive/#{@version}.tar.gz"
   source_sha256 'ebe2ad1480d27383e4bf4211e2ca2ef312d5e6a09eba869fd2e8a5c5d553ded2'
 
   binary_url({

--- a/packages/alien.rb
+++ b/packages/alien.rb
@@ -3,8 +3,8 @@ require 'package'
 class Alien < Package
   description 'This program converts linux packages between the rpm, deb, tgz and slp packages.'
   homepage 'https://sourceforge.net/projects/alien-pkg-convert/'
-  @_ver = '8.95'
-  version "#{@_ver}-1"
+  version '8.95'
+  revision 1
   license 'LGPL-2.1'
   compatibility 'all'
   source_url 'https://downloads.sourceforge.net/project/alien-pkg-convert/release/alien_8.95.tar.xz'

--- a/packages/ansible.rb
+++ b/packages/ansible.rb
@@ -3,12 +3,11 @@ require 'package'
 class Ansible < Package
   description 'Ansible is a radically simple IT automation engine that automates cloud provisioning, configuration management, application deployment, intra-service orchestration, and many other IT needs.'
   homepage 'https://www.ansible.com/'
-  @_ver = '2.11.6'
-  version @_ver
+  version '2.11.6'
   license 'GPL-3'
   compatibility 'all'
   source_url 'https://github.com/ansible/ansible.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{@version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ansible/2.11.6_armv7l/ansible-2.11.6-chromeos-armv7l.tpxz',

--- a/packages/antlr4.rb
+++ b/packages/antlr4.rb
@@ -3,8 +3,8 @@ require 'package'
 class Antlr4 < Package
   description 'ANTLR (ANother Tool for Language Recognition) is a powerful parser generator for reading, processing, executing, or translating structured text or binary files.'
   homepage 'https://www.antlr.org/'
-  @_ver = '4.12.0'
-  version "#{@_ver}-1"
+  version '4.12.0'
+  revision 1
   license 'BSD'
   compatibility 'all'
   source_url 'https://github.com/antlr/antlr4/archive/4.12.0.tar.gz'
@@ -28,8 +28,8 @@ class Antlr4 < Package
   def self.build
     @antlrenv = <<~ANTLR_EOF
       # ANTLR (ANother Tool for Language Recognition) configuration
-      CLASSPATH=".:#{CREW_PREFIX}/share/antlr/antlr-#{@_ver}-complete.jar:$CLASSPATH"
-      alias antlr4="java -jar #{CREW_PREFIX}/share/antlr/antlr-#{@_ver}-complete.jar"
+      CLASSPATH=".:#{CREW_PREFIX}/share/antlr/antlr-#{@version}-complete.jar:$CLASSPATH"
+      alias antlr4="java -jar #{CREW_PREFIX}/share/antlr/antlr-#{@version}-complete.jar"
       alias grun="java org.antlr.v4.gui.TestRig"
     ANTLR_EOF
     Dir.chdir 'runtime/Cpp' do
@@ -39,12 +39,12 @@ class Antlr4 < Package
   end
 
   def self.install
-    downloader "https://www.antlr.org/download/antlr-#{@_ver}-complete.jar",
+    downloader "https://www.antlr.org/download/antlr-#{@version}-complete.jar",
                '88f18a2bfac0dde1009eda5c7dce358a52877faef7868f56223a5bcc15329e43'
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/env.d"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/antlr"
     File.write("#{CREW_DEST_PREFIX}/etc/env.d/10-antlr4", @antlrenv)
-    FileUtils.install "antlr-#{@_ver}-complete.jar", "#{CREW_DEST_PREFIX}/share/antlr", mode: 0o644
+    FileUtils.install "antlr-#{@version}-complete.jar", "#{CREW_DEST_PREFIX}/share/antlr", mode: 0o644
     Dir.chdir 'runtime/Cpp' do
       system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
     end

--- a/packages/apng2gif.rb
+++ b/packages/apng2gif.rb
@@ -3,11 +3,10 @@ require 'package'
 class Apng2gif < Package
   description 'Convert APNG animations into animated GIF format.'
   homepage 'https://sourceforge.net/projects/apng2gif/'
-  @_ver = '1.8'
-  version @_ver
+  version '1.8'
   license 'ZLIB'
   compatibility 'all'
-  source_url "https://sourceforge.net/projects/apng2gif/files/#{@_ver}/apng2gif-#{@_ver}-src.zip"
+  source_url "https://sourceforge.net/projects/apng2gif/files/#{@version}/apng2gif-#{@version}-src.zip"
   source_sha256 '9a07e386017dc696573cd7bc7b46b2575c06da0bc68c3c4f1c24a4b39cdedd4d'
 
   binary_url({
@@ -39,7 +38,7 @@ class Apng2gif < Package
     system 'make'
     system "help2man -s 1 -N -h '' \
             -n '#{description.downcase.delete! '.'}' \
-            --version-string='#{@_ver}' \
+            --version-string='#{@version}' \
             ./apng2gif -o apng2gif.1"
   end
 

--- a/packages/aria2.rb
+++ b/packages/aria2.rb
@@ -3,12 +3,11 @@ require 'package'
 class Aria2 < Package
   description 'aria2 is a lightweight multi-protocol & multi-source, cross platform download utility operated in command-line. It supports HTTP/HTTPS, FTP, SFTP, BitTorrent and Metalink.'
   homepage 'https://aria2.github.io/'
-  @_ver = '1.36.0'
-  version @_ver
+  version '1.36.0'
   license 'GPL-2+-with-openssl-exception'
   compatibility 'all'
   source_url 'https://github.com/aria2/aria2.git'
-  git_hashtag "release-#{@_ver}"
+  git_hashtag "release-#{@version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/aria2/1.36.0_armv7l/aria2-1.36.0-chromeos-armv7l.tar.zst',

--- a/packages/aribb24.rb
+++ b/packages/aribb24.rb
@@ -3,12 +3,11 @@ require 'package'
 class Aribb24 < Package
   description 'aribb24 is a basic implementation of the ARIB STD-B24 public standard.'
   homepage 'https://github.com/nkoriyama/aribb24/'
-  @_ver = '1.0.3'
-  version @_ver
+  version '1.0.3'
   compatibility 'all'
   license 'LGPL-3'
   source_url 'https://github.com/nkoriyama/aribb24.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{@version}"
 
   binary_url({
     aarch64: 'file:///usr/local/tmp/packages/aribb24-1.0.3-chromeos-armv7l.tpxz',

--- a/packages/aribb25.rb
+++ b/packages/aribb25.rb
@@ -3,12 +3,11 @@ require 'package'
 class Aribb25 < Package
   description 'aribb25 is a basic implementation of the ARIB STD-B25 public standard.'
   homepage 'https://code.videolan.org/videolan/aribb25/'
-  @_ver = '0.2.7'
-  version @_ver
+  version '0.2.7'
   compatibility 'all'
   license 'ISC'
   source_url 'https://code.videolan.org/videolan/aribb25.git'
-  git_hashtag @_ver
+  git_hashtag @version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/aribb25/0.2.7_armv7l/aribb25-0.2.7-chromeos-armv7l.tpxz',

--- a/packages/asciinema.rb
+++ b/packages/asciinema.rb
@@ -3,12 +3,11 @@ require 'package'
 class Asciinema < Package
   description 'Terminal session recorder'
   homepage 'https://asciinema.org/'
-  @_ver = '2.1.0'
-  version @_ver
+  version '2.1.0'
   license 'GPL-3+'
   compatibility 'all'
   source_url 'https://github.com/asciinema/asciinema.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{@version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/asciinema/2.1.0_armv7l/asciinema-2.1.0-chromeos-armv7l.tpxz',

--- a/packages/avocado_framework.rb
+++ b/packages/avocado_framework.rb
@@ -3,12 +3,11 @@ require 'package'
 class Avocado_framework < Package
   description 'Avocado is a next generation testing framework inspired by Autotest and modern development tools such as git.'
   homepage 'https://avocado-framework.github.io/'
-  @_ver = '94.0'
-  version @_ver
+  version '94.0'
   license 'GPL-2 and GPL-2+'
   compatibility 'all'
   source_url 'https://github.com/avocado-framework/avocado.git'
-  git_hashtag @_ver
+  git_hashtag @version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/avocado_framework/94.0_armv7l/avocado_framework-94.0-chromeos-armv7l.tar.xz',

--- a/packages/aws2.rb
+++ b/packages/aws2.rb
@@ -3,21 +3,16 @@ require 'package'
 class Aws2 < Package
   description 'This package makes it easy to start, stop and save AWS spot instances; and to manage EC2 resources.'
   homepage 'https://github.com/simonm3/aws2'
-  @_ver = '0.2.7'
-  version "#{@_ver}-1"
+  version '0.2.7'
+  revision 1
   license 'GPL-3'
   compatibility 'all'
   source_url 'SKIP'
-
-  binary_url({
-  })
-  binary_sha256({
-  })
 
   depends_on 'rust' => :build
   depends_on 'python3' => :build
 
   def self.install
-    system "pip install --prefix #{CREW_PREFIX} --root #{CREW_DEST_DIR} -I aws2==#{@_ver} --no-warn-script-location"
+    system "pip install --prefix #{CREW_PREFIX} --root #{CREW_DEST_DIR} -I aws2==#{@version} --no-warn-script-location"
   end
 end


### PR DESCRIPTION
**Not tested yet**

Currently, we use `@_ver` to store the upstream version and put our custom subversion inside of `version "#{@_ver}-..."`, but having two different variables for the version might confuse new contributors.

This PR adds a new entry called `revision` for our custom subversion and is optional for backward compatibility, here are some examples:
```ruby
# before
@_ver = '1.1'
version "#{@_ver}-1"

# after
version '1.1'
revision 1
```

I only applied it to some packages as there are so many packages that use `@_ver` for versioning 😅

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/supechicken/chromebrew.git CREW_TESTING_BRANCH=add_release CREW_TESTING=1 crew update
```
