### PR TITLE
crew prepare_package: sort filelist, use CREW_DEST_MAN_PREFIX, CREW_LOCAL_MANIFEST_PATH writable check

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1100,7 +1100,7 @@ def prepare_package(destdir)
     system "find .#{CREW_PREFIX} -type l >> ../filelist"
     system 'cut -c2- ../filelist | sort -o filelist'
 
-    if Dir.exist?(CREW_LOCAL_MANIFEST_PATH)
+    if Dir.exist?(CREW_LOCAL_MANIFEST_PATH) && File.writable?(CREW_LOCAL_MANIFEST_PATH)
       FileUtils.mkdir_p "#{CREW_LOCAL_MANIFEST_PATH}/#{ARCH}/#{@pkg.name.chr.downcase}"
       FileUtils.cp 'filelist', "#{CREW_LOCAL_MANIFEST_PATH}/#{ARCH}/#{@pkg.name.chr.downcase}/#{@pkg.name}.filelist"
     end

--- a/bin/crew
+++ b/bin/crew
@@ -1086,10 +1086,23 @@ def prepare_package(destdir)
       system "find #{CREW_DEST_DIR} -type f \\( -name '.packlist' -o -name perllocal.pod \\) -delete"
     end
 
-    # compress manual files
+    # Compress manual files, and move errant files to the correct
+    # locations.
+    if File.exist?("#{CREW_DEST_PREFIX}/man")
+      puts "Files in #{CREW_PREFIX}/man will be moved to #{CREW_MAN_PREFIX}.".orange
+      FileUtils.mkdir_p CREW_DEST_MAN_PREFIX.to_s
+      FileUtils.mv Dir["#{CREW_DEST_PREFIX}/man/*"], "#{CREW_DEST_MAN_PREFIX}/"
+      Dir.rmdir "#{CREW_DEST_PREFIX}/man" if Dir.empty?("#{CREW_DEST_PREFIX}/man")
+    end
+    if File.exist?("#{CREW_DEST_PREFIX}/info")
+      puts "Files in #{CREW_PREFIX}/info will be moved to #{CREW_PREFIX}/share/info.".orange
+      FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/info/"
+      FileUtils.mv Dir["#{CREW_DEST_PREFIX}/info/*"], "#{CREW_DEST_PREFIX}/share/info/"
+      Dir.rmdir "#{CREW_DEST_PREFIX}/info" if Dir.empty?("#{CREW_DEST_PREFIX}/info")
+    end
+    # Remove the "share/info/dir.*" file since it causes conflicts.
+    FileUtils.rm_f Dir["#{CREW_DEST_PREFIX}/share/info/dir*"]
     compress_doc CREW_DEST_MAN_PREFIX.to_s
-    compress_doc "#{CREW_DEST_PREFIX}/info"
-    compress_doc "#{CREW_DEST_PREFIX}/man"
     compress_doc "#{CREW_DEST_PREFIX}/share/info"
 
     # Allow postbuild to override the filelist contents

--- a/bin/crew
+++ b/bin/crew
@@ -1087,9 +1087,9 @@ def prepare_package(destdir)
     end
 
     # compress manual files
-    compress_doc "#{CREW_DEST_PREFIX}/man"
+    compress_doc CREW_DEST_MAN_PREFIX.to_s
     compress_doc "#{CREW_DEST_PREFIX}/info"
-    compress_doc "#{CREW_DEST_PREFIX}/share/man"
+    compress_doc "#{CREW_DEST_PREFIX}/man"
     compress_doc "#{CREW_DEST_PREFIX}/share/info"
 
     # Allow postbuild to override the filelist contents
@@ -1098,7 +1098,7 @@ def prepare_package(destdir)
     # create file list
     system "find .#{CREW_PREFIX} -type f > ../filelist"
     system "find .#{CREW_PREFIX} -type l >> ../filelist"
-    system 'cut -c2- ../filelist > filelist'
+    system 'cut -c2- ../filelist | sort -o filelist'
 
     if Dir.exist?(CREW_LOCAL_MANIFEST_PATH)
       FileUtils.mkdir_p "#{CREW_LOCAL_MANIFEST_PATH}/#{ARCH}/#{@pkg.name.chr.downcase}"

--- a/bin/crew
+++ b/bin/crew
@@ -1580,7 +1580,8 @@ end
 def build_package(pwd)
   abort 'It is not possible to build a fake package'.lightred if @pkg.is_fake?
   abort 'It is not possible to build without source'.lightred unless @pkg.is_source?(@device[:architecture])
