### PR TITLE
Add missing license (MIT) to musl_libucontext.rb

### DIFF
--- a/packages/musl_libucontext.rb
+++ b/packages/musl_libucontext.rb
@@ -5,6 +5,7 @@ class Musl_libucontext < Package
   homepage 'https://github.com/kaniini/libucontext'
   @_ver = '1.1'
   version @_ver
+  license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/kaniini/libucontext.git'
   git_hashtag "libucontext-#{@_ver}"


### PR DESCRIPTION
Noticed this on my #8370 warpath.

Tested and working on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=clocked CREW_TESTING=1 crew update
```
