### PR TITLE
Remove basic uses of @_ver for git_hashtag "v#{@_ver}"

### DIFF
--- a/packages/ansible.rb
+++ b/packages/ansible.rb
@@ -3,12 +3,11 @@ require 'package'
 class Ansible < Package
   description 'Ansible is a radically simple IT automation engine that automates cloud provisioning, configuration management, application deployment, intra-service orchestration, and many other IT needs.'
   homepage 'https://www.ansible.com/'
-  @_ver = '2.11.6'
-  version @_ver
+  version '2.11.6'
   license 'GPL-3'
   compatibility 'all'
   source_url 'https://github.com/ansible/ansible.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ansible/2.11.6_armv7l/ansible-2.11.6-chromeos-armv7l.tpxz',

--- a/packages/aribb24.rb
+++ b/packages/aribb24.rb
@@ -3,12 +3,11 @@ require 'package'
 class Aribb24 < Package
   description 'aribb24 is a basic implementation of the ARIB STD-B24 public standard.'
   homepage 'https://github.com/nkoriyama/aribb24/'
-  @_ver = '1.0.3'
-  version @_ver
+  version '1.0.3'
   compatibility 'all'
   license 'LGPL-3'
   source_url 'https://github.com/nkoriyama/aribb24.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   depends_on 'libpng'
 

--- a/packages/asciinema.rb
+++ b/packages/asciinema.rb
@@ -3,12 +3,11 @@ require 'package'
 class Asciinema < Package
   description 'Terminal session recorder'
   homepage 'https://asciinema.org/'
-  @_ver = '2.1.0'
-  version @_ver
+  version '2.1.0'
   license 'GPL-3+'
   compatibility 'all'
   source_url 'https://github.com/asciinema/asciinema.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/asciinema/2.1.0_armv7l/asciinema-2.1.0-chromeos-armv7l.tpxz',

--- a/packages/cbonsai.rb
+++ b/packages/cbonsai.rb
@@ -3,12 +3,11 @@ require 'package'
 class Cbonsai < Package
   description 'A CLI bonsai tree generator, grow bonsai trees in our terminal'
   homepage 'https://gitlab.com/jallbrit/cbonsai'
-  @_ver = '1.3.1'
-  version @_ver
+  version '1.3.1'
   license 'GPL-3'
   compatibility 'all'
   source_url 'https://gitlab.com/jallbrit/cbonsai.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
      aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cbonsai/1.3.1_armv7l/cbonsai-1.3.1-chromeos-armv7l.tar.zst',

--- a/packages/cmake.rb
+++ b/packages/cmake.rb
@@ -3,12 +3,11 @@ require 'package'
 class Cmake < Package
   description 'CMake is an open-source, cross-platform family of tools designed to build, test and package software.'
   homepage 'https://cmake.org/'
-  @_ver = '3.26.3'
-  version @_ver
+  version '3.26.3'
   license 'CMake'
   compatibility 'all'
   source_url 'https://github.com/Kitware/CMake.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cmake/3.26.3_armv7l/cmake-3.26.3-chromeos-armv7l.tar.zst',

--- a/packages/compressdoc.rb
+++ b/packages/compressdoc.rb
@@ -3,12 +3,11 @@ require 'package'
 class Compressdoc < Package
   description 'Compress all man pages in a hierarchy and update symlinks. Supports a variety of compression algorithms.'
   homepage 'https://github.com/saltedcoffii/compressdoc/'
-  @_ver = '20221119'
-  version @_ver
+  version '20221119'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/saltedcoffii/compressdoc.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/compressdoc/20221119_armv7l/compressdoc-20221119-chromeos-armv7l.tar.zst',

--- a/packages/cups.rb
+++ b/packages/cups.rb
@@ -3,12 +3,11 @@ require 'package'
 class Cups < Package
   description 'CUPS is the standards-based, open source printing system'
   homepage 'https://github.com/OpenPrinting/cups'
-  @_ver = '2.4.2'
-  version @_ver
+  version '2.4.2'
   license 'Apache-2.0'
   compatibility 'all'
   source_url 'https://github.com/OpenPrinting/cups.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/cups/2.4.2_armv7l/cups-2.4.2-chromeos-armv7l.tar.zst',

