### PR TITLE
OpenSSL 3.0.8 updates & rebuilds, plus update PAGER logic, pagers...

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -691,9 +691,7 @@ def upgrade(*pkgs, build_from_source: false)
   # Upgrade OpenSSL first if OpenSSL is in the upgrade list, as other
   # package upgrades, especially their postinstalls, may break until the
   # new version of OpenSSL is installed.
-  if to_be_upgraded.include?('openssl')
-    to_be_upgraded.insert(0, to_be_upgraded.delete('openssl'))
-  end
+  to_be_upgraded.insert(0, to_be_upgraded.delete('openssl')) if to_be_upgraded.include?('openssl')
 
   # Only upgrade ruby if ruby is in the upgrade list, as other
   # package upgrades may break until crew is rerun with the new

--- a/bin/crew
+++ b/bin/crew
@@ -721,7 +721,7 @@ def upgrade(*pkgs, build_from_source: false)
   end
 
   puts 'Packages have been updated.'.lightgreen unless @rerun_upgrade
-  puts "Ruby was upgraded. Please run 'crew upgrade' again to make sure upgrades are complete.".lightblue if @rerun_upgrade
+  puts "An important package was upgraded. Please run 'crew upgrade' again to make sure upgrades are complete.".lightblue if @rerun_upgrade
 end
 
 def download

--- a/bin/crew
+++ b/bin/crew
@@ -692,6 +692,14 @@ def upgrade(*pkgs, build_from_source: false)
     @rerun_upgrade = true
   end
 
+  # Only upgrade openssl if openssl is in the upgrade list, as other
+  # package upgrades may break until crew is rerun with the new
+  # version of openssl.
+  if to_be_upgraded.include?('openssl')
+    to_be_upgraded = ['openssl']
+    @rerun_upgrade = true
+  end
+
   # install new dependencies (if any)
   to_be_upgraded.each do |pkgName|
     search(pkgName)

--- a/bin/crew
+++ b/bin/crew
@@ -684,6 +684,10 @@ def upgrade(*pkgs, build_from_source: false)
     return true
   end
 
+  # Eventually, we should have the upgrade order generated based upon an
+  # analysis of the dependency hierarchy, to make sure that earlier
+  # dependencies get upgraded first.
+
   # Upgrade OpenSSL first if OpenSSL is in the upgrade list, as other
   # package upgrades, especially their postinstalls, may break until the
   # new version of OpenSSL is installed.

--- a/bin/crew
+++ b/bin/crew
@@ -684,19 +684,18 @@ def upgrade(*pkgs, build_from_source: false)
     return true
   end
 
+  # Upgrade OpenSSL first if OpenSSL is in the upgrade list, as other
+  # package upgrades, especially their postinstalls, may break until the
+  # new version of OpenSSL is installed.
+  if to_be_upgraded.include?('openssl')
+    to_be_upgraded.insert(0, to_be_upgraded.delete('openssl'))
+  end
+
   # Only upgrade ruby if ruby is in the upgrade list, as other
   # package upgrades may break until crew is rerun with the new
   # version of ruby.
   if to_be_upgraded.include?('ruby')
     to_be_upgraded = ['ruby']
-    @rerun_upgrade = true
-  end
-
-  # Only upgrade openssl if openssl is in the upgrade list, as other
-  # package upgrades may break until crew is rerun with the new
-  # version of openssl.
-  if to_be_upgraded.include?('openssl')
-    to_be_upgraded = ['openssl']
     @rerun_upgrade = true
   end
 
@@ -721,7 +720,7 @@ def upgrade(*pkgs, build_from_source: false)
   end
 
   puts 'Packages have been updated.'.lightgreen unless @rerun_upgrade
-  puts "An important package was upgraded. Please run 'crew upgrade' again to make sure upgrades are complete.".lightblue if @rerun_upgrade
+  puts "Ruby was upgraded. Please run 'crew upgrade' again to make sure upgrades are complete.".lightblue if @rerun_upgrade
 end
 
 def download

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.32.3'
+CREW_VERSION = '1.32.4'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/packages/cmake.rb
+++ b/packages/cmake.rb
@@ -3,7 +3,7 @@ require 'package'
 class Cmake < Package
   description 'CMake is an open-source, cross-platform family of tools designed to build, test and package software.'
   homepage 'https://cmake.org/'
-  @_ver = '3.26.1'
+  @_ver = '3.26.3'
   version @_ver
   license 'CMake'
   compatibility 'all'
@@ -11,16 +11,16 @@ class Cmake < Package
   git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.26.1_armv7l/cmake-3.26.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.26.1_armv7l/cmake-3.26.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.26.1_i686/cmake-3.26.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.26.1_x86_64/cmake-3.26.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.26.3_armv7l/cmake-3.26.3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.26.3_armv7l/cmake-3.26.3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.26.3_i686/cmake-3.26.3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.26.3_x86_64/cmake-3.26.3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '54d07f7a6d459a45e876a40d659d860eb8959f8d5b691951431689b116b37775',
-     armv7l: '54d07f7a6d459a45e876a40d659d860eb8959f8d5b691951431689b116b37775',
-       i686: '674f8bde7e417691c7d400dee1632facf9694a91def8aa84a0cfc01146b30494',
-     x86_64: '1001e552edfa12f4c1b00860081a908d776299474c72195acdad9203d07bf02b'
+    aarch64: 'd34f102d0a7a780cbb62c36fad3be03e36cb645b4d9a3dbcf08f887bfc2b0f53',
+     armv7l: 'd34f102d0a7a780cbb62c36fad3be03e36cb645b4d9a3dbcf08f887bfc2b0f53',
+       i686: 'dbdb8eb039fce12920255b85229f979cfb33b5d848b3810afe9ee97a8b8ca7dc',
+     x86_64: '7606cedd3efc463333b9a9360d98570bd65acbf32b9bc0f65feccf4e871eac8d'
   })
 
   depends_on 'expat'
@@ -45,7 +45,7 @@ class Cmake < Package
           #{CREW_CMAKE_OPTIONS} \
           -DCMAKE_USE_SYSTEM_LIBRARIES=ON \
           -DBUILD_QtDialog=NO"
-    system "mold -run #{CREW_NINJA} -C builddir"
+    system "#{CREW_NINJA} -C builddir"
   end
 
   # Failed tests:

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -3,15 +3,14 @@ require 'package'
 class Crew_profile_base < Package
   description 'Crew-profile-base sets up Chromebrew\'s environment capabilities.'
   homepage 'https://github.com/chromebrew/crew-profile-base'
-  @_ver = '0.0.8'
-  version "#{@_ver}-1"
+  @_ver = '0.0.10'
+  version @_ver
   license 'GPL-3+'
   compatibility 'all'
-  source_url "https://github.com/chromebrew/crew-profile-base/archive/#{@_ver}.tar.gz"
-  source_sha256 '95642b0a8c7fe83ade2338ca68425ebf4598705633e8c0655cce8991b04697b7'
+  source_url "https://github.com/chromebrew/crew-profile-base/archive/refs/tags/#{@_ver}.tar.gz"
+  source_sha256 '73c60cabbae1050a55f031dc3c88738c3dbe52b516d5daca54f4d8890856a5f3'
 
   no_compile_needed
-  no_patchelf
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/"

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -4,7 +4,7 @@ class Crew_profile_base < Package
   description 'Crew-profile-base sets up Chromebrew\'s environment capabilities.'
   homepage 'https://github.com/chromebrew/crew-profile-base'
   @_ver = '0.0.8'
-  version @_ver
+  version "#{@_ver}-1"
   license 'GPL-3+'
   compatibility 'all'
   source_url "https://github.com/chromebrew/crew-profile-base/archive/#{@_ver}.tar.gz"
@@ -70,5 +70,27 @@ class Crew_profile_base < Package
       # save changes
       File.write rc_path, rc_file.join("\n")
     end
+    puts 'Choose your default pager:'.yellow
+    @pager_options = [
+      { value: 'most', description: 'Most Pager' },
+      { value: 'more',  description: 'More Pager' },
+      { value: 'less',  description: 'Less Pager' }
+    ]
+
+    @pager_default = Selector.new(@pager_options).show_prompt
+    File.write 'pagerenv', <<~PAGER_ENV_EOF
+      # The user's preferred pager is set here by the crew_profile_base
+      # postinstall.
+
+      # PAGER from container PAGER variable is passed through into the
+      # CONTAINER_PAGER variable.
+      if [ -z "$CONTAINER_PAGER" ]; then
+        PAGER="#{@pager_default}"
+      else
+        PAGER="$CONTAINER_PAGER"
+      fi
+    PAGER_ENV_EOF
+    FileUtils.install 'pagerenv', "#{CREW_PREFIX}/etc/env.d/03-pager", mode: 0o644
+    puts "The default PAGER has been set to #{@pager_default}.".lightblue
   end
 end

