### PR TITLE
Add @_ver comment to crew_mvdir

### DIFF
--- a/packages/crew_mvdir.rb
+++ b/packages/crew_mvdir.rb
@@ -3,7 +3,7 @@ require 'package'
 class Crew_mvdir < Package
   description 'Faster alternative to "rsync --remove-source-files dir1/ dir2/"'
   homepage 'https://github.com/chromebrew/crew-mvdir'
-  version '0.2-1'
+  version '0.2-1' # Do not use @_ver here, it will break the installer.
   license 'GPL-3'
   compatibility 'all'
   source_url 'https://github.com/chromebrew/crew-mvdir.git'


### PR DESCRIPTION
Necessary for #7297 to work, because the `sed` expression I currently use in there requires a ending comment on the `version` value to work. I could do it another way, but that would require even more sed nonsense, and at any rate this comment is important to have on all of these packages to ensure the installation isin't broken by someone unknowingly using `@_ver` on a bootstrap package.

I do see #8196, and I do look foward to that landing, but in the meantime I'll keep 7927 based on master. If 7297 gets merged before 8196, I'll provide the sed changes required to the installer for 8196 to work. If #7082, after 7927 gets merged, also gets merged before 8196, I'll provide the `lib/package.rb` changes required for 8196 to work. If 8196 gets merged before 7297 I'll rebase and update 7927 to work with 8196, and the same applies for 7082.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=atatver CREW_TESTING=1 crew update
```