### PR TITLE
Remove remaining basic uses of @_ver in git_hashtag

### DIFF
--- a/packages/aribb25.rb
+++ b/packages/aribb25.rb
@@ -3,12 +3,11 @@ require 'package'
 class Aribb25 < Package
   description 'aribb25 is a basic implementation of the ARIB STD-B25 public standard.'
   homepage 'https://code.videolan.org/videolan/aribb25/'
-  @_ver = '0.2.7'
-  version @_ver
+  version '0.2.7'
   compatibility 'all'
   license 'ISC'
   source_url 'https://code.videolan.org/videolan/aribb25.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/aribb25/0.2.7_armv7l/aribb25-0.2.7-chromeos-armv7l.tpxz',

--- a/packages/avocado_framework.rb
+++ b/packages/avocado_framework.rb
@@ -3,12 +3,11 @@ require 'package'
 class Avocado_framework < Package
   description 'Avocado is a next generation testing framework inspired by Autotest and modern development tools such as git.'
   homepage 'https://avocado-framework.github.io/'
-  @_ver = '94.0'
-  version @_ver
+  version '94.0'
   license 'GPL-2 and GPL-2+'
   compatibility 'all'
   source_url 'https://github.com/avocado-framework/avocado.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/avocado_framework/94.0_armv7l/avocado_framework-94.0-chromeos-armv7l.tar.xz',

--- a/packages/bz3.rb
+++ b/packages/bz3.rb
@@ -3,12 +3,11 @@ require 'package'
 class Bz3 < Package
   description 'bzip3 is a better and stronger spiritual successor to bzip2.'
   homepage 'https://github.com/kspalaiologos/bzip3'
-  @_ver = '1.2.2'
-  version @_ver
+  version '1.2.2'
   license 'LGPL-3'
   compatibility 'all'
   source_url 'https://github.com/kspalaiologos/bzip3.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/bz3/1.2.2_armv7l/bz3-1.2.2-chromeos-armv7l.tar.zst',

--- a/packages/evolution_data_server.rb
+++ b/packages/evolution_data_server.rb
@@ -2,12 +2,11 @@ require 'package'
 
 class Evolution_data_server < Package
   description 'Centralized access to appointments and contacts'
-  @_ver = '3.48.1'
-  version @_ver
+  version '3.48.1'
   license 'LGPL-2 or LGPL-3, BSD and Sleepycat'
   compatibility 'x86_64'
   source_url 'https://gitlab.gnome.org/GNOME/evolution-data-server.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/evolution_data_server/3.48.1_x86_64/evolution_data_server-3.48.1-chromeos-x86_64.tar.zst'

--- a/packages/fragments.rb
+++ b/packages/fragments.rb
@@ -3,12 +3,11 @@ require 'package'
 class Fragments < Package
   description 'Fragments is an easy to use BitTorrent client for the GNOME desktop environment.'
   homepage 'https://gitlab.gnome.org/World/Fragments'
-  @_ver = '2.1'
-  version @_ver
+  version '2.1'
   license 'GPL-3'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/World/Fragments.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/fragments/2.1_armv7l/fragments-2.1-chromeos-armv7l.tar.zst',

--- a/packages/gittools.rb
+++ b/packages/gittools.rb
@@ -3,12 +3,11 @@ require 'package'
 class Gittools < Package
   description 'Tools for analyzing .git repositories'
   homepage 'https://github.com/internetwache/GitTools'
-  @_ver = '24eaef0d11e590643e65d188b017b49414d81cc2'
-  version @_ver
+  version '24eaef0d11e590643e65d188b017b49414d81cc2'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/internetwache/GitTools.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gittools/24eaef0d11e590643e65d188b017b49414d81cc2_armv7l/gittools-24eaef0d11e590643e65d188b017b49414d81cc2-chromeos-armv7l.tpxz',

--- a/packages/glib.rb
+++ b/packages/glib.rb
@@ -3,12 +3,11 @@ require 'package'
 class Glib < Package
   description 'GLib provides the core application building blocks for libraries and applications written in C.'
   homepage 'https://developer.gnome.org/glib'
-  @_ver = '2.76.2'
-  version @_ver
+  version '2.76.2'
   license 'LGPL-2.1'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/glib.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib/2.76.2_armv7l/glib-2.76.2-chromeos-armv7l.tar.zst',