--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -4,23 +4,23 @@ class Curl < Package
   description 'Command line tool and library for transferring data with URLs.'
   homepage 'https://curl.se/'
   @_ver = '8.0.1'
-  version @_ver
+  version "#{@_ver}-1"
   license 'curl'
   compatibility 'all'
   source_url 'https://curl.se/download/curl-8.0.1.tar.xz'
   source_sha256 '0a381cd82f4d00a9a334438b8ca239afea5bfefcfa9a1025f2bf118e79e0b5f0'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/8.0.1_armv7l/curl-8.0.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/8.0.1_armv7l/curl-8.0.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/8.0.1_i686/curl-8.0.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/8.0.1_x86_64/curl-8.0.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/8.0.1-1_armv7l/curl-8.0.1-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/8.0.1-1_armv7l/curl-8.0.1-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/8.0.1-1_i686/curl-8.0.1-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/8.0.1-1_x86_64/curl-8.0.1-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'aa1584ebca641a8fa7513f81cfa59bf5d6382be85f56c4cd4ffacf4bd0490375',
-     armv7l: 'aa1584ebca641a8fa7513f81cfa59bf5d6382be85f56c4cd4ffacf4bd0490375',
-       i686: '23894ab8f2afcf3c1d01b23f596ce45dd4119a45d1c3449d36a29b30398b3e87',
-     x86_64: '3af563e88ba9335a871cab2620f0c8703bd35275ef1ff717dd01e7b6a0d37dc2'
+    aarch64: '7abe4fb18e0f8e1e7c6b3eebfc7bdbc3e796b3c3401c325fa478d9fd4b348358',
+     armv7l: '7abe4fb18e0f8e1e7c6b3eebfc7bdbc3e796b3c3401c325fa478d9fd4b348358',
+       i686: '6c8fcc1fb9563f9ca8eda52296672a5a74b099cd26cb820a245aecd2d2792255',
+     x86_64: 'c095e8a0910b840c949de5cc0829bdfcc004c83bcfb49332a827325688ec40e0'
   })
 
   depends_on 'brotli' # R
@@ -41,8 +41,6 @@ class Curl < Package
   depends_on 'zlibpkg' # R
   depends_on 'zstd' # R
 
-  no_patchelf
-
   def self.build
     system '[ -x configure ] || autoreconf -fvi'
     system 'filefix'
@@ -59,7 +57,7 @@ class Curl < Package
       --with-openssl \
       --without-gnutls \
       --without-librtmp"
-    system "mold -run make -j #{CREW_NPROC}"
+    system 'make'
   end
 
   def self.install

--- a/packages/gnutls.rb
+++ b/packages/gnutls.rb
@@ -3,23 +3,23 @@ require 'package'
 class Gnutls < Package
   description 'GnuTLS is a secure communications library implementing the SSL, TLS and DTLS protocols and technologies around them.'
   homepage 'http://gnutls.org/'
-  version '3.7.9'
+  version '3.8.0'
   license 'GPL-3'
   compatibility 'all'
-  source_url 'https://www.gnupg.org/ftp/gcrypt/gnutls/v3.7/gnutls-3.7.9.tar.xz'
-  source_sha256 'aaa03416cdbd54eb155187b359e3ec3ed52ec73df4df35a0edd49429ff64d844'
+  source_url 'https://www.gnupg.org/ftp/gcrypt/gnutls/v3.8/gnutls-3.8.0.tar.xz'
+  source_sha256 '0ea0d11a1660a1e63f960f157b197abe6d0c8cb3255be24e1fb3815930b9bdc5'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnutls/3.7.9_armv7l/gnutls-3.7.9-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnutls/3.7.9_armv7l/gnutls-3.7.9-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnutls/3.7.9_i686/gnutls-3.7.9-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnutls/3.7.9_x86_64/gnutls-3.7.9-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnutls/3.8.0_armv7l/gnutls-3.8.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnutls/3.8.0_armv7l/gnutls-3.8.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnutls/3.8.0_i686/gnutls-3.8.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnutls/3.8.0_x86_64/gnutls-3.8.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '4a7ed8769bc725a52a49d2cf6a00ba6cf582cbbb2cb64fde92c4ff2de325ef7f',
-     armv7l: '4a7ed8769bc725a52a49d2cf6a00ba6cf582cbbb2cb64fde92c4ff2de325ef7f',
-       i686: '208ccbca3dda2b6a0fce1d915dbdca10bb12dc017268d74edc279a120f034add',
-     x86_64: 'acfaf2260b1fed8a1d9bcab454cdf0ad21433cd9ad81b02aacb4a71a8516f596'
+    aarch64: '0a897675292ac7dac0705366de6e43ec3d49ef5f981984570d6574be2416af20',
+     armv7l: '0a897675292ac7dac0705366de6e43ec3d49ef5f981984570d6574be2416af20',
+       i686: 'e13f1dd743d212689362e087300db5c2b96bb524d38dcaf9c05e9a408fd7f261',
+     x86_64: 'f3629c95675ce0f48d8de9f525d7aa359f50c3f84fc5970e83ecf3fd50477a7a'
   })
 
   depends_on 'brotli' # R
@@ -34,9 +34,9 @@ class Gnutls < Package
   depends_on 'libunistring' # R
   depends_on 'nettle' # R
   depends_on 'openssl' # R
-  depends_on 'p11kit' # R This package cannot be built statically.
+  depends_on 'p11kit' # R
   depends_on 'trousers' => :build
-  depends_on 'zlibpkg' => :build
+  depends_on 'zlibpkg' # R
   depends_on 'zstd' # R
 
   no_env_options

--- a/packages/krb5.rb
+++ b/packages/krb5.rb
@@ -3,23 +3,23 @@ require 'package'
 class Krb5 < Package
   description 'Kerberos is a network authentication protocol.'
   homepage 'https://web.mit.edu/kerberos'
-  version '1.20.1'
+  version '1.20.1-1'
   license 'openafs-krb5-a, BSD, MIT, OPENLDAP, BSD-2, HPND, BSD-4, ISC, RSA, CC-BY-SA-3.0 and BSD-2 or GPL-2+ )'
   compatibility 'all'
   source_url 'https://web.mit.edu/kerberos/dist/krb5/1.20/krb5-1.20.1.tar.gz'
   source_sha256 '704aed49b19eb5a7178b34b2873620ec299db08752d6a8574f95d41879ab8851'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/krb5/1.20.1_armv7l/krb5-1.20.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/krb5/1.20.1_armv7l/krb5-1.20.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/krb5/1.20.1_i686/krb5-1.20.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/krb5/1.20.1_x86_64/krb5-1.20.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/krb5/1.20.1-1_armv7l/krb5-1.20.1-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/krb5/1.20.1-1_armv7l/krb5-1.20.1-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/krb5/1.20.1-1_i686/krb5-1.20.1-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/krb5/1.20.1-1_x86_64/krb5-1.20.1-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '9c02f47739672ffb168d41bc654e77ab6a3b07c3fbe7f4f32d2e4be279ee89ad',
-     armv7l: '9c02f47739672ffb168d41bc654e77ab6a3b07c3fbe7f4f32d2e4be279ee89ad',
-       i686: 'f41117ab29c09af9a50c2d064d6bbd0e7915c720e427869d714550b74c1ad0de',
-     x86_64: '0dc50e8a13a6843f5ba79b62a3bcf303b6f9fbb3db9d241f65c5f07286dd1d50'
+    aarch64: '80b1c0a265ce4a1ad7838189c010513aae8dd8b10578d98a8d7e56df66fc70ce',
+     armv7l: '80b1c0a265ce4a1ad7838189c010513aae8dd8b10578d98a8d7e56df66fc70ce',
+       i686: 'ed85e0ab5d700e98aa67e616b23c13734234255332cb6b51e6872238f3c2998e',
+     x86_64: 'e31008fe76d9db3740c6c874bb501cf5d716c7ceb5fe61e8f43a25b653042e8b'
   })
 
   depends_on 'ccache' => :build
