### PR TITLE
fixup glibc packages, ccache => 4.8.2

### DIFF
--- a/packages/ccache.rb
+++ b/packages/ccache.rb
@@ -3,41 +3,42 @@ require 'package'
 class Ccache < Package
   description 'Compiler cache that speeds up recompilation by caching previous compilations'
   homepage 'https://ccache.samba.org/'
-  @_ver = '4.7.4'
-  version @_ver
+  version '4.8.2'
   license 'GPL-3 and LGPL-3'
   compatibility 'all'
-  source_url "https://github.com/ccache/ccache/releases/download/v#{@_ver}/ccache-#{@_ver}.tar.xz"
-  source_sha256 'df0c64d15d3efaf0b4f6837dd6b1467e40eeaaa807db25ce79c3a08a46a84e36'
+  source_url "https://github.com/ccache/ccache/releases/download/v#{version}/ccache-#{version}.tar.xz"
+  source_sha256 '3d3fb3f888a5b16c4fa7ee5214cca76348afd6130e8443de5f6f2424f2076a49'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ccache/4.7.4_armv7l/ccache-4.7.4-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ccache/4.7.4_armv7l/ccache-4.7.4-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ccache/4.7.4_i686/ccache-4.7.4-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ccache/4.7.4_x86_64/ccache-4.7.4-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ccache/4.8.2_armv7l/ccache-4.8.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ccache/4.8.2_armv7l/ccache-4.8.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ccache/4.8.2_i686/ccache-4.8.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ccache/4.8.2_x86_64/ccache-4.8.2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '29e5721a8ae9cbe2cb60e2cf7f7f04021c259c832f4622288cda1f96273d2e5c',
-     armv7l: '29e5721a8ae9cbe2cb60e2cf7f7f04021c259c832f4622288cda1f96273d2e5c',
-       i686: '6b0c3062486bcb56b1be202dc477113fa61eaf3e596d228db8dbfd3509db3792',
-     x86_64: '195ba7619b377aa52a59511b62e9bfe7e34ae463dd0662ca2870b9743fd1a5f1'
+    aarch64: '279ee8b2baba8170657f548d0dfef3754acd0dc9c3c58c91a689ef1135ed9f5a',
+     armv7l: '279ee8b2baba8170657f548d0dfef3754acd0dc9c3c58c91a689ef1135ed9f5a',
+       i686: '84eee2802132145654a3e32d16702d502e0e2d8e474322555e251dce37ecb452',
+     x86_64: '3df947b2666aea7f86b1399211799ea182f1a6d5b74d635e8589fff050521bec'
   })
 
-  depends_on 'xdg_base'
+  depends_on 'gcc_dev' # R
+  depends_on 'gcc_lib' # R
+  depends_on 'glibc' # R
   depends_on 'ruby_asciidoctor' => :build
+  depends_on 'xdg_base'
+  depends_on 'zstd' # R
 
   def self.build
-    Dir.mkdir 'build'
-    Dir.chdir 'build' do
-      system "cmake -G Ninja \
+    system "cmake -B builddir -G Ninja \
       #{CREW_CMAKE_OPTIONS} \
       -DCMAKE_INSTALL_SYSCONFDIR=#{CREW_PREFIX}/etc \
-      -DZSTD_FROM_INTERNET=ON \
-      -DHIREDIS_FROM_INTERNET=ON \
-      .."
-      system 'mold -run ninja'
-    end
-    @ccacheenv = <<~CCACHEEOF
+      -DENABLE_IPO=ON \
+      -DENABLE_TESTING=OFF \
+      -DZSTD_FROM_INTERNET=OFF \
+      -DHIREDIS_FROM_INTERNET=ON"
+    system "#{CREW_NINJA} -C builddir"
+    File.write 'ccache_env', <<~CCACHEEOF
       # ccache configuration
       if [[ $PATH != *"ccache/bin"* ]]; then
         PATH="#{CREW_LIB_PREFIX}/ccache/bin:$PATH"
@@ -46,7 +47,7 @@ class Ccache < Package
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C build install"
+    system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
     FileUtils.mkdir_p "#{CREW_DEST_LIB_PREFIX}/ccache/bin"
     Dir.chdir "#{CREW_DEST_LIB_PREFIX}/ccache/bin" do
       %w[gcc g++ c++].each do |bin|
@@ -56,7 +57,6 @@ class Ccache < Package
         FileUtils.ln_s '../../../bin/ccache', bin
       end
     end
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/env.d/"
-    File.write("#{CREW_DEST_PREFIX}/etc/env.d/00-ccache", @ccacheenv)
+    FileUtils.install 'ccache_env', "#{CREW_DEST_PREFIX}/etc/env.d/00-ccache", mode: 0o644
   end
 end

--- a/packages/glibc_dev.rb
+++ b/packages/glibc_dev.rb
@@ -1,12 +1,11 @@
 require 'package'
+require_relative 'glibc'
 require_relative 'glibc_build235'
 
 class Glibc_dev < Package
   description 'glibc: everything except what is in glibc_lib'
-  homepage Glibc_build235.homepage
-  version '2.35'
-  license Glibc_build235.license
-  compatibility 'x86_64 aarch64 armv7l'
+  homepage Glibc.homepage.to_s
+  license Glibc.license.to_s
   source_url 'SKIP'
 
   is_fake
@@ -16,5 +15,9 @@ class Glibc_dev < Package
     version Glibc_build235.version.to_s
     compatibility Glibc_build235.compatibility.to_s
     depends_on 'glibc_dev235'
+  else
+    version Glibc.version.to_s
+    compatibility Glibc.compatibility.to_s
+    depends_on 'glibc'
   end
 end

--- a/packages/glibc_lib.rb
+++ b/packages/glibc_lib.rb
@@ -1,13 +1,11 @@
 require 'package'
-require_relative 'glibc_build235'
 require_relative 'glibc'
+require_relative 'glibc_build235'
 
 class Glibc_lib < Package
   description 'glibc libraries'
-  homepage Glibc_build235.homepage
-  version '2.35' # Do not use @_ver here, it will break the installer.
-  license Glibc_build235.license
-  compatibility 'x86_64 aarch64 armv7l'
+  homepage Glibc.homepage
+  license Glibc.license
   source_url 'SKIP'
 
   is_fake


### PR DESCRIPTION
- non glibc 2.35 packages needed to depend on the stub glibc package for versioning, etc.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=glibc_ccache CREW_TESTING=1 crew update
```