-  abort "Unable to locate CREW_LOCAL_MANIFEST_PATH.  Please try again in the chromebrew/release/#{ARCH} directory.".lightred if CREW_LOCAL_MANIFEST_PATH.empty?
+  abort "Unable to locate CREW_LOCAL_MANIFEST_PATH. Please try again in the chromebrew/release/#{ARCH} directory.".lightred if CREW_LOCAL_MANIFEST_PATH.empty?
+  abort "CREW_LOCAL_MANIFEST_PATH: #{CREW_LOCAL_MANIFEST_PATH} is not writable.".lightred unless File.writable?(CREW_LOCAL_MANIFEST_PATH)
 
   # download source codes and unpack it
   meta = download

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.33.8'
+CREW_VERSION = '1.33.9'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -74,9 +74,9 @@ if CREW_IN_CONTAINER && ENV['CREW_KERNEL_VERSION'].to_s.empty?
   when 'i686'
     CREW_KERNEL_VERSION = '3.8'
   when 'aarch64', 'armv7l'
-    CREW_KERNEL_VERSION = '4.14'
+    CREW_KERNEL_VERSION = '5.10'
   when 'x86_64'
-    CREW_KERNEL_VERSION = '4.14'
+    CREW_KERNEL_VERSION = '5.10'
   end
 else
   CREW_KERNEL_VERSION = ENV.fetch('CREW_KERNEL_VERSION', `uname -r`.rpartition('.')[0])

--- a/manifest/armv7l/f/figlet.filelist
+++ b/manifest/armv7l/f/figlet.filelist
@@ -2,10 +2,6 @@
 /usr/local/bin/figlet
 /usr/local/bin/figlist
 /usr/local/bin/showfigfonts
-/usr/local/man/man6/chkfont.6.gz
-/usr/local/man/man6/figlet.6.gz
-/usr/local/man/man6/figlist.6.gz
-/usr/local/man/man6/showfigfonts.6.gz
 /usr/local/share/figlet/646-ca2.flc
 /usr/local/share/figlet/646-ca.flc
 /usr/local/share/figlet/646-cn.flc
@@ -63,3 +59,7 @@
 /usr/local/share/figlet/ushebrew.flc
 /usr/local/share/figlet/uskata.flc
 /usr/local/share/figlet/utf8.flc
+/usr/local/share/man/man6/chkfont.6.zst
+/usr/local/share/man/man6/figlet.6.zst
+/usr/local/share/man/man6/figlist.6.zst
+/usr/local/share/man/man6/showfigfonts.6.zst

--- a/manifest/armv7l/w/wol.filelist
+++ b/manifest/armv7l/w/wol.filelist
@@ -1,11 +1,10 @@
 /usr/local/bin/wol
 /usr/local/bin/wol-bootptab
 /usr/local/bin/wol-dhcpdconf
-/usr/local/info/dir.gz
-/usr/local/info/wol.info.gz
+/usr/local/share/info/wol.info.zst
 /usr/local/share/locale/de/LC_MESSAGES/wol.mo
 /usr/local/share/locale/es/LC_MESSAGES/wol.mo
 /usr/local/share/locale/fr/LC_MESSAGES/wol.mo
 /usr/local/share/locale/it/LC_MESSAGES/wol.mo
 /usr/local/share/locale/sv/LC_MESSAGES/wol.mo
-/usr/local/share/man/man1/wol.1.gz
+/usr/local/share/man/man1/wol.1.zst

--- a/manifest/i686/f/figlet.filelist
+++ b/manifest/i686/f/figlet.filelist
@@ -2,10 +2,6 @@
 /usr/local/bin/figlet
 /usr/local/bin/figlist
 /usr/local/bin/showfigfonts
-/usr/local/man/man6/chkfont.6.gz
-/usr/local/man/man6/figlet.6.gz
-/usr/local/man/man6/figlist.6.gz
-/usr/local/man/man6/showfigfonts.6.gz
 /usr/local/share/figlet/646-ca2.flc
 /usr/local/share/figlet/646-ca.flc
 /usr/local/share/figlet/646-cn.flc
@@ -63,3 +59,7 @@
 /usr/local/share/figlet/ushebrew.flc
 /usr/local/share/figlet/uskata.flc
 /usr/local/share/figlet/utf8.flc