@@ -28,40 +28,15 @@ class Krb5 < Package
   depends_on 'glibc' # R
   depends_on 'openssl' # R
 
-  @k5libs = %w[libgssapi_krb5.a libgssrpc.a libk5crypto.a
-               libkadm5clnt_mit.a libkadm5clnt.a libkadm5srv_mit.a libkadm5srv.a
-               libkdb5.a libkrad.a libkrb5.a libkrb5support.a libverto.a]
-
   def self.build
-    # First we build static libraries, then rebuild for shared libaries.
     Dir.chdir 'src' do
       # krb5 built with gcc10 or newer needs -fcommon
       # See https://github.com/ripple/rippled/pull/3813
       @cppflags = "#{CREW_COMMON_FLAGS} -I#{CREW_PREFIX}/include/et -fcommon"
       @path = "#{CREW_PREFIX}/bin:" + ENV.fetch('PATH', nil)
-      system "env CC='ccache gcc' #{CREW_ENV_OPTIONS} \
-      CPPFLAGS='#{@cppflags}' \
+      system "CPPFLAGS='#{@cppflags}' \
       PATH=#{@path} \
-      ./configure #{CREW_OPTIONS} \
-      --localstatedir=#{CREW_PREFIX}/var/krb5kdc \
-      --disable-shared \
-      --enable-static \
-      --with-system-et \
-      --with-system-ss \
-      --without-system-verto"
-      system "env PATH=#{@path} \
-      make -j#{CREW_NPROC}"
-      # Set aside the static libraries.
-      Dir.chdir 'lib' do
-        @k5libs.each do |lib|
-          FileUtils.cp lib, '../../' if File.exist?(lib)
-        end
-      end
-      system 'make clean'
-      system "env CC='ccache gcc' #{CREW_ENV_OPTIONS} \
-      CPPFLAGS='#{@cppflags}' \
-      PATH=#{@path} \
-      ./configure #{CREW_OPTIONS} \
+      mold -run ./configure #{CREW_OPTIONS} \
       --localstatedir=#{CREW_PREFIX}/var/krb5kdc \
       --enable-shared \
       --with-system-et \
@@ -75,10 +50,6 @@ class Krb5 < Package
   def self.install
     Dir.chdir 'src' do
       system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    end
-    # Now install the static libraries.
-    @k5libs.each do |lib|
-      FileUtils.cp lib, CREW_DEST_LIB_PREFIX if File.exist?(lib)
     end
   end
 end

--- a/packages/less.rb
+++ b/packages/less.rb
@@ -3,23 +3,23 @@ require 'package'
 class Less < Package
   description 'GNU less is a program similar to more, but which allows backward movement in the file as well as forward movement.'
   homepage 'https://www.gnu.org/software/less/'
-  version '633x-35aac3f'
+  version '633'
   license 'GPL-3 or BSD-2'
   compatibility 'all'
-  source_url 'https://github.com/gwsw/less.git'
-  git_hashtag '35aac3f11104ed597886d05fa9d3264387c3f6e6'
+  source_url "https://greenwoodsoftware.com/less/less-#{version}.tar.gz"
+  source_sha256 '2f201d64b828b88af36dfe6cfdba3e0819ece2e446ebe6224813209aaefed04f'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/less/633x-35aac3f_armv7l/less-633x-35aac3f-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/less/633x-35aac3f_armv7l/less-633x-35aac3f-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/less/633x-35aac3f_i686/less-633x-35aac3f-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/less/633x-35aac3f_x86_64/less-633x-35aac3f-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/less/633_armv7l/less-633-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/less/633_armv7l/less-633-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/less/633_i686/less-633-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/less/633_x86_64/less-633-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '400dd810afa42f62d45fe724aa1f8eb5df1c3491731f4f3cc70bd21c09d0e96c',
-     armv7l: '400dd810afa42f62d45fe724aa1f8eb5df1c3491731f4f3cc70bd21c09d0e96c',
-       i686: '31bf6c9a0f46b70d99626c94ec8f59c92603574fa1be10fe48495ecf76368e79',
-     x86_64: '421e919875a8b600cd710aba4d910b64f6767217c1cf8387bfa419ee0d656573'
+    aarch64: '0ce05f43a05e71150e80ab0663640c8802a2d9c258b9d014e293a637801ababb',
+     armv7l: '0ce05f43a05e71150e80ab0663640c8802a2d9c258b9d014e293a637801ababb',
+       i686: 'a18c9f5a8420cad3ff50a6b3ad3a15c507f319aec4cfc711cbde06ba8957d0a8',
+     x86_64: 'fcb65cc3739f3c868cee842d0fc88e51152f52cd0ac93c00fe47c91b74944d03'
   })
 
   depends_on 'glibc' # R
@@ -27,7 +27,6 @@ class Less < Package
   depends_on 'gcc' # R
 
   def self.build
-    system 'make -f Makefile.aut distfiles'
     system "./configure #{CREW_OPTIONS} --with-regex=posix"
     system 'make'
     File.write 'lessenv', <<~LESS_ENV_EOF

--- a/packages/less.rb
+++ b/packages/less.rb
@@ -3,23 +3,23 @@ require 'package'
 class Less < Package
   description 'GNU less is a program similar to more, but which allows backward movement in the file as well as forward movement.'
   homepage 'https://www.gnu.org/software/less/'
-  version '633-35aac3f'
+  version '633x-35aac3f'
   license 'GPL-3 or BSD-2'
   compatibility 'all'
   source_url 'https://github.com/gwsw/less.git'
   git_hashtag '35aac3f11104ed597886d05fa9d3264387c3f6e6'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/less/633-35aac3f_armv7l/less-633-35aac3f-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/less/633-35aac3f_armv7l/less-633-35aac3f-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/less/633-35aac3f_i686/less-633-35aac3f-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/less/633-35aac3f_x86_64/less-633-35aac3f-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/less/633x-35aac3f_armv7l/less-633x-35aac3f-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/less/633x-35aac3f_armv7l/less-633x-35aac3f-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/less/633x-35aac3f_i686/less-633x-35aac3f-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/less/633x-35aac3f_x86_64/less-633x-35aac3f-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'b283871b97bfd389e0fa51162ed5a8cf8fcf7d0e9cd83d823790cf401f726108',
-     armv7l: 'b283871b97bfd389e0fa51162ed5a8cf8fcf7d0e9cd83d823790cf401f726108',
-       i686: '707d064aef30f451325ab2afbd88b4dee2154e7cfe99b3e02ddd042b468928ec',
-     x86_64: '2614ec735bf3b05b20fbef0ecfe9a6553b1564b7e385d803d9771041b59572ea'
+    aarch64: '400dd810afa42f62d45fe724aa1f8eb5df1c3491731f4f3cc70bd21c09d0e96c',
+     armv7l: '400dd810afa42f62d45fe724aa1f8eb5df1c3491731f4f3cc70bd21c09d0e96c',
+       i686: '31bf6c9a0f46b70d99626c94ec8f59c92603574fa1be10fe48495ecf76368e79',
+     x86_64: '421e919875a8b600cd710aba4d910b64f6767217c1cf8387bfa419ee0d656573'
   })
 
   depends_on 'glibc' # R
@@ -31,7 +31,6 @@ class Less < Package
     system "./configure #{CREW_OPTIONS} --with-regex=posix"
     system 'make'
     File.write 'lessenv', <<~LESS_ENV_EOF
-      PAGER=#{CREW_PREFIX}/bin/less
       LESS='--quit-if-one-screen --ignore-case --status-column --LONG-PROMPT --RAW-CONTROL-CHARS --HILITE-UNREAD --tabs=4 --no-init --window=-4 --use-color'
     LESS_ENV_EOF
   end
@@ -39,9 +38,5 @@ class Less < Package
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     FileUtils.install 'lessenv', "#{CREW_DEST_PREFIX}/etc/env.d/less", mode: 0o644
-  end
-
-  def self.postinstall
-    puts 'The default PAGER has been set to less.'.lightblue
   end
 end

--- a/packages/less.rb
+++ b/packages/less.rb
@@ -3,23 +3,23 @@ require 'package'
 class Less < Package
   description 'GNU less is a program similar to more, but which allows backward movement in the file as well as forward movement.'
   homepage 'https://www.gnu.org/software/less/'
-  version '608'
+  version '633-35aac3f'
   license 'GPL-3 or BSD-2'
   compatibility 'all'
