### PR TITLE
Fix CREW_LOCAL_MANIFEST_PATH discovery logic

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -583,7 +583,7 @@ def updatefiles
   FileUtils.rm_rf "#{CREW_MANIFEST_CACHE_DIR}/*"
   # if CREW_LOCAL_MANIFEST_PATH.empty?
   Dir.chdir CREW_MANIFEST_CACHE_DIR do
-    if CREW_TESTING
+    if ENV['CREW_TESTING'] == '1'
       system "curl -L#O https://github.com/#{CREW_TESTING_ACCOUNT}/chromebrew/archive/#{CREW_TESTING_BRANCH}.tar.gz"
       system "tar x#{@verbose}f #{CREW_TESTING_BRANCH}.tar.gz chromebrew-#{CREW_TESTING_BRANCH}/manifest"
     else
@@ -1094,11 +1094,7 @@ def prepare_package(destdir)
     system "find .#{CREW_PREFIX} -type f > ../filelist"
     system "find .#{CREW_PREFIX} -type l >> ../filelist"
     system 'cut -c2- ../filelist > filelist'
-    if CREW_LOCAL_MANIFEST_PATH != '' && File.basename(CREW_LOCAL_MANIFEST_PATH) == 'chromebrew'
-      FileUtils.cp 'filelist', "#{CREW_LOCAL_MANIFEST_PATH}/#{@pkg.name.initial}/#{@pkg.name}.filelist"
-    else
-      abort 'Unable to locate CREW_LOCAL_MANIFEST_PATH.  Please try again in the chromebrew repository.'.lightred
-    end
+    FileUtils.cp 'filelist', "#{CREW_LOCAL_MANIFEST_PATH}/#{@pkg.name.initial}/#{@pkg.name}.filelist"
 
     # check for FHS3 compliance
     puts 'Checking for FHS3 compliance...'
@@ -1575,6 +1571,7 @@ end
 def build_package(pwd)
   abort 'It is not possible to build a fake package'.lightred if @pkg.is_fake?
   abort 'It is not possible to build without source'.lightred unless @pkg.is_source?(@device[:architecture])
+  abort "Unable to locate CREW_LOCAL_MANIFEST_PATH.  Please try again in the chromebrew/release/#{ARCH} directory.".lightred if CREW_LOCAL_MANIFEST_PATH.empty?
 
   # download source codes and unpack it
   meta = download

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.33.0'
+CREW_VERSION = '1.33.1'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp
@@ -98,7 +98,13 @@ CREW_GITHUB_BRANCH = 'master'
 CREW_GITHUB_REPO = 'https://github.com/chromebrew/chromebrew.git'
 
 # Local constants for contributors.
-CREW_LOCAL_REPO_ROOT = `git rev-parse --show-toplevel 2> /dev/null`.chomp.to_s
+repo_root = `git rev-parse --show-toplevel 2> /dev/null`.chomp.to_s
+if repo_root.empty? || File.basename(repo_root) != 'chromebrew'
+  Dir.chdir '../..' do
+    repo_root = `git rev-parse --show-toplevel 2> /dev/null`.chomp.to_s
+  end
+end
+CREW_LOCAL_REPO_ROOT = repo_root
 CREW_LOCAL_REPO_BASE = CREW_LOCAL_REPO_ROOT.empty? ? '' : File.basename(CREW_LOCAL_REPO_ROOT)
 CREW_LOCAL_MANIFEST_PATH = CREW_LOCAL_REPO_BASE == CREW_GITHUB_ACCOUNT ? "#{CREW_LOCAL_REPO_ROOT}/manifest" : ''
 


### PR DESCRIPTION
- If CREW_LOCAL_MANIFEST_PATH is not found, abort prior to the build process
- Change CREW_TESTING conditional to execute 'crew updatefiles' correctly