### PR TITLE
Github_cli 2.27.0 => 2.29.0

### DIFF
--- a/packages/gh.rb
+++ b/packages/gh.rb
@@ -1,0 +1,14 @@
+require 'package'
+require_relative 'github_cli'
+
+class Gh < Package
+  description Github_cli.description.to_s
+  homepage Github_cli.homepage.to_s
+  version Github_cli.version.to_s
+  license Github_cli.license.to_s
+  compatibility Github_cli.compatibility.to_s
+
+  is_fake
+
+  depends_on 'github_cli'
+end

--- a/packages/github_cli.rb
+++ b/packages/github_cli.rb
@@ -3,20 +3,20 @@ require 'package'
 class Github_cli < Package
   description 'Official Github CLI tool'
   homepage 'https://cli.github.com/'
-  version '2.27.0'
+  version '2.29.0'
   license 'MIT'
   compatibility 'all'
   source_url({
-    aarch64: 'https://github.com/cli/cli/releases/download/v2.27.0/gh_2.27.0_linux_armv6.tar.gz',
-     armv7l: 'https://github.com/cli/cli/releases/download/v2.27.0/gh_2.27.0_linux_armv6.tar.gz',
-       i686: 'https://github.com/cli/cli/releases/download/v2.27.0/gh_2.27.0_linux_386.tar.gz',
-     x86_64: 'https://github.com/cli/cli/releases/download/v2.27.0/gh_2.27.0_linux_amd64.tar.gz'
+    aarch64: 'https://github.com/cli/cli/releases/download/v2.29.0/gh_2.29.0_linux_armv6.tar.gz',
+     armv7l: 'https://github.com/cli/cli/releases/download/v2.29.0/gh_2.29.0_linux_armv6.tar.gz',
+       i686: 'https://github.com/cli/cli/releases/download/v2.29.0/gh_2.29.0_linux_386.tar.gz',
+     x86_64: 'https://github.com/cli/cli/releases/download/v2.29.0/gh_2.29.0_linux_amd64.tar.gz'
   })
   source_sha256({
-    aarch64: '2289fa1537bbf424947e1643f4616fb1c6b7e011b43b25e2e72af1b1e4d74f97',
-     armv7l: '2289fa1537bbf424947e1643f4616fb1c6b7e011b43b25e2e72af1b1e4d74f97',
-       i686: '5139f84c5e4a51a3b29798797091c2b9f69ee0bf3ecacc30d69f7caf92606c86',
-     x86_64: 'a3e2987e49ede4e90e0192f64c5e1480d6a1ee3196d51a4fcfbe0ccd0a627747'
+    aarch64: '193bc95e024a3e53a3d3850fc2e619ddc9ca1bf3de384abb0f15e68ff1aaefbd',
+     armv7l: '193bc95e024a3e53a3d3850fc2e619ddc9ca1bf3de384abb0f15e68ff1aaefbd',
+       i686: '99c8b66f18b1d5e71950f2e04f8e41f466316179f838816d73c4c94fc632a7a7',
+     x86_64: '9fe05f43a11a7bf8eacf731422452d1997e6708d4160ef0efcb13c103320390e'
   })
 
   no_compile_needed


### PR DESCRIPTION
Tested on all architectures.  Added fake package for convenience.