### PR TITLE
crew const: Default to CREW_IS_INTEL

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.33.7'
+CREW_VERSION = '1.33.8'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp
@@ -60,9 +60,11 @@ end
 CREW_IN_CONTAINER = File.exist?('/.dockerenv') || !ENV['CREW_IN_CONTAINER'].to_s.empty?
 
 CREW_CPU_VENDOR = CPUINFO['vendor_id'] || 'unknown'
-# vendor_id may not exist on non-x86 platforms.
+# The vendor_id may not exist on non-x86 platforms, or when a container
+# is virtualized on non-x86 platforms. Default to CREW_IS_INTEL for x86
+# architectures.
 CREW_IS_AMD = ARCH == 'x86_64' ? CPUINFO['vendor_id'].include?('AuthenticAMD') : false
-CREW_IS_INTEL = ARCH == 'x86_64' || ARCH == 'i686' ? CPUINFO['vendor_id'].include?('GenuineIntel') : false
+CREW_IS_INTEL = ARCH == 'x86_64' || ARCH == 'i686' ? ( CREW_CPU_VENDOR == 'unknown' or CPUINFO['vendor_id'].include?('GenuineIntel') ) : false
 
 # Use sane minimal defaults if in container and no override specified.
 if CREW_IN_CONTAINER && ENV['CREW_KERNEL_VERSION'].to_s.empty?

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -60,10 +60,12 @@ end
 CREW_IN_CONTAINER = File.exist?('/.dockerenv') || !ENV['CREW_IN_CONTAINER'].to_s.empty?
 
 CREW_CPU_VENDOR = CPUINFO['vendor_id'] || 'unknown'
-# The vendor_id may not exist on non-x86 platforms, or when a container
-# is virtualized on non-x86 platforms. Default to CREW_IS_INTEL for x86
-# architectures.
-CREW_IS_AMD = ARCH == 'x86_64' ? CPUINFO['vendor_id'].include?('AuthenticAMD') : false
+# The cpuinfo vendor_id may not exist on non-x86 platforms, or when a
+# container is virtualized on non-x86 platforms. Default to
+# CREW_IS_INTEL for x86 architectures. Note that a QEMU_EMULATED check
+# is not relevant here since qemu can be configured to pass through a
+# cpuinfo vendor_id.
+CREW_IS_AMD = ARCH == 'x86_64' ? ( CREW_CPU_VENDOR != 'unknown' and CPUINFO['vendor_id'].include?('AuthenticAMD') ) : false
 CREW_IS_INTEL = ARCH == 'x86_64' || ARCH == 'i686' ? ( CREW_CPU_VENDOR == 'unknown' or CPUINFO['vendor_id'].include?('GenuineIntel') ) : false
 
 # Use sane minimal defaults if in container and no override specified.


### PR DESCRIPTION
- i686 and x86_64 containers on non-x86 hosts get a crew error from `CPUINFO['vendor_id']` not existing on those hosts.
- This PR sets `CREW_IS_INTEL` for crew on x86 containers on such hosts so `crew update` doesn't fail.
- This will require container rebuilds since the initial `crew update` fails because of this failure from `const.rb`

x86_64 container on an aarch64 host:
```
chronos@rpi4b-x86_64 /usr/local/lib/crew/packages $  crew const CREW_IS_INTEL
/usr/local/lib/crew/lib/const.rb:64:in `<top (required)>': undefined method `include?' for nil:NilClass (NoMethodError)

CREW_IS_AMD = ARCH == 'x86_64' ? CPUINFO['vendor_id'].include?('AuthenticAMD') : false
                                                     ^^^^^^^^^
        from /usr/local/bin/crew:9:in `require_relative'
        from /usr/local/bin/crew:9:in `<main>'

```
After manually copying in the new `const.rb` so crew update succeeds...
```
chronos@rpi4b-x86_64 /usr/local/lib/crew/packages $ CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=intel_virt CREW_TESTING=1 crew update ;  crew const CREW_IS_INTEL
Updating crew from testing repository...
remote: Enumerating objects: 25, done.
remote: Counting objects: 100% (25/25), done.
remote: Compressing objects: 100% (11/11), done.
remote: Total 18 (delta 13), reused 11 (delta 6), pack-reused 0
Unpacking objects: 100% (18/18), 3.28 KiB | 12.00 KiB/s, done.
From https://github.com/satmandu/chromebrew
 * branch            intel_virt -> FETCH_HEAD
 * [new branch]      intel_virt -> testing/intel_virt
Updating files: 100% (2114/2114), done.
HEAD is now at 1dd894c expand comment
Package lists, crew, and library updated.
Checking for package updates...
curl could be updated from 8.0.1-1 to 8.1.0