-  source_url 'https://ftpmirror.gnu.org/gnu/less/less-608.tar.gz'
-  source_sha256 'a69abe2e0a126777e021d3b73aa3222e1b261f10e64624d41ec079685a6ac209'
+  source_url 'https://github.com/gwsw/less.git'
+  git_hashtag '35aac3f11104ed597886d05fa9d3264387c3f6e6'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/less/608_armv7l/less-608-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/less/608_armv7l/less-608-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/less/608_i686/less-608-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/less/608_x86_64/less-608-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/less/633-35aac3f_armv7l/less-633-35aac3f-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/less/633-35aac3f_armv7l/less-633-35aac3f-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/less/633-35aac3f_i686/less-633-35aac3f-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/less/633-35aac3f_x86_64/less-633-35aac3f-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '5a945772c06719f52ac9d8435a64611d53c29714e7f9c34fc342c38c1912afda',
-     armv7l: '5a945772c06719f52ac9d8435a64611d53c29714e7f9c34fc342c38c1912afda',
-       i686: 'ed9e9b0d5edd476252dc909aa9753e81d0aa4f8167d624ac6d1d6956d18d75ea',
-     x86_64: 'd19353c6ea34e7da8554eab1ec322b655bc581232bc48ecff28fb852420265b1'
+    aarch64: 'b283871b97bfd389e0fa51162ed5a8cf8fcf7d0e9cd83d823790cf401f726108',
+     armv7l: 'b283871b97bfd389e0fa51162ed5a8cf8fcf7d0e9cd83d823790cf401f726108',
+       i686: '707d064aef30f451325ab2afbd88b4dee2154e7cfe99b3e02ddd042b468928ec',
+     x86_64: '2614ec735bf3b05b20fbef0ecfe9a6553b1564b7e385d803d9771041b59572ea'
   })
 
   depends_on 'glibc' # R
@@ -27,11 +27,21 @@ class Less < Package
   depends_on 'gcc' # R
 
   def self.build
+    system 'make -f Makefile.aut distfiles'
     system "./configure #{CREW_OPTIONS} --with-regex=posix"
     system 'make'
+    File.write 'lessenv', <<~LESS_ENV_EOF
+      PAGER=#{CREW_PREFIX}/bin/less
+      LESS='--quit-if-one-screen --ignore-case --status-column --LONG-PROMPT --RAW-CONTROL-CHARS --HILITE-UNREAD --tabs=4 --no-init --window=-4 --use-color'
+    LESS_ENV_EOF
   end
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    FileUtils.install 'lessenv', "#{CREW_DEST_PREFIX}/etc/env.d/less", mode: 0o644
+  end
+
+  def self.postinstall
+    puts 'The default PAGER has been set to less.'.lightblue
   end
 end

--- a/packages/libarchive.rb
+++ b/packages/libarchive.rb
@@ -4,23 +4,23 @@ class Libarchive < Package
   description 'Multi-format archive and compression library.'
   homepage 'https://www.libarchive.org/'
   @_ver = '3.6.2'
-  version "#{@_ver}-1"
+  version "#{@_ver}-2"
   license 'BSD, BSD-2, BSD-4 and public-domain'
   compatibility 'all'
   source_url "https://www.libarchive.org/downloads/libarchive-#{@_ver}.tar.xz"
   source_sha256 '9e2c1b80d5fbe59b61308fdfab6c79b5021d7ff4ff2489fb12daf0a96a83551d'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libarchive/3.6.2-1_armv7l/libarchive-3.6.2-1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libarchive/3.6.2-1_armv7l/libarchive-3.6.2-1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libarchive/3.6.2-1_i686/libarchive-3.6.2-1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libarchive/3.6.2-1_x86_64/libarchive-3.6.2-1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libarchive/3.6.2-2_armv7l/libarchive-3.6.2-2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libarchive/3.6.2-2_armv7l/libarchive-3.6.2-2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libarchive/3.6.2-2_i686/libarchive-3.6.2-2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libarchive/3.6.2-2_x86_64/libarchive-3.6.2-2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '79d1a1b9dd755eca23827575de2a5337675f50ae90ba39c7821947eaf0ca66f7',
-     armv7l: '79d1a1b9dd755eca23827575de2a5337675f50ae90ba39c7821947eaf0ca66f7',
-       i686: '9367d373e29a70798e4beb787551bc603fd31c5391f1b531cdd3c614e79d463a',
-     x86_64: '24980bda1ab951b1b68b7f4270dd0ba356969d0a203e7810c14614b4735ad517'
+    aarch64: '083845ff184ba1f7a302a0ff726ccf32353c5c91a5d2df3b92d3c732c16d2a14',
+     armv7l: '083845ff184ba1f7a302a0ff726ccf32353c5c91a5d2df3b92d3c732c16d2a14',
+       i686: '733706856e6127ff3513f4c88927adf07a8ad7d27dbb8afe17dbe21096ec5fe7',
+     x86_64: '148a1207346590f14a7243552f5620cf3c928fd50726e3d2349ede7acf7c21be'
   })
 
   depends_on 'acl' # R
@@ -34,11 +34,10 @@ class Libarchive < Package
   depends_on 'xzutils' # R
   depends_on 'zlibpkg' # R
   depends_on 'zstd' # R
+  depends_on 'gcc' # R
 
   def self.build
-    raise StandardError, 'Please remove libiconv before building.' if File.exist?("#{CREW_LIB_PREFIX}/libcharset.so")
-
-    system "./configure #{CREW_OPTIONS}"
+    system "mold -run ./configure #{CREW_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libcyrussasl.rb
+++ b/packages/libcyrussasl.rb
@@ -3,23 +3,23 @@ require 'package'
 class Libcyrussasl < Package
   description 'Simple Authentication and Security Layer (SASL) is a specification that describes how authentication mechanisms can be plugged into an application protocol on the wire. Cyrus SASL is an implementation of SASL that makes it easy for application developers to integrate authentication mechanisms into their application in a generic way.'
   homepage 'https://www.cyrusimap.org/sasl'
-  version '2.1.28'
+  version '2.1.28-1'
   license 'custom'
   compatibility 'all'
   source_url 'https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-2.1.28/cyrus-sasl-2.1.28.tar.gz'
   source_sha256 '7ccfc6abd01ed67c1a0924b353e526f1b766b21f42d4562ee635a8ebfc5bb38c'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcyrussasl/2.1.28_armv7l/libcyrussasl-2.1.28-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcyrussasl/2.1.28_armv7l/libcyrussasl-2.1.28-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcyrussasl/2.1.28_i686/libcyrussasl-2.1.28-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcyrussasl/2.1.28_x86_64/libcyrussasl-2.1.28-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcyrussasl/2.1.28-1_armv7l/libcyrussasl-2.1.28-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcyrussasl/2.1.28-1_armv7l/libcyrussasl-2.1.28-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcyrussasl/2.1.28-1_i686/libcyrussasl-2.1.28-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcyrussasl/2.1.28-1_x86_64/libcyrussasl-2.1.28-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'be22b132e1bd8d4576fcce5b05fd8d9954c118f7b08ee5ecc81695216a57b21f',
-     armv7l: 'be22b132e1bd8d4576fcce5b05fd8d9954c118f7b08ee5ecc81695216a57b21f',
-       i686: '80f070c21fd19968a95c4a5f5db1d63f4de4c7555eccfb0f4d27cdecce0f3980',
-     x86_64: 'fa5421975beaac8151c7039d48164e3fbe12ece34e28f84445303bd2ab91ce35'
+    aarch64: '9fcab15850eaa1926182c9f5a0184eba152ebe7c11b1d532f88c1b69d58af3d2',
+     armv7l: '9fcab15850eaa1926182c9f5a0184eba152ebe7c11b1d532f88c1b69d58af3d2',
+       i686: '5dfe33f38a6de869fe1a07ba18bf65f6034cc2958629d297127c1fa5d77dac8d',
+     x86_64: 'b2b76d5cc971e651cb3d926c899cdc6eb259844b9df44f84eb7fac934bcfaa7f'
   })
 
   depends_on 'diffutils' => :build
@@ -35,10 +35,9 @@ class Libcyrussasl < Package
   end
 
   def self.build
-    system "./configure \
+    system "mold -run ./configure \
       #{CREW_OPTIONS} \
       --enable-shared \
-      --enable-static \
       --with-configdir=#{CREW_PREFIX}/etc/sasl2 \
       --with-cxx-shared \
       --with-dbpath=#{CREW_PREFIX}/etc/sasldb2"

