### PR TITLE
bubblewrap => 0.8.0

### DIFF
--- a/manifest/armv7l/b/bubblewrap.filelist
+++ b/manifest/armv7l/b/bubblewrap.filelist
@@ -1,3 +1,5 @@
 /usr/local/bin/bwrap
 /usr/local/bin/bwrap.elf
 /usr/local/share/bash-completion/completions/bwrap
+/usr/local/share/man/man1/bwrap.1.zst
+/usr/local/share/zsh/site-functions/_bwrap

--- a/manifest/i686/b/bubblewrap.filelist
+++ b/manifest/i686/b/bubblewrap.filelist
@@ -1,3 +1,5 @@
 /usr/local/bin/bwrap
 /usr/local/bin/bwrap.elf
 /usr/local/share/bash-completion/completions/bwrap
+/usr/local/share/man/man1/bwrap.1.zst
+/usr/local/share/zsh/site-functions/_bwrap

--- a/manifest/x86_64/b/bubblewrap.filelist
+++ b/manifest/x86_64/b/bubblewrap.filelist
@@ -1,3 +1,5 @@
 /usr/local/bin/bwrap
 /usr/local/bin/bwrap.elf
 /usr/local/share/bash-completion/completions/bwrap
+/usr/local/share/man/man1/bwrap.1.zst
+/usr/local/share/zsh/site-functions/_bwrap


### PR DESCRIPTION
Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=bubblewrap CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
