### PR TITLE
Add warning/rescue for failed mkdir_p CREW_MANIFEST_CACHE_DIR

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.33.4'
+CREW_VERSION = '1.33.5'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp
@@ -127,7 +127,12 @@ CREW_CACHE_DIR = if ENV['CREW_CACHE_DIR'].to_s.empty?
                  end
 
 CREW_MANIFEST_CACHE_DIR = "#{CREW_CACHE_DIR}manifest"
-FileUtils.mkdir_p CREW_MANIFEST_CACHE_DIR
+begin
+  FileUtils.mkdir_p CREW_MANIFEST_CACHE_DIR
+rescue Errno::ENOENT => e
+  puts "Error creating CREW_MANIFEST_CACHE_DIR: #{CREW_MANIFEST_CACHE_DIR}".lightred
+  puts "#{e.message}".orange
+end
 CREW_CACHE_BUILD = ENV.fetch('CREW_CACHE_BUILD', nil)
 CREW_CACHE_FAILED_BUILD = ENV.fetch('CREW_CACHE_FAILED_BUILD', nil)
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -131,7 +131,7 @@ begin
   FileUtils.mkdir_p CREW_MANIFEST_CACHE_DIR
 rescue Errno::ENOENT => e
   puts "Error creating CREW_MANIFEST_CACHE_DIR: #{CREW_MANIFEST_CACHE_DIR}".lightred
-  puts "#{e.message}".orange
+  puts e.message.to_s.orange
 end
 CREW_CACHE_BUILD = ENV.fetch('CREW_CACHE_BUILD', nil)
 CREW_CACHE_FAILED_BUILD = ENV.fetch('CREW_CACHE_FAILED_BUILD', nil)


### PR DESCRIPTION
- This handles the case (especially when building containers) where the external filesystem is r/o.

![image](https://github.com/chromebrew/chromebrew/assets/1096701/5105af86-6abe-4f89-89c8-83caf909aa23)

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=const_mkdir_fix CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
