### PR TITLE
add rescue for EROFS r/o fs error, updatefiles: only extract ARCH specific manifest files, only delete manifest specific files

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -585,10 +585,10 @@ def updatefiles
   Dir.chdir CREW_MANIFEST_CACHE_DIR do
     if ENV['CREW_TESTING'] == '1'
       system "curl -L#O https://github.com/#{CREW_TESTING_ACCOUNT}/chromebrew/archive/#{CREW_TESTING_BRANCH}.tar.gz"
-      system "tar x#{@verbose}f #{CREW_TESTING_BRANCH}.tar.gz chromebrew-#{CREW_TESTING_BRANCH}/manifest"
+      system "tar x#{@verbose}f #{CREW_TESTING_BRANCH}.tar.gz chromebrew-#{CREW_TESTING_BRANCH}/manifest/#{ARCH}"
     else
       system "curl -L#O https://github.com/#{CREW_GITHUB_ACCOUNT}/chromebrew/archive/#{CREW_GITHUB_BRANCH}.tar.gz"
-      system "tar x#{@verbose}f #{CREW_GITHUB_BRANCH}.tar.gz chromebrew-#{CREW_GITHUB_BRANCH}/manifest"
+      system "tar x#{@verbose}f #{CREW_GITHUB_BRANCH}.tar.gz chromebrew-#{CREW_GITHUB_BRANCH}/manifest/#{ARCH}"
     end
   end
   # else

--- a/bin/crew
+++ b/bin/crew
@@ -580,16 +580,24 @@ end
 
 def updatefiles
   puts 'Rebuilding crew files cache...'.yellow
-  FileUtils.rm_rf "#{CREW_MANIFEST_CACHE_DIR}/*"
-  # if CREW_LOCAL_MANIFEST_PATH.empty?
-  Dir.chdir CREW_MANIFEST_CACHE_DIR do
-    if ENV['CREW_TESTING'] == '1'
-      system "curl -L#O https://github.com/#{CREW_TESTING_ACCOUNT}/chromebrew/archive/#{CREW_TESTING_BRANCH}.tar.gz"
-      system "tar x#{@verbose}f #{CREW_TESTING_BRANCH}.tar.gz chromebrew-#{CREW_TESTING_BRANCH}/manifest/#{ARCH}"
-    else
-      system "curl -L#O https://github.com/#{CREW_GITHUB_ACCOUNT}/chromebrew/archive/#{CREW_GITHUB_BRANCH}.tar.gz"
-      system "tar x#{@verbose}f #{CREW_GITHUB_BRANCH}.tar.gz chromebrew-#{CREW_GITHUB_BRANCH}/manifest/#{ARCH}"
+  if File.writable?(CREW_MANIFEST_CACHE_DIR)
+    # Be careful when removing items in a CREW_MANIFEST_CACHE_DIR crew
+    # has been pointed to.
+    FileUtils.rm_rf Dir.glob("#{CREW_MANIFEST_CACHE_DIR}/*.tar.gz")
+    FileUtils.rm_rf Dir.glob("#{CREW_MANIFEST_CACHE_DIR}/*/manifest")
+    # if CREW_LOCAL_MANIFEST_PATH.empty?
+    Dir.chdir CREW_MANIFEST_CACHE_DIR do
+      if ENV['CREW_TESTING'] == '1'
+        system "curl -L#O https://github.com/#{CREW_TESTING_ACCOUNT}/chromebrew/archive/#{CREW_TESTING_BRANCH}.tar.gz"
+        system "tar x#{@verbose}f #{CREW_TESTING_BRANCH}.tar.gz chromebrew-#{CREW_TESTING_BRANCH}/manifest/#{ARCH}"
+      else
+        system "curl -L#O https://github.com/#{CREW_GITHUB_ACCOUNT}/chromebrew/archive/#{CREW_GITHUB_BRANCH}.tar.gz"
+        system "tar x#{@verbose}f #{CREW_GITHUB_BRANCH}.tar.gz chromebrew-#{CREW_GITHUB_BRANCH}/manifest/#{ARCH}"
+      end
     end
+  else
+    puts "CREW_MANIFEST_CACHE_DIR #{CREW_MANIFEST_CACHE_DIR} is not writable.".lightred
+    puts "The crew files cache cannot be rebuilt.".lightred
   end
   # else
   #   FileUtils.cp_r Dir["#{CREW_LOCAL_MANIFEST_PATH}/*"], CREW_MANIFEST_CACHE_DIR, verbose: @fileutils_verbose

