### PR TITLE
Add automatic builds

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -1,0 +1,72 @@
+---
+name: Build
+on:
+  workflow_call:
+    inputs:
+      packages:
+        required: true
+        type: string
+jobs:
+  build_x86_64:
+    runs-on: ubuntu-latest
+    container:
+      # This is using an older version of the dockerfile to avoid issues with actions/upload-artifact
+      image: satmandu/crewbuild:amd64@sha256:8ce37cddc8950a6717c2b6a335580aa4142393926fff0640ec64b6b78ee530b8
+      options: -u chronos
+    steps:
+      - name: Setup environment
+        run: |
+          mkdir /usr/local/manifests
+          mkdir /usr/local/build
+      - name: Build package
+        run: |
+          export CREW_LOCAL_MANIFEST_PATH=/usr/local/manifests
+          cd /usr/local/build
+          for package in ${{ inputs.packages }}; do
+            yes | crew build $package
+          done
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifacts_x86_64
+          path: |
+            /usr/local/build
+            /usr/local/manifests
+          retention-days: 1
+  commit:
+    needs: build_x86_64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v3
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: artifacts_x86_64
+          path: ${{ github.workspace }}
+      - name: Update filelists
+        run: |
+          for package in ${{ inputs.packages }}; do
+              cp -f ${{ github.workspace }}/manifests/x86_64/${package:0:1}/$package.filelist ${{ github.workspace }}/manifest/x86_64/${package:0:1}/$package.filelist
+          done
+      - name: Update binaries
+        env:
+          gitlab_token: ${{ secrets.gitlab_token  }}
+        run: |
+          for package in ${{ inputs.packages }}; do
+              mkdir ./${{ github.workspace }}/release/x86_64
+              find ./${{ github.workspace }}/builds/ -name '$package-*' -exec cp {} ./${{ github.workspace }}/release/x86_64/ \;
+              cd ./${{ github.workspace }}/tools
+              export GITLAB_TOKEN=${{ secrets.gitlab_token  }}
+              ./gl.sh $package
+          done
+      - name: Configure git
+        run: |
+          git config --global user.name github-actions
+          git config --global user.email actions@example.com
+      - name: Commit updates
+        run: |
+          for package in ${{ inputs.packages }}; do
+              git commit -o ${{ github.workspace }}/manifest/*/${package:0:1}/$package.filelist ${{ github.workspace }}/packages/$package.rb -m "Update filelists and binaries for $package"
+              git push
+          done

--- a/.github/workflows/Handoff.yml
+++ b/.github/workflows/Handoff.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       category: ${{ steps.changed-file-extensions.outputs.category }}
+      packages: ${{ steps.changed-file-extensions.outputs.packages }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -19,7 +20,11 @@ jobs:
         id: changed-file-extensions
         run: |
           category=
+          packages=
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            # If any packages were changed, get their name.
+            [[ "$(dirname $file)" == "packages" ]] && packages+="$(basename -s .rb $file) "
+            # Get the extensions of the changed files, see what type they are.
             ext="${file##*.}"
             case $ext in
               md)
@@ -37,19 +42,26 @@ jobs:
             [[ "$(file -b $file | cut -d' ' -f1)" == "Ruby" ]] && category+=" Ruby"
           done
           echo "category=$category" >> $GITHUB_OUTPUT
-  # Github won't let us do this neatly, see https://github.com/orgs/community/discussions/25246
-  markdown:
+          echo "packages=$packages" >> $GITHUB_OUTPUT
+  # Ruby workflows
+  rubocop:
     needs: handoff
-    if: contains(needs.handoff.outputs.category, 'Markdown')
-    uses: ./.github/workflows/Markdown-lint.yml
-  ruby:
-    needs: handoff
-    if: contains(needs.handoff.outputs.category, 'Ruby')
+    if: ${{ needs.handoff.outputs.category == 'Ruby' }}
     uses: ./.github/workflows/Rubocop.yml
+  build:
+    needs: handoff
+    if: ${{ needs.handoff.outputs.packages != '' }}
+    uses: ./.github/workflows/Build.yml
+    with:
+      packages: ${{ needs.handoff.outputs.packages }}
   bash:
     needs: handoff
     if: contains(needs.handoff.outputs.category, 'Bash')
     uses: ./.github/workflows/ShellCheck.yml
+  markdown:
+    needs: handoff
+    if: contains(needs.handoff.outputs.category, 'Markdown')
+    uses: ./.github/workflows/Markdown-lint.yml
   yaml:
     needs: handoff
     if: contains(needs.handoff.outputs.category, 'YAML')


### PR DESCRIPTION
When finished, this PR will automatically build changed packages, update the filelists, upload new binaries and update the sha256s, and commit them to the PR.

Right now, it only does that on x86_64. Or, at least, it could. It needs a gitlab secret (I've discussed this further on the slack channel), and currently artifacts are broken. However, it does work. For a period of 2 builds uploading artifacts worked, before a change in the docker file broke them.

I've got an issue for the broken uploading artifacts over at actions/upload-artifact#409, but it may be a better solution to fix the docker file, as I doubt I'm gonna get a response on that issue any time soon.

In terms of fixing the docker file, I might need @satmandu's help here, given that its their docker file. 

Additionally, I need help getting `crewbuild:386` and `crewbuild:arm32v7` working. In particular, I need to be able to use them the way I'm using `satmandu/crewbuild:amd64`, using the github actions integration.

Once those are working, I'll adjust this PR and the workflow accordingly.