--- a/packages/gnome_autoar.rb
+++ b/packages/gnome_autoar.rb
@@ -3,12 +3,11 @@ require 'package'
 class Gnome_autoar < Package
   description 'Automatic archives creating and extracting library'
   homepage 'https://gitlab.gnome.org/GNOME/gnome-autoar'
-  @_ver = '0.4.4'
-  version @_ver
+  version '0.4.4'
   license 'LGPL-2.1'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.gnome.org/GNOME/gnome-autoar.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_autoar/0.4.4_armv7l/gnome_autoar-0.4.4-chromeos-armv7l.tar.zst',

--- a/packages/gnome_calculator.rb
+++ b/packages/gnome_calculator.rb
@@ -3,12 +3,11 @@ require 'package'
 class Gnome_calculator < Package
   description 'GNOME desktop calculator'
   homepage 'https://wiki.gnome.org/Apps/Calculator'
-  @_ver = '43.0.1'
-  version @_ver
+  version '43.0.1'
   license 'LGPL-2.1+'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/gnome-calculator.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_calculator/43.0.1_armv7l/gnome_calculator-43.0.1-chromeos-armv7l.tar.zst',

--- a/packages/gnome_settings_daemon.rb
+++ b/packages/gnome_settings_daemon.rb
@@ -3,12 +3,11 @@ require 'package'
 class Gnome_settings_daemon < Package
   description 'GNOME Settings Daemon'
   homepage 'https://gitlab.gnome.org/GNOME/gnome-settings-daemon'
-  @_ver = '43.0'
-  version @_ver
+  version '43.0'
   license 'GPL-2+ and LGPL-2+'
   compatibility 'x86_64 aarch64 armv7l' # not compatible with i686 upstream
   source_url 'https://gitlab.gnome.org/GNOME/gnome-settings-daemon.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_settings_daemon/43.0_armv7l/gnome_settings_daemon-43.0-chromeos-armv7l.tar.zst',

--- a/packages/gnome_terminal.rb
+++ b/packages/gnome_terminal.rb
@@ -3,12 +3,11 @@ require 'package'
 class Gnome_terminal < Package
   description 'The GNOME Terminal Emulator'
   homepage 'https://wiki.gnome.org/Apps/Terminal'
-  @_ver = '3.48.0'
-  version @_ver
+  version '3.48.0'
   license 'GPL-3+'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.gnome.org/GNOME/gnome-terminal.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_terminal/3.48.0_armv7l/gnome_terminal-3.48.0-chromeos-armv7l.tar.zst',

--- a/packages/graphviz.rb
+++ b/packages/graphviz.rb
@@ -3,12 +3,11 @@ require 'package'
 class Graphviz < Package
   description 'Graphviz is open source graph visualization software.'
   homepage 'https://www.graphviz.org/'
-  @_ver = '7.1.0'
-  version @_ver
+  version '7.1.0'
   license 'BSD'
   compatibility 'all'
   source_url 'https://gitlab.com/graphviz/graphviz.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/graphviz/7.1.0_armv7l/graphviz-7.1.0-chromeos-armv7l.tar.zst',

--- a/packages/gsettings_desktop_schemas.rb
+++ b/packages/gsettings_desktop_schemas.rb
@@ -3,12 +3,11 @@ require 'package'
 class Gsettings_desktop_schemas < Package
   description 'Collection of GSettings schemas for GNOME desktop.'
   homepage 'https://git.gnome.org/browse/gsettings-desktop-schemas'
-  @_ver = '44.0'
-  version @_ver
+  version '44.0'
   license 'LGPL-2.1+'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/gsettings-desktop-schemas.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gsettings_desktop_schemas/44.0_armv7l/gsettings_desktop_schemas-44.0-chromeos-armv7l.tar.zst',

--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -3,12 +3,11 @@ require 'package'
 class Gtk3 < Package
   description 'GTK+ is a multi-platform toolkit for creating graphical user interfaces.'
   homepage 'https://developer.gnome.org/gtk3/3.0/'
-  @_ver = '3.24.37'
-  version @_ver
+  version '3.24.37'
   license 'LGPL-2.1'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.gnome.org/GNOME/gtk.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk3/3.24.37_armv7l/gtk3-3.24.37-chromeos-armv7l.tar.zst',

