### PR TITLE
adjust detection of aarch64 in install.sh, add LD_LIBRARY_PREFIX to CREW_ENV_OPTIONS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -105,7 +105,8 @@ case "${ARCH}" in
   # x86_64 and aarch64 userspace
   # shellcheck disable=SC2046
   [ $(od -An -t x1 -j 4 -N 1  /bin/bash) == 02 ] && LIB_SUFFIX='64'
-  if [[ $LIB_SUFFIX == '64' ]] && { [[ $ARCH == 'armv7l' ]] || [[ $ARCH == 'armv8l' ]] || [[ $ARCH == 'aarch64' ]]; } ; then
+  # shellcheck disable=SC1083
+  if [[ $LIB_SUFFIX == '64' ]] && { [[ "$ARCH" =~ ^(armv7l|armv81|aarch64)$ ]] }; then
     echo_error "Your device is not supported by Chromebrew yet, installing as armv7l."
     LIB_SUFFIX=
     ARMV7LONAARCH64=1

--- a/install.sh
+++ b/install.sh
@@ -105,7 +105,7 @@ case "${ARCH}" in
   # x86_64 and aarch64 userspace
   # shellcheck disable=SC2046
   [ $(od -An -t x1 -j 4 -N 1  /bin/bash) == 02 ] && LIB_SUFFIX='64'
-  if [[ $LIB_SUFFIX == '64' ]] && [[ $ARCH == 'aarch64' ]]; then
+  if [[ $LIB_SUFFIX == '64' ]] && { [[ $ARCH == 'armv7l' ]] || [[ $ARCH == 'armv8l' ]] || [[ $ARCH == 'aarch64' ]]; } ; then
     echo_error "Your device is not supported by Chromebrew yet, installing as armv7l."
     LIB_SUFFIX=
     ARMV7LONAARCH64=1

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.34.2'
+CREW_VERSION = '1.34.3'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp
@@ -254,22 +254,24 @@ CREW_ENV_OPTIONS_HASH = if CREW_DISABLE_ENV_OPTIONS
                           { 'CREW_DISABLE_ENV_OPTIONS' => '1' }
                         else
                           {
-                            'CFLAGS'   => CREW_COMMON_FLAGS,
-                            'CXXFLAGS' => CREW_COMMON_FLAGS,
-                            'FCFLAGS'  => CREW_COMMON_FLAGS,
-                            'FFLAGS'   => CREW_COMMON_FLAGS,
-                            'LDFLAGS'  => CREW_LDFLAGS
+                            'CFLAGS'          => CREW_COMMON_FLAGS,
+                            'CXXFLAGS'        => CREW_COMMON_FLAGS,
+                            'FCFLAGS'         => CREW_COMMON_FLAGS,
+                            'FFLAGS'          => CREW_COMMON_FLAGS,
+                            'LD_LIBRARY_PATH' => CREW_LIB_PREFIX,
+                            'LDFLAGS'         => CREW_LDFLAGS
                           }
                         end
 # parse from hash to shell readable string
 CREW_ENV_OPTIONS = CREW_ENV_OPTIONS_HASH.map { |k, v| "#{k}=\"#{v}\"" }.join(' ')
 
 CREW_ENV_FNO_LTO_OPTIONS_HASH = {
-  'CFLAGS'   => CREW_COMMON_FNO_LTO_FLAGS,
-  'CXXFLAGS' => CREW_COMMON_FNO_LTO_FLAGS,
-  'FCFLAGS'  => CREW_COMMON_FNO_LTO_FLAGS,
-  'FFLAGS'   => CREW_COMMON_FNO_LTO_FLAGS,
-  'LDFLAGS'  => CREW_FNO_LTO_LDFLAGS
+  'CFLAGS'          => CREW_COMMON_FNO_LTO_FLAGS,
+  'CXXFLAGS'        => CREW_COMMON_FNO_LTO_FLAGS,
+  'FCFLAGS'         => CREW_COMMON_FNO_LTO_FLAGS,
+  'FFLAGS'          => CREW_COMMON_FNO_LTO_FLAGS,
+  'LD_LIBRARY_PATH' => CREW_LIB_PREFIX,
+  'LDFLAGS'         => CREW_FNO_LTO_LDFLAGS
 }
 # parse from hash to shell readable string
 CREW_ENV_FNO_LTO_OPTIONS = CREW_ENV_FNO_LTO_OPTIONS_HASH.map { |k, v| "#{k}=\"#{v}\"" }.join(' ')

--- a/packages/mandb.rb
+++ b/packages/mandb.rb
@@ -68,7 +68,7 @@ class Mandb < Package
     puts 'Started mandb cache rebuild. (Errors from this can either be ignored or reported upstream to the relevant package maintainers.)'.yellow
     # See https://gitlab.com/man-db/man-db/-/issues/4
     # Also https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1003089
-    system "unset MANPATH && MAN_DISABLE_SECCOMP=1 mandb -C #{CREW_PREFIX}/etc/man_db.conf -psc"
+    system "MANPATH='' MAN_DISABLE_SECCOMP=1 mandb -C #{CREW_PREFIX}/etc/man_db.conf -psc"
     puts 'Finished mandb cache rebuild.'.lightgreen
   end
 end


### PR DESCRIPTION
- Detection of `aarch64` adjusted to account for variation in container vs actual hardware.
- Also modifes `mandb` postinstall to not use `&&` in command line.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=aarch64_install CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
