### PR TITLE
install.sh: move env.d LD_LIBRARY_PATH setting to before crew runs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -151,6 +151,10 @@ for dir in "${CREW_CONFIG_PATH}/meta" "${CREW_DEST_DIR}" "${CREW_PACKAGES_PATH}"
   fi
 done
 
+if [[ "$ARMV7LONAARCH64" == '1' ]]; then
+  mkdir -p "${CREW_PREFIX}/etc/env.d/"
+  echo "export LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}"> "${CREW_PREFIX}/etc/env.d/00-library"
+fi
 echo_info "\nDownloading information for Bootstrap packages..."
 echo -en "${GRAY}"
 # Use parallel mode if available.
@@ -411,6 +415,5 @@ if [[ "$ARMV7LONAARCH64" == '1' ]]; then
 Since you have installed an armv7l Chromebrew on an aarch64 userspace
 system, you MUST run this command to complete your installation:
 "
-  echo "export LD_LIBRARY_PATH=${CREW_PREFIX}/lib${LIB_SUFFIX}"> "${CREW_PREFIX}/etc/env.d/00-library"
   echo_info "source ~/.bashrc"
 fi


### PR DESCRIPTION
- This just moves the creation of the LD_LIBRARY_PATH setting env.d file to before crew does installations, which fixes the issue I was having with installing on the aarch64 userspace container.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=container_aarch64_fix CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