Run `crew upgrade` to update all packages or `crew upgrade <package1> [<package2> ...]` to update specific packages.
CREW_IS_INTEL=true
```
i686 container on an aarch64 host:
```
chronos@rpi4b-i686 /usr/local/lib/crew/packages $ crew const CREW_IS_INTEL
/usr/local/lib/crew/lib/const.rb:65:in `<top (required)>': undefined method `include?' for nil:NilClass (NoMethodError)

CREW_IS_INTEL = ARCH == 'x86_64' || ARCH == 'i686' ? CPUINFO['vendor_id'].include?('GenuineIntel') || CREW_CPU_VENDOR == 'unknown' : false
                                                                         ^^^^^^^^^
        from /usr/local/bin/crew:9:in `require_relative'
        from /usr/local/bin/crew:9:in `<main>'
```
After manually copying in the new `const.rb` so crew update succeeds...
```
chronos@rpi4b-i686 /usr/local/lib/crew/packages $  CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=intel_virt CREW_TESTING=1 crew update ;  crew const CREW_IS_INTEL
Updating crew from testing repository...
remote: Enumerating objects: 11, done.
remote: Counting objects: 100% (11/11), done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 8 (delta 6), reused 5 (delta 3), pack-reused 0
Unpacking objects: 100% (8/8), 1.37 KiB | 9.00 KiB/s, done.
From https://github.com/satmandu/chromebrew
 * branch            intel_virt -> FETCH_HEAD
 * [new branch]      intel_virt -> testing/intel_virt
HEAD is now at 1dd894c expand comment
Package lists, crew, and library updated.
Checking for package updates...
curl could be updated from 8.0.1-1 to 8.1.0

Run `crew upgrade` to update all packages or `crew upgrade <package1> [<package2> ...]` to update specific packages.
CREW_IS_INTEL=true
```
Doesn't break native i686 container:
```
chronos@cheekon-i686 /usr/local/lib/crew/packages $  CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=intel_virt CREW_TESTING=1 crew update ;  crew const CREW_IS_INTEL
Updating crew from testing repository...
remote: Enumerating objects: 11, done.
remote: Counting objects: 100% (11/11), done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 8 (delta 6), reused 5 (delta 3), pack-reused 0
Unpacking objects: 100% (8/8), 1.37 KiB | 468.00 KiB/s, done.
From https://github.com/satmandu/chromebrew
 * branch            intel_virt -> FETCH_HEAD
 * [new branch]      intel_virt -> testing/intel_virt
HEAD is now at 1dd894c expand comment
Package lists, crew, and library updated.
Checking for package updates...
curl could be updated from 8.0.1-1 to 8.1.0

Run `crew upgrade` to update all packages or `crew upgrade <package1> [<package2> ...]` to update specific packages.
CREW_IS_INTEL=true
```
or x86_64 container:
```
chronos@cheekon-x86_64 /usr/local/lib/crew/packages $  CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=intel_virt CREW_TESTING=1 crew update ;  crew const CREW_IS_INTEL
Updating crew from testing repository...
remote: Enumerating objects: 11, done.
remote: Counting objects: 100% (11/11), done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 8 (delta 6), reused 5 (delta 3), pack-reused 0
Unpacking objects: 100% (8/8), 1.37 KiB | 468.00 KiB/s, done.
From https://github.com/satmandu/chromebrew
 * branch            intel_virt -> FETCH_HEAD
 * [new branch]      intel_virt -> testing/intel_virt
HEAD is now at 1dd894c expand comment
Package lists, crew, and library updated.
Checking for package updates...
curl could be updated from 8.0.1-1 to 8.1.0

Run `crew upgrade` to update all packages or `crew upgrade <package1> [<package2> ...]` to update specific packages.
CREW_IS_INTEL=true
```
or native arm container:
```
chronos@rpi4b-armv7l /usr/local/lib/crew/packages $  CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=intel_virt CREW_TESTING=1 crew update ;  crew const CREW_IS_INTEL
Updating crew from testing repository...
remote: Enumerating objects: 11, done.
remote: Counting objects: 100% (11/11), done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 8 (delta 6), reused 5 (delta 3), pack-reused 0
Unpacking objects: 100% (8/8), 1.37 KiB | 70.00 KiB/s, done.
From https://github.com/satmandu/chromebrew
 * branch            intel_virt -> FETCH_HEAD
 * [new branch]      intel_virt -> testing/intel_virt
HEAD is now at 1dd894c expand comment
Package lists, crew, and library updated.
Checking for package updates...
curl could be updated from 8.0.1-1 to 8.1.0

Run `crew upgrade` to update all packages or `crew upgrade <package1> [<package2> ...]` to update specific packages.
CREW_IS_INTEL=fals
```

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=intel_virt CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
