### PR TITLE
Remove simple (and unnecessary) uses of @_ver

### DIFF
--- a/packages/cairomm_1_0.rb
+++ b/packages/cairomm_1_0.rb
@@ -3,8 +3,7 @@ require 'package'
 class Cairomm_1_0 < Package
   description 'The Cairomm package provides a C++ interface to Cairo.'
   homepage 'https://www.cairographics.org/'
-  @_ver = '1.14.4'
-  version @_ver
+  version '1.14.4'
   license 'LGPL-2+'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/cairo/cairomm.git'

--- a/packages/cairomm_1_16.rb
+++ b/packages/cairomm_1_16.rb
@@ -3,8 +3,7 @@ require 'package'
 class Cairomm_1_16 < Package
   description 'The Cairomm package provides a C++ interface to Cairo.'
   homepage 'https://www.cairographics.org/'
-  @_ver = '1.16.2'
-  version @_ver
+  version '1.16.2'
   license 'LGPL-2+'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/cairo/cairomm.git'

--- a/packages/cantarell_fonts.rb
+++ b/packages/cantarell_fonts.rb
@@ -3,8 +3,7 @@ require 'package'
 class Cantarell_fonts < Package
   description 'Humanist sans serif font'
   homepage 'https://gitlab.gnome.org/GNOME/cantarell-fonts'
-  @_ver = '0.303.1'
-  version @_ver
+  version '0.303.1'
   license 'OFL-1.1'
   compatibility 'all'
   source_url 'https://download.gnome.org/core/43/43.0/sources/cantarell-fonts-0.303.1.tar.xz'

--- a/packages/cunit.rb
+++ b/packages/cunit.rb
@@ -3,8 +3,7 @@ require 'package'
 class Cunit < Package
   description 'CUnit is an automated testing framework for C.'
   homepage 'http://cunit.sourceforge.net/'
-  @_ver = '2.1.3'
-  version @_ver
+  version '2.1.3'
   compatibility 'all'
   license 'LGPL-2'
   source_url 'https://sourceforge.net/projects/cunit/files/CUnit/2.1-3/CUnit-2.1-3.tar.bz2'

--- a/packages/dav1d.rb
+++ b/packages/dav1d.rb
@@ -3,8 +3,7 @@ require 'package'
 class Dav1d < Package
   description '**dav1d** is a new **AV1** cross-platform **d**ecoder, open-source, and focused on speed and correctness.'
   homepage 'https://code.videolan.org/videolan/dav1d'
-  @_ver = '1.2.1'
-  version @_ver
+  version '1.2.1'
   license 'BSD-2'
   compatibility 'all'
   source_url 'https://code.videolan.org/videolan/dav1d.git'

--- a/packages/ffmpeg.rb
+++ b/packages/ffmpeg.rb
@@ -3,8 +3,7 @@ require 'package'
 class Ffmpeg < Package
   description 'Complete solution to record, convert and stream audio and video'
   homepage 'https://ffmpeg.org/'
-  @_ver = '6.0-27205c0'
-  version @_ver
+  version '6.0-27205c0'
   license 'LGPL-2,1, GPL-2, GPL-3, and LGPL-3' # When changing ffmpeg's configure options, make sure this variable is still accurate.
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://git.ffmpeg.org/ffmpeg.git'

--- a/packages/glibmm_2_4.rb
+++ b/packages/glibmm_2_4.rb
@@ -3,8 +3,7 @@ require 'package'
 class Glibmm_2_4 < Package
   description 'C++ bindings for GLib'
   homepage 'https://www.gtkmm.org'
-  @_ver = '2.66.5'
-  version @_ver
+  version '2.66.5'
   license 'LGPL-2.1+'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/glibmm.git'

--- a/packages/glibmm_2_68.rb
+++ b/packages/glibmm_2_68.rb
@@ -3,8 +3,7 @@ require 'package'
 class Glibmm_2_68 < Package
   description 'C++ bindings for GLib api version 2.68'
   homepage 'https://www.gtkmm.org'
-  @_ver = '2.75.0'
-  version @_ver
+  version '2.75.0'
   license 'LGPL-2.1+'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/glibmm.git'