--- a/packages/gtk4.rb
+++ b/packages/gtk4.rb
@@ -3,12 +3,11 @@ require 'package'
 class Gtk4 < Package
   description 'GTK+ is a multi-platform toolkit for creating graphical user interfaces.'
   homepage 'https://developer.gnome.org/gtk4/'
-  @_ver = '4.10.4'
-  version @_ver
+  version '4.10.4'
   license 'LGPL-2.1'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.gnome.org/GNOME/gtk.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtk4/4.10.4_armv7l/gtk4-4.10.4-chromeos-armv7l.tar.zst',

--- a/packages/gtksourceview_4.rb
+++ b/packages/gtksourceview_4.rb
@@ -3,12 +3,11 @@ require 'package'
 class Gtksourceview_4 < Package
   description 'Source code editing widget'
   homepage 'https://wiki.gnome.org/Projects/GtkSourceView'
-  @_ver = '4.8.3'
-  version @_ver
+  version '4.8.3'
   license 'LGPL-2.1+'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/gtksourceview.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtksourceview_4/4.8.3_armv7l/gtksourceview_4-4.8.3-chromeos-armv7l.tar.zst',

--- a/packages/gtksourceview_5.rb
+++ b/packages/gtksourceview_5.rb
@@ -3,12 +3,11 @@ require 'package'
 class Gtksourceview_5 < Package
   description 'Source code editing widget'
   homepage 'https://wiki.gnome.org/Projects/GtkSourceView'
-  @_ver = '5.6.1'
-  version @_ver
+  version '5.6.1'
   license 'LGPL-2.1+'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/gtksourceview.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtksourceview_5/5.6.1_armv7l/gtksourceview_5-5.6.1-chromeos-armv7l.tar.zst',

--- a/packages/gvfs.rb
+++ b/packages/gvfs.rb
@@ -3,12 +3,11 @@ require 'package'
 class Gvfs < Package
   description 'Virtual filesystem implementation for GIO'
   homepage 'https://wiki.gnome.org/Projects/gvfs'
-  @_ver = '1.50.4'
-  version @_ver
+  version '1.50.4'
   license 'GPLv2'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.gnome.org/GNOME/gvfs.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gvfs/1.50.4_armv7l/gvfs-1.50.4-chromeos-armv7l.tar.zst',

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -4,12 +4,11 @@ require 'package'
 class Harfbuzz < Package
   description 'HarfBuzz is an OpenType text shaping engine.'
   homepage 'https://www.freedesktop.org/wiki/Software/HarfBuzz/'
-  @_ver = '7.1.0'
-  version @_ver
+  version '7.1.0'
   license 'Old-MIT, ISC and icu'
   compatibility 'all'
   source_url 'https://github.com/harfbuzz/harfbuzz.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/harfbuzz/7.1.0_armv7l/harfbuzz-7.1.0-chromeos-armv7l.tar.zst',

--- a/packages/leptonica.rb
+++ b/packages/leptonica.rb
@@ -3,12 +3,11 @@ require 'package'
 class Leptonica < Package
   description 'Software that is broadly useful for image processing and image analysis applications'
   homepage 'http://www.leptonica.com/'
-  @_ver = '1.83.1'
-  version @_ver
+  version '1.83.1'
   license 'Apache-2.0'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://github.com/DanBloomberg/leptonica.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/leptonica/1.83.1_armv7l/leptonica-1.83.1-chromeos-armv7l.tar.zst',

--- a/packages/libadwaita.rb
+++ b/packages/libadwaita.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libadwaita < Package
   description 'Library of GNOME-specific UI patterns, replacing libhandy for GTK4'
   homepage 'https://gitlab.gnome.org/GNOME/libadwaita/'
-  @_ver = '1.3.2'
-  version @_ver
+  version '1.3.2'
   license 'LGPL-2.1+'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.gnome.org/GNOME/libadwaita.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libadwaita/1.3.2_armv7l/libadwaita-1.3.2-chromeos-armv7l.tar.zst',

--- a/packages/libbsd.rb
+++ b/packages/libbsd.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libbsd < Package
   description 'This library provides useful functions commonly found on BSD systems, and lacking on others like GNU systems, thus making it easier to port projects with strong BSD origins, without needing to embed the same code over and over again on each project.'
   homepage 'https://libbsd.freedesktop.org/wiki'
