### PR TITLE
crew: check for rsync ACLs support.

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1347,7 +1347,13 @@ def install_files(src, dst = File.join( CREW_PREFIX, src.delete_prefix('./usr/lo
       if File.executable?("#{CREW_PREFIX}/bin/rsync") && system("#{CREW_PREFIX}/bin/rsync --version > /dev/null")
         # rsync src path needs a trailing slash
         src << '/' unless src.end_with?('/')
-        system 'rsync', "-ah#{@verbose}HAXW", '--remove-source-files', src, dst, exception: true
+        # Check for ACLs support.
+        @rsync_version = `rsync --version`.chomp
+        if @rsync_version.include?('ACLs')
+          system 'rsync', "-ah#{@verbose}HAXW", '--remove-source-files', src, dst, exception: true
+        else
+          system 'rsync', "-ah#{@verbose}HXW", '--remove-source-files', src, dst, exception: true
+        end
       else
         system "cd #{src}; tar -cf - ./* | (cd #{dst}; tar -x#{@verbose}p --keep-directory-symlink -f -)", exception: true
       end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.33.9'
+CREW_VERSION = '1.34.0'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
Fixes #8321 #8235 #8134 

- Older rsync builds didn't include ACLs support, which causes problems when `crew` tries to use the `-A` flag.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=crew_rsync CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