+/usr/local/share/man/man6/chkfont.6.zst
+/usr/local/share/man/man6/figlet.6.zst
+/usr/local/share/man/man6/figlist.6.zst
+/usr/local/share/man/man6/showfigfonts.6.zst

--- a/manifest/i686/w/wol.filelist
+++ b/manifest/i686/w/wol.filelist
@@ -1,10 +1,10 @@
 /usr/local/bin/wol
 /usr/local/bin/wol-bootptab
 /usr/local/bin/wol-dhcpdconf
-/usr/local/info/wol.info.gz
+/usr/local/share/info/wol.info.zst
 /usr/local/share/locale/de/LC_MESSAGES/wol.mo
 /usr/local/share/locale/es/LC_MESSAGES/wol.mo
 /usr/local/share/locale/fr/LC_MESSAGES/wol.mo
 /usr/local/share/locale/it/LC_MESSAGES/wol.mo
 /usr/local/share/locale/sv/LC_MESSAGES/wol.mo
-/usr/local/share/man/man1/wol.1.gz
+/usr/local/share/man/man1/wol.1.zst

--- a/manifest/x86_64/f/figlet.filelist
+++ b/manifest/x86_64/f/figlet.filelist
@@ -2,10 +2,6 @@
 /usr/local/bin/figlet
 /usr/local/bin/figlist
 /usr/local/bin/showfigfonts
-/usr/local/man/man6/chkfont.6.gz
-/usr/local/man/man6/figlet.6.gz
-/usr/local/man/man6/figlist.6.gz
-/usr/local/man/man6/showfigfonts.6.gz
 /usr/local/share/figlet/646-ca2.flc
 /usr/local/share/figlet/646-ca.flc
 /usr/local/share/figlet/646-cn.flc
@@ -63,3 +59,7 @@
 /usr/local/share/figlet/ushebrew.flc
 /usr/local/share/figlet/uskata.flc
 /usr/local/share/figlet/utf8.flc
+/usr/local/share/man/man6/chkfont.6.zst
+/usr/local/share/man/man6/figlet.6.zst
+/usr/local/share/man/man6/figlist.6.zst
+/usr/local/share/man/man6/showfigfonts.6.zst

--- a/manifest/x86_64/w/wol.filelist
+++ b/manifest/x86_64/w/wol.filelist
@@ -1,10 +1,10 @@
 /usr/local/bin/wol
 /usr/local/bin/wol-bootptab
 /usr/local/bin/wol-dhcpdconf
-/usr/local/info/wol.info.gz
+/usr/local/share/info/wol.info.zst
 /usr/local/share/locale/de/LC_MESSAGES/wol.mo
 /usr/local/share/locale/es/LC_MESSAGES/wol.mo
 /usr/local/share/locale/fr/LC_MESSAGES/wol.mo
 /usr/local/share/locale/it/LC_MESSAGES/wol.mo
 /usr/local/share/locale/sv/LC_MESSAGES/wol.mo
-/usr/local/share/man/man1/wol.1.gz
+/usr/local/share/man/man1/wol.1.zst

--- a/packages/figlet.rb
+++ b/packages/figlet.rb
@@ -3,24 +3,26 @@ require 'package'
 class Figlet < Package
   description 'FIGlet is a program for making large letters out of ordinary text.'
   homepage 'http://www.figlet.org/'
-  version '2.2.5'
+  version '2.2.5-a565ae1'
   license 'BSD'
   compatibility 'all'
