### PR TITLE
Remove basic uses of @_ver in source_url

### DIFF
--- a/packages/abseil_cpp.rb
+++ b/packages/abseil_cpp.rb
@@ -3,11 +3,10 @@ require 'package'
 class Abseil_cpp < Package
   description 'Abseil Common Libraries C++'
   homepage 'https://abseil.io/'
-  @_ver = '20200923.3'
-  version @_ver
+  version '20200923.3'
   license 'Apache-2.0'
   compatibility 'all'
-  source_url "https://github.com/abseil/abseil-cpp/archive/#{@_ver}.tar.gz"
+  source_url "https://github.com/abseil/abseil-cpp/archive/#{version}.tar.gz"
   source_sha256 'ebe2ad1480d27383e4bf4211e2ca2ef312d5e6a09eba869fd2e8a5c5d553ded2'
 
   binary_url({

--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -3,11 +3,10 @@ require 'package'
 class Binutils < Package
   description 'The GNU Binutils are a collection of binary tools.'
   homepage 'https://www.gnu.org/software/binutils/'
-  @_ver = '2.40'
-  version @_ver
+  version '2.40'
   license 'GPL-3+'
   compatibility 'all'
-  source_url "https://ftpmirror.gnu.org/binutils/binutils-#{@_ver}.tar.bz2"
+  source_url "https://ftpmirror.gnu.org/binutils/binutils-#{version}.tar.bz2"
   source_sha256 'f8298eb153a4b37d112e945aa5cb2850040bcf26a3ea65b5a715c83afe05e48a'
 
   binary_url({

--- a/packages/bison.rb
+++ b/packages/bison.rb
@@ -3,11 +3,10 @@ require 'package'
 class Bison < Package
   description 'Bison is a general-purpose parser generator that converts an annotated context-free grammar into a deterministic LR or generalized LR (GLR) parser employing LALR(1) parser tables.'
   homepage 'https://www.gnu.org/software/bison/'
-  @_ver = '3.8.2'
-  version @_ver
+  version '3.8.2'
   license 'GPL-2'
   compatibility 'all'
-  source_url "https://ftpmirror.gnu.org/bison/bison-#{@_ver}.tar.lz"
+  source_url "https://ftpmirror.gnu.org/bison/bison-#{version}.tar.lz"
   source_sha256 'fdf98bfe82abb04a34d4356753f7748dbbd2ef1221b1f202852a2b5ce0f78534'
 
   binary_url({

--- a/packages/bubblewrap.rb
+++ b/packages/bubblewrap.rb
@@ -3,11 +3,10 @@ require 'package'
 class Bubblewrap < Package
   description 'bubblewrap works by creating a new, completely empty, mount namespace'
   homepage 'https://github.com/containers/bubblewrap'
-  @_ver = '0.8.0'
-  version @_ver
+  version '0.8.0'
   license 'LGPL-2+'
   compatibility 'all'
-  source_url "https://github.com/containers/bubblewrap/releases/download/v#{@_ver}/bubblewrap-#{@_ver}.tar.xz"
+  source_url "https://github.com/containers/bubblewrap/releases/download/v#{version}/bubblewrap-#{version}.tar.xz"
   source_sha256 '957ad1149db9033db88e988b12bcebe349a445e1efc8a9b59ad2939a113d333a'
 
   binary_url({

--- a/packages/busybox.rb
+++ b/packages/busybox.rb
@@ -3,11 +3,10 @@ require 'package'
 class Busybox < Package
   description 'BusyBox combines tiny versions of many common UNIX utilities into a single small executable.'
   homepage 'https://busybox.net/'
-  @_ver = '1.36.0'
-  version @_ver
+  version '1.36.0'
   license 'GPL-3'
   compatibility 'all'
-  source_url "https://busybox.net/downloads/busybox-#{@_ver}.tar.bz2"
+  source_url "https://busybox.net/downloads/busybox-#{version}.tar.bz2"
   source_sha256 '542750c8af7cb2630e201780b4f99f3dcceeb06f505b479ec68241c1e6af61a5'
 
   binary_url({

--- a/packages/colord.rb
+++ b/packages/colord.rb
@@ -3,11 +3,10 @@ require 'package'
 class Colord < Package
   description 'colord is a system service that makes it easy to manage, install and generate color profiles to accurately color manage input and output devices.'
   homepage 'https://www.freedesktop.org/software/colord/'
-  @_ver = '1.4.5'
-  version @_ver
+  version '1.4.5'
   license 'GPL-2'
   compatibility 'all'
-  source_url "https://www.freedesktop.org/software/colord/releases/colord-#{@_ver}.tar.xz"
+  source_url "https://www.freedesktop.org/software/colord/releases/colord-#{version}.tar.xz"
   source_sha256 'b774ea443d239f4a2ee1853bd678426e669ddeda413dcb71cea1638c4d6c5e17'
 
   binary_url({

--- a/packages/consolekit.rb
+++ b/packages/consolekit.rb
@@ -3,11 +3,10 @@ require 'package'
 class Consolekit < Package
   description 'A framework for defining and tracking users, login sessions, and seats'
   homepage 'https://github.com/ConsoleKit2/ConsoleKit2'
-  @_ver = '1.2.2'
-  version @_ver
+  version '1.2.2'
   license 'GPL-2+'
   compatibility 'all'
-  source_url "https://github.com/ConsoleKit2/ConsoleKit2/archive/#{@_ver}.tar.gz"
+  source_url "https://github.com/ConsoleKit2/ConsoleKit2/archive/#{version}.tar.gz"
   source_sha256 '104fd9f41c2d572ad62f4032de46c4c384c3522602b0ad953cf55759c6c64c1d'
 
   binary_url({

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -3,11 +3,10 @@ require 'package'
 class Crew_profile_base < Package
   description 'Crew-profile-base sets up Chromebrew\'s environment capabilities.'
   homepage 'https://github.com/chromebrew/crew-profile-base'
-  @_ver = '0.0.10'
-  version @_ver
+  version '0.0.10'
   license 'GPL-3+'
   compatibility 'all'
-  source_url "https://github.com/chromebrew/crew-profile-base/archive/refs/tags/#{@_ver}.tar.gz"
+  source_url "https://github.com/chromebrew/crew-profile-base/archive/refs/tags/#{version}.tar.gz"
   source_sha256 '73c60cabbae1050a55f031dc3c88738c3dbe52b516d5daca54f4d8890856a5f3'
 
   no_compile_needed

--- a/packages/e2fsprogs.rb
+++ b/packages/e2fsprogs.rb
@@ -3,11 +3,10 @@ require 'package'
 class E2fsprogs < Package
   description 'e2fsprogs are ext2/3/4 file system utilities.'
   homepage 'http://e2fsprogs.sourceforge.net/'
-  @_ver = '1.46.5'
-  version @_ver
+  version '1.46.5'
   license 'GPL-2 and BSD'
   compatibility 'all'
-  source_url "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v#{@_ver}/e2fsprogs-#{@_ver}.tar.xz"
+  source_url "https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v#{version}/e2fsprogs-#{version}.tar.xz"
   source_sha256 '2f16c9176704cf645dc69d5b15ff704ae722d665df38b2ed3cfc249757d8d81e'
 
   binary_url({

--- a/packages/elfutils.rb
+++ b/packages/elfutils.rb
@@ -3,11 +3,10 @@ require 'package'
 class Elfutils < Package
   description 'elfutils is a collection of utilities and libraries to read, create and modify ELF binary files, find and handle DWARF debug data, symbols, thread state and stacktraces for processes and core files on GNU/Linux.'
   homepage 'https://sourceware.org/elfutils/'
-  @_ver = '0.188'
-  version @_ver
+  version '0.188'
   license 'GPL-2+ or LGPL-3+'
   compatibility 'all'
-  source_url "https://sourceware.org/elfutils/ftp/#{@_ver}/elfutils-#{@_ver}.tar.bz2"
+  source_url "https://sourceware.org/elfutils/ftp/#{version}/elfutils-#{version}.tar.bz2"
   source_sha256 'fb8b0e8d0802005b9a309c60c1d8de32dd2951b56f0c3a3cb56d21ce01595dff'
 
   binary_url({

--- a/packages/enchant.rb
+++ b/packages/enchant.rb
@@ -3,11 +3,10 @@ require 'package'
 class Enchant < Package
   description 'Enchant is a library (and command-line program) that wraps a number of different spelling libraries and programs with a consistent interface.'
   homepage 'https://abiword.github.io/enchant/'
-  @_ver = '2.2.15'
-  version @_ver
+  version '2.2.15'
   license 'LGPL-2.1+'
   compatibility 'all'
-  source_url "https://github.com/AbiWord/enchant/archive/v#{@_ver}.tar.gz"
+  source_url "https://github.com/AbiWord/enchant/archive/v#{version}.tar.gz"
   source_sha256 '85295934102a4ab94f209cbc7c956affcb2834e7a5fb2101e2db436365e2922d'
 
   binary_url({

--- a/packages/exempi.rb
+++ b/packages/exempi.rb
@@ -6,11 +6,10 @@ require 'package'
 class Exempi < Package
   description 'A library to parse XMP metadata'
   homepage 'https://libopenraw.freedesktop.org/wiki/Exempi'
-  @_ver = '2.6.3'
-  version @_ver
+  version '2.6.3'
   license 'BSD'
   compatibility 'all'
-  source_url "https://gitlab.freedesktop.org/libopenraw/exempi/-/archive/#{@_ver}/exempi-#{@_ver}.tar.bz2"
+  source_url "https://gitlab.freedesktop.org/libopenraw/exempi/-/archive/#{version}/exempi-#{version}.tar.bz2"
   source_sha256 'e79995bb3c5319293e3f2abfc9da83a9ee5a83102724336599d535d874509632'
 
   binary_url({

--- a/packages/f2fs_tools.rb
+++ b/packages/f2fs_tools.rb
@@ -3,11 +3,10 @@ require 'package'
 class F2fs_tools < Package
   description 'Tools for Flash-Friendly File System F2FS'
   homepage 'https://git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/f2fs-tools.git/about/'
-  @_ver = '1.14.0'
-  version @_ver
+  version '1.14.0'
   license 'GPL-2'
   compatibility 'all'
-  source_url "https://git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/f2fs-tools.git/snapshot/f2fs-tools-#{@_ver}.tar.gz"
+  source_url "https://git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/f2fs-tools.git/snapshot/f2fs-tools-#{version}.tar.gz"
   source_sha256 '619263d4e2022152a1472c1d912eaae104f20bd227ce0bb9d41d1d6608094bd1'
 
   binary_url({

--- a/packages/fftw.rb
+++ b/packages/fftw.rb
@@ -3,11 +3,10 @@ require 'package'
 class Fftw < Package
   description 'FFTW is a C subroutine library for computing the discrete Fourier transform (DFT) in one or more dimensions, of arbitrary input size, and of both real and complex data'
   homepage 'http://www.fftw.org/'
-  @_ver = '3.3.9'
-  version @_ver
+  version '3.3.9'
   license 'GPL-2+'
   compatibility 'all'
-  source_url "http://www.fftw.org/fftw-#{@_ver}.tar.gz"
+  source_url "http://www.fftw.org/fftw-#{version}.tar.gz"
   source_sha256 'bf2c7ce40b04ae811af714deb512510cc2c17b9ab9d6ddcf49fe4487eea7af3d'
 
   binary_url({

--- a/packages/folks.rb
+++ b/packages/folks.rb
@@ -3,11 +3,10 @@ require 'package'
 class Folks < Package
   description 'Library to aggregates people into metacontacts'
   homepage 'https://wiki.gnome.org/Projects/Folks'
-  @_ver = '0.15.5'
-  version @_ver
+  version '0.15.5'
   license 'LGPL-2.1'
   compatibility 'all'
-  source_url "https://gitlab.gnome.org/GNOME/folks/-/archive/#{@_ver}/folks-#{@_ver}.tar.bz2"
+  source_url "https://gitlab.gnome.org/GNOME/folks/-/archive/#{version}/folks-#{version}.tar.bz2"
   source_sha256 'f79952f6b0c8f6c0fa2efefbcfc4d4875a2ee5e4518f7d4bf520b62b5c89568c'
 
   binary_url({

--- a/packages/gcr_3.rb
+++ b/packages/gcr_3.rb
@@ -3,11 +3,10 @@ require 'package'
 class Gcr_3 < Package
   description 'GNOME crypto package'
   homepage 'https://www.gnome.org'
-  @_ver = '3.41.1'
-  version @_ver
+  version '3.41.1'
   license 'GPL-2+ and LGPL-2+'
   compatibility 'all'
-  source_url "https://gitlab.gnome.org/GNOME/gcr/-/archive/#{@_ver}/gcr-#{@_ver}.tar.bz2"
+  source_url "https://gitlab.gnome.org/GNOME/gcr/-/archive/#{version}/gcr-#{version}.tar.bz2"
   source_sha256 '7e06e86e12aadaac6a72f2ee7eeaaaa6228a0ba3b92cadd50b45c0f05f0d91c6'
 
   binary_url({

--- a/packages/gcr_4.rb
+++ b/packages/gcr_4.rb
@@ -3,11 +3,10 @@ require 'package'
 class Gcr_4 < Package
   description 'GNOME crypto package'
   homepage 'https://www.gnome.org'
-  @_ver = '4.0.0'
-  version @_ver
+  version '4.0.0'
   license 'GPL-2+ and LGPL-2+'
   compatibility 'all'
-  source_url "https://gitlab.gnome.org/GNOME/gcr/-/archive/#{@_ver}/gcr-#{@_ver}.tar.bz2"
+  source_url "https://gitlab.gnome.org/GNOME/gcr/-/archive/#{version}/gcr-#{version}.tar.bz2"
   source_sha256 'e33e5daae4715a4701a37c05775ea4ab6da17cb005adedf617f3b367be018e4b'
 
   binary_url({

--- a/packages/gdbm.rb
+++ b/packages/gdbm.rb
@@ -3,11 +3,10 @@ require 'package'
 class Gdbm < Package
   description 'GNU dbm is a set of database routines that use extensible hashing.'
   homepage 'https://www.gnu.org/software/gdbm/'
-  @_ver = '1.23'
-  version @_ver
+  version '1.23'
   license 'GPL-3'
   compatibility 'all'
-  source_url "https://ftpmirror.gnu.org/gdbm/gdbm-#{@_ver}.tar.gz"
+  source_url "https://ftpmirror.gnu.org/gdbm/gdbm-#{version}.tar.gz"
   source_sha256 '74b1081d21fff13ae4bd7c16e5d6e504a4c26f7cde1dca0d963a484174bbcacd'
 
   binary_url({

--- a/packages/git_lfs.rb
+++ b/packages/git_lfs.rb
@@ -3,11 +3,10 @@ require 'package'
 class Git_lfs < Package
   description 'Git extension for versioning large files'
   homepage 'https://git-lfs.github.com'
-  @_ver = '2.13.2'
-  version @_ver
+  version '2.13.2'
   license 'AGPL-3'
   compatibility 'all'
-  source_url "https://github.com/git-lfs/git-lfs/releases/download/v#{@_ver}/git-lfs-v#{@_ver}.tar.gz"
+  source_url "https://github.com/git-lfs/git-lfs/releases/download/v#{version}/git-lfs-v#{version}.tar.gz"
   source_sha256 '782e6275df9ca370730945112e16a0b8c64b9819f0b61fae52ba1ebbc8dce2d5'
 
   binary_url({

--- a/packages/gnome_maps.rb
+++ b/packages/gnome_maps.rb
@@ -3,11 +3,10 @@ require 'package'
 class Gnome_maps < Package
   description 'A simple GNOME maps application'
   homepage 'https://wiki.gnome.org/Apps/Maps'
-  @_ver = '43.0'
-  version @_ver
+  version '43.0'
   license 'GPL-2+, LGPL-2+, MIT, CC-BY-3.0 and CC-BY-SA-3.0'
   compatibility 'armv7l aarch64 x86_64'
-  source_url "https://gitlab.gnome.org/GNOME/gnome-maps/-/archive/v#{@_ver}/gnome-maps-v#{@_ver}.tar.bz2"
+  source_url "https://gitlab.gnome.org/GNOME/gnome-maps/-/archive/v#{version}/gnome-maps-v#{version}.tar.bz2"
   source_sha256 '5e580c23a86f6b63d7c923aac7e6351e7b6765c74298f6a811d5a398a378db12'
 
   binary_url({

--- a/packages/gnome_online_accounts.rb
+++ b/packages/gnome_online_accounts.rb
@@ -3,11 +3,10 @@ require 'package'
 class Gnome_online_accounts < Package
   description 'Single sign-on framework for GNOME'
   homepage 'https://wiki.gnome.org/Projects/GnomeOnlineAccounts'
-  @_ver = '3.39.92'
-  version @_ver
+  version '3.39.92'
   license 'LGPL-2+'
   compatibility 'all'
-  source_url "https://gitlab.gnome.org/GNOME/gnome-online-accounts/-/archive/#{@_ver}/gnome-online-accounts-#{@_ver}.tar.bz2"
+  source_url "https://gitlab.gnome.org/GNOME/gnome-online-accounts/-/archive/#{version}/gnome-online-accounts-#{version}.tar.bz2"
   source_sha256 '89e27c886c0266b8c84a56dbb0fb0baefa704dd4d0ec47dd154a26590554adc9'
 
   binary_url({

--- a/packages/gnome_session.rb
+++ b/packages/gnome_session.rb
@@ -3,11 +3,10 @@ require 'package'
 class Gnome_session < Package
   description 'The GNOME Session Handler'
   homepage 'https://gitlab.gnome.org/GNOME/gnome-session'
-  @_ver = '43.0'
-  version @_ver
+  version '43.0'
   license 'GPL-2+'
   compatibility 'all'
-  source_url "https://gitlab.gnome.org/GNOME/gnome-session/-/archive/#{@_ver}/gnome-session-#{@_ver}.tar.bz2"
+  source_url "https://gitlab.gnome.org/GNOME/gnome-session/-/archive/#{version}/gnome-session-#{version}.tar.bz2"
   source_sha256 'a56b5a4179e4e567fb360e98ae1a1b8b8e3deed8fb0ff66d3f343e4623f59f3c'
 
   binary_url({

--- a/packages/gparted.rb
+++ b/packages/gparted.rb
@@ -3,11 +3,10 @@ require 'package'
 class Gparted < Package
   description 'A Partition Magic clone, frontend to GNU Parted'
   homepage 'https://gparted.org/'
-  @_ver = '1.5.0'
-  version @_ver
+  version '1.5.0'
   license 'GPL-2+ and FDL-1.2+'
   compatibility 'aarch64,armv7l,x86_64'
-  source_url "https://downloads.sourceforge.net/project/gparted/gparted/gparted-#{@_ver}/gparted-#{@_ver}.tar.gz"
+  source_url "https://downloads.sourceforge.net/project/gparted/gparted/gparted-#{version}/gparted-#{version}.tar.gz"
   source_sha256 '3c95ea26a944083ff1d9b17639b1e2ad9758df225dc751ff407b2a6aa092a8de'
 
   binary_url({

--- a/packages/gpgme.rb
+++ b/packages/gpgme.rb
@@ -3,11 +3,10 @@ require 'package'
 class Gpgme < Package
   description 'GnuPG Made Easy (GPGME) is a library designed to make access to GnuPG easier for applications.'
   homepage 'https://www.gnupg.org/related_software/gpgme/index.html'
-  @_ver = '1.17.1'
-  version @_ver
+  version '1.17.1'
   license 'GPL-2 and LGPL-2.1'
   compatibility 'all'
-  source_url "https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-#{@_ver}.tar.bz2"
+  source_url "https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-#{version}.tar.bz2"
   source_sha256 '711eabf5dd661b9b04be9edc9ace2a7bc031f6bd9d37a768d02d0efdef108f5f'
 
   binary_url({

--- a/packages/gsm.rb
+++ b/packages/gsm.rb
@@ -3,11 +3,10 @@ require 'package'
 class Gsm < Package
   description 'Shared libraries for GSM 06.10 lossy speech compression'
   homepage 'http://www.quut.com/gsm/'
-  @_ver = '1.0.19'
-  version @_ver
+  version '1.0.19'
   license 'gsm'
   compatibility 'all'
-  source_url "http://www.quut.com/gsm/gsm-#{@_ver}.tar.gz"
+  source_url "http://www.quut.com/gsm/gsm-#{version}.tar.gz"
   source_sha256 '4903652f68a8c04d0041f0d19b1eb713ddcd2aa011c5e595b3b8bca2755270f6'
 
   binary_url({

--- a/packages/gst_editing_services.rb
+++ b/packages/gst_editing_services.rb
@@ -3,11 +3,10 @@ require 'package'
 class Gst_editing_services < Package
   description 'GStreamer library for creating audio/video editors'
   homepage 'https://gstreamer.freedesktop.org/modules/gst-editing-services.html'
-  @_ver = '1.18.4'
-  version @_ver
+  version '1.18.4'
   license 'LGPL-2.0+'
   compatibility 'all'
-  source_url "https://gstreamer.freedesktop.org/src/gst-editing-services/gst-editing-services-#{@_ver}.tar.xz"
+  source_url "https://gstreamer.freedesktop.org/src/gst-editing-services/gst-editing-services-#{version}.tar.xz"
   source_sha256 '4687b870a7de18aebf50f45ff572ad9e0138020e3479e02a6f056a0c4c7a1d04'
 
   binary_url({

--- a/packages/gusb.rb
+++ b/packages/gusb.rb
@@ -3,11 +3,10 @@ require 'package'
 class Gusb < Package
   description 'LibGUsb is a GObject wrapper for libusb1'
   homepage 'https://www.openhub.net/p/gusb'
-  @_ver = '0.3.5'
-  version @_ver
+  version '0.3.5'
   license 'LGPL-2.1+'
   compatibility 'all'
-  source_url "https://github.com/hughsie/libgusb/archive/#{@_ver}.tar.gz"
+  source_url "https://github.com/hughsie/libgusb/archive/#{version}.tar.gz"
   source_sha256 '188c7964422417d39b02a5c645e136b1389c80e38e7abfa911fc196b9c748f45'
 
   binary_url({

--- a/packages/inetutils.rb
+++ b/packages/inetutils.rb
@@ -3,11 +3,10 @@ require 'package'
 class Inetutils < Package
   description 'The Inetutils package contains programs for basic networking. Such as dnsdomainname, ftp, hostname, ifconfig, ping, ping6, talk, telnet, tftp, traceroute'
   homepage 'https://www.gnu.org/software/inetutils/'
-  @_ver = '2.2'
-  version @_ver
+  version '2.2'
   license 'GPL-3'
   compatibility 'all'
-  source_url "https://ftpmirror.gnu.org/inetutils/inetutils-#{@_ver}.tar.xz"
+  source_url "https://ftpmirror.gnu.org/inetutils/inetutils-#{version}.tar.xz"
   source_sha256 'd547f69172df73afef691a0f7886280fd781acea28def4ff4b4b212086a89d80'
 
   binary_url({

--- a/packages/jack.rb
+++ b/packages/jack.rb
@@ -3,11 +3,10 @@ require 'package'
 class Jack < Package
   description 'JACK (JACK Audio Connection Kit) refers to an API that provides a basic infrastructure for audio applications to communicate with each other and with audio hardware.'
   homepage 'https://jackaudio.org/'
-  @_ver = '1.9.21'
-  version @_ver
+  version '1.9.21'
   license 'GPL-2+'
   compatibility 'all'
-  source_url "https://github.com/jackaudio/jack2/archive/v#{@_ver}.tar.gz"
+  source_url "https://github.com/jackaudio/jack2/archive/v#{version}.tar.gz"
   source_sha256 '8b044a40ba5393b47605a920ba30744fdf8bf77d210eca90d39c8637fe6bc65d'
 
   binary_url({

--- a/packages/jansson.rb
+++ b/packages/jansson.rb
@@ -3,11 +3,10 @@ require 'package'
 class Jansson < Package
   description 'Jansson is a C library for encoding, decoding and manipulating JSON data.'
   homepage 'http://www.digip.org/jansson/'
-  @_ver = '2.13.1'
-  version @_ver
+  version '2.13.1'
   license 'MIT'
   compatibility 'all'
-  source_url "https://github.com/akheron/jansson/archive/v#{@_ver}.tar.gz"
+  source_url "https://github.com/akheron/jansson/archive/v#{version}.tar.gz"
   source_sha256 'f22901582138e3203959c9257cf83eba9929ac41d7be4a42557213a22ebcc7a0'
 
   binary_url({

--- a/packages/l_smash.rb
+++ b/packages/l_smash.rb
@@ -3,11 +3,10 @@ require 'package'
 class L_smash < Package
   description 'MP4 muxer and other tools'
   homepage 'https://github.com/l-smash/l-smash'
-  @_ver = '2.14.5'
-  version @_ver
+  version '2.14.5'
   license 'ISC'
   compatibility 'all'
-  source_url "https://github.com/l-smash/l-smash/archive/v#{@_ver}.tar.gz"
+  source_url "https://github.com/l-smash/l-smash/archive/v#{version}.tar.gz"
   source_sha256 'e6f7c31de684f4b89ee27e5cd6262bf96f2a5b117ba938d2d606cf6220f05935'
 
   binary_url({

--- a/packages/lcms.rb
+++ b/packages/lcms.rb
@@ -3,11 +3,10 @@ require 'package'
 class Lcms < Package
   description 'Little CMS intends to be an OPEN SOURCE small-footprint color management engine, with special focus on accuracy and performance.'
   homepage 'http://www.littlecms.com/'
-  @_ver = '2.12'
-  version @_ver
+  version '2.12'
   license 'MIT'
   compatibility 'all'
-  source_url "https://github.com/mm2/Little-CMS/releases/download/lcms#{@_ver}/lcms2-#{@_ver}.tar.gz"
+  source_url "https://github.com/mm2/Little-CMS/releases/download/lcms#{version}/lcms2-#{version}.tar.gz"
   source_sha256 '18663985e864100455ac3e507625c438c3710354d85e5cbb7cd4043e11fe10f5'
 
   binary_url({

--- a/packages/libde265.rb
+++ b/packages/libde265.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libde265 < Package
   description 'Open h.265 video codec implementation.'
   homepage 'https://github.com/strukturag/libde265'
-  @_ver = '1.0.11'
-  version @_ver
+  version '1.0.11'
   license 'GPL-3'
   compatibility 'x86_64 aarch64 armv7l'
-  source_url "https://github.com/strukturag/libde265/releases/download/v#{@_ver}/libde265-#{@_ver}.tar.gz"
+  source_url "https://github.com/strukturag/libde265/releases/download/v#{version}/libde265-#{version}.tar.gz"
   source_sha256 '2f8f12cabbdb15e53532b7c1eb964d4e15d444db1be802505e6ac97a25035bab'
 
   binary_url({

--- a/packages/libgpgerror.rb
+++ b/packages/libgpgerror.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libgpgerror < Package
   description 'Libgpg-error is a small library that defines common error values for all GnuPG components.'
   homepage 'https://www.gnupg.org/related_software/libgpg-error/index.html'
-  @_ver = '1.46'
-  version @_ver
+  version '1.46'
   license 'GPL-2 and LGPL-2.1'
   compatibility 'all'
-  source_url "https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-#{@_ver}.tar.bz2"
+  source_url "https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-#{version}.tar.bz2"
   source_sha256 'b7e11a64246bbe5ef37748de43b245abd72cfcd53c9ae5e7fc5ca59f1c81268d'
 
   binary_url({

--- a/packages/libmbim.rb
+++ b/packages/libmbim.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libmbim < Package
   description 'libmbim is a glib-based library for talking to WWAN modems and devices which speak the Mobile Interface Broadband Model (MBIM) protocol.'
   homepage 'https://www.freedesktop.org/wiki/Software/libmbim/'
-  @_ver = '1.24.6'
-  version @_ver
+  version '1.24.6'
   license 'LGPL-2'
   compatibility 'all'
-  source_url "https://www.freedesktop.org/software/libmbim/libmbim-#{@_ver}.tar.xz"
+  source_url "https://www.freedesktop.org/software/libmbim/libmbim-#{version}.tar.xz"
   source_sha256 '760465caaa1ccd699c14290e9791da456d5300dd11ebf4c1486151033e875dfd'
 
   binary_url({

--- a/packages/libnewt.rb
+++ b/packages/libnewt.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libnewt < Package
   description 'Not Eriks Windowing Toolkit - text mode windowing with slang'
   homepage 'https://pagure.io/newt'
-  @_ver = '0.52.21'
-  version @_ver
+  version '0.52.21'
   license 'LGPL-2'
   compatibility 'all'
-  source_url "https://releases.pagure.org/newt/newt-#{@_ver}.tar.gz"
+  source_url "https://releases.pagure.org/newt/newt-#{version}.tar.gz"
   source_sha256 '265eb46b55d7eaeb887fca7a1d51fe115658882dfe148164b6c49fccac5abb31'
 
   binary_url({

--- a/packages/libnotify.rb
+++ b/packages/libnotify.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libnotify < Package
   description 'A library for sending desktop notifications.'
   homepage 'https://git.gnome.org/browse/libnotify'
-  @_ver = '0.8.1'
-  version @_ver
+  version '0.8.1'
   license 'LGPL-2.1+'
   compatibility 'all'
-  source_url "https://github.com/GNOME/libnotify/archive/#{@_ver}.tar.gz"
+  source_url "https://github.com/GNOME/libnotify/archive/#{version}.tar.gz"
   source_sha256 '7c0b252edecbf08db50d775f9e720ecc03c742fb97c25f3966a8b7a4bedf8133'
 
   binary_url({

--- a/packages/libostree.rb
+++ b/packages/libostree.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libostree < Package
   description 'libostree manages operating system and container binary deployment and upgrades.'
   homepage 'https://ostreedev.github.io/ostree/'
-  @_ver = '2020.8'
-  version @_ver
+  version '2020.8'
   license 'LGPL-2+'
   compatibility 'all'
-  source_url "https://github.com/ostreedev/ostree/releases/download/v#{@_ver}/libostree-#{@_ver}.tar.xz"
+  source_url "https://github.com/ostreedev/ostree/releases/download/v#{version}/libostree-#{version}.tar.xz"
   source_sha256 'fdaa5992d0a6f62157152355449ac8476c50df6602be398e9ad10438cc1e679b'
 
   binary_url({

--- a/packages/libotf.rb
+++ b/packages/libotf.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libotf < Package
   description 'OpenType Font library'
   homepage 'https://www.nongnu.org/m17n/'
-  @_ver = '0.9.16'
-  version @_ver
+  version '0.9.16'
   license 'LGPL-2.1'
   compatibility 'all'
-  source_url "https://download.savannah.gnu.org/releases/m17n/libotf-#{@_ver}.tar.gz"
+  source_url "https://download.savannah.gnu.org/releases/m17n/libotf-#{version}.tar.gz"
   source_sha256 '68db0ca3cda2d46a663a92ec26e6eb5adc392ea5191bcda74268f0aefa78066b'
 
   binary_url({

--- a/packages/libpipeline.rb
+++ b/packages/libpipeline.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libpipeline < Package
   description 'libpipeline is a C library for manipulating pipelines of subprocesses in a flexible and convenient way.'
   homepage 'http://libpipeline.nongnu.org/'
-  @_ver = '1.5.3'
-  version @_ver
+  version '1.5.3'
   license 'GPL-3'
   compatibility 'all'
-  source_url "https://mirror.csclub.uwaterloo.ca/nongnu/libpipeline/libpipeline-#{@_ver}.tar.gz"
+  source_url "https://mirror.csclub.uwaterloo.ca/nongnu/libpipeline/libpipeline-#{version}.tar.gz"
   source_sha256 '5dbf08faf50fad853754293e57fd4e6c69bb8e486f176596d682c67e02a0adb0'
 
   binary_url({

--- a/packages/libqmi.rb
+++ b/packages/libqmi.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libqmi < Package
   description 'libqmi is a glib-based library for talking to WWAN modems and devices which speak the Qualcomm MSM Interface (QMI) protocol.'
   homepage 'https://www.freedesktop.org/wiki/Software/libqmi/'
-  @_ver = '1.28.2'
-  version @_ver
+  version '1.28.2'
   license 'LGPL-2'
   compatibility 'all'
-  source_url "https://www.freedesktop.org/software/libqmi/libqmi-#{@_ver}.tar.xz"
+  source_url "https://www.freedesktop.org/software/libqmi/libqmi-#{version}.tar.xz"
   source_sha256 '8c8c3ee719874d2529bce9b35b028fe435b36f003979a360d3ad0938449db783'
 
   binary_url({

--- a/packages/libseccomp.rb
+++ b/packages/libseccomp.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libseccomp < Package
   description 'The libseccomp library provides an easy to use, platform independent, interface to the Linux Kernel\'s syscall filtering mechanism.'
   homepage 'https://github.com/seccomp/libseccomp'
-  @_ver = '2.5.4'
-  version @_ver
+  version '2.5.4'
   license 'LGPL-2.1'
   compatibility 'all'
-  source_url "https://github.com/seccomp/libseccomp/archive/v#{@_ver}.tar.gz"
+  source_url "https://github.com/seccomp/libseccomp/archive/v#{version}.tar.gz"
   source_sha256 '96bbadb4384716272a6d2be82801dc564f7aab345febfe9b698b70fc606e3f75'
 
   binary_url({

--- a/packages/libsigcplusplus.rb
+++ b/packages/libsigcplusplus.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libsigcplusplus < Package
   description 'libsigc++ implements a typesafe callback system for standard C++.'
   homepage 'https://github.com/libsigcplusplus/libsigcplusplus/'
-  @_ver = '2.10.8'
-  version @_ver
+  version '2.10.8'
   license 'LGPL-3'
   compatibility 'all'
-  source_url "https://github.com/libsigcplusplus/libsigcplusplus/archive/#{@_ver}.tar.gz"
+  source_url "https://github.com/libsigcplusplus/libsigcplusplus/archive/#{version}.tar.gz"
   source_sha256 '3a66dfb699cf5301f5e141895c9db728006c2e09f006af62d847e3808609e418'
 
   binary_url({

--- a/packages/libsigcplusplus3.rb
+++ b/packages/libsigcplusplus3.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libsigcplusplus3 < Package
   description 'libsigc++ implements a typesafe callback system for standard C++.'
   homepage 'https://github.com/libsigcplusplus/libsigcplusplus/'
-  @_ver = '3.0.6'
-  version @_ver
+  version '3.0.6'
   license 'LGPL-3'
   compatibility 'all'
-  source_url "https://github.com/libsigcplusplus/libsigcplusplus/archive/#{@_ver}.tar.gz"
+  source_url "https://github.com/libsigcplusplus/libsigcplusplus/archive/#{version}.tar.gz"
   source_sha256 '25ff9bf59c28e185c3901963f11bbdac58ce866281c65c870145b119e59a0836'
 
   binary_url({

--- a/packages/libtirpc.rb
+++ b/packages/libtirpc.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libtirpc < Package
   description 'Libtirpc is a port of Suns Transport-Independent RPC library to Linux.'
   homepage 'https://sourceforge.net/projects/libtirpc'
-  @_ver = '1.3.3'
-  version @_ver
+  version '1.3.3'
   license 'GPL-2'
   compatibility 'all'
-  source_url "http://downloads.sourceforge.net/project/libtirpc/libtirpc/#{@_ver}/libtirpc-#{@_ver}.tar.bz2"
+  source_url "http://downloads.sourceforge.net/project/libtirpc/libtirpc/#{version}/libtirpc-#{version}.tar.bz2"
   source_sha256 '6474e98851d9f6f33871957ddee9714fdcd9d8a5ee9abb5a98d63ea2e60e12f3'
 
   binary_url({

--- a/packages/libunbound.rb
+++ b/packages/libunbound.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libunbound < Package
   description 'Unbound is a validating, recursive, and caching DNS resolver.'
   homepage 'https://nlnetlabs.nl/projects/unbound/about/'
-  @_ver = '1.17.1'
-  version @_ver
+  version '1.17.1'
   license 'BSD and GPL-2'
   compatibility 'all'
-  source_url "https://nlnetlabs.nl/downloads/unbound/unbound-#{@_ver}.tar.gz"
+  source_url "https://nlnetlabs.nl/downloads/unbound/unbound-#{version}.tar.gz"
   source_sha256 'ee4085cecce12584e600f3d814a28fa822dfaacec1f94c84bfd67f8a5571a5f4'
 
   binary_url({

--- a/packages/libusb.rb
+++ b/packages/libusb.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libusb < Package
   description 'A cross-platform library that gives apps easy access to USB devices'
   homepage 'https://sourceforge.net/projects/libusb/'
-  @_ver = '1.0.26'
-  version @_ver
+  version '1.0.26'
   license 'LGPL-2.1'
   compatibility 'all'
-  source_url "https://github.com/libusb/libusb/releases/download/v#{@_ver}/libusb-#{@_ver}.tar.bz2"
+  source_url "https://github.com/libusb/libusb/releases/download/v#{version}/libusb-#{version}.tar.bz2"
   source_sha256 '12ce7a61fc9854d1d2a1ffe095f7b5fac19ddba095c259e6067a46500381b5a5'
 
   binary_url({

--- a/packages/libuv.rb
+++ b/packages/libuv.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libuv < Package
   description 'libuv is a multi-platform support library with a focus on asynchronous I/O.'
   homepage 'https://libuv.org/'
-  @_ver = '1.44.2'
-  version @_ver
+  version '1.44.2'
   license 'BSD, BSD-2, ISC and MIT'
   compatibility 'all'
-  source_url "https://dist.libuv.org/dist/v#{@_ver}/libuv-v#{@_ver}.tar.gz"
+  source_url "https://dist.libuv.org/dist/v#{version}/libuv-v#{version}.tar.gz"
   source_sha256 'ccfcdc968c55673c6526d8270a9c8655a806ea92468afcbcabc2b16040f03cb4'
 
   binary_url({

--- a/packages/libva_utils.rb
+++ b/packages/libva_utils.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libva_utils < Package
   description 'Libva-utils is a collection of tests for VA-API (VIdeo Acceleration API)'
   homepage 'https://01.org/linuxmedia'
-  @_ver = '2.11.1'
-  version @_ver
+  version '2.11.1'
   license 'MIT'
   compatibility 'all'
-  source_url "https://github.com/intel/libva-utils/archive/refs/tags/#{@_ver}.tar.gz"
+  source_url "https://github.com/intel/libva-utils/archive/refs/tags/#{version}.tar.gz"
   source_sha256 '0c1eb7f717e391d00da74c53a9fe5caf3d6c510dcd35bac7f71a0e59ad1b8d26'
 
   binary_url({

--- a/packages/libvips.rb
+++ b/packages/libvips.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libvips < Package
   description 'A fast image processing library with low memory needs'
   homepage 'https://libvips.github.io/libvips/'
-  @_ver = '8.10.6-beta2'
-  version @_ver
+  version '8.10.6-beta2'
   license 'LGPL-2.1'
   compatibility 'all'
-  source_url "https://github.com/libvips/libvips/archive/v#{@_ver}.tar.gz"
+  source_url "https://github.com/libvips/libvips/archive/v#{version}.tar.gz"
   source_sha256 'b2412f580ba83129d55e57a73c7c4fdb53e60a39c48910acc5f0d80518deb7a5'
 
   binary_url({

--- a/packages/libvncserver.rb
+++ b/packages/libvncserver.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libvncserver < Package
   description 'LibVNCServer/LibVNCClient are cross-platform C libraries that allow you to easily implement VNC server or client functionality in your program.'
   homepage 'https://github.com/LibVNC/libvncserver'
-  @_ver = '0.9.14'
-  version @_ver
+  version '0.9.14'
   compatibility 'all'
   license 'GPL-2, GPL-2+, LGPL-2.1+, BSD and MIT'
-  source_url "https://github.com/LibVNC/libvncserver/archive/LibVNCServer-#{@_ver}.tar.gz"
+  source_url "https://github.com/LibVNC/libvncserver/archive/LibVNCServer-#{version}.tar.gz"
   source_sha256 '83104e4f7e28b02f8bf6b010d69b626fae591f887e949816305daebae527c9a5'
 
   binary_url({

--- a/packages/libvpx.rb
+++ b/packages/libvpx.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libvpx < Package
   description 'VP8/VP9 Codec SDK'
   homepage 'http://www.webmproject.org/code/'
-  @_ver = '1.10.0-rc1'
-  version @_ver
+  version '1.10.0-rc1'
   license 'BSD'
   compatibility 'all'
-  source_url "https://github.com/webmproject/libvpx/archive/v#{@_ver}.tar.gz"
+  source_url "https://github.com/webmproject/libvpx/archive/v#{version}.tar.gz"
   source_sha256 '8e55e04cdefeb1596968e70c5167e13d26132ca214d276292d5cda737a430af5'
 
   binary_url({

--- a/packages/libwpe.rb
+++ b/packages/libwpe.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libwpe < Package
   description 'General-purpose library for WPE WebKit'
   homepage 'https://wpewebkit.org'
-  @_ver = '1.14.0'
-  version @_ver
+  version '1.14.0'
   license 'BSD-2'
   compatibility 'all'
-  source_url "https://github.com/WebPlatformForEmbedded/libwpe/releases/download/#{@_ver}/libwpe-#{@_ver}.tar.xz"
+  source_url "https://github.com/WebPlatformForEmbedded/libwpe/releases/download/#{version}/libwpe-#{version}.tar.xz"
   source_sha256 'c073305bbac5f4402cc1c8a4753bfa3d63a408901f86182051eaa5a75dd89c00'
 
   binary_url({

--- a/packages/libx265.rb
+++ b/packages/libx265.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libx265 < Package
   description 'x265 is a H.265 / HEVC video encoder application library.'
   homepage 'http://x265.org/'
-  @_ver = '3.4'
-  version @_ver
+  version '3.4'
   license 'GPL-2'
   compatibility 'all'
-  source_url "https://github.com/videolan/x265/archive/#{@_ver}.tar.gz"
+  source_url "https://github.com/videolan/x265/archive/#{version}.tar.gz"
   source_sha256 '544d147bf146f8994a7bf8521ed878c93067ea1c7c6e93ab602389be3117eaaf'
 
   binary_url({

--- a/packages/libxcrypt.rb
+++ b/packages/libxcrypt.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libxcrypt < Package
   description 'Modern library for one-way hashing of passwords'
   homepage 'https://github.com/besser82/libxcrypt/'
-  @_ver = '4.4.18'
-  version @_ver
+  version '4.4.18'
   license 'LGPL-2.1+, public-domain, BSD and BSD-2'
   compatibility 'all'
-  source_url "https://github.com/besser82/libxcrypt/archive/v#{@_ver}.tar.gz"
+  source_url "https://github.com/besser82/libxcrypt/archive/v#{version}.tar.gz"
   source_sha256 '3801f0263a8596b15ec466343fc1fdc4ad4ec7416c51e038a3528fd47f3be01a'
 
   binary_url({

--- a/packages/libxcursor.rb
+++ b/packages/libxcursor.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libxcursor < Package
   description 'X.org X Cursor management library'
   homepage 'http://www.x.org'
-  @_ver = '1.2.1'
-  version @_ver
+  version '1.2.1'
   license 'MIT'
   compatibility 'all'
-  source_url "https://www.x.org/archive/individual/lib/libXcursor-#{@_ver}.tar.gz"
+  source_url "https://www.x.org/archive/individual/lib/libXcursor-#{version}.tar.gz"
   source_sha256 '77f96b9ad0a3c422cfa826afabaf1e02b9bfbfc8908c5fa1a45094faad074b98'
 
   binary_url({

--- a/packages/libxi.rb
+++ b/packages/libxi.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libxi < Package
   description 'X.org libXi Client library for XInput'
   homepage 'https://x.org'
-  @_ver = '1.7.10'
-  version @_ver
+  version '1.7.10'
   license 'MIT and custom'
   compatibility 'all'
-  source_url "https://www.x.org/archive/individual/lib/libXi-#{@_ver}.tar.gz"
+  source_url "https://www.x.org/archive/individual/lib/libXi-#{version}.tar.gz"
   source_sha256 'b51e106c445a49409f3da877aa2f9129839001b24697d75a54e5c60507e9a5e3'
 
   binary_url({

--- a/packages/libxkbcommon.rb
+++ b/packages/libxkbcommon.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libxkbcommon < Package
   description 'Keymap handling library for toolkits and window systems'
   homepage 'https://xkbcommon.org'
-  @_ver = '1.0.3'
-  version @_ver
+  version '1.0.3'
   license 'MIT'
   compatibility 'all'
-  source_url "https://xkbcommon.org/download/libxkbcommon-#{@_ver}.tar.xz"
+  source_url "https://xkbcommon.org/download/libxkbcommon-#{version}.tar.xz"
   source_sha256 'a2202f851e072b84e64a395212cbd976ee18a8ee602008b0bad02a13247dbc52'
 
   binary_url({

--- a/packages/mercurial.rb
+++ b/packages/mercurial.rb
@@ -3,11 +3,10 @@ require 'package'
 class Mercurial < Package
   description 'Mercurial is a free, distributed source control management tool. It efficiently handles projects of any size and offers an easy and intuitive interface.'
   homepage 'https://www.mercurial-scm.org/'
-  @_ver = '5.9.2'
-  version @_ver
+  version '5.9.2'
   license 'GPL-2+'
   compatibility 'all'
-  source_url "https://www.mercurial-scm.org/release/mercurial-#{@_ver}.tar.gz"
+  source_url "https://www.mercurial-scm.org/release/mercurial-#{version}.tar.gz"
   source_sha256 '1edad93096f64d5cae55b9550bb835ac73840c7406861c3cf4e14c3b443bec54'
 
   binary_url({

--- a/packages/mobile_broadband_provider_info.rb
+++ b/packages/mobile_broadband_provider_info.rb
@@ -3,11 +3,10 @@ require 'package'
 class Mobile_broadband_provider_info < Package
   description 'Network Management daemon'
   homepage 'https://gitlab.gnome.org/GNOME/mobile-broadband-provider-info'
-  @_ver = '20201225'
-  version @_ver
+  version '20201225'
   license 'CC-PD'
   compatibility 'all'
-  source_url "https://gitlab.gnome.org/GNOME/mobile-broadband-provider-info/-/archive/#{@_ver}/mobile-broadband-provider-info-#{@_ver}.tar.bz2"
+  source_url "https://gitlab.gnome.org/GNOME/mobile-broadband-provider-info/-/archive/#{version}/mobile-broadband-provider-info-#{version}.tar.bz2"
   source_sha256 '0616b3d0580575741d4319ac71ca67c9a378879943d32a67ac0460615767bcdf'
 
   binary_url({

--- a/packages/modemmanager.rb
+++ b/packages/modemmanager.rb
@@ -3,11 +3,10 @@ require 'package'
 class Modemmanager < Package
   description 'ModemManager is a DBus-activated daemon which controls mobile broadband (2G/3G/4G) devices and connections.'
   homepage 'https://www.freedesktop.org/wiki/Software/ModemManager/'
-  @_ver = '1.16.2'
-  version @_ver
+  version '1.16.2'
   license 'GPL-2+'
   compatibility 'all'
-  source_url "https://www.freedesktop.org/software/ModemManager/ModemManager-#{@_ver}.tar.xz"
+  source_url "https://www.freedesktop.org/software/ModemManager/ModemManager-#{version}.tar.xz"
   source_sha256 'efa9a963499e0885f3f163096d433334143c4937545134ecd682e0157fa591e3'
 
   binary_url({

--- a/packages/mono.rb
+++ b/packages/mono.rb
@@ -3,11 +3,10 @@ require 'package'
 class Mono < Package
   description 'Mono is a software platform designed to allow developers to easily create cross platform applications part of the .NET Foundation.'
   homepage 'http://www.mono-project.com/'
-  @_ver = '6.12.0.122'
-  version @_ver
+  version '6.12.0.122'
   license 'MIT, LGPL-2.1, GPL-2, BSD-4, NPL-1.1, Ms-PL, GPL-3-with-linking-exception and IDPL'
   compatibility 'all'
-  source_url "https://download.mono-project.com/sources/mono/mono-#{@_ver}.tar.xz"
+  source_url "https://download.mono-project.com/sources/mono/mono-#{version}.tar.xz"
   source_sha256 '29c277660fc5e7513107aee1cbf8c5057c9370a4cdfeda2fc781be6986d89d23'
 
   binary_url({

--- a/packages/mtools.rb
+++ b/packages/mtools.rb
@@ -3,11 +3,10 @@ require 'package'
 class Mtools < Package
   description 'Mtools is a collection of utilities to access MS-DOS disks from GNU and Unix without mounting them.'
   homepage 'https://www.gnu.org/software/mtools/'
-  @_ver = '4.0.26'
-  version @_ver
+  version '4.0.26'
   license 'GPL-3'
   compatibility 'all'
-  source_url "https://ftp.gnu.org/gnu/mtools/mtools-#{@_ver}.tar.lz"
+  source_url "https://ftp.gnu.org/gnu/mtools/mtools-#{version}.tar.lz"
   source_sha256 'd09cff66d7277ad36a7573fc3e9803bfa558cdda83baabaafbf7761317462283'
 
   binary_url({

--- a/packages/musl_curl.rb
+++ b/packages/musl_curl.rb
@@ -3,11 +3,10 @@ require 'package'
 class Musl_curl < Package
   description 'Command line tool and library for transferring data with URLs.'
   homepage 'https://curl.se/'
-  @_ver = '7.84.0'
-  version @_ver
+  version '7.84.0'
   license 'curl'
   compatibility 'all'
-  source_url "https://curl.se/download/curl-#{@_ver}.tar.xz"
+  source_url "https://curl.se/download/curl-#{version}.tar.xz"
   source_sha256 '2d118b43f547bfe5bae806d8d47b4e596ea5b25a6c1f080aef49fbcd817c5db8'
 
   binary_url({

--- a/packages/musl_libunbound.rb
+++ b/packages/musl_libunbound.rb
@@ -3,11 +3,10 @@ require 'package'
 class Musl_libunbound < Package
   description 'Unbound is a validating, recursive, and caching DNS resolver.'
   homepage 'https://nlnetlabs.nl/projects/unbound/about/'
-  @_ver = '1.15.0'
-  version @_ver
+  version '1.15.0'
   license 'BSD and GPL-2'
   compatibility 'all'
-  source_url "https://nlnetlabs.nl/downloads/unbound/unbound-#{@_ver}.tar.gz"
+  source_url "https://nlnetlabs.nl/downloads/unbound/unbound-#{version}.tar.gz"
   source_sha256 'a480dc6c8937447b98d161fe911ffc76cfaffa2da18788781314e81339f1126f'
 
   binary_url({

--- a/packages/musl_openssl.rb
+++ b/packages/musl_openssl.rb
@@ -3,11 +3,10 @@ require 'package'
 class Musl_openssl < Package
   description 'The Open Source toolkit for Secure Sockets Layer and Transport Layer Security'
   homepage 'https://www.openssl.org'
-  @_ver = '3.0.9'
-  version @_ver
+  version '3.0.9'
   license 'openssl'
   compatibility 'all'
-  source_url "https://www.openssl.org/source/openssl-#{@_ver}.tar.gz"
+  source_url "https://www.openssl.org/source/openssl-#{version}.tar.gz"
   source_sha256 'eb1ab04781474360f77c318ab89d8c5a03abc38e63d65a603cabbf1b00a1dc90'
 
   binary_url({

--- a/packages/nettle.rb
+++ b/packages/nettle.rb
@@ -3,11 +3,10 @@ require 'package'
 class Nettle < Package
   description 'Nettle is a cryptographic library that is designed to fit easily in more or less any context: In crypto toolkits for object-oriented languages (C++, Python, Pike, ...), in applications like LSH or GNUPG, or even in kernel space.'
   homepage 'http://www.lysator.liu.se/~nisse/nettle/'
-  @_ver = '3.7.2'
-  version @_ver
+  version '3.7.2'
   license 'LGPL-3 or LGPL-2.1'
   compatibility 'all'
-  source_url "https://ftpmirror.gnu.org/nettle/nettle-#{@_ver}.tar.gz"
+  source_url "https://ftpmirror.gnu.org/nettle/nettle-#{version}.tar.gz"
   source_sha256 '8d2a604ef1cde4cd5fb77e422531ea25ad064679ff0adf956e78b3352e0ef162'
 
   binary_url({

--- a/packages/networkmanager.rb
+++ b/packages/networkmanager.rb
@@ -3,11 +3,10 @@ require 'package'
 class Networkmanager < Package
   description 'Network connection manager and user applications'
   homepage 'https://wiki.gnome.org/Projects/NetworkManager'
-  @_ver = '1.42.2'
-  version @_ver
+  version '1.42.2'
   license 'GPL-2+ and LGPL-2.1+'
   compatibility 'aarch64,armv7l,x86_64'
-  source_url "https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/archive/#{@_ver}/NetworkManager#{@_ver}.tar.bz2"
+  source_url "https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/archive/#{version}/NetworkManager#{version}.tar.bz2"
   source_sha256 '939a27acb0520efc4af3bb7a7dac1e85c34a4b8bbec2f59e2247baf93ac81403'
 
   binary_url({

--- a/packages/openldap.rb
+++ b/packages/openldap.rb
@@ -3,11 +3,10 @@ require 'package'
 class Openldap < Package
   description 'OpenLDAP Software is an open source implementation of the Lightweight Directory Access Protocol.'
   homepage 'https://www.openldap.org/'
-  @_ver = '2.6.4'
-  version @_ver
+  version '2.6.4'
   license 'OpenLDAP and GPL-2'
   compatibility 'all'
-  source_url "https://openldap.org/software/download/OpenLDAP/openldap-release/openldap-#{@_ver}.tgz"
+  source_url "https://openldap.org/software/download/OpenLDAP/openldap-release/openldap-#{version}.tgz"
   source_sha256 'd51704e50178430c06cf3d8aa174da66badf559747a47d920bb54b2d4aa40991'
 
   binary_url({

--- a/packages/poppler.rb
+++ b/packages/poppler.rb
@@ -3,11 +3,10 @@ require 'package'
 class Poppler < Package
   description 'Poppler is a PDF rendering library based on the xpdf-3.0 code base.'
   homepage 'https://poppler.freedesktop.org/'
-  @_ver = '23.05.0'
-  version @_ver
+  version '23.05.0'
   license 'GPL-2'
   compatibility 'x86_64 aarch64 armv7l'
-  source_url "https://poppler.freedesktop.org/poppler-#{@_ver}.tar.xz"
+  source_url "https://poppler.freedesktop.org/poppler-#{version}.tar.xz"
   source_sha256 '38294de7149ebe458191a6e6d0e2837da7dba8683900a635252f6d0ee235f990'
 
   binary_url({

--- a/packages/poppler_data.rb
+++ b/packages/poppler_data.rb
@@ -3,11 +3,10 @@ require 'package'
 class Poppler_data < Package
   description 'This additional package consists of encoding files for use with Poppler.'
   homepage 'https://poppler.freedesktop.org/'
-  @_ver = '0.4.12'
-  version @_ver
+  version '0.4.12'
   license 'BSD, GPL-2 and MIT'
   compatibility 'x86_64 aarch64 armv7l'
-  source_url "https://poppler.freedesktop.org/poppler-data-#{@_ver}.tar.gz"
+  source_url "https://poppler.freedesktop.org/poppler-data-#{version}.tar.gz"
   source_sha256 'c835b640a40ce357e1b83666aabd95edffa24ddddd49b8daff63adb851cdab74'
 
   binary_url({

--- a/packages/protobuf.rb
+++ b/packages/protobuf.rb
@@ -6,11 +6,10 @@ require 'package'
 class Protobuf < Package
   description 'Protocol Buffers - Googles data interchange format'
   homepage 'https://developers.google.com/protocol-buffers/'
-  @_ver = '21.12'
-  version @_ver
+  version '21.12'
   license 'BSD'
   compatibility 'all'
-  source_url "https://github.com/protocolbuffers/protobuf/archive/v#{@_ver}/protobuf-#{@_ver}.tar.gz"
+  source_url "https://github.com/protocolbuffers/protobuf/archive/v#{version}/protobuf-#{version}.tar.gz"
   source_sha256 '22fdaf641b31655d4b2297f9981fa5203b2866f8332d3c6333f6b0107bb320de'
 
   binary_url({

--- a/packages/psmisc.rb
+++ b/packages/psmisc.rb
@@ -3,11 +3,10 @@ require 'package'
 class Psmisc < Package
   description 'PSmisc is a set of some small useful utilities that use the proc filesystem.'
   homepage 'https://gitlab.com/psmisc/psmisc'
-  @_ver = '23.6'
-  version @_ver
+  version '23.6'
   license 'GPL-2'
   compatibility 'all'
-  source_url "https://gitlab.com/psmisc/psmisc/-/archive/v#{@_ver}/psmisc-v#{@_ver}.tar.bz2"
+  source_url "https://gitlab.com/psmisc/psmisc/-/archive/v#{version}/psmisc-v#{version}.tar.bz2"
   source_sha256 '91573ca0a1a50bd491b7c3cbe400126b0dadef9a2e328030d6469bb2448e0794'
 
   binary_url({

--- a/packages/python3.rb
+++ b/packages/python3.rb
@@ -3,11 +3,10 @@ require 'package'
 class Python3 < Package
   description 'Python is a programming language that lets you work quickly and integrate systems more effectively.'
   homepage 'https://www.python.org/'
-  @_ver = '3.11.4'
-  version @_ver
+  version '3.11.4'
   license 'PSF-2.0'
   compatibility 'all'
-  source_url "https://www.python.org/ftp/python/#{@_ver}/Python-#{@_ver}.tar.xz"
+  source_url "https://www.python.org/ftp/python/#{version}/Python-#{version}.tar.xz"
   source_sha256 '2f0e409df2ab57aa9fc4cbddfb976af44e4e55bf6f619eee6bc5c2297264a7f6'
 
   binary_url({

--- a/packages/re2.rb
+++ b/packages/re2.rb
@@ -3,12 +3,11 @@ require 'package'
 class Re2 < Package
   description 'RE2 is a fast, safe, thread-friendly alternative to backtracking regular expression engines like those used in PCRE, Perl, and Python.'
   homepage 'https://github.com/google/re2/'
-  @_ver = '2021-02-02'
-  version @_ver
+  version '2021-02-02'
   license 'BSD'
   compatibility 'all'
 
-  source_url "https://github.com/google/re2/archive/#{@_ver}.tar.gz"
+  source_url "https://github.com/google/re2/archive/#{version}.tar.gz"
   source_sha256 '1396ab50c06c1a8885fb68bf49a5ecfd989163015fd96699a180d6414937f33f'
 
   binary_url({

--- a/packages/readline.rb
+++ b/packages/readline.rb
@@ -3,11 +3,10 @@ require 'package'
 class Readline < Package
   description 'The GNU Readline library provides a set of functions for use by applications that allow users to edit command lines as they are typed in.'
   homepage 'http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html'
-  @_ver = '8.2'
-  version @_ver
+  version '8.2'
   license 'GPL-2'
   compatibility 'all'
-  source_url "https://ftpmirror.gnu.org/readline/readline-#{@_ver}.tar.gz"
+  source_url "https://ftpmirror.gnu.org/readline/readline-#{version}.tar.gz"
   source_sha256 '3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35'
 
   binary_url({

--- a/packages/rest.rb
+++ b/packages/rest.rb
@@ -3,11 +3,10 @@ require 'package'
 class Rest < Package
   description 'Helper library for RESTful services'
   homepage 'https://wiki.gnome.org/Projects/Librest'
-  @_ver = '0.9.1'
-  version @_ver
+  version '0.9.1'
   license 'LGPL-2.1'
   compatibility 'all'
-  source_url "https://gitlab.gnome.org/GNOME/librest/-/archive/#{@_ver}/librest-#{@_ver}.tar.bz2"
+  source_url "https://gitlab.gnome.org/GNOME/librest/-/archive/#{version}/librest-#{version}.tar.bz2"
   source_sha256 '5c39f6696b271194546880e0f360e21496b2882f72e4bb85433125de98fce03a'
 
   binary_url({

--- a/packages/rlottie.rb
+++ b/packages/rlottie.rb
@@ -3,11 +3,10 @@ require 'package'
 class Rlottie < Package
   description 'rlottie is a platform independent standalone c++ library for rendering vector based animations and art in realtime.'
   homepage 'https://github.com/Samsung/rlottie'
-  @_ver = '0.2'
-  version @_ver
+  version '0.2'
   license 'BSD, FTL, JSON and MIT'
   compatibility 'all'
-  source_url "https://github.com/Samsung/rlottie/archive/v#{@_ver}.tar.gz"
+  source_url "https://github.com/Samsung/rlottie/archive/v#{version}.tar.gz"
   source_sha256 '030ccbc270f144b4f3519fb3b86e20dd79fb48d5d55e57f950f12bab9b65216a'
 
   binary_url({

--- a/packages/sccache.rb
+++ b/packages/sccache.rb
@@ -3,11 +3,10 @@ require 'package'
 class Sccache < Package
   description 'Shared Compilation Cache'
   homepage 'https://github.com/mozilla/sccache/'
-  @_ver = '0.2.15'
-  version @_ver
+  version '0.2.15'
   license 'Apache-2.0, Apache-2.0-with-LLVM-exceptions, BSD, BSD-2, Boost-1.0, ISC, MIT, Unlicense and ZLIB'
   compatibility 'all'
-  source_url "https://github.com/mozilla/sccache/archive/v#{@_ver}.tar.gz"
+  source_url "https://github.com/mozilla/sccache/archive/v#{version}.tar.gz"
   source_sha256 '7dbe71012f9b0b57d8475de6b36a9a3b4802e44a135e886f32c5ad1b0eb506e0'
 
   binary_url({

--- a/packages/shadow.rb
+++ b/packages/shadow.rb
@@ -3,11 +3,10 @@ require 'package'
 class Shadow < Package
   description 'Shadow password file utilities'
   homepage 'https://github.com/shadow-maint/shadow'
-  @_ver = '4.13'
-  version @_ver
+  version '4.13'
   license 'BSD and GPL-2'
   compatibility 'all'
-  source_url "https://github.com/shadow-maint/shadow/releases/download/#{@_ver}/shadow-#{@_ver}.tar.xz"
+  source_url "https://github.com/shadow-maint/shadow/releases/download/#{version}/shadow-#{version}.tar.xz"
   source_sha256 '9afe245d79a2e7caac5f1ed62519b17416b057ec89df316df1c3935502f9dd2c'
 
   binary_url({

--- a/packages/srt.rb
+++ b/packages/srt.rb
@@ -3,11 +3,10 @@ require 'package'
 class Srt < Package
   description 'Secure Reliable Transport library'
   homepage 'https://www.srtalliance.org/'
-  @_ver = '1.4.3-rc.0'
-  version @_ver
+  version '1.4.3-rc.0'
   license 'MPL-2.0'
   compatibility 'all'
-  source_url "https://github.com/Haivision/srt/archive/v#{@_ver}.tar.gz"
+  source_url "https://github.com/Haivision/srt/archive/v#{version}.tar.gz"
   source_sha256 '50a05239602f2a402b4a96bc8b8e1ebf98808aa2966311c14f814ad477018a56'
 
   binary_url({

--- a/packages/stressng.rb
+++ b/packages/stressng.rb
@@ -4,11 +4,10 @@ class Stressng < Package
   description 'stress-ng will stress test a computer system in various selectable ways.'
   homepage 'https://kernel.ubuntu.com/~cking/stress-ng/'
   # 0.12.06 would not build as of 2021.04.07
-  @_ver = '0.12.05'
-  version @_ver
+  version '0.12.05'
   license 'GPL-2'
   compatibility 'all'
-  source_url "https://kernel.ubuntu.com/~cking/tarballs/stress-ng/stress-ng-#{@_ver}.tar.xz"
+  source_url "https://kernel.ubuntu.com/~cking/tarballs/stress-ng/stress-ng-#{version}.tar.xz"
   source_sha256 'af7779aee38e6d94726ed7d5cf36384a64d50c86e42fff89c141d8609913f425'
 
   binary_url({

--- a/packages/svt_av1.rb
+++ b/packages/svt_av1.rb
@@ -5,11 +5,10 @@ require 'package'
 class Svt_av1 < Package
   description 'Scalable Video Technology AV1 encoder and decoder'
   homepage 'https://gitlab.com/AOMediaCodec/SVT-AV1'
-  @_ver = '1.3.0'
-  version @_ver
+  version '1.3.0'
   license 'BSD-2, Apache-2.0, BSD, ISC, MIT and LGPG-2.1+'
   compatibility 'all'
-  source_url "https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v#{@_ver}/SVT-AV1-v#{@_ver}.tar.bz2"
+  source_url "https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v#{version}/SVT-AV1-v#{version}.tar.bz2"
   source_sha256 'f85fd13ef16880550e425797bdfdf1b0ba310c21d6b343f74ea79dd2fbb2336e'
 
   binary_url({

--- a/packages/swi_prolog.rb
+++ b/packages/swi_prolog.rb
@@ -3,11 +3,10 @@ require 'package'
 class Swi_prolog < Package
   description 'SWI-Prolog offers a comprehensive free Prolog environment. Since its start in 1987, SWI-Prolog development has been driven by the needs of real world applications. SWI-Prolog is widely used in research and education as well as commercial applications. Join over a million users who have downloaded SWI-Prolog.'
   homepage 'https://www.swi-prolog.org/'
-  @_ver = '8.2.4'
-  version @_ver
+  version '8.2.4'
   license 'BSD-2'
   compatibility 'i686,x86_64'
-  source_url "https://www.swi-prolog.org/download/stable/src/swipl-#{@_ver}.tar.gz"
+  source_url "https://www.swi-prolog.org/download/stable/src/swipl-#{version}.tar.gz"
   source_sha256 'f4bcc78437f9080ab089762e9e6afa7071df7f584c14999b92b9a90a4efbd7d8'
 
   binary_url({

--- a/packages/symlinks.rb
+++ b/packages/symlinks.rb
@@ -3,11 +3,10 @@ require 'package'
 class Symlinks < Package
   description 'scan/change symbolic links'
   homepage 'https://metadata.ftp-master.debian.org/changelogs//main/s/symlinks/symlinks_1.4-4_copyright'
-  @_ver = '1.4-4'
-  version @_ver
+  version '1.4-4'
   license 'symlinks'
   compatibility 'all'
-  source_url "https://salsa.debian.org/debian/symlinks/-/archive/debian/#{@_ver}/symlinks-debian-#{@_ver}.tar.bz2"
+  source_url "https://salsa.debian.org/debian/symlinks/-/archive/debian/#{version}/symlinks-debian-#{version}.tar.bz2"
   source_sha256 'f4469a9f366ccfaa7273b1f78bd540b8a6fa96f8b2b81a95d131944fb77efdd4'
 
   binary_url({

--- a/packages/telepathy_glib.rb
+++ b/packages/telepathy_glib.rb
@@ -3,11 +3,10 @@ require 'package'
 class Telepathy_glib < Package
   description 'GLib bindings for the Telepathy D-Bus protocol'
   homepage 'https://telepathy.freedesktop.org'
-  @_ver = '0.24.2'
-  version @_ver
+  version '0.24.2'
   license 'LGPL-2.1+'
   compatibility 'all'
-  source_url "https://telepathy.freedesktop.org/releases/telepathy-glib/telepathy-glib-#{@_ver}.tar.gz"
+  source_url "https://telepathy.freedesktop.org/releases/telepathy-glib/telepathy-glib-#{version}.tar.gz"
   source_sha256 'b0a374d771cdd081125f38c3abd079657642301c71a543d555e2bf21919273f0'
 
   binary_url({

--- a/packages/usbutils.rb
+++ b/packages/usbutils.rb
@@ -3,11 +3,10 @@ require 'package'
 class Usbutils < Package
   description 'Tools for examining usb devices'
   homepage 'http://linux-usb.sourceforge.net/'
-  @_ver = '013'
-  version @_ver
+  version '013'
   license 'GPL-2'
   compatibility 'all'
-  source_url "https://mirrors.kernel.org/pub/linux/utils/usb/usbutils/usbutils-#{@_ver}.tar.xz"
+  source_url "https://mirrors.kernel.org/pub/linux/utils/usb/usbutils/usbutils-#{version}.tar.xz"
   source_sha256 '9e23494fcc78b7a80ee29a07dd179c95ae2f71509c35728dbbabc2d1cca41338'
 
   binary_url({

--- a/packages/util_macros.rb
+++ b/packages/util_macros.rb
@@ -3,11 +3,10 @@ require 'package'
 class Util_macros < Package
   description 'The util-macros package contains the m4 macros used by all of the Xorg packages'
   homepage 'https://www.linuxfromscratch.org/blfs/view/svn/util-macros.html'
-  @_ver = '1.19.3'
-  version @_ver
+  version '1.19.3'
   license 'MIT'
   compatibility 'all'
-  source_url "https://xorg.freedesktop.org/releases/individual/util/util-macros-#{@_ver}.tar.bz2"
+  source_url "https://xorg.freedesktop.org/releases/individual/util/util-macros-#{version}.tar.bz2"
   source_sha256 '0f812e6e9d2786ba8f54b960ee563c0663ddbe2434bf24ff193f5feab1f31971'
 
   binary_url({

--- a/packages/v4l_utils.rb
+++ b/packages/v4l_utils.rb
@@ -3,11 +3,10 @@ require 'package'
 class V4l_utils < Package
   description 'The v4l-utils are a series of packages for handling media devices.'
   homepage 'https://www.linuxtv.org/wiki/index.php/V4l-utils'
-  @_ver = '1.22.1'
-  version @_ver
+  version '1.22.1'
   license 'GPL-2+ and LGPL-2.1+'
   compatibility 'all'
-  source_url "https://linuxtv.org/downloads/v4l-utils/v4l-utils-#{@_ver}.tar.bz2"
+  source_url "https://linuxtv.org/downloads/v4l-utils/v4l-utils-#{version}.tar.bz2"
   source_sha256 '65c6fbe830a44ca105c443b027182c1b2c9053a91d1e72ad849dfab388b94e31'
 
   binary_url({

--- a/packages/vmaf.rb
+++ b/packages/vmaf.rb
@@ -3,11 +3,10 @@ require 'package'
 class Vmaf < Package
   description 'Perceptual video quality assessment algorithm based on multi-method fusion'
   homepage 'https://github.com/Netflix/vmaf/'
-  @_ver = '2.1.1'
-  version @_ver
+  version '2.1.1'
   license 'BSD-2'
   compatibility 'all'
-  source_url "https://github.com/Netflix/vmaf/archive/v#{@_ver}.tar.gz"
+  source_url "https://github.com/Netflix/vmaf/archive/v#{version}.tar.gz"
   source_sha256 'e7fc00ae1322a7eccfcf6d4f1cdf9c67eec8058709887c8c6c3795c617326f77'
 
   binary_url({

--- a/packages/wpebackend_fdo.rb
+++ b/packages/wpebackend_fdo.rb
@@ -3,11 +3,10 @@ require 'package'
 class Wpebackend_fdo < Package
   description 'Freedesktop.org backend for WPE WebKit'
   homepage 'https://wpewebkit.org'
-  @_ver = '1.14.0'
-  version @_ver
+  version '1.14.0'
   license 'BSD-2'
   compatibility 'all'
-  source_url "https://github.com/Igalia/WPEBackend-fdo/releases/download/#{@_ver}/wpebackend-fdo-#{@_ver}.tar.xz"
+  source_url "https://github.com/Igalia/WPEBackend-fdo/releases/download/#{version}/wpebackend-fdo-#{version}.tar.xz"
   source_sha256 'e75b0cb2c7145448416e8696013d8883f675c66c11ed750e06865efec5809155'
 
   binary_url({

--- a/packages/yaru.rb
+++ b/packages/yaru.rb
@@ -3,11 +3,10 @@ require 'package'
 class Yaru < Package
   description 'Yaru default ubuntu theme'
   homepage 'https://github.com/ubuntu/yaru'
-  @_ver = '21.04.1'
-  version @_ver
+  version '21.04.1'
   license 'GPL-3 and CC-BY-SA-4.0'
   compatibility 'all'
-  source_url "https://github.com/ubuntu/yaru/archive/refs/tags/#{@_ver}.tar.gz"
+  source_url "https://github.com/ubuntu/yaru/archive/refs/tags/#{version}.tar.gz"
   source_sha256 '8cbbb1fcc7fa1e46e48d870cc1f941069e8213ac53200001aa9548ad79086836'
 
   binary_url({

--- a/packages/yelp.rb
+++ b/packages/yelp.rb
@@ -3,11 +3,10 @@ require 'package'
 class Yelp < Package
   description 'Get help with GNOME'
   homepage 'https://wiki.gnome.org/Apps/Yelp'
-  @_ver = '40.0'
-  version @_ver
+  version '40.0'
   license 'GPL-2+'
   compatibility 'all'
-  source_url "https://gitlab.gnome.org/GNOME/yelp/-/archive/#{@_ver}/yelp-#{@_ver}.tar.bz2"
+  source_url "https://gitlab.gnome.org/GNOME/yelp/-/archive/#{version}/yelp-#{version}.tar.bz2"
   source_sha256 'ec640d7a56970ab3ac6283d6c3a90ae45b7676c739671b303cbfb2f4323bf7af'
 
   binary_url({

--- a/packages/zimg.rb
+++ b/packages/zimg.rb
@@ -3,11 +3,10 @@ require 'package'
 class Zimg < Package
   description 'Scaling, colorspace conversion, and dithering library'
   homepage 'https://github.com/sekrit-twc/zimg'
-  @_ver = '3.0.1'
-  version @_ver
+  version '3.0.1'
   license 'WTFPL-2'
   compatibility 'all'
-  source_url "https://github.com/sekrit-twc/zimg/archive/release-#{@_ver}.tar.gz"
+  source_url "https://github.com/sekrit-twc/zimg/archive/release-#{version}.tar.gz"
   source_sha256 'c50a0922f4adac4efad77427d13520ed89b8366eef0ef2fa379572951afcc73f'
 
   binary_url({


### PR DESCRIPTION
Following on from #8381, I am removing 94 uses of `@_ver` from packages that use it like this:
```
@_ver = '1.2.3'
version @_ver
...
source_url "https://github.com/abseil/abseil-cpp/archive/#{@_ver}.tar.gz"
```
which now becomes:
```
version '1.2.3'
...
source_url "https://github.com/abseil/abseil-cpp/archive/#{version}.tar.gz"
```

Tested and working on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=laver5 CREW_TESTING=1 crew update
```
