### PR TITLE
Add require 'package' to some packages which were missing it

### DIFF
--- a/packages/webkit2gtk_4.rb
+++ b/packages/webkit2gtk_4.rb
@@ -1,3 +1,5 @@
+require 'package'
+
 class Webkit2gtk_4 < Package
   description 'Web content engine for GTK'
   homepage 'https://webkitgtk.org'

--- a/packages/webkit2gtk_4_1.rb
+++ b/packages/webkit2gtk_4_1.rb
@@ -1,3 +1,5 @@
+require 'package'
+
 class Webkit2gtk_4_1 < Package
   description 'Web content engine for GTK'
   homepage 'https://webkitgtk.org'

--- a/packages/webkitgtk_6.rb
+++ b/packages/webkitgtk_6.rb
@@ -1,3 +1,5 @@
+require 'package'
+
 class Webkitgtk_6 < Package
   description 'Web content engine for GTK'
   homepage 'https://webkitgtk.org'


### PR DESCRIPTION
`webkit2gtk_4` and `webkit2gtk_4_1` lost theirs in 194b87b1882f4b420b8c4d071337041e0992cb29, while `webkitgtk_6.rb` never had it. Why? Who knows!

Anyways, i'm adding them back for consistency, because it helps with 7082 and because `require 'package'` is probably important.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=wheredidtheygo CREW_TESTING=1 crew update
```

