### PR TITLE
Re-add filecmd dependency to glibc

### DIFF
--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -7,7 +7,7 @@ class Glibc < Package
   compatibility 'all'
 
   depends_on 'gawk' => :build
-  depends_on 'filecmd'
+  depends_on 'filecmd' # L Fixes creating symlinks on a fresh install.
   depends_on 'libidn2' => :build
   depends_on 'texinfo' => :build
   depends_on 'hashpipe' => :build

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -7,6 +7,7 @@ class Glibc < Package
   compatibility 'all'
 
   depends_on 'gawk' => :build
+  depends_on 'filecmd'
   depends_on 'libidn2' => :build
   depends_on 'texinfo' => :build
   depends_on 'hashpipe' => :build


### PR DESCRIPTION
Added in #7402, removed in #7472. 

Not sure why it was removed, and I didnt notice it was removed at the time.
Until now, when I encountered the error again today while testing.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=fix2v2eb CREW_TESTING=1 crew update
```