--- a/packages/fetch.rb
+++ b/packages/fetch.rb
@@ -3,12 +3,11 @@ require 'package'
 class Fetch < Package
   description 'FreeBSD Fetch retrieves files by URL.'
   homepage 'https://github.com/jrmarino/fetch-freebsd/'
-  @_ver = '12.0.10'
-  version @_ver
+  version '12.0.10'
   license 'BSD-3'
   compatibility 'all'
   source_url 'https://github.com/jrmarino/fetch-freebsd.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fetch/12.0.10_armv7l/fetch-12.0.10-chromeos-armv7l.tar.xz',

--- a/packages/flatseal.rb
+++ b/packages/flatseal.rb
@@ -3,12 +3,11 @@ require 'package'
 class Flatseal < Package
   description 'Flatseal is a graphical utility to review and modify permissions from your Flatpak applications.'
   homepage 'https://github.com/tchx84/Flatseal/'
-  @_ver = '1.7.5'
-  version @_ver
+  version '1.7.5'
   license 'GPL-3+'
   compatibility 'all'
   source_url 'https://github.com/tchx84/Flatseal.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/flatseal/1.7.5_armv7l/flatseal-1.7.5-chromeos-armv7l.tpxz',

--- a/packages/gvim.rb
+++ b/packages/gvim.rb
@@ -3,12 +3,11 @@ require 'package'
 class Gvim < Package
   description 'Vim is a highly configurable text editor built to make creating and changing any kind of text very efficient. (with advanced features, such as a GUI)'
   homepage 'http://www.vim.org/'
-  @_ver = '9.0.1145'
-  version @_ver
+  version '9.0.1145'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://github.com/vim/vim.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gvim/9.0.1145_armv7l/gvim-9.0.1145-chromeos-armv7l.tar.zst',

--- a/packages/gyp_next.rb
+++ b/packages/gyp_next.rb
@@ -3,12 +3,11 @@ require 'package'
 class Gyp_next < Package
   description 'GYP is a fork of the GYP build system for use in the Node.js projects.'
   homepage 'https://github.com/nodejs/gyp-next/'
-  @_ver = '0.10.0'
-  version @_ver
+  version '0.10.0'
   license 'BSD-3'
   compatibility 'all'
   source_url 'https://github.com/nodejs/gyp-next.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gyp_next/0.10.0_armv7l/gyp_next-0.10.0-chromeos-armv7l.tpxz',

--- a/packages/iw.rb
+++ b/packages/iw.rb
@@ -3,12 +3,11 @@ require 'package'
 class Iw < Package
   description 'iw is a new nl80211 based CLI configuration utility for wireless devices.'
   homepage 'https://wireless.wiki.kernel.org/en/users/documentation/iw/'
-  @_ver = '5.19'
-  version @_ver
+  version '5.19'
   license 'ISC'
   compatibility 'all'
   source_url 'https://git.kernel.org/pub/scm/linux/kernel/git/jberg/iw.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/iw/5.19_armv7l/iw-5.19-chromeos-armv7l.tar.zst',

--- a/packages/lapack.rb
+++ b/packages/lapack.rb
@@ -3,12 +3,11 @@ require 'package'
 class Lapack < Package
   description 'Lapack is a linear algebra package.'
   homepage 'https://www.netlib.org/lapack/'
-  @_ver = '3.11.0'
-  version @_ver
+  version '3.11.0'
   license 'BSD'
   compatibility 'all'
   source_url 'https://github.com/Reference-LAPACK/lapack.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lapack/3.11.0_armv7l/lapack-3.11.0-chromeos-armv7l.tar.zst',

--- a/packages/libavif.rb
+++ b/packages/libavif.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libavif < Package
   description 'Library for encoding and decoding .avif files'
   homepage 'https://github.com/AOMediaCodec/libavif'
-  @_ver = '0.11.1'
-  version @_ver
+  version '0.11.1'
   license 'BSD-2'
   compatibility 'all'
   source_url 'https://github.com/AOMediaCodec/libavif.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libavif/0.11.1_armv7l/libavif-0.11.1-chromeos-armv7l.tar.zst',