-  @_ver = '0.11.7'
-  version @_ver
+  version '0.11.7'
   license 'BSD, BSD-2, BSD-4, ISC'
   compatibility 'all'
   source_url 'https://git.hadrons.org/git/libbsd.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libbsd/0.11.7_armv7l/libbsd-0.11.7-chromeos-armv7l.tar.zst',

--- a/packages/libfaudio.rb
+++ b/packages/libfaudio.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libfaudio < Package
   description 'FAudio is an XAudio reimplementation that focuses solely on developing fully accurate DirectX Audio runtime libraries for the FNA project.'
   homepage 'https://fna-xna.github.io/'
-  @_ver = '23.01'
-  version @_ver
+  version '23.01'
   license 'ZLIB'
   compatibility 'all'
   source_url 'https://github.com/fna-xna/faudio.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libfaudio/23.01_armv7l/libfaudio-23.01-chromeos-armv7l.tar.zst',

--- a/packages/libgme.rb
+++ b/packages/libgme.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libgme < Package
   description 'Blargg\'s video game music file emulation/playback library.'
   homepage 'https://bitbucket.org/mpyne/game-music-emu/'
-  @_ver = '0.6.3'
-  version @_ver
+  version '0.6.3'
   compatibility 'all'
   license 'LGPL-2.1'
   source_url 'https://bitbucket.org/mpyne/game-music-emu.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libgme/0.6.3_armv7l/libgme-0.6.3-chromeos-armv7l.tpxz',

--- a/packages/libhandy.rb
+++ b/packages/libhandy.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libhandy < Package
   description 'The aim of the handy library is to help with developing UI for mobile devices using GTK/GNOME.'
   homepage 'https://gitlab.gnome.org/GNOME/libhandy/'
-  @_ver = '1.8.2'
-  version @_ver
+  version '1.8.2'
   license 'LGPL-2.1+'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.gnome.org/GNOME/libhandy.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libhandy/1.8.2_armv7l/libhandy-1.8.2-chromeos-armv7l.tar.zst',

--- a/packages/libinput.rb
+++ b/packages/libinput.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libinput < Package
   description 'libinput is a library to handle input devices in Wayland compositors and to provide a generic X.Org input driver.'
   homepage 'https://www.freedesktop.org/wiki/Software/libinput'
-  @_ver = '1.21.0'
-  version @_ver
+  version '1.21.0'
   license 'MIT'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/libinput/libinput.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libinput/1.21.0_armv7l/libinput-1.21.0-chromeos-armv7l.tar.zst',

--- a/packages/libjpeg.rb
+++ b/packages/libjpeg.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libjpeg < Package
   description 'Libjpeg-turbo implements both the traditional libjpeg API as well as the less powerful but more straightforward TurboJPEG API.'
   homepage 'https://libjpeg-turbo.org'
-  @_ver = '2.1.5.1'
-  version @_ver
+  version '2.1.5.1'
   compatibility 'all'
   source_url 'https://github.com/libjpeg-turbo/libjpeg-turbo.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libjpeg/2.1.5.1_armv7l/libjpeg-2.1.5.1-chromeos-armv7l.tar.zst',

--- a/packages/libmd.rb
+++ b/packages/libmd.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libmd < Package
   description 'libmd provides message digest functions found on BSD systems.'
   homepage 'https://www.hadrons.org/software/libmd/'
-  @_ver = '1.0.4'
-  version @_ver
+  version '1.0.4'
   license 'BSD-3, BSD-2, ISC, Beerware, public-domain'
   compatibility 'all'
   source_url 'https://git.hadrons.org/git/libmd.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libmd/1.0.4_armv7l/libmd-1.0.4-chromeos-armv7l.tpxz',

--- a/packages/libmicrodns.rb
+++ b/packages/libmicrodns.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libmicrodns < Package
   description 'libmicrodns is a minimal cross-platform mDNS resolver and announcer.'
   homepage 'https://github.com/videolabs/libmicrodns/'
-  @_ver = '0.2.0'
-  version @_ver
+  version '0.2.0'
   compatibility 'all'
   license 'LGPL-2.1'
   source_url 'https://github.com/videolabs/libmicrodns.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libmicrodns/0.2.0_armv7l/libmicrodns-0.2.0-chromeos-armv7l.tpxz',