--- a/packages/libnghttp2.rb
+++ b/packages/libnghttp2.rb
@@ -3,47 +3,46 @@ require 'package'
 class Libnghttp2 < Package
   description 'library implementing HTTP/2 protocol'
   homepage 'https://nghttp2.org/'
-  @_ver = '1.50.0'
-  version "#{@_ver}-1"
+  @_ver = '1.52.0'
+  version "#{@_ver}-py3.11"
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/nghttp2/nghttp2.git'
   git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.50.0-1_armv7l/libnghttp2-1.50.0-1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.50.0-1_armv7l/libnghttp2-1.50.0-1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.50.0-1_i686/libnghttp2-1.50.0-1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.50.0-1_x86_64/libnghttp2-1.50.0-1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.52.0-py3.11_armv7l/libnghttp2-1.52.0-py3.11-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.52.0-py3.11_armv7l/libnghttp2-1.52.0-py3.11-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.52.0-py3.11_i686/libnghttp2-1.52.0-py3.11-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libnghttp2/1.52.0-py3.11_x86_64/libnghttp2-1.52.0-py3.11-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '9e5436c76f6ebdaaae493c95d2e2c12e61444a93b03d13927e5429c40451df3b',
-     armv7l: '9e5436c76f6ebdaaae493c95d2e2c12e61444a93b03d13927e5429c40451df3b',
-       i686: '55cc3719629bb2086909b9d8542c1c2524039028da0e18c49b8ebfb44fdec0b8',
-     x86_64: '1c2011cfb262d79a8a280d6a914a37a362e119ea7c95efa3882063cd160babe2'
+    aarch64: '9e1dd21f94b5e6f0df0201cf86ced7c671b16608b6c557f2d7d116154171b6bb',
+     armv7l: '9e1dd21f94b5e6f0df0201cf86ced7c671b16608b6c557f2d7d116154171b6bb',
+       i686: '0bd8cad70903ea163887184d2bdec1b95f3504c641a40289f9d8582a928e7d9b',
+     x86_64: 'f1aabfbc800d64f80a93dd72576b2f24d61270cc738e50da7b1db0e79ba2b541'
   })
 
   depends_on 'glibc' # R
   depends_on 'jansson'
   depends_on 'jemalloc'
   depends_on 'libev' => :build
+  depends_on 'openssl' # R
+  depends_on 'python3' => :build
   depends_on 'py3_cython' => :build
 
   def self.build
-    FileUtils.mkdir 'builddir'
-    Dir.chdir 'builddir' do
-      system "mold -run cmake -G Ninja #{CREW_CMAKE_OPTIONS} \
-        -DENABLE_SHARED_LIB=ON \
-        -DENABLE_STATIC_LIB=ON .."
-      system 'mold -run samu'
-    end
+    system "mold -run cmake -B builddir -G Ninja #{CREW_CMAKE_OPTIONS} \
+      -DENABLE_SHARED_LIB=ON \
+      -DENABLE_LIB_ONLY=ON"
+    system "#{CREW_NINJA} -C builddir"
   end
 
   def self.check
-    system 'samu -C builddir test'
+    system "#{CREW_NINJA} -C builddir test"
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
+    system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
   end
 end

--- a/packages/librhash.rb
+++ b/packages/librhash.rb
@@ -3,7 +3,7 @@ require 'package'
 class Librhash < Package
   description 'RHash is a console utility for computing and verifying hash sums of files.'
   homepage 'http://rhash.anz.ru/'
-  @_ver = '1.4.2'
+  @_ver = '1.4.3'
   version @_ver
   license 'MIT'
   compatibility 'all'
@@ -11,20 +11,24 @@ class Librhash < Package
   git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librhash/1.4.2_armv7l/librhash-1.4.2-chromeos-armv7l.tpxz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librhash/1.4.2_armv7l/librhash-1.4.2-chromeos-armv7l.tpxz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librhash/1.4.2_i686/librhash-1.4.2-chromeos-i686.tpxz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librhash/1.4.2_x86_64/librhash-1.4.2-chromeos-x86_64.tpxz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librhash/1.4.3_armv7l/librhash-1.4.3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librhash/1.4.3_armv7l/librhash-1.4.3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librhash/1.4.3_i686/librhash-1.4.3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librhash/1.4.3_x86_64/librhash-1.4.3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '59805811b7e2933f16bd2114d865802ffc42ea025f353c7ae70326443d502a9e',
-     armv7l: '59805811b7e2933f16bd2114d865802ffc42ea025f353c7ae70326443d502a9e',
-       i686: '32a3acd47df5deb05dc97177438d9ef6d7c0b66940d82e6e9a5206ebec6a6bba',
-     x86_64: '60784cf7c9145aaf4c3f98e705ec4c0b2d1d6468957cee41f12f851731431a5a'
+    aarch64: 'fdb6b38162bd3a25a3797a2e151262b45338bd56915555f97402308d6290b4c8',
+     armv7l: 'fdb6b38162bd3a25a3797a2e151262b45338bd56915555f97402308d6290b4c8',
+       i686: 'e3a3a89ca257d2132713f6770aa66774af98def033e2eaa44225da969e7ef1f6',
+     x86_64: 'bdcf6b36fe18f40f153b083daca45f3b634face054642ff469076afa46934299'
   })
 
+  depends_on 'glibc' # R
+  depends_on 'openssl' # R
+  depends_on 'gcc' # R
+
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure \
+    system "mold -run ./configure \
             --prefix=#{CREW_PREFIX} \
             --libdir=#{CREW_LIB_PREFIX}\
             --cc=#{CREW_TGT}-gcc \

--- a/packages/libssh.rb
+++ b/packages/libssh.rb
@@ -3,25 +3,25 @@ require 'package'
 class Libssh < Package
   description 'libssh is a multiplatform C library implementing the SSHv2 and SSHv1 protocol on client and server side.'
   homepage 'https://www.libssh.org/'
-  @_ver = '0.10.3'
-  version "#{@_ver}-1"
+  @_ver = '0.10.4'
+  version @_ver
   @_ver_prelastdot = @_ver.rpartition('.')[0]
   license 'LGPL-2.1'
   compatibility 'all'
   source_url "https://www.libssh.org/files/#{@_ver_prelastdot}/libssh-#{@_ver}.tar.xz"
-  source_sha256 '6e889dbe4f3eecd13a452ca868ec85525ab9c39d778519a9c141b83da738c8aa'
+  source_sha256 '07392c54ab61476288d1c1f0a7c557b50211797ad00c34c3af2bbc4dbc4bd97d'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.10.3-1_armv7l/libssh-0.10.3-1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.10.3-1_armv7l/libssh-0.10.3-1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.10.3-1_i686/libssh-0.10.3-1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.10.3-1_x86_64/libssh-0.10.3-1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.10.4_armv7l/libssh-0.10.4-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.10.4_armv7l/libssh-0.10.4-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.10.4_i686/libssh-0.10.4-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libssh/0.10.4_x86_64/libssh-0.10.4-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'd99b1ce240d1bd5b6bb01ffd779a0d3d25981afe1417110a8f7e86f425269aa7',
-     armv7l: 'd99b1ce240d1bd5b6bb01ffd779a0d3d25981afe1417110a8f7e86f425269aa7',
-       i686: '135303c2fbb04e1ef746326c2cd4fa82c707c52471033357deeef089dce8e770',
-     x86_64: 'e30f47fa94fd694f0d6947f597c9195923d7509096f3a9a51ce099970501c913'
+    aarch64: '98672786020015c554b39a7b17f638793d7849c59927b1a9e183d6597d8f2abf',
+     armv7l: '98672786020015c554b39a7b17f638793d7849c59927b1a9e183d6597d8f2abf',
+       i686: '3ec59d6b418e0c461ad1b2eab9c8df4feee538132179a7cd5f4dea29ea29f127',
+     x86_64: '9310e650799e8a08431b5064fad373818787f4fab6bb98d7f95010f350ba2ba8'
   })
 
   depends_on 'e2fsprogs'
@@ -29,28 +29,17 @@ class Libssh < Package
   depends_on 'libgcrypt'
   depends_on 'py3_abimap' => :build
   depends_on 'zlibpkg'
+  depends_on 'glibc' # R
+  depends_on 'openssl' # R
 
   def self.build