--- a/packages/libdeflate.rb
+++ b/packages/libdeflate.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libdeflate < Package
   description 'Heavily optimized library for DEFLATE compression and decompression'
   homepage 'https://github.com/ebiggers/libdeflate/'
-  @_ver = '1.17'
-  version @_ver
+  version '1.17'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/ebiggers/libdeflate.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdeflate/1.17_armv7l/libdeflate-1.17-chromeos-armv7l.tar.zst',

--- a/packages/libdsm.rb
+++ b/packages/libdsm.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libdsm < Package
   description 'Defective SMb: A minimalist implementation of a client library for SMB using C.'
   homepage 'https://videolabs.github.io/libdsm/'
-  @_ver = '0.3.2'
-  version @_ver
+  version '0.3.2'
   compatibility 'all'
   license 'LGPL-2.1+'
   source_url 'https://github.com/videolabs/libdsm.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libdsm/0.3.2_armv7l/libdsm-0.3.2-chromeos-armv7l.tpxz',

--- a/packages/libffi.rb
+++ b/packages/libffi.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libffi < Package
   description 'The libffi library provides a portable, high level programming interface to various calling conventions.'
   homepage 'https://github.com/libffi/libffi/'
-  @_ver = '3.4.4'
-  version @_ver
+  version '3.4.4'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/libffi/libffi.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libffi/3.4.4_armv7l/libffi-3.4.4-chromeos-armv7l.tar.zst',

--- a/packages/libgit2.rb
+++ b/packages/libgit2.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libgit2 < Package
   description 'A portable, pure C implementation of the Git core methods'
   homepage 'https://libgit2.org/'
-  @_ver = '1.5.1'
-  version @_ver
+  version '1.5.1'
   license 'GPL-2-with-linking-exception'
   compatibility 'all'
   source_url 'https://github.com/libgit2/libgit2.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgit2/1.5.1_armv7l/libgit2-1.5.1-chromeos-armv7l.tar.zst',

--- a/packages/libglvnd.rb
+++ b/packages/libglvnd.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libglvnd < Package
   description 'The GL Vendor-Neutral Dispatch library'
   homepage 'https://gitlab.freedesktop.org/glvnd/libglvnd'
-  @_ver = '1.6.0'
-  version @_ver
+  version '1.6.0'
   license 'MIT'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/glvnd/libglvnd.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libglvnd/1.6.0_armv7l/libglvnd-1.6.0-chromeos-armv7l.tar.zst',

--- a/packages/libheif.rb
+++ b/packages/libheif.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libheif < Package
   description 'libheif is a ISO/IEC 23008-12:2017 HEIF file format decoder and encoder.'
   homepage 'https://github.com/strukturag/libheif'
-  @_ver = '1.16.2'
-  version @_ver
+  version '1.16.2'
   license 'GPL-3'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://github.com/strukturag/libheif.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libheif/1.16.2_armv7l/libheif-1.16.2-chromeos-armv7l.tar.zst',

--- a/packages/libinstpatch.rb
+++ b/packages/libinstpatch.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libinstpatch < Package
   description 'libInstPatch is a library for processing digital sample based MIDI instrument "patch" files.'
   homepage 'https://github.com/swami/libinstpatch/'
-  @_ver = '1.1.6'
-  version @_ver
+  version '1.1.6'
   compatibility 'all'
   license 'LGPL-2.1'
   source_url 'https://github.com/swami/libinstpatch.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libinstpatch/1.1.6_armv7l/libinstpatch-1.1.6-chromeos-armv7l.tpxz',

--- a/packages/libmtp.rb
+++ b/packages/libmtp.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libmtp < Package
   description 'libmtp is a library to access MTP (Media Transfer Protocol) Devices.'
   homepage 'https://github.com/libmtp/libmtp/'
-  @_ver = '1.1.19'
-  version @_ver
+  version '1.1.19'
   compatibility 'all'
   license 'LGPL-2.1'
   source_url 'https://github.com/libmtp/libmtp.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   depends_on 'libusb'
   depends_on 'eudev'

--- a/packages/libmysofa.rb
+++ b/packages/libmysofa.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libmysofa < Package
   description 'libmysofa is a reader for AES SOFA files to get better HRTFs.'
   homepage 'https://github.com/hoene/libmysofa/'