--- a/bin/crew
+++ b/bin/crew
@@ -581,12 +581,7 @@ end
 def updatefiles
   puts 'Rebuilding crew files cache...'.yellow
   if File.writable?(CREW_MANIFEST_CACHE_DIR)
-    # Be careful when removing items in a CREW_MANIFEST_CACHE_DIR crew
-    # has been pointed to.
-    FileUtils.rm_rf Dir.glob("#{CREW_MANIFEST_CACHE_DIR}/*.tar.gz")
-    FileUtils.rm_rf Dir.glob("#{CREW_MANIFEST_CACHE_DIR}/*/manifest")
-    # Delete empty dirs in CREW_MANIFEST_CACHE_DIR.
-    Dir["#{CREW_MANIFEST_CACHE_DIR}/*"].reverse_each { Dir.rmdir(_1) if Dir.empty?(_1) }
+    FileUtils.rm_rf Dir["#{CREW_MANIFEST_CACHE_DIR}/chromebrew-*"]
     # if CREW_LOCAL_MANIFEST_PATH.empty?
     Dir.chdir CREW_MANIFEST_CACHE_DIR do
       if ENV['CREW_TESTING'] == '1'

--- a/bin/crew
+++ b/bin/crew
@@ -585,6 +585,8 @@ def updatefiles
     # has been pointed to.
     FileUtils.rm_rf Dir.glob("#{CREW_MANIFEST_CACHE_DIR}/*.tar.gz")
     FileUtils.rm_rf Dir.glob("#{CREW_MANIFEST_CACHE_DIR}/*/manifest")
+    # Delete empty dirs in CREW_MANIFEST_CACHE_DIR.
+    Dir["#{CREW_MANIFEST_CACHE_DIR}/*"].reverse_each { Dir.rmdir(_1) if Dir.empty?(_1) }
     # if CREW_LOCAL_MANIFEST_PATH.empty?
     Dir.chdir CREW_MANIFEST_CACHE_DIR do
       if ENV['CREW_TESTING'] == '1'

--- a/bin/crew
+++ b/bin/crew
@@ -597,7 +597,7 @@ def updatefiles
     end
   else
     puts "CREW_MANIFEST_CACHE_DIR #{CREW_MANIFEST_CACHE_DIR} is not writable.".lightred
-    puts "The crew files cache cannot be rebuilt.".lightred
+    puts 'The crew files cache cannot be rebuilt.'.lightred
   end
   # else
   #   FileUtils.cp_r Dir["#{CREW_LOCAL_MANIFEST_PATH}/*"], CREW_MANIFEST_CACHE_DIR, verbose: @fileutils_verbose

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -138,7 +138,7 @@ rescue Errno::EACCES => e
   puts "Error creating CREW_MANIFEST_CACHE_DIR: #{CREW_MANIFEST_CACHE_DIR}".lightred
   puts e.message.to_s.orange
 rescue Errno::ENOENT => e
-  # weird fs
+  # weird fs e.g., /proc
   puts "Error creating CREW_MANIFEST_CACHE_DIR: #{CREW_MANIFEST_CACHE_DIR}".lightred
   puts e.message.to_s.orange
 end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -130,9 +130,15 @@ CREW_MANIFEST_CACHE_DIR = "#{CREW_CACHE_DIR}manifest"
 begin
   FileUtils.mkdir_p CREW_MANIFEST_CACHE_DIR
 rescue Errno::EROFS => e
+  # r/o fs
+  puts "Error creating CREW_MANIFEST_CACHE_DIR: #{CREW_MANIFEST_CACHE_DIR}".lightred
+  puts e.message.to_s.orange
+rescue Errno::EACCES => e
+  # no write access
   puts "Error creating CREW_MANIFEST_CACHE_DIR: #{CREW_MANIFEST_CACHE_DIR}".lightred
   puts e.message.to_s.orange
 rescue Errno::ENOENT => e
+  # weird fs
   puts "Error creating CREW_MANIFEST_CACHE_DIR: #{CREW_MANIFEST_CACHE_DIR}".lightred
   puts e.message.to_s.orange
 end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -127,19 +127,20 @@ CREW_CACHE_DIR = if ENV['CREW_CACHE_DIR'].to_s.empty?
                  end
 
 CREW_MANIFEST_CACHE_DIR = "#{CREW_CACHE_DIR}manifest"