-    FileUtils.mkdir('builddir')
-    Dir.chdir('builddir') do
-      system "mold -run cmake #{CREW_CMAKE_OPTIONS} \
-      -DWITH_EXAMPLES=OFF \
-      -DBUILD_SHARED_LIBS=OFF \
-      ../ -G Ninja"
-    end
-    system 'mold -run samu -C builddir'
-    Dir.chdir('builddir') do
-      FileUtils.cp 'src/libssh.a', '../' if File.exist?('src/libssh.a')
-      system "mold -run cmake #{CREW_CMAKE_OPTIONS} \
-      -DWITH_EXAMPLES=OFF \
-      -DBUILD_SHARED_LIBS=ON \
-      ../ -G Ninja"
-    end
-    system 'mold -run samu -C builddir'
+    system "mold -run cmake -B builddir #{CREW_CMAKE_OPTIONS} -G Ninja \
+    -DWITH_EXAMPLES=OFF \
+    -DBUILD_SHARED_LIBS=ON"
+    system "#{CREW_NINJA} -C builddir"
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
-    FileUtils.cp 'libssh.a', CREW_DEST_LIB_PREFIX if File.exist?('libssh.a')
+    system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
   end
 end

--- a/packages/libunbound.rb
+++ b/packages/libunbound.rb
@@ -3,26 +3,28 @@ require 'package'
 class Libunbound < Package
   description 'Unbound is a validating, recursive, and caching DNS resolver.'
   homepage 'https://nlnetlabs.nl/projects/unbound/about/'
-  @_ver = '1.15.0'
+  @_ver = '1.17.1'
   version @_ver
   license 'BSD and GPL-2'
   compatibility 'all'
   source_url "https://nlnetlabs.nl/downloads/unbound/unbound-#{@_ver}.tar.gz"
-  source_sha256 'a480dc6c8937447b98d161fe911ffc76cfaffa2da18788781314e81339f1126f'
+  source_sha256 'ee4085cecce12584e600f3d814a28fa822dfaacec1f94c84bfd67f8a5571a5f4'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunbound/1.15.0_armv7l/libunbound-1.15.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunbound/1.15.0_armv7l/libunbound-1.15.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunbound/1.15.0_i686/libunbound-1.15.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunbound/1.15.0_x86_64/libunbound-1.15.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunbound/1.17.1_armv7l/libunbound-1.17.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunbound/1.17.1_armv7l/libunbound-1.17.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunbound/1.17.1_i686/libunbound-1.17.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libunbound/1.17.1_x86_64/libunbound-1.17.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '138691148c63f343b99d70e58405f26a5efc185cefb0aa6e7f9d96a8e5738131',
-     armv7l: '138691148c63f343b99d70e58405f26a5efc185cefb0aa6e7f9d96a8e5738131',
-       i686: '1eb7e176be91f7fa902a75295a81d1116745b3fd71ef87588964b7c2e129c363',
-     x86_64: '5c4125bce66bb83fc775a5fe236718dee958b9724d5b6adf55d3b682c2b05401'
+    aarch64: '221a8882a2903fb0783c4708113c2f630a8a1fc61de2427e664823421172b43e',
+     armv7l: '221a8882a2903fb0783c4708113c2f630a8a1fc61de2427e664823421172b43e',
+       i686: 'e4f090cdb6f1df7cc0df9750a6e6cf5f05a113dd7889cdfd015e7c4480d7fae4',
+     x86_64: '7d7ffb5749599f0a772e6b3304a398f1b8a7b17d7ec30858d98da5057522739d'
   })
 
+  depends_on 'expat' # R
+  depends_on 'gcc' # R
   depends_on 'glibc' # R
   depends_on 'openssl' # R On i686 openssl needs to be installed before libunbound.
 
@@ -31,9 +33,8 @@ class Libunbound < Package
   end
 
   def self.build
-    system "./configure \
+    system "mold -run ./configure \
     #{CREW_OPTIONS} \
-    #{CREW_ENV_OPTIONS} \
     --enable-shared \
     --enable-static \
     --with-pic"

--- a/packages/mold.rb
+++ b/packages/mold.rb
@@ -6,22 +6,22 @@ require 'package'
 class Mold < Package
   description 'A Modern Linker'
   homepage 'https://github.com/rui314/mold'
-  version '1.11.0-4610013'
+  version '1.11.0-dce8ebe'
   compatibility 'all'
   source_url 'https://github.com/rui314/mold.git'
-  git_hashtag '461001328bccf3b61709ee4531c6768c5280e289'
+  git_hashtag 'dce8ebe5265b615f35999272d3dc666b1c246ff4'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.11.0-4610013_armv7l/mold-1.11.0-4610013-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.11.0-4610013_armv7l/mold-1.11.0-4610013-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.11.0-4610013_i686/mold-1.11.0-4610013-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.11.0-4610013_x86_64/mold-1.11.0-4610013-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.11.0-dce8ebe_armv7l/mold-1.11.0-dce8ebe-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.11.0-dce8ebe_armv7l/mold-1.11.0-dce8ebe-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.11.0-dce8ebe_i686/mold-1.11.0-dce8ebe-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/1.11.0-dce8ebe_x86_64/mold-1.11.0-dce8ebe-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'cbe0e18bcd3a58d72342e4369d4cd42a2017f352a96daaebb60c7016cdc98409',
-     armv7l: 'cbe0e18bcd3a58d72342e4369d4cd42a2017f352a96daaebb60c7016cdc98409',
-       i686: 'ef84fd60c77e04d7ba97f171b7a6bd353d4ac23ab0e8912c8d97dd91b403d2b4',
-     x86_64: 'f3bdf8618e34e7aa23ddcfdd94e6576e3e052fc9a467eba50e2afca2a078451c'
+    aarch64: 'df0c064788a64611a0b7f051bac1601350b42ab8567f739a369f623443a52495',
+     armv7l: 'df0c064788a64611a0b7f051bac1601350b42ab8567f739a369f623443a52495',
+       i686: '450456d45ac0ffc4a0dbeafd7c6a404263932aa436828550915a63a253998c80',
+     x86_64: '8851d9188f83533dbf94000b9960a2cba816e46493d91297f092eba97d178f8f'
   })
 
   depends_on 'zlibpkg' # R
@@ -46,7 +46,11 @@ class Mold < Package
     system "#{CREW_NINJA} -C builddir"
     File.write 'moldenv', <<~MOLD_ENV_EOF
       # See https://github.com/rui314/mold/commit/36fc0655489eb96e1be15b03b3f5e227cd97a22e
-      MOLD_JOBS=1
+      if [[ $(free | head -n 2 | tail -n 1 | awk '{print $4}') -gt '4096000' ]]; then
+        unset MOLD_JOBS
+      else
+        MOLD_JOBS=1
+      fi
     MOLD_ENV_EOF
   end
 

--- a/packages/most.rb
+++ b/packages/most.rb
@@ -3,27 +3,28 @@ require 'package'
 class Most < Package
   description 'MOST is a powerful paging program for Unix, VMS, MSDOS, and win32 systems.'
   homepage 'http://www.jedsoft.org/most/'
-  version '5.1.0'
+  version '5.2.0'
   license 'GPL-2'
   compatibility 'all'
-  source_url 'https://www.jedsoft.org/releases/most/most-5.1.0.tar.gz'
-  source_sha256 'db805d1ffad3e85890802061ac8c90e3c89e25afb184a794e03715a3ed190501'
+  source_url "https://www.jedsoft.org/releases/most/most-#{version}.tar.gz"
+  source_sha256 '9455aeb8f826fa8385c850dc22bf0f22cf9069b3c3423fba4bf2c6f6226d9903'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/most/5.1.0_armv7l/most-5.1.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/most/5.1.0_armv7l/most-5.1.0-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/most/5.1.0_i686/most-5.1.0-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/most/5.1.0_x86_64/most-5.1.0-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/most/5.2.0_armv7l/most-5.2.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/most/5.2.0_armv7l/most-5.2.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/most/5.2.0_i686/most-5.2.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/most/5.2.0_x86_64/most-5.2.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '333fee656f76d9a8d5343edf9d2e1c29c48d73b4c21992a76439644c7edf7f70',
-     armv7l: '333fee656f76d9a8d5343edf9d2e1c29c48d73b4c21992a76439644c7edf7f70',
-       i686: '5e3463ae4c793fcc7ee528c0b722bfe665792f831e87e7d6b88c0a1bda124825',
-     x86_64: '3fcf532ef15440abe83413ae0c422e480096a6b4997890eca2825ef288ed13ed'
+    aarch64: '12068a13f4a6dbf37c5a22a13834e306c5b91999af51e2a7cfa3ebc244473f1f',
+     armv7l: '12068a13f4a6dbf37c5a22a13834e306c5b91999af51e2a7cfa3ebc244473f1f',
+       i686: '2988c796e2d092d1026b2db237f084bb5562fa924884acac60182bad54764322',
+     x86_64: '068c1106e867493a8a2b7566c08df4202e44e7e7d740e98fceac2e74346781a1'
   })
 
   depends_on 'glibc' # R
   depends_on 'slang' # R