-  @_ver = '1.2.1'
-  version @_ver
+  version '1.2.1'
   compatibility 'all'
   license 'LGPL-2.1'
   source_url 'https://github.com/hoene/libmysofa.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libmysofa/1.2.1_armv7l/libmysofa-1.2.1-chromeos-armv7l.tpxz',

--- a/packages/librhash.rb
+++ b/packages/librhash.rb
@@ -3,12 +3,11 @@ require 'package'
 class Librhash < Package
   description 'RHash is a console utility for computing and verifying hash sums of files.'
   homepage 'http://rhash.anz.ru/'
-  @_ver = '1.4.3'
-  version @_ver
+  version '1.4.3'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/rhash/RHash.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/librhash/1.4.3_armv7l/librhash-1.4.3-chromeos-armv7l.tar.zst',

--- a/packages/musl_libnghttp2.rb
+++ b/packages/musl_libnghttp2.rb
@@ -3,12 +3,11 @@ require 'package'
 class Musl_libnghttp2 < Package
   description 'library implementing HTTP/2 protocol'
   homepage 'https://nghttp2.org/'
-  @_ver = '1.46.0'
-  version @_ver
+  version '1.46.0'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/nghttp2/nghttp2.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_libnghttp2/1.46.0_armv7l/musl_libnghttp2-1.46.0-chromeos-armv7l.tpxz',

--- a/packages/musl_obstack.rb
+++ b/packages/musl_obstack.rb
@@ -3,12 +3,11 @@ require 'package'
 class Musl_obstack < Package
   description 'Void Linux copy + paste of the obstack functions and macros found in GNU gcc libiberty library for use with musl libc'
   homepage 'https://github.com/void-linux/musl-obstack'
-  @_ver = '1.2.2'
-  version @_ver
+  version '1.2.2'
   license 'zlib'
   compatibility 'all'
   source_url 'https://github.com/void-linux/musl-obstack.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_obstack/1.2.2_armv7l/musl_obstack-1.2.2-chromeos-armv7l.tpxz',

--- a/packages/musl_zstd.rb
+++ b/packages/musl_zstd.rb
@@ -3,12 +3,11 @@ require 'package'
 class Musl_zstd < Package
   description 'Zstandard - Fast real-time compression algorithm'
   homepage 'http://www.zstd.net'
-  @_ver = '1.5.4'
-  version @_ver
+  version '1.5.4'
   license 'BSD or GPL-2'
   compatibility 'all'
   source_url 'https://github.com/facebook/zstd.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/musl_zstd/1.5.4_armv7l/musl_zstd-1.5.4-chromeos-armv7l.tar.xz',

--- a/packages/mypaint_brushes.rb
+++ b/packages/mypaint_brushes.rb
@@ -3,12 +3,11 @@ require 'package'
 class Mypaint_brushes < Package
   description 'Brushes used by MyPaint and other software using libmypaint.'
   homepage 'http://mypaint.org/'
-  @_ver = '2.0.2'
-  version @_ver
+  version '2.0.2'
   license 'CC0-1.0'
   compatibility 'all'
   source_url 'https://github.com/mypaint/mypaint-brushes.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mypaint_brushes/2.0.2_armv7l/mypaint_brushes-2.0.2-chromeos-armv7l.tpxz',

--- a/packages/mypaint_brushes_1.rb
+++ b/packages/mypaint_brushes_1.rb
@@ -3,12 +3,11 @@ require 'package'
 class Mypaint_brushes_1 < Package
   description 'Brushes used by MyPaint and other software using libmypaint.'
   homepage 'http://mypaint.org/'
-  @_ver = '1.3.1'
-  version @_ver
+  version '1.3.1'
   license 'CC0-1.0'
   compatibility 'all'
   source_url 'https://github.com/mypaint/mypaint-brushes.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mypaint_brushes_1/1.3.1_armv7l/mypaint_brushes_1-1.3.1-chromeos-armv7l.tar.zst',

--- a/packages/neo_matrix.rb
+++ b/packages/neo_matrix.rb
@@ -3,12 +3,11 @@ require 'package'
 class Neo_matrix < Package
   description 'Simulates the digital rain from "The Matrix" (A CMatrix clone with 32-bit color and Unicode support)'
   homepage 'https://github.com/st3w/neo'
