### PR TITLE
rebuild texinfo against current perl, fixup getrealdeps script

### DIFF
--- a/packages/texinfo.rb
+++ b/packages/texinfo.rb
@@ -3,42 +3,36 @@ require 'package'
 class Texinfo < Package
   description 'Texinfo is the official documentation format of the GNU project.'
   homepage 'https://www.gnu.org/software/texinfo/'
-  version '7.0.3'
+  version '7.0.3-perl5.36'
   license 'GPL-3'
   compatibility 'all'
   source_url 'https://ftpmirror.gnu.org/texinfo/texinfo-7.0.3.tar.xz'
   source_sha256 '74b420d09d7f528e84f97aa330f0dd69a98a6053e7a4e01767eed115038807bf'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/texinfo/7.0.3_armv7l/texinfo-7.0.3-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/texinfo/7.0.3_armv7l/texinfo-7.0.3-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/texinfo/7.0.3_i686/texinfo-7.0.3-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/texinfo/7.0.3_x86_64/texinfo-7.0.3-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/texinfo/7.0.3-perl5.36_armv7l/texinfo-7.0.3-perl5.36-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/texinfo/7.0.3-perl5.36_armv7l/texinfo-7.0.3-perl5.36-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/texinfo/7.0.3-perl5.36_i686/texinfo-7.0.3-perl5.36-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/texinfo/7.0.3-perl5.36_x86_64/texinfo-7.0.3-perl5.36-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '477c405025570b2e6b723af86c5931b0d6e5e1df424d4d0e712ea0bd46c84aac',
-     armv7l: '477c405025570b2e6b723af86c5931b0d6e5e1df424d4d0e712ea0bd46c84aac',
-       i686: 'eabbfd13da1d8b08bfb0f06c729054db098ed708b9443410432250fc9a660697',
-     x86_64: 'd9fa00e921ebef6d30fe29005b404656c1b698e97b5a46d10408d1ebf71a5a4f'
+    aarch64: '1e11dfe2022f476c2fd5c20eba7d7b7a294a2887667e10943eacfb6ca5628839',
+     armv7l: '1e11dfe2022f476c2fd5c20eba7d7b7a294a2887667e10943eacfb6ca5628839',
+       i686: 'ec6a3eb3994b45d78b5017eec9afab338047af03910cdfab855f3ff30d073642',
+     x86_64: '30eab94981ad9ccd2cafbeb8f557bf0c2e99f14c964ea5736269dfdec75e6a57'
   })
 
-  depends_on 'glibc' # R
-  depends_on 'perl'
-  depends_on 'perl_locale_messages'
-  depends_on 'perl_text_unidecode'
-  depends_on 'perl_unicode_eastasianwidth'
+  depends_on 'glibc_lib' # R
   depends_on 'ncurses' # R
+  depends_on 'perl' # L
+  depends_on 'perl_locale_messages' => :build
+  depends_on 'perl_text_unidecode' => :build
+  depends_on 'perl_unicode_eastasianwidth' => :build
 
   def self.build
-    # configure and make
-    # LDflags set to workaround i686 build issues.
-    @ldflags = ''
-    @ldflags = 'LDFLAGS=-static' if ARCH == 'i686'
-    system "#{@ldflags} ./configure #{CREW_OPTIONS} \
+    system "mold -run ./configure #{CREW_OPTIONS} \
       --with-external-Text-Unidecode \
       --with-external-Unicode-EastAsianWidth"
-    # Fix broken i686 build.
-    system "sed -i 's/-static//' info/Makefile" if ARCH == 'i686'
     system 'make'
   end
 

--- a/tools/getrealdeps.sh
+++ b/tools/getrealdeps.sh
@@ -124,6 +124,8 @@ echo "$lines" | tr " " "\n" | awk '!x[$0]++')
 pkgdeps=$(tr " " "\n" <<< "$pkgdeps" | sed "/${pkg}/d" | sort -u )
 # Replace glibc_build packages with glibc
 pkgdeps=$(tr " " "\n" <<< "$pkgdeps" | sed 's/glibc_build.*/glibc/' | sort -u )
+# Replace glibc_lib* packages with glibc_lib
+pkgdeps=$(tr " " "\n" <<< "$pkgdeps" | sed 's/glibc_lib.*/glibc_lib/' | sort -u )
 
 # Note which dependencies are missing, but ignore :build lines, since
 # build depenencies may still be runtime dependencies.


### PR DESCRIPTION
- This fixes builds of `gcc`, which depend upon `texinfo`...
- Also managed to get rid of the workarounds for `i686`.
- modified `getrealdeps` script to handle the `glibc_lib`* packages.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=texinfo_perl536 CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