--- a/packages/gtksourceview_3.rb
+++ b/packages/gtksourceview_3.rb
@@ -3,8 +3,7 @@ require 'package'
 class Gtksourceview_3 < Package
   description 'Source code editing widget'
   homepage 'https://wiki.gnome.org/Projects/GtkSourceView'
-  @_ver = '3.24.11'
-  version @_ver
+  version '3.24.11'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://download.gnome.org/sources/gtksourceview/3.24/gtksourceview-3.24.11.tar.xz'

--- a/packages/libaio.rb
+++ b/packages/libaio.rb
@@ -3,8 +3,7 @@ require 'package'
 class Libaio < Package
   description 'Linux-native asynchronous I/O access library'
   homepage 'https://pagure.io/libaio'
-  @_ver = '0.3.113-932de6c'
-  version @_ver
+  version '0.3.113-932de6c'
   license 'LGPL-2'
   # Use release patched to fix lto issues as per
   # https://marc.info/?l=linux-aio&m=164999309120529&w=2

--- a/packages/libexiv2.rb
+++ b/packages/libexiv2.rb
@@ -3,8 +3,7 @@ require 'package'
 class Libexiv2 < Package
   description 'Exiv2 is a Cross-platform C++ library and a command line utility to manage image metadata.'
   homepage 'http://exiv2.org/'
-  @_ver = '0.27.5'
-  version @_ver
+  version '0.27.5'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://github.com/Exiv2/exiv2/archive/refs/tags/v0.27.5.tar.gz'

--- a/packages/libminigbm.rb
+++ b/packages/libminigbm.rb
@@ -7,8 +7,7 @@ class Libminigbm < Package
   description 'Generic Buffer Management GBM implementation used in Chromium OS'
   homepage 'https://chromium.googlesource.com/chromiumos/platform/minigbm/'
   git_hashtag '407eb0ebf3ce52fd4b3d79712d1b86d7b021c29b'
-  @_ver = git_hashtag[0, 7]
-  version @_ver
+  version git_hashtag[0, 7]
   license 'custom'
   compatibility 'all'
   source_url 'https://chromium.googlesource.com/chromiumos/platform/minigbm.git'

--- a/packages/librsvg.rb
+++ b/packages/librsvg.rb
@@ -3,8 +3,7 @@ require 'package'
 class Librsvg < Package
   description 'SVG library for GNOME'
   homepage 'https://wiki.gnome.org/Projects/LibRsvg'
-  @_ver = '2.56.0-59d5d83'
-  version @_ver
+  version '2.56.0-59d5d83'
   license 'LGPL-2+'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/librsvg.git'

--- a/packages/libssh2.rb
+++ b/packages/libssh2.rb
@@ -3,8 +3,7 @@ require 'package'
 class Libssh2 < Package
   description 'libssh2 is a client-side C library implementing the SSH2 protocol.'
   homepage 'https://www.libssh2.org/'
-  @_ver = '1.10.0'
-  version @_ver
+  version '1.10.0'
   compatibility 'all'
   license 'BSD'
   source_url 'https://www.libssh2.org/download/libssh2-1.10.0.tar.gz'

--- a/packages/libxdmcp.rb
+++ b/packages/libxdmcp.rb
@@ -3,8 +3,7 @@ require 'package'
 class Libxdmcp < Package
   description 'The libXdmcp package contains a library implementing the X Display Manager Control Protocol.'
   homepage 'http://www.x.org'
-  @_ver = '4a71fdf'
-  version @_ver
+  version '4a71fdf'
   license 'MIT'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/xorg/lib/libxdmcp.git'

--- a/packages/mjpegtools.rb
+++ b/packages/mjpegtools.rb
@@ -3,8 +3,7 @@ require 'package'
 class Mjpegtools < Package
   description 'Video capture, editing, playback, and compression to MPEG of MJPEG video'
   homepage 'https://mjpeg.sourceforge.io/'
-  @_ver = '2.2.1'
-  version @_ver
+  version '2.2.1'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://sourceforge.net/projects/mjpeg/files/mjpegtools/2.2.1/mjpegtools-2.2.1.tar.gz'

