### PR TITLE
Replace #{@version} with #{version} in filecmd.rb

### DIFF
--- a/packages/filecmd.rb
+++ b/packages/filecmd.rb
@@ -6,7 +6,7 @@ class Filecmd < Package
   version '5.44'
   license 'BSD-2 and GPL-3+' # Chromebrew's filefix is GPL-3+, file itself is BSD-2
   compatibility 'all'
-  source_url "http://ftp.astron.com/pub/file/file-#{@version}.tar.gz"
+  source_url "http://ftp.astron.com/pub/file/file-#{version}.tar.gz"
   source_sha256 '3751c7fba8dbc831cb8d7cc8aff21035459b8ce5155ef8b0880a27d028475f3b'
 
   binary_url({


### PR DESCRIPTION
Noticed this on my #8370 warpath.

Tested and working on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=filecmd CREW_TESTING=1 crew update
```
