### PR TITLE
@_ver fixes for bootstrap packages

### DIFF
--- a/packages/gmp.rb
+++ b/packages/gmp.rb
@@ -3,7 +3,7 @@ require 'package'
 class Gmp < Package
   description 'GMP is a free library for arbitrary precision arithmetic, operating on signed integers, rational numbers, and floating-point numbers.'
   homepage 'https://gmplib.org/'
-  version '6.2.1'
+  version '6.2.1' # Do not use @_ver here, it will break the installer.
   license 'LGPL-3+ and GPL-2+'
   compatibility 'all'
   source_url 'https://gmplib.org/download/gmp/gmp-6.2.1.tar.lz'

--- a/packages/zlibpkg.rb
+++ b/packages/zlibpkg.rb
@@ -3,14 +3,13 @@ require 'package'
 class Zlibpkg < Package
   description 'zlib is a massively spiffy yet delicately unobtrusive compression library.'
   homepage 'https://www.zlib.net/'
-  @_ver = '1.2.13'
-  version "#{@_ver}-1"
+  version = '1.2.13-1' # Do not use @_ver here, it will break the installer.
   # When upgrading zlibpkg, be sure to upgrade minizip in tandem.
   # The following breaks the installer script.
   # puts "#{self} version differs from Minizip version #{Minizip.version}".orange if @_ver != Minizip.version
   license 'zlib'
   compatibility 'all'
-  source_url "https://www.zlib.net/zlib-#{@_ver}.tar.gz"
+  source_url "https://www.zlib.net/zlib-1.2.13.tar.gz"
   source_sha256 'b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30'
 
   binary_url({


### PR DESCRIPTION
Just some fixes for 7297-- not sure what originally caused the breakage of the old installer on zlibpkg, it might not break on the refactored one (but at any rate thats a PR for after 7297 gets merged).

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=cleanupcrew CREW_TESTING=1 crew update
```