--- a/packages/mm_common.rb
+++ b/packages/mm_common.rb
@@ -3,8 +3,7 @@ require 'package'
 class Mm_common < Package
   description 'Common build files of the C++ bindings'
   homepage 'http://www.gtkmm.org/'
-  @_ver = '1.0.5'
-  version @_ver
+  version '1.0.5'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/mm-common.git'

--- a/packages/musl_expat.rb
+++ b/packages/musl_expat.rb
@@ -3,8 +3,7 @@ require 'package'
 class Musl_expat < Package
   description 'James Clark\'s Expat XML parser library in C.'
   homepage 'https://sourceforge.net/projects/expat/'
-  @_ver = '2.4.8'
-  version @_ver
+  version '2.4.8'
   license 'MIT'
   compatibility 'all'
   source_url 'https://prdownloads.sourceforge.net/project/expat/expat/2.4.8/expat-2.4.8.tar.xz'

--- a/packages/musl_libunwind.rb
+++ b/packages/musl_libunwind.rb
@@ -3,8 +3,7 @@ require 'package'
 class Musl_libunwind < Package
   description 'libunwind is a portable and efficient C programming interface (API) to determine the call-chain of a program.'
   homepage 'https://www.nongnu.org/libunwind/'
-  @_ver = '1.5.0'
-  version @_ver
+  version '1.5.0'
   license 'MIT'
   compatibility 'all'
   source_url 'https://download.savannah.gnu.org/releases/libunwind/libunwind-1.5.0.tar.gz'

--- a/packages/musl_ncurses.rb
+++ b/packages/musl_ncurses.rb
@@ -3,8 +3,7 @@ require 'package'
 class Musl_ncurses < Package
   description 'The ncurses (new curses) library is a free software emulation of curses in System V Release 4.0 (SVr4), and more. — Wide character'
   homepage 'https://www.gnu.org/software/ncurses/'
-  @_ver = '6.3-20220402'
-  version @_ver
+  version '6.3-20220402'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/mirror/ncurses.git'

--- a/packages/nasm.rb
+++ b/packages/nasm.rb
@@ -3,8 +3,7 @@ require 'package'
 class Nasm < Package
   description 'The Netwide Assembler'
   homepage 'https://www.nasm.us/'
-  @_ver = '2.15.05'
-  version @_ver
+  version '2.15.05'
   license 'BSD'
   compatibility 'all'
   source_url 'https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/nasm-2.15.05.tar.xz'

--- a/packages/openhab.rb
+++ b/packages/openhab.rb
@@ -3,8 +3,7 @@ require 'package'
 class Openhab < Package
   description 'A vendor and technology agnostic open source automation software for your home'
   homepage 'https://www.openhab.org/'
-  @_ver = '3.2.0'
-  version @_ver
+  version '3.2.0'
   license 'Eclipse Public License 2.0'
   compatibility 'x86_64'
   source_url 'https://openhab.jfrog.io/artifactory/libs-release-local/org/openhab/distro/openhab/3.2.0/openhab-3.2.0.tar.gz'

--- a/packages/pangomm_1_4.rb
+++ b/packages/pangomm_1_4.rb
@@ -3,8 +3,7 @@ require 'package'
 class Pangomm_1_4 < Package
   description 'pangomm is the official C++ interface for the Pango font layout library.'
   homepage 'https://developer.gnome.org/pangomm/stable/'
-  @_ver = '2.46.3'
-  version @_ver
+  version '2.46.3'
   license 'LGPL-2.1+'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/pangomm.git'

--- a/packages/pangomm_2_48.rb
+++ b/packages/pangomm_2_48.rb
@@ -3,8 +3,7 @@ require 'package'
 class Pangomm_2_48 < Package
   description 'pangomm is the official C++ interface for the Pango font layout library.'
   homepage 'https://developer.gnome.org/pangomm/stable/'
-  @_ver = '2.50.1'
-  version @_ver
+  version '2.50.1'
   license 'LGPL-2.1+'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/pangomm.git'

--- a/packages/pcre.rb
+++ b/packages/pcre.rb
@@ -3,8 +3,7 @@ require 'package'
 class Pcre < Package
   description 'The PCRE library is a set of functions that implement regular expression pattern matching using the same syntax and semantics as Perl 5.'
   homepage 'http://pcre.org/'