-  @_ver = '0.6.1'
-  version @_ver
+  version '0.6.1'
   license 'GPL-3'
   compatibility 'all'
   source_url 'https://github.com/st3w/neo.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   depends_on 'ttf_hanazono' # L
   depends_on 'glibc' # R

--- a/packages/oci_cli.rb
+++ b/packages/oci_cli.rb
@@ -3,12 +3,11 @@ require 'package'
 class Oci_cli < Package
   description 'Command Line Interface for Oracle Cloud Infrastructure'
   homepage 'https://github.com/oracle/oci-cli/'
-  @_ver = '3.1.2'
-  version @_ver
+  version '3.1.2'
   license 'UPL-1.0'
   compatibility 'all'
   source_url 'https://github.com/oracle/oci-cli.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/oci_cli/3.1.2_armv7l/oci_cli-3.1.2-chromeos-armv7l.tpxz',

--- a/packages/opencl_headers.rb
+++ b/packages/opencl_headers.rb
@@ -3,12 +3,11 @@ require 'package'
 class Opencl_headers < Package
   description 'OpenCL header files'
   homepage 'https://github.com/KhronosGroup/OpenCL-Headers'
-  @_ver = '2022.09.30'
-  version @_ver
+  version '2022.09.30'
   license 'Apache-2.0'
   compatibility 'all'
   source_url 'https://github.com/KhronosGroup/OpenCL-Headers.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/opencl_headers/2022.09.30_armv7l/opencl_headers-2022.09.30-chromeos-armv7l.tar.zst',

--- a/packages/opencl_icd_loader.rb
+++ b/packages/opencl_icd_loader.rb
@@ -3,12 +3,11 @@ require 'package'
 class Opencl_icd_loader < Package
   description 'OpenCL Installable Client Driver ICD Loader'
   homepage 'https://github.com/KhronosGroup/OpenCL-ICD-Loader'
-  @_ver = '2022.09.30'
-  version @_ver
+  version '2022.09.30'
   license 'Apache-2.0'
   compatibility 'all'
   source_url 'https://github.com/KhronosGroup/OpenCL-ICD-Loader.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/opencl_icd_loader/2022.09.30_armv7l/opencl_icd_loader-2022.09.30-chromeos-armv7l.tar.zst',

--- a/packages/qemu.rb
+++ b/packages/qemu.rb
@@ -3,8 +3,7 @@ require 'package'
 class Qemu < Package
   description 'QEMU is a generic and open source machine emulator and virtualizer.'
   homepage 'http://www.qemu.org/'
-  @_ver = '8.0.1'
-  version @_ver
+  version '8.0.1'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://github.com/qemu/qemu.git'
   git_hashtag "v#{@_ver}"

--- a/packages/s3cmd.rb
+++ b/packages/s3cmd.rb
@@ -3,12 +3,11 @@ require 'package'
 class S3cmd < Package
   description 'Command line tool for managing Amazon S3 and CloudFront services'
   homepage 'http://s3tools.org/s3cmd'
-  @_ver = '2.2.0'
-  version @_ver
+  version '2.2.0'
   license 'GPL-2+'
   compatibility 'all'
   source_url 'https://github.com/s3tools/s3cmd.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/s3cmd/2.2.0_armv7l/s3cmd-2.2.0-chromeos-armv7l.tpxz',

--- a/packages/sphinx.rb
+++ b/packages/sphinx.rb
@@ -3,12 +3,11 @@ require 'package'
 class Sphinx < Package
   description 'Sphinx is a tool that makes it easy to create intelligent and beautiful documentation.'
   homepage 'https://www.sphinx-doc.org/'
-  @_ver = '4.2.0'
-  version @_ver
+  version '4.2.0'
   license 'BSD'
   compatibility 'all'
   source_url 'https://github.com/sphinx-doc/sphinx.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/sphinx/4.2.0_armv7l/sphinx-4.2.0-chromeos-armv7l.tpxz',

--- a/packages/textract.rb
+++ b/packages/textract.rb
@@ -3,12 +3,11 @@ require 'package'
 class Textract < Package
   description 'Textract provides text extracting tools for many formats.'
   homepage 'http://textract.readthedocs.io/'
