### PR TITLE
Remove frozen_string_literal comment from pcre2.rb

### DIFF
--- a/packages/pcre2.rb
+++ b/packages/pcre2.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'package'
 
 class Pcre2 < Package


### PR DESCRIPTION
Works properly:
- [x] `x86_64`
- [ ] `i686`
- [ ] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=literallywarmstring CREW_TESTING=1 crew update
```