--- a/packages/libshine.rb
+++ b/packages/libshine.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libshine < Package
   description 'shine is a rapid fixed-point MP3 encoder.'
   homepage 'https://github.com/toots/shine/'
-  @_ver = '3.1.1'
-  version @_ver
+  version '3.1.1'
   compatibility 'all'
   license 'GPL-2'
   source_url 'https://github.com/toots/shine.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   def self.build
     system 'autoreconf -fiv'

--- a/packages/libsoup.rb
+++ b/packages/libsoup.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libsoup < Package
   description 'libsoup is an HTTP client/server library for GNOME.'
   homepage 'https://wiki.gnome.org/Projects/libsoup'
-  @_ver = '3.4.1'
-  version @_ver
+  version '3.4.1'
   license 'LGPL-2.1+'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/libsoup.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libsoup/3.4.1_armv7l/libsoup-3.4.1-chromeos-armv7l.tar.zst',

--- a/packages/libva.rb
+++ b/packages/libva.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libva < Package
   description 'Libva is an implementation for VA-API (Video Acceleration API)'
   homepage 'https://01.org/linuxmedia'
-  @_ver = '2.17.0'
-  version @_ver
+  version '2.17.0'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/intel/libva.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libva/2.17.0_armv7l/libva-2.17.0-chromeos-armv7l.tar.zst',

--- a/packages/opam.rb
+++ b/packages/opam.rb
@@ -6,11 +6,10 @@ require 'package'
 class Opam < Package
   description 'OCaml package manager'
   homepage 'https://opam.ocaml.org/'
-  @_ver = '2.1.4'
-  version @_ver
+  version '2.1.4'
   compatibility 'all'
   source_url 'https://github.com/ocaml/opam.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/opam/2.1.4_armv7l/opam-2.1.4-chromeos-armv7l.tar.zst',

--- a/packages/pango.rb
+++ b/packages/pango.rb
@@ -4,12 +4,11 @@ require 'package'
 class Pango < Package
   description 'Pango is a library for laying out and rendering of text, with an emphasis on internationalization.'
   homepage 'https://pango.gnome.org/'
-  @_ver = '1.50.14'
-  version @_ver
+  version '1.50.14'
   license 'LGPL-2+ and FTL'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/pango.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/pango/1.50.14_armv7l/pango-1.50.14-chromeos-armv7l.tar.zst',

--- a/packages/py2_pip.rb
+++ b/packages/py2_pip.rb
@@ -3,12 +3,11 @@ require 'package'
 class Py2_pip < Package
   description 'Pip is the python package manager from the Python Packaging Authority.'
   homepage 'https://pip.pypa.io/'
-  @_ver = '20.3.4'
-  version @_ver
+  version '20.3.4'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/pypa/pip.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py2_pip/20.3.4_armv7l/py2_pip-20.3.4-chromeos-armv7l.tar.xzz',

--- a/packages/py2_six.rb
+++ b/packages/py2_six.rb
@@ -3,12 +3,11 @@ require 'package'
 class Py2_six < Package
   description 'Six is a Python 2 and 3 compatibility library.'
   homepage 'https://six.readthedocs.io/'
-  @_ver = '1.15.0'
-  version @_ver
+  version '1.15.0'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/benjaminp/six.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py2_six/1.15.0_armv7l/py2_six-1.15.0-chromeos-armv7l.tar.xz',

--- a/packages/py2_wheel.rb
+++ b/packages/py2_wheel.rb
@@ -3,12 +3,11 @@ require 'package'
 class Py2_wheel < Package
   description 'Wheel is the binary package format for python.'
   homepage 'https://wheel.readthedocs.io/'
-  @_ver = '0.36.2'
-  version @_ver
+  version '0.36.2'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/pypa/wheel.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py2_wheel/0.36.2_armv7l/py2_wheel-0.36.2-chromeos-armv7l.tar.xz',

--- a/packages/tesseract.rb
+++ b/packages/tesseract.rb
@@ -3,12 +3,11 @@ require 'package'
 class Tesseract < Package
   description 'A neural net (LSTM) based OCR engine which is focused on line recognition & an older OCR engine which recognizes character patterns.'
   homepage 'https://github.com/tesseract-ocr/tesseract'