-  @_ver = '8.45'
-  version @_ver
+  version '8.45'
   license 'BSD-3'
   compatibility 'all'
   source_url 'https://sourceforge.net/projects/pcre/files/pcre/8.45/pcre-8.45.tar.bz2'

--- a/packages/pcre2.rb
+++ b/packages/pcre2.rb
@@ -3,8 +3,7 @@ require 'package'
 class Pcre2 < Package
   description 'The PCRE2 package contains a new generation of the Perl Compatible Regular Expression libraries.'
   homepage 'http://pcre.org/'
-  @_ver = '10.42'
-  version @_ver
+  version '10.42'
   license 'BSD-3'
   compatibility 'all'
   source_url 'https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.42/pcre2-10.42.tar.gz'

--- a/packages/rav1e.rb
+++ b/packages/rav1e.rb
@@ -3,8 +3,7 @@ require 'package'
 class Rav1e < Package
   description 'An AV1 encoder focused on speed and safety'
   homepage 'https://github.com/xiph/rav1e/'
-  @_ver = '0.5.1-p20220927'
-  version @_ver
+  version '0.5.1-p20220927'
   license 'BSD-2, Apache-2.0, MIT and Unlicense'
   compatibility 'all'
   source_url 'https://github.com/xiph/rav1e.git'

--- a/packages/virglrenderer.rb
+++ b/packages/virglrenderer.rb
@@ -3,8 +3,7 @@ require 'package'
 class Virglrenderer < Package
   description 'Virtual OpenGL renderer for QEMU virtual machines'
   homepage 'https://virgil3d.github.io/'
-  @_ver = '0.9.1-486d891'
-  version @_ver
+  version '0.9.1-486d891'
   license 'MIT'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/virgl/virglrenderer.git'

--- a/packages/webrtc_audio_processing.rb
+++ b/packages/webrtc_audio_processing.rb
@@ -3,8 +3,7 @@ require 'package'
 class Webrtc_audio_processing < Package
   description 'AudioProcessing library based on Googles implementation of WebRTC'
   homepage 'https://freedesktop.org/software/pulseaudio/webrtc-audio-processing/'
-  @_ver = '0.3.1'
-  version @_ver
+  version '0.3.1'
   license 'BSD'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/pulseaudio/webrtc-audio-processing/-/archive/v0.3.1/webrtc-audio-processing-v0.3.1.tar.bz2'

--- a/packages/zsh.rb
+++ b/packages/zsh.rb
@@ -3,8 +3,7 @@ require 'package'
 class Zsh < Package
   description 'Zsh is a shell designed for interactive use, although it is also a powerful scripting language.'
   homepage 'http://zsh.sourceforge.net/'
-  @_ver = '5.9'
-  version @_ver
+  version '5.9'
   license 'ZSH and GPL-2'
   compatibility 'all'
   source_url 'https://downloads.sourceforge.net/project/zsh/zsh/5.9/zsh-5.9.tar.xz'


### PR DESCRIPTION
We use `@_ver` a lot. Specifically, 545 out of our 2087 packages use `@_ver` in some way.

Most of the time, those packages don't need to use `@_ver`. Some of them use `@_ver` for absolutely nothing (these are the ones I am fixing in this PR), others use it for setting a `git_hashtag` variable (uneccesarily), some use it for other reasons and the remainder use it for revisions. #8196 is taking care of the revision usecases, and all of the other uses aren't necessary. 

In this series of PR's I'll be going through the codenase and gradually removing all uses of `@_ver` except the ones covered by 8196, and possibly some other legitimate uses which I have yet to stumble on.

In this PR specifically, I am removing 29 uses of `@_ver` from packages that use it like this:
```
@_ver = '1.2.3'
version @_ver
```
which now becomes:
```
version '1.2.3'
```

where this is the only usage of `@_ver` in the entire package.

I'm also removing a very similar usage of `@_ver` from `libminigbm.rb` as it was the only other package with a total of 2 occurences of `@_ver`, and as such tripped up my sed script.

Tested and working on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=laver1 CREW_TESTING=1 crew update
```