+@crew_manifest_cache_error = "Error creating CREW_MANIFEST_CACHE_DIR: #{CREW_MANIFEST_CACHE_DIR}"
 begin
   FileUtils.mkdir_p CREW_MANIFEST_CACHE_DIR
 rescue Errno::EROFS => e
   # r/o fs
-  puts "Error creating CREW_MANIFEST_CACHE_DIR: #{CREW_MANIFEST_CACHE_DIR}".lightred
+  puts @crew_manifest_cache_error.lightred
   puts e.message.to_s.orange
 rescue Errno::EACCES => e
   # no write access
-  puts "Error creating CREW_MANIFEST_CACHE_DIR: #{CREW_MANIFEST_CACHE_DIR}".lightred
+  puts @crew_manifest_cache_error.lightred
   puts e.message.to_s.orange
 rescue Errno::ENOENT => e
   # weird fs e.g., /proc
-  puts "Error creating CREW_MANIFEST_CACHE_DIR: #{CREW_MANIFEST_CACHE_DIR}".lightred
+  puts @crew_manifest_cache_error.lightred
   puts e.message.to_s.orange
 end
 CREW_CACHE_BUILD = ENV.fetch('CREW_CACHE_BUILD', nil)

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.33.5'
+CREW_VERSION = '1.33.6'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp
@@ -129,6 +129,9 @@ CREW_CACHE_DIR = if ENV['CREW_CACHE_DIR'].to_s.empty?
 CREW_MANIFEST_CACHE_DIR = "#{CREW_CACHE_DIR}manifest"
 begin
   FileUtils.mkdir_p CREW_MANIFEST_CACHE_DIR
+rescue Errno::EROFS => e
+  puts "Error creating CREW_MANIFEST_CACHE_DIR: #{CREW_MANIFEST_CACHE_DIR}".lightred
+  puts e.message.to_s.orange
 rescue Errno::ENOENT => e
   puts "Error creating CREW_MANIFEST_CACHE_DIR: #{CREW_MANIFEST_CACHE_DIR}".lightred
   puts e.message.to_s.orange


### PR DESCRIPTION
- We need to handle this EROFS  (Error R/O FS) error during container builds:
```
#9 13.46 /usr/local/lib64/ruby/3.2.0/fileutils.rb:402:in `mkdir': Read-only file system @ dir_s_mkdir - /input/pkg_cache/manifest (Errno::EROFS)
#9 13.46 	from /usr/local/lib64/ruby/3.2.0/fileutils.rb:402:in `fu_mkdir'
#9 13.46 	from /usr/local/lib64/ruby/3.2.0/fileutils.rb:380:in `block (2 levels) in mkdir_p'
#9 13.46 	from /usr/local/lib64/ruby/3.2.0/fileutils.rb:378:in `reverse_each'
#9 13.46 	from /usr/local/lib64/ruby/3.2.0/fileutils.rb:378:in `block in mkdir_p'
#9 13.46 	from /usr/local/lib64/ruby/3.2.0/fileutils.rb:370:in `each'
#9 13.46 	from /usr/local/lib64/ruby/3.2.0/fileutils.rb:370:in `mkdir_p'
#9 13.46 	from /usr/local/lib/crew/lib/const.rb:131:in `<top (required)>'
#9 13.46 	from /usr/local/bin/crew:9:in `require_relative'
#9 13.46 	from /usr/local/bin/crew:9:in `<main>'
```
- Handle the case where there is no write access:
```
CREW_CACHE_DIR=/output/nowrite crew const CREW_CACHE_DIR
Error creating CREW_MANIFEST_CACHE_DIR: /output/nowrite/manifest
Permission denied @ dir_s_mkdir - /output/nowrite/manifest
CREW_CACHE_DIR=/output/nowrite/
```
- Only extract ARCH specific manifest files during `crew updatefiles`.
- Be careful when trying to use `updatefiles`, and show a non-fatal error if the `CREW_MANIFEST_CACHE_DIR` is not writable and `updatefiles` is attempted.
![image](https://github.com/chromebrew/chromebrew/assets/1096701/1a7e0ff5-8578-43a9-ac09-42186c17ce83)


Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=rescue_erofs CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