-  @_ver = '5.3.1'
-  version @_ver
+  version '5.3.1'
   license 'Apache-2.0'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://github.com/tesseract-ocr/tesseract.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/tesseract/5.3.1_armv7l/tesseract-5.3.1-chromeos-armv7l.tar.zst',

--- a/packages/thefuck.rb
+++ b/packages/thefuck.rb
@@ -3,12 +3,11 @@ require 'package'
 class Thefuck < Package
   description 'Thef*ck is a magnificent app which corrects your previous console command.'
   homepage 'https://github.com/nvbn/thefuck/'
-  @_ver = '3.31'
-  version @_ver
+  version '3.31'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/nvbn/thefuck.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/thefuck/3.31_armv7l/thefuck-3.31-chromeos-armv7l.tpxz',

--- a/packages/vte.rb
+++ b/packages/vte.rb
@@ -3,12 +3,11 @@ require 'package'
 class Vte < Package
   description 'Virtual Terminal Emulator widget for use with GTK'
   homepage 'https://wiki.gnome.org/Apps/Terminal/VTE'
-  @_ver = '0.72.1'
-  version @_ver
+  version '0.72.1'
   license 'LGPL-2+ and GPL-3+'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.gnome.org/GNOME/vte.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/vte/0.72.1_armv7l/vte-0.72.1-chromeos-armv7l.tar.zst',

--- a/packages/wayland.rb
+++ b/packages/wayland.rb
@@ -3,12 +3,11 @@ require 'package'
 class Wayland < Package
   description 'Wayland is intended as a simpler replacement for X, easier to develop and maintain.'
   homepage 'https://wayland.freedesktop.org'
-  @_ver = '1.22.0'
-  version @_ver
+  version '1.22.0'
   license 'MIT'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/wayland/wayland.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland/1.22.0_armv7l/wayland-1.22.0-chromeos-armv7l.tar.zst',

--- a/packages/wayland_proxy_virtwl.rb
+++ b/packages/wayland_proxy_virtwl.rb
@@ -3,11 +3,10 @@ require 'package'
 class Wayland_proxy_virtwl < Package
   description 'Proxy Wayland connections across the VM boundary'
   homepage 'https://github.com/talex5/wayland-proxy-virtwl'
-  @_ver = 'd7f58d405514dd031f2f12e402c8c6a58e62a885'
-  version @_ver
+  version 'd7f58d405514dd031f2f12e402c8c6a58e62a885'
   compatibility 'all'
   source_url 'https://github.com/talex5/wayland-proxy-virtwl.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wayland_proxy_virtwl/d7f58d405514dd031f2f12e402c8c6a58e62a885_armv7l/wayland_proxy_virtwl-d7f58d405514dd031f2f12e402c8c6a58e62a885-chromeos-armv7l.tpxz',

--- a/packages/weston.rb
+++ b/packages/weston.rb
@@ -3,12 +3,11 @@ require 'package'
 class Weston < Package
   description 'Weston is the reference implementation of a Wayland compositor, and a useful compositor in its own right.'
   homepage 'http://wayland.freedesktop.org'
-  @_ver = '12.0.0'
-  version @_ver
+  version '12.0.0'
   license 'MIT and CC-BY-SA-3.0'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.freedesktop.org/wayland/weston.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/weston/12.0.0_armv7l/weston-12.0.0-chromeos-armv7l.tar.zst',

--- a/packages/youtube_dl.rb
+++ b/packages/youtube_dl.rb
@@ -3,12 +3,11 @@ require 'package'
 class Youtube_dl < Package
   description 'Command-line program to download videos from YouTube.com and other video sites'
   homepage 'https://youtube-dl.org/'
-  @_ver = '2021.12.17'
-  version @_ver
+  version '2021.12.17'
   license 'public-domain'
   compatibility 'all'
   source_url 'https://github.com/ytdl-org/youtube-dl.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/youtube_dl/2021.12.17_armv7l/youtube_dl-2021.12.17-chromeos-armv7l.tar.zst',


### PR DESCRIPTION
Following on from #8374, I am removing 44 uses of `@_ver` from packages that use it like this:
```
@_ver = '1.2.3'
version @_ver
...
git_hashtag @_ver
```
which now becomes:
```
version '1.2.3'
...
git_hashtag version
```

Tested and working on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=laver4 CREW_TESTING=1 crew update
```