+  depends_on 'gcc' # R
 
   def self.build
     system "./configure #{CREW_OPTIONS}"

--- a/packages/most.rb
+++ b/packages/most.rb
@@ -16,10 +16,10 @@ class Most < Package
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/most/5.2.0_x86_64/most-5.2.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '12068a13f4a6dbf37c5a22a13834e306c5b91999af51e2a7cfa3ebc244473f1f',
-     armv7l: '12068a13f4a6dbf37c5a22a13834e306c5b91999af51e2a7cfa3ebc244473f1f',
-       i686: '2988c796e2d092d1026b2db237f084bb5562fa924884acac60182bad54764322',
-     x86_64: '068c1106e867493a8a2b7566c08df4202e44e7e7d740e98fceac2e74346781a1'
+    aarch64: '6689e97e303c8e6ab015a54dcc518e8f3aaafb67c3d7c4921a1fdebaf112c3c4',
+     armv7l: '6689e97e303c8e6ab015a54dcc518e8f3aaafb67c3d7c4921a1fdebaf112c3c4',
+       i686: '7cae7bae27f55159d799d83824e00e6a25ec3b2fc4ec8f2c74b5e793e1cc50d6',
+     x86_64: 'afc592b6140eb946a257197597f624a5125ae1f694f4883d5013461be388e071'
   })
 
   depends_on 'glibc' # R

--- a/packages/openldap.rb
+++ b/packages/openldap.rb
@@ -3,24 +3,24 @@ require 'package'
 class Openldap < Package
   description 'OpenLDAP Software is an open source implementation of the Lightweight Directory Access Protocol.'
   homepage 'https://www.openldap.org/'
-  @_ver = '2.6.3'
+  @_ver = '2.6.4'
   version @_ver
   license 'OpenLDAP and GPL-2'
   compatibility 'all'
   source_url "https://openldap.org/software/download/OpenLDAP/openldap-release/openldap-#{@_ver}.tgz"
-  source_sha256 'd2a2a1d71df3d77396b1c16ad7502e674df446e06072b0e5a4e941c3d06c0d46'
+  source_sha256 'd51704e50178430c06cf3d8aa174da66badf559747a47d920bb54b2d4aa40991'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.6.3_armv7l/openldap-2.6.3-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.6.3_armv7l/openldap-2.6.3-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.6.3_i686/openldap-2.6.3-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.6.3_x86_64/openldap-2.6.3-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.6.4_armv7l/openldap-2.6.4-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.6.4_armv7l/openldap-2.6.4-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.6.4_i686/openldap-2.6.4-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.6.4_x86_64/openldap-2.6.4-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'e33440e146ed109636f46a3f5cf05db4798e6b16905f0335fdffd7a9f2f0f135',
-     armv7l: 'e33440e146ed109636f46a3f5cf05db4798e6b16905f0335fdffd7a9f2f0f135',
-       i686: '2a63e953489dc70695b841afca334218754cc883a018ef68b08f6861247cbef9',
-     x86_64: '2a2aa9b72b4a9c6f5503e388372d1a6af4b3b389ae5f9bc506df6d0afd1b0fdb'
+    aarch64: 'd7fb060b540a91e103aa4252e5ebaa3d219cb86372277f72e91b8d590c8c7592',
+     armv7l: 'd7fb060b540a91e103aa4252e5ebaa3d219cb86372277f72e91b8d590c8c7592',
+       i686: '6e4b3f2cb18c7eda1159ef59ef27120406557fc5513ed7edbb49708dfe744bc5',
+     x86_64: '1b78e492b4ba7924669f25da5b0a059f001d230bb50f5e614764ee4067ca77ef'
   })
 
   depends_on 'e2fsprogs' => :build
@@ -36,7 +36,7 @@ class Openldap < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS} #{CREW_ENV_OPTIONS} --disable-slapd"
+    system "mold -run ./configure #{CREW_OPTIONS} --disable-slapd"
     system 'make'
     system 'make depend'
   end

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -73,8 +73,8 @@ class Openssl < Package
     # Builds and rebuilds of packages against OpenSSL should automatically
     # build against OpenSSL 3.x and not against OpenSSL 1.1.1x.
     File.write 'openssl111_files', <<~EOF
-      #{CREW_LIB_PREFIX[1..-1]}/libcrypto.so.1.1
-      #{CREW_LIB_PREFIX[1..-1]}/libssl.so.1.1
+      #{CREW_LIB_PREFIX[1..]}/libcrypto.so.1.1
+      #{CREW_LIB_PREFIX[1..]}/libssl.so.1.1
     EOF
     @cur_dir = `pwd`.chomp
     @legacy_version = '1.1.1t'

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -73,8 +73,8 @@ class Openssl < Package
     # Builds and rebuilds of packages against OpenSSL should automatically
     # build against OpenSSL 3.x and not against OpenSSL 1.1.1x.
     File.write 'openssl111_files', <<~EOF
-      usr/local/#{ARCH_LIB}/libcrypto.so.1.1
-      usr/local/#{ARCH_LIB}/libssl.so.1.1
+      #{CREW_LIB_PREFIX.chr}/libcrypto.so.1.1
+      #{CREW_LIB_PREFIX.chr}/libssl.so.1.1
     EOF
     @cur_dir = `pwd`.chomp
     case ARCH

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -73,23 +73,24 @@ class Openssl < Package
     # Builds and rebuilds of packages against OpenSSL should automatically
     # build against OpenSSL 3.x and not against OpenSSL 1.1.1x.
     File.write 'openssl111_files', <<~EOF
-      #{CREW_LIB_PREFIX.chr}/libcrypto.so.1.1
-      #{CREW_LIB_PREFIX.chr}/libssl.so.1.1
+      #{CREW_LIB_PREFIX[1..-1]}/libcrypto.so.1.1
+      #{CREW_LIB_PREFIX[1..-1]}/libssl.so.1.1
     EOF
     @cur_dir = `pwd`.chomp
+    @legacy_version = '1.1.1t'
     case ARCH
     when 'aarch64', 'armv7l'
-      downloader 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1t_armv7l/openssl-1.1.1t-chromeos-armv7l.tar.xz',
-                 '88a36d1539c7c01af1f5e469b64c2760f43126bb75c0e63b53d3d61c2a6fbe7f', 'openssl-1.1.1t-chromeos.tar.xz'
+      downloader "https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/#{@legacy_version}_armv7l/openssl-#{@legacy_version}-chromeos-armv7l.tar.xz",
+                 '88a36d1539c7c01af1f5e469b64c2760f43126bb75c0e63b53d3d61c2a6fbe7f', "openssl-#{@legacy_version}-chromeos.tar.xz"
     when 'i686'
-      downloader 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1t_i686/openssl-1.1.1t-chromeos-i686.tar.xz',
-                 'ce98c1898e57df1cbcceab08912e219fb5f27b0e4585315f7babdf524fa844dc', 'openssl-1.1.1t-chromeos.tar.xz'
+      downloader "https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/#{@legacy_version}_i686/openssl-#{@legacy_version}-chromeos-i686.tar.xz",
+                 'ce98c1898e57df1cbcceab08912e219fb5f27b0e4585315f7babdf524fa844dc', "openssl-#{@legacy_version}-chromeos.tar.xz"
     when 'x86_64'
-      downloader 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/1.1.1t_x86_64/openssl-1.1.1t-chromeos-x86_64.tar.xz',
-                 'd6583dc2c7566da33402cb8d7f9025189d65b8ba6300e752edcb0d74ebcb1f68', 'openssl-1.1.1t-chromeos.tar.xz'
+      downloader "https://gitlab.com/api/v4/projects/26210301/packages/generic/openssl/#{@legacy_version}_x86_64/openssl-#{@legacy_version}-chromeos-x86_64.tar.xz",
+                 'd6583dc2c7566da33402cb8d7f9025189d65b8ba6300e752edcb0d74ebcb1f68', "openssl-#{@legacy_version}-chromeos.tar.xz"
     end
     Dir.chdir(CREW_DEST_DIR) do