-  source_url 'ftp://ftp.figlet.org/pub/figlet/program/unix/figlet-2.2.5.tar.gz'
-  source_sha256 'bf88c40fd0f077dab2712f54f8d39ac952e4e9f2e1882f1195be9e5e4257417d'
+  source_url 'https://github.com/cmatsuoka/figlet.git'
+  git_hashtag 'a565ae1e8f8254044219260dda2a6b51984930dc'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/figlet/2.2.5_armv7l/figlet-2.2.5-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/figlet/2.2.5_armv7l/figlet-2.2.5-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/figlet/2.2.5_i686/figlet-2.2.5-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/figlet/2.2.5_x86_64/figlet-2.2.5-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/figlet/2.2.5-a565ae1_armv7l/figlet-2.2.5-a565ae1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/figlet/2.2.5-a565ae1_armv7l/figlet-2.2.5-a565ae1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/figlet/2.2.5-a565ae1_i686/figlet-2.2.5-a565ae1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/figlet/2.2.5-a565ae1_x86_64/figlet-2.2.5-a565ae1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '6f4f9e4777710551e5ff6a7da662f628bb150f29ff8cec5cdc5763c3fd24f16f',
-     armv7l: '6f4f9e4777710551e5ff6a7da662f628bb150f29ff8cec5cdc5763c3fd24f16f',
-       i686: 'e8a3bf134593f61e6cae88cd202db8a23007e6313c847299ba29e0f254d23ef5',
-     x86_64: 'd4e024831412e63a6c722cbd1c0c2b51e702c3b10739fa597741123f6126738b'
+    aarch64: '49d91067c62e2bf4d74047211638a4319c3190c82b3636709cc055d011a26665',
+     armv7l: '49d91067c62e2bf4d74047211638a4319c3190c82b3636709cc055d011a26665',
+       i686: 'f50377baacc1c0e7f8c07065837408d4ffbfbeda0ce7d35194f99304ced70914',
+     x86_64: 'bf7c55cceb0b1eb05c92e278c7792b3d80c1730edf14238e5382d6bf1f524f56'
   })
+
+  depends_on 'glibc' # R
 
   def self.build
     system 'make', "PREFIX=#{CREW_PREFIX}"

--- a/packages/wol.rb
+++ b/packages/wol.rb
@@ -2,28 +2,30 @@ require 'package'
 
 class Wol < Package
   description 'Wake up hardware that is Magic Packet compliant'
-  homepage 'http://ahh.sourceforge.net/wol/'
-  version '0.7.1'
+  homepage 'https://ahh.sourceforge.net/wol/'
+  version '0.7.1-1'
   license 'GPL-2+'
   compatibility 'all'
   source_url 'https://downloads.sourceforge.net/ahh/wol-0.7.1.tar.gz'
   source_sha256 'e0086c9b9811df2bdf763ec9016dfb1bcb7dba9fa6d7858725b0929069a12622'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wol/0.7.1_armv7l/wol-0.7.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wol/0.7.1_armv7l/wol-0.7.1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wol/0.7.1_i686/wol-0.7.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wol/0.7.1_x86_64/wol-0.7.1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wol/0.7.1-1_armv7l/wol-0.7.1-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wol/0.7.1-1_armv7l/wol-0.7.1-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wol/0.7.1-1_i686/wol-0.7.1-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wol/0.7.1-1_x86_64/wol-0.7.1-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '83abf28069852e88d080740c682be692007134532e9f045173cf10def41bc26d',
-     armv7l: '83abf28069852e88d080740c682be692007134532e9f045173cf10def41bc26d',
-       i686: 'e0c1b4a267d50208fa0e1979effbb425fa14aeffe1a49029e0f45967cedc3e7f',
-     x86_64: '27cf6ed4e02b068ffc59b650d165b575a921403c64fe74be8875860c96357c13'
+    aarch64: 'b07eb72d647bbb6907b62196ea0d88c23d7564bc0335fd32f3bb1b2c9f1eab6a',
+     armv7l: 'b07eb72d647bbb6907b62196ea0d88c23d7564bc0335fd32f3bb1b2c9f1eab6a',
+       i686: '09bdc20009def407f64d45814deb7415381fd1f6b3ccebd83e67dabd3f809dbc',
+     x86_64: '01b2449b8062b3d188d9caadbc327894f24af04942409e5a620eae28e20d106d'
   })
 
+  depends_on 'glibc' # R
+
   def self.build
-    system './configure', "--prefix=#{CREW_PREFIX}", "--mandir=#{CREW_MAN_PREFIX}"
+    system "./configure #{CREW_OPTIONS}"
     system 'make'
   end
 


### PR DESCRIPTION
Fixes https://github.com/chromebrew/chromebrew/issues/8275
- sort package `filelist`
- Use `CREW_DEST_MAN_PREFIX` in compressdoc section
- Only write `filelist` to `CREW_LOCAL_MANIFEST_PATH` if it is writable (for instance, if the disk with that dir runs out of space during build for some reason.) 
- Error out of starting a build if `CREW_LOCAL_MANIFEST_PATH` is not writable.
- Set default `CREW_KERNEL_VERSION` in containers to 5.10 for building packages.
- Move `man` and `info` pages left in `/usr/local/man` and `/usr/local/info` during the build process.
  - Rebuilt `wol` and `figlet` packages using new algorithm to confirm that the man and info pages were correctly moved.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=cleanup_prepare_package CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
