### PR TITLE
fix #8327

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1368,7 +1368,7 @@ def install_files(src, dst = File.join( CREW_PREFIX, src.delete_prefix('./usr/lo
         src << '/' unless src.end_with?('/')
         # Check for ACLs support.
         @rsync_version = `rsync --version`.chomp
-        if @rsync_version.include?('ACLs')
+        if @rsync_version.include?('ACLs') && !@rsync_version.include?('no ACLs')
           system 'rsync', "-ah#{@verbose}HAXW", '--remove-source-files', src, dst, exception: true
         else
           system 'rsync', "-ah#{@verbose}HXW", '--remove-source-files', src, dst, exception: true


### PR DESCRIPTION
Only tested on my aarch64 userspace chromebook. I found `no ACLs` in my rsync version output

Fixes #8327

<!-- (let GitHub automatically close an issue when this pull request gets merged) -->

<!--
## Before you submit a pull request

This template is not necessary when you do simple things like updating packages to the latest version. But in doubt, it's always better so provide some information.
-->

## Description
<!--
Provide a description, what your changes do and why they are important

Please link issues and other pull requests connected to this one.
-->

## Additional information
<!-- Mention things we might need to know. Like: -->

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```

curl -Ls https://raw.github.com/skycocker/chromebrew/master/install.sh | OWNER=mio-19 REPO=chromebrew BRANCH=patch-1 bash

CREW_TESTING_REPO=https://github.com/mio-19/chromebrew.git CREW_TESTING_BRANCH=patch-1 CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