-      system "tar -xv --files-from #{@cur_dir}/openssl111_files -f #{@cur_dir}/openssl-1.1.1t-chromeos.tar.xz"
+      system "tar -xv --files-from #{@cur_dir}/openssl111_files -f #{@cur_dir}/openssl-#{@legacy_version}-chromeos.tar.xz"
     end
   end
 end

--- a/packages/openssl.rb
+++ b/packages/openssl.rb
@@ -45,7 +45,6 @@ class Openssl < Package
 
   def self.build
     @no_tests_target = `openssl version | awk '{print $2}'`.chomp == version.to_s ? 'no-tests' : ''
-    puts "@no_tests_target is #{@no_tests_target}"
 
     # This gives you the list of OpenSSL configure targets
     system './Configure LIST'

--- a/packages/slang.rb
+++ b/packages/slang.rb
@@ -3,35 +3,33 @@ require 'package'
 class Slang < Package
   description 'S-Lang is a multi-platform programmer\'s library designed to allow a developer to create robust multi-platform software.'
   homepage 'http://www.jedsoft.org/slang/'
-  version '2.3.2'
+  version '2.3.3'
   license 'GPL-2'
   compatibility 'all'
-  source_url 'https://www.jedsoft.org/releases/slang/slang-2.3.2.tar.bz2'
-  source_sha256 'fc9e3b0fc4f67c3c1f6d43c90c16a5c42d117b8e28457c5b46831b8b5d3ae31a'
+  source_url 'https://www.jedsoft.org/releases/slang/slang-2.3.3.tar.bz2'
+  source_sha256 'f9145054ae131973c61208ea82486d5dd10e3c5cdad23b7c4a0617743c8f5a18'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/slang/2.3.2_armv7l/slang-2.3.2-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/slang/2.3.2_armv7l/slang-2.3.2-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/slang/2.3.2_i686/slang-2.3.2-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/slang/2.3.2_x86_64/slang-2.3.2-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/slang/2.3.3_armv7l/slang-2.3.3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/slang/2.3.3_armv7l/slang-2.3.3-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/slang/2.3.3_i686/slang-2.3.3-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/slang/2.3.3_x86_64/slang-2.3.3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'c957e37812aadaecea026ef184729f1892fe5a24a843bc0b28fc0ee322855e87',
-     armv7l: 'c957e37812aadaecea026ef184729f1892fe5a24a843bc0b28fc0ee322855e87',
-       i686: '8fa398bb8d47a423eac2a687c16a409c671342edaa6bb1afeeceac440c0459ca',
-     x86_64: '6d7968b8a251a184c06d96e0466c9c7fabae9033c7be9ad9fc4b2b60816eaa37'
+    aarch64: '880cf91fde278118fc476633095172a1e7b6d4beb0f87fbd13cfc9a294320509',
+     armv7l: '880cf91fde278118fc476633095172a1e7b6d4beb0f87fbd13cfc9a294320509',
+       i686: '4ccef4c49d5d25d944278242b75bde60a06d3bdb949bcec3433fcb3c02ed1e80',
+     x86_64: '777a1a2a147ee1778a33d15fb1955aa41b1e67f3160d90bbba4c9be2f9a46206'
   })
 
   depends_on 'glibc' # R
   depends_on 'libpng' # R
   depends_on 'pcre' # R
   depends_on 'zlibpkg' # R
+  depends_on 'gcc' # R
 
   def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           '--without-x'
+    system "mold -run ./configure #{CREW_OPTIONS} --without-x"
 
     # force to compile in sequential since slang Makefile doesn't work in parallel
     system 'make', '-j1'

--- a/packages/trousers.rb
+++ b/packages/trousers.rb
@@ -4,23 +4,23 @@ class Trousers < Package
   description 'The open-source TCG Software Stack.'
   homepage 'http://trousers.sourceforge.net/'
   @_ver = '0.3.15'
-  version "#{@_ver}-1"
+  version "#{@_ver}-2"
   license 'CPL-1.0 and GPL-2'
   compatibility 'all'
   source_url "https://downloads.sourceforge.net/project/trousers/trousers/#{@_ver}/trousers-#{@_ver}.tar.gz"
   source_sha256 '1e5be93e518372acf1d92d2f567d01a46fdb0b730487e544e6fb896c59cac77f'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/trousers/0.3.15-1_armv7l/trousers-0.3.15-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/trousers/0.3.15-1_armv7l/trousers-0.3.15-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/trousers/0.3.15-1_i686/trousers-0.3.15-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/trousers/0.3.15-1_x86_64/trousers-0.3.15-1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/trousers/0.3.15-2_armv7l/trousers-0.3.15-2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/trousers/0.3.15-2_armv7l/trousers-0.3.15-2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/trousers/0.3.15-2_i686/trousers-0.3.15-2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/trousers/0.3.15-2_x86_64/trousers-0.3.15-2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '3f164e9a58f163ccb8105c8932a0aef22b15d1e425307948e80ea052c2b60989',
-     armv7l: '3f164e9a58f163ccb8105c8932a0aef22b15d1e425307948e80ea052c2b60989',
-       i686: '2f62ba92301c5fc9753b5d159b783bd00d109bac32e0b198309acee2ec01a2b2',
-     x86_64: 'ae6c76c54c1337dc41efc95b6017e45999a56a3470620420d95f76e7e671a0d2'
+    aarch64: '17010e0e4cdc72fb91eebab4a8e9b549af1f53d7dd46ddcb4c080cd83bfb6082',
+     armv7l: '17010e0e4cdc72fb91eebab4a8e9b549af1f53d7dd46ddcb4c080cd83bfb6082',
+       i686: 'cc723134d4817400e656861b72adb6c9ec51df428cc7d798463b8c3a94f3f52f',
+     x86_64: '195bca093e6085636b522970c9244054fec6b0474ab717ac3106bef2577240d1'
   })
 
   depends_on 'glibc' # R
@@ -28,7 +28,7 @@ class Trousers < Package
 
   def self.build
     system './bootstrap.sh'
-    system "./configure \
+    system "mold -run ./configure \
       #{CREW_OPTIONS} \
       --with-gui=none"
     system 'make'

--- a/packages/trousers.rb
+++ b/packages/trousers.rb
@@ -23,11 +23,12 @@ class Trousers < Package
      x86_64: 'ae6c76c54c1337dc41efc95b6017e45999a56a3470620420d95f76e7e671a0d2'
   })
 
+  depends_on 'glibc' # R
+  depends_on 'openssl' # R
+
   def self.build
     system './bootstrap.sh'
-    system "CFLAGS='-flto=auto' CXXFLAGS='-flto=auto'
-      LDFLAGS='-flto=auto' \
-      ./configure \
+    system "./configure \
       #{CREW_OPTIONS} \
       --with-gui=none"
     system 'make'


### PR DESCRIPTION
- The OpenSSL 3.0.8 package includes the libraries from OpenSSL 1.1.1t, so existing packages do not break.
- Mold rebuild has the MOLD_JOBS variable only set for systems with less than 4Gb of free RAM.
- Libraries are set to only build as shared, and instructions to build static libraries have been removed.
- Updated `less` and `most`.
- `crew_profile_base` now asks for `PAGER` selection in the postinstall.
- `crew` is adjusted to install openssl first in a set of upgrades. (Really though, the upgrades should walk a dependency hierarchy to figure this order out automatically.)
- All relevant packages in a default install have been updated.
- The following code will show what other packages need updating:
```
for i in *.so ; do lddtree $i 2>/dev/null | grep "libcrypto.so.1.1\|libssl.so.1.1" && crew whatprovides $i ; done | grep -v "Total\|=" | awk -F : '{print $1}' | sort -u
``` 
Here's a list of packages on my system that are not broken but need to be rebuilt against OpenSSL 3.x based on running that command:
```
audacious_plugins
bind
cups
ffmpeg
freerdp
freetds
ghostscript
graphicsmagick
gstreamer
libevent
libgit2
libgxps
libimobiledevice
libkmod
libspectre
libssh2
libvncserver
mpv
neon
qtwebengine
spice_gtk
srt
tesseract
```

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=openssl308 CREW_TESTING=1 crew update ; crew upgrade ; crew upgrade

```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