-  @_ver = '1.6.4'
-  version @_ver
+  version '1.6.4'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/deanmalmgren/textract.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/textract/1.6.4_armv7l/textract-1.6.4-chromeos-armv7l.tpxz',

--- a/packages/vim.rb
+++ b/packages/vim.rb
@@ -3,12 +3,11 @@ require 'package'
 class Vim < Package
   description 'Vim is a highly configurable text editor built to make creating and changing any kind of text very efficient.'
   homepage 'http://www.vim.org/'
-  @_ver = '9.0.1145'
-  version @_ver
+  version '9.0.1145'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://github.com/vim/vim.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vim/9.0.1145_armv7l/vim-9.0.1145-chromeos-armv7l.tar.zst',

--- a/packages/vim_runtime.rb
+++ b/packages/vim_runtime.rb
@@ -3,12 +3,11 @@ require 'package'
 class Vim_runtime < Package
   description 'Vim is a highly configurable text editor built to make creating and changing any kind of text very efficient. (shared runtime)'
   homepage 'http://www.vim.org/'
-  @_ver = '9.0.1145'
-  version @_ver
+  version '9.0.1145'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://github.com/vim/vim.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vim_runtime/9.0.1145_armv7l/vim_runtime-9.0.1145-chromeos-armv7l.tar.zst',

--- a/packages/vulkan_headers.rb
+++ b/packages/vulkan_headers.rb
@@ -3,12 +3,11 @@ require 'package'
 class Vulkan_headers < Package
   description 'Vulkan header files'
   homepage 'https://github.com/KhronosGroup/Vulkan-Headers'
-  @_ver = '1.3.252'
-  version @_ver
+  version '1.3.252'
   license 'Apache-2.0'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://github.com/KhronosGroup/Vulkan-Headers.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_headers/1.3.252_armv7l/vulkan_headers-1.3.252-chromeos-armv7l.tar.zst',

--- a/packages/vulkan_icd_loader.rb
+++ b/packages/vulkan_icd_loader.rb
@@ -3,12 +3,11 @@ require 'package'
 class Vulkan_icd_loader < Package
   description 'Vulkan Installable Client Driver ICD Loader'
   homepage 'https://github.com/KhronosGroup/Vulkan-Loader'
-  @_ver = '1.3.251'
-  version @_ver
+  version '1.3.251'
   license 'Apache-2.0'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://github.com/KhronosGroup/Vulkan-Loader.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vulkan_icd_loader/1.3.251_armv7l/vulkan_icd_loader-1.3.251-chromeos-armv7l.tar.zst',

--- a/packages/wxwidgets.rb
+++ b/packages/wxwidgets.rb
@@ -3,12 +3,11 @@ require 'package'
 class Wxwidgets < Package
   description 'wxWidgets is a C++ library that lets developers create applications for Windows, macOS, Linux and other platforms with a single code base.'
   homepage 'https://www.wxwidgets.org/'
-  @_ver = '3.2.2.1'
-  version @_ver
+  version '3.2.2.1'
   license 'GPL-2'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://github.com/wxWidgets/wxWidgets.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wxwidgets/3.2.2.1_armv7l/wxwidgets-3.2.2.1-chromeos-armv7l.tar.zst',

--- a/packages/xxd_standalone.rb
+++ b/packages/xxd_standalone.rb
@@ -3,12 +3,11 @@ require 'package'
 class Xxd_standalone < Package
   description 'Hexdump utility from vim'
   homepage 'http://www.vim.org'
-  @_ver = '9.0.1145'
-  version @_ver
+  version '9.0.1145'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://github.com/vim/vim.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xxd_standalone/9.0.1145_armv7l/xxd_standalone-9.0.1145-chromeos-armv7l.tar.zst',


### PR DESCRIPTION
Following on from #8370, I am removing 43 uses of `@_ver` from packages that use it like this:
```
@_ver = '1.2.3'
version @_ver
...
git_hashtag "v#{@_ver}"
```
which now becomes:
```
version '1.2.3'
...
git_hashtag "v#{version}"
```

Tested and working on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=laver2 CREW_TESTING=1 crew update
```
