### PR TITLE
Remove basic miscellaneous uses of @_ver

### DIFF
--- a/packages/apng2gif.rb
+++ b/packages/apng2gif.rb
@@ -3,11 +3,10 @@ require 'package'
 class Apng2gif < Package
   description 'Convert APNG animations into animated GIF format.'
   homepage 'https://sourceforge.net/projects/apng2gif/'
-  @_ver = '1.8'
-  version @_ver
+  version '1.8'
   license 'ZLIB'
   compatibility 'all'
-  source_url "https://sourceforge.net/projects/apng2gif/files/#{@_ver}/apng2gif-#{@_ver}-src.zip"
+  source_url "https://sourceforge.net/projects/apng2gif/files/#{version}/apng2gif-#{version}-src.zip"
   source_sha256 '9a07e386017dc696573cd7bc7b46b2575c06da0bc68c3c4f1c24a4b39cdedd4d'
 
   binary_url({
@@ -39,7 +38,7 @@ class Apng2gif < Package
     system 'make'
     system "help2man -s 1 -N -h '' \
             -n '#{description.downcase.delete! '.'}' \
-            --version-string='#{@_ver}' \
+            --version-string='#{version}' \
             ./apng2gif -o apng2gif.1"
   end
 

--- a/packages/balena_etcher.rb
+++ b/packages/balena_etcher.rb
@@ -3,13 +3,12 @@ require 'package'
 class Balena_etcher < Package
   description 'Flash OS images to SD cards & USB drives, safely and easily.'
   homepage 'https://www.balena.io/etcher/'
-  @_ver = '1.18.6'
-  version @_ver
+  version '1.18.6'
   license 'Apache-2.0'
   compatibility 'x86_64'
 
   source_url({
-    x86_64: "https://github.com/balena-io/etcher/releases/download/v#{@_ver}/balenaEtcher-#{@_ver}-x64.AppImage"
+    x86_64: "https://github.com/balena-io/etcher/releases/download/v#{version}/balenaEtcher-#{version}-x64.AppImage"
   })
 
   source_sha256({

--- a/packages/dart.rb
+++ b/packages/dart.rb
@@ -3,16 +3,15 @@ require 'package'
 class Dart < Package
   description 'The Dart SDK is a set of tools and libraries for the Dart programming language.  You can find information about Dart online at dartlang.org.'
   homepage 'https://dart.dev'
-  @_ver = '3.0.4'
-  version @_ver
+  version '3.0.4'
   license 'BSD-3'
   compatibility 'all'
 
   source_url({
-    aarch64: "https://storage.googleapis.com/dart-archive/channels/stable/release/#{@_ver}/sdk/dartsdk-linux-arm-release.zip",
-     armv7l: "https://storage.googleapis.com/dart-archive/channels/stable/release/#{@_ver}/sdk/dartsdk-linux-arm-release.zip",
-       i686: "https://storage.googleapis.com/dart-archive/channels/stable/release/#{@_ver}/sdk/dartsdk-linux-ia32-release.zip",
-     x86_64: "https://storage.googleapis.com/dart-archive/channels/stable/release/#{@_ver}/sdk/dartsdk-linux-x64-release.zip"
+    aarch64: "https://storage.googleapis.com/dart-archive/channels/stable/release/#{version}/sdk/dartsdk-linux-arm-release.zip",
+     armv7l: "https://storage.googleapis.com/dart-archive/channels/stable/release/#{version}/sdk/dartsdk-linux-arm-release.zip",
+       i686: "https://storage.googleapis.com/dart-archive/channels/stable/release/#{version}/sdk/dartsdk-linux-ia32-release.zip",
+     x86_64: "https://storage.googleapis.com/dart-archive/channels/stable/release/#{version}/sdk/dartsdk-linux-x64-release.zip"
   })
   source_sha256({
     aarch64: '36aebf7bf6d43574dc3f66872e1926e184dd2ef8641212240e57ab895403a967',

--- a/packages/depot_tools.rb
+++ b/packages/depot_tools.rb
@@ -3,8 +3,7 @@ require 'package'
 class Depot_tools < Package
   description 'Chromium uses a package of scripts, the depot_tools, to manage interaction with the Chromium source code repository and the Chromium development process.'
   homepage 'https://dev.chromium.org/developers/how-tos/depottools'
-  @_ver = 'da768751'
-  version @_ver
+  version 'da768751'
   license 'BSD-Google'
   compatibility 'all'
   source_url 'SKIP'
@@ -27,7 +26,7 @@ class Depot_tools < Package
   def self.install
     system 'git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git --depth 10'
     Dir.chdir 'depot_tools' do
-      system "git checkout #{@_ver}"
+      system "git checkout #{version}"
       FileUtils.rm_rf 'man/src/'
       FileUtils.rm_rf Dir.glob('.git*')
       system 'find -name \'*.bat\' -delete'

--- a/packages/duktape.rb
+++ b/packages/duktape.rb
@@ -6,11 +6,10 @@ require 'package'
 class Duktape < Package
   description 'Embeddable Javascript engine'
   homepage 'https://duktape.org/'
-  @_ver = '2.6.0'
-  version @_ver
+  version '2.6.0'
   compatibility 'all'
   license 'MIT'
-  source_url "https://duktape.org/duktape-#{@_ver}.tar.xz"
+  source_url "https://duktape.org/duktape-#{version}.tar.xz"
   source_sha256 '96f4a05a6c84590e53b18c59bb776aaba80a205afbbd92b82be609ba7fe75fa7'
 
   binary_url({
@@ -41,7 +40,7 @@ class Duktape < Package
 
       Name: duktape
       Description: Embeddable Javascript engine
-      Version: #{@_ver}
+      Version: #{version}
       Libs: -L\${libdir} -lduktape
       Cflags: -I\${includedir}
     DUKTAPEPCEOF

--- a/packages/gif2apng.rb
+++ b/packages/gif2apng.rb
@@ -3,11 +3,10 @@ require 'package'
 class Gif2apng < Package
   description 'Convert GIF animations into APNG format.'
   homepage 'https://sourceforge.net/projects/gif2apng/'
-  @_ver = '1.9'
-  version @_ver
+  version '1.9'
   license 'ZLIB LGPL-2.1'
   compatibility 'all'
-  source_url "https://sourceforge.net/projects/gif2apng/files/#{@_ver}/gif2apng-#{@_ver}-src.zip"
+  source_url "https://sourceforge.net/projects/gif2apng/files/#{version}/gif2apng-#{version}-src.zip"
   source_sha256 '3b21308e935d799b3ffb4a86c6e00ffa4cb9b3f72f52d58d51c66eb0574ae7d2'
 
   binary_url({
@@ -39,7 +38,7 @@ class Gif2apng < Package
     system 'make'
     system "help2man -s 1 -N -h '' \
             -n '#{description.downcase.delete! '.'}' \
-            --version-string='#{@_ver}' \
+            --version-string='#{version}' \
             ./gif2apng -o gif2apng.1"
   end
 

--- a/packages/go_fetch.rb
+++ b/packages/go_fetch.rb
@@ -3,12 +3,11 @@ require 'package'
 class Go_fetch < Package
   description 'fetch makes it easy to download files, folders, or release assets from a specific commit, branch, or tag of a public or private GitHub repo.'
   homepage 'https://github.com/gruntwork-io/fetch/'
-  @_ver = '0.4.2'
-  version @_ver
+  version '0.4.2'
   license 'LGPL-2.1'
   compatibility 'all'
   source_url 'https://github.com/gruntwork-io/fetch.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/go_fetch/0.4.2_armv7l/go_fetch-0.4.2-chromeos-armv7l.tar.xz',
@@ -33,6 +32,6 @@ class Go_fetch < Package
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
-    system "go build -ldflags \"-X main.VERSION=v#{@_ver}\" -o #{CREW_DEST_PREFIX}/bin/go-fetch"
+    system "go build -ldflags \"-X main.VERSION=v#{version}\" -o #{CREW_DEST_PREFIX}/bin/go-fetch"
   end
 end

--- a/packages/go_tools.rb
+++ b/packages/go_tools.rb
@@ -3,8 +3,7 @@ require 'package'
 class Go_tools < Package
   description 'Developer tools for the Go programming language'
   homepage 'https://github.com/golang/tools'
-  @_ver = '0.6.6'
-  version @_ver
+  version '0.6.6'
   license 'BSD'
   compatibility 'all'
   source_url 'SKIP'
@@ -26,7 +25,7 @@ class Go_tools < Package
 
   def self.install
     @git_dir = 'go_tools_git'
-    @git_hash = "gopls/v#{@_ver}"
+    @git_hash = "gopls/v#{version}"
     @git_url = 'https://github.com/golang/tools/'
     FileUtils.rm_rf(@git_dir)
     FileUtils.mkdir_p(@git_dir)

--- a/packages/ibus.rb
+++ b/packages/ibus.rb
@@ -3,8 +3,7 @@ require 'package'
 class Ibus < Package
   description 'Next Generation Input Bus for Linux'
   homepage 'https://github.com/ibus/ibus/wiki'
-  @_ver = '1.5.28'
-  version @_ver
+  version '1.5.28'
   license 'LGPL-2.1'
   compatibility 'all'
   source_url 'https://github.com/ibus/ibus.git'
@@ -78,7 +77,7 @@ class Ibus < Package
     --with-python=python3 \
     --with-ucd-dir=#{CREW_PREFIX}/share/unicode"
     unless File.exist?('engine/denylist.txt')
-      downloader "https://github.com/ibus/ibus/raw/#{@_ver}/engine/denylist.txt",
+      downloader "https://github.com/ibus/ibus/raw/#{version}/engine/denylist.txt",
                  '8589b87200d2e7dbf8a413129270d678e83b727bb5b7f8607e62cb9e40d2fdf1'
     end
     system 'make'

--- a/packages/jdk17.rb
+++ b/packages/jdk17.rb
@@ -4,8 +4,7 @@ require 'uri'
 class Jdk17 < Package
   description 'The Oracle JDK is a development environment for building applications, applets, and components using the Java programming language.'
   homepage 'https://www.oracle.com/java'
-  @_ver = '17.0.4.1'
-  version @_ver
+  version '17.0.4.1'
   license 'Oracle-BCLA-JavaSE'
   compatibility 'x86_64'
 
@@ -15,7 +14,7 @@ class Jdk17 < Package
      x86_64: 'x64'
   }
 
-  source_url File.join('file://', HOME, 'Downloads', "jdk-#{@_ver}_linux-x64_bin.tar.gz")
+  source_url File.join('file://', HOME, 'Downloads', "jdk-#{version}_linux-x64_bin.tar.gz")
   source_sha256 '2ac20cd72aa09c6577438e5ab5fd67e2dab606c724a84cfd289feecf6c22a1cf'
 
   no_compile_needed
@@ -50,7 +49,7 @@ class Jdk17 < Package
       You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
       https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html
 
-      Download "jdk-#{@_ver}_linux-x64_bin.tar.gz" (Linux x64 Compressed Archive) to Chrome OS download folder to continue.
+      Download "jdk-#{version}_linux-x64_bin.tar.gz" (Linux x64 Compressed Archive) to Chrome OS download folder to continue.
     EOT
   end
 

--- a/packages/jdk18.rb
+++ b/packages/jdk18.rb
@@ -4,12 +4,11 @@ require 'uri'
 class Jdk18 < Package
   description 'The Oracle JDK is a development environment for building applications, applets, and components using the Java programming language.'
   homepage 'https://www.oracle.com/java'
-  @_ver = '18.0.2.1'
-  version @_ver
+  version '18.0.2.1'
   license 'Oracle-BCLA-JavaSE'
   compatibility 'x86_64'
 
-  source_url File.join('file://', HOME, 'Downloads', "jdk-#{@_ver}_linux-x64_bin.tar.gz")
+  source_url File.join('file://', HOME, 'Downloads', "jdk-#{version}_linux-x64_bin.tar.gz")
   source_sha256 'cd905013facbb5c2b5354165cc372e327259de4991c28f31c7d4231dbf638934'
 
   no_compile_needed
@@ -44,7 +43,7 @@ class Jdk18 < Package
       You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
       https://www.oracle.com/java/technologies/javase/jdk18-archive-downloads.html
 
-      Download "jdk-#{@_ver}_linux-x64_bin.tar.gz" (Linux x64 Compressed Archive) to Chrome OS download folder to continue.
+      Download "jdk-#{version}_linux-x64_bin.tar.gz" (Linux x64 Compressed Archive) to Chrome OS download folder to continue.
     EOT
   end
 

--- a/packages/jdk8.rb
+++ b/packages/jdk8.rb
@@ -4,8 +4,7 @@ require 'uri'
 class Jdk8 < Package
   description 'The Oracle JDK is a development environment for building applications, applets, and components using the Java programming language.'
   homepage 'https://www.oracle.com/java'
-  @_ver = '8u341'
-  version @_ver
+  version '8u341'
   license 'Oracle-BCLA-JavaSE'
   compatibility 'all'
 
@@ -23,10 +22,10 @@ class Jdk8 < Package
   }
 
   source_url({
-    aarch64: File.join('file://', HOME, 'Downloads', "jdk-#{@_ver}-linux-#{@jdk_arch[:armv7l]}.tar.gz"),
-     armv7l: File.join('file://', HOME, 'Downloads', "jdk-#{@_ver}-linux-#{@jdk_arch[:armv7l]}.tar.gz"),
-       i686: File.join('file://', HOME, 'Downloads', "jdk-#{@_ver}-linux-#{@jdk_arch[:i686]}.tar.gz"),
-     x86_64: File.join('file://', HOME, 'Downloads', "jdk-#{@_ver}-linux-#{@jdk_arch[:x86_64]}.tar.gz")
+    aarch64: File.join('file://', HOME, 'Downloads', "jdk-#{version}-linux-#{@jdk_arch[:armv7l]}.tar.gz"),
+     armv7l: File.join('file://', HOME, 'Downloads', "jdk-#{version}-linux-#{@jdk_arch[:armv7l]}.tar.gz"),
+       i686: File.join('file://', HOME, 'Downloads', "jdk-#{version}-linux-#{@jdk_arch[:i686]}.tar.gz"),
+     x86_64: File.join('file://', HOME, 'Downloads', "jdk-#{version}-linux-#{@jdk_arch[:x86_64]}.tar.gz")
   })
 
   source_sha256({
@@ -61,7 +60,7 @@ class Jdk8 < Package
 
     return if File.exist?( URI( get_source_url(ARCH.to_sym) ).path )
 
-    # check if we should prompt user to the archive page or download page based on #{@_ver}
+    # check if we should prompt user to the archive page or download page based on #{version}
     # download page only contains latest version while archive page only contains older versions
 
     # get latest available version
@@ -76,7 +75,7 @@ class Jdk8 < Package
       You must login at https://login.oracle.com/mysso/signon.jsp and then visit:
       #{jdk_download_url}
 
-      Download "jdk-#{@_ver}-linux-#{@jdk_arch[ARCH.to_sym]}.tar.gz" (#{@jdk_description[ARCH.to_sym]}) to Chrome OS download folder to continue.
+      Download "jdk-#{version}-linux-#{@jdk_arch[ARCH.to_sym]}.tar.gz" (#{@jdk_description[ARCH.to_sym]}) to Chrome OS download folder to continue.
     EOT
   end
 

--- a/packages/js102.rb
+++ b/packages/js102.rb
@@ -2,11 +2,10 @@ require 'package'
 
 class Js102 < Package
   description 'Spidermonkey is a javaScript interpreter with libraries from Mozilla — Version 102'
-  @_ver = '102.4.0'
-  version @_ver
+  version '102.4.0'
   license 'MPL-2.0'
   compatibility 'all'
-  source_url "https://archive.mozilla.org/pub/firefox/releases/#{@_ver}esr/source/firefox-#{@_ver}esr.source.tar.xz"
+  source_url "https://archive.mozilla.org/pub/firefox/releases/#{version}esr/source/firefox-#{version}esr.source.tar.xz"
   source_sha256 'e79f0ddd4914dfbff61c5eea7ff28ad2dd12ecfbf3d63a41dab57d50171d904e'
 
   binary_url({

--- a/packages/js78.rb
+++ b/packages/js78.rb
@@ -2,11 +2,10 @@ require 'package'
 
 class Js78 < Package
   description 'Spidermonkey is a javaScript interpreter with libraries from Mozilla — Version 78'
-  @_ver = '78.7.0'
-  version @_ver
+  version '78.7.0'
   license 'MPL-2.0'
   compatibility 'all'
-  source_url "https://archive.mozilla.org/pub/firefox/releases/#{@_ver}esr/source/firefox-#{@_ver}esr.source.tar.xz"
+  source_url "https://archive.mozilla.org/pub/firefox/releases/#{version}esr/source/firefox-#{version}esr.source.tar.xz"
   source_sha256 '1aa041db28cd742e93d663a9da8defd33040b38d8b9470350538473251621643'
 
   binary_url({

--- a/packages/js91.rb
+++ b/packages/js91.rb
@@ -2,11 +2,10 @@ require 'package'
 
 class Js91 < Package
   description 'Spidermonkey is a javaScript interpreter with libraries from Mozilla — Version 91'
-  @_ver = '91.4.1'
-  version @_ver
+  version '91.4.1'
   license 'MPL-2.0'
   compatibility 'all'
-  source_url "https://archive.mozilla.org/pub/firefox/releases/#{@_ver}esr/source/firefox-#{@_ver}esr.source.tar.xz"
+  source_url "https://archive.mozilla.org/pub/firefox/releases/#{version}esr/source/firefox-#{version}esr.source.tar.xz"
   source_sha256 '75e98daf53c5aea19d711a625d5d5e6dfdc8335965d3a19567c62f9d2961fc75'
 
   binary_url({

--- a/packages/libevent.rb
+++ b/packages/libevent.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libevent < Package
   description 'The libevent API provides a mechanism to execute a callback function when a specific event occurs on a file descriptor or after a timeout has been reached.'
   homepage 'http://libevent.org/'
-  @_ver = '2.1.12'
-  version @_ver
+  version '2.1.12'
   license 'BSD'
   compatibility 'all'
-  source_url "https://github.com/libevent/libevent/releases/download/release-#{@_ver}-stable/libevent-#{@_ver}-stable.tar.gz"
+  source_url "https://github.com/libevent/libevent/releases/download/release-#{version}-stable/libevent-#{version}-stable.tar.gz"
   source_sha256 '92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb'
 
   binary_url({

--- a/packages/llvm_stage1.rb
+++ b/packages/llvm_stage1.rb
@@ -3,11 +3,10 @@ require 'package'
 class Llvm_stage1 < Package
   description 'THIS IS NOT THE LLVM PACKAGE. This is only a Limited Stage 1 compile of LLVM.'
   homepage 'http://llvm.org/'
-  @_ver = '13.0.0'
-  version @_ver
+  version '13.0.0'
   license 'Apache-2.0-with-LLVM-exceptions, UoI-NCSA, BSD, public-domain and rc'
   compatibility 'all'
-  source_url "https://github.com/llvm/llvm-project/releases/download/llvmorg-#{@_ver}/llvm-project-#{@_ver}.src.tar.xz"
+  source_url "https://github.com/llvm/llvm-project/releases/download/llvmorg-#{version}/llvm-project-#{version}.src.tar.xz"
   source_sha256 '6075ad30f1ac0e15f07c1bf062c1e1268c241d674f11bd32cdf0e040c71f2bf3'
 
   binary_url({

--- a/packages/moreutils.rb
+++ b/packages/moreutils.rb
@@ -3,11 +3,10 @@ require 'package'
 class Moreutils < Package
   description 'moreutils is a growing collection of the unix tools that nobody thought to write long ago when unix was young.'
   homepage 'https://joeyh.name/code/moreutils/'
-  @_ver = '0.65'
-  version @_ver
+  version '0.65'
   license 'GPL-2'
   compatibility 'all'
-  source_url "http://http.debian.net/debian/pool/main/m/moreutils/moreutils_#{@_ver}.orig.tar.xz"
+  source_url "http://http.debian.net/debian/pool/main/m/moreutils/moreutils_#{version}.orig.tar.xz"
   source_sha256 'ba0cfaa1ff6ead2b15c62a67292de66a366f9b815a09697b54677f7e15f5a2b2'
 
   binary_url({

--- a/packages/php73.rb
+++ b/packages/php73.rb
@@ -3,11 +3,10 @@ require 'package'
 class Php73 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  @_ver = '7.3.33'
-  version @_ver
+  version '7.3.33'
   license 'PHP-3.01'
   compatibility 'all'
-  source_url "https://www.php.net/distributions/php-#{@_ver}.tar.xz"
+  source_url "https://www.php.net/distributions/php-#{version}.tar.xz"
   source_sha256 '166eaccde933381da9516a2b70ad0f447d7cec4b603d07b9a916032b215b90cc'
 
   binary_url({

--- a/packages/php74.rb
+++ b/packages/php74.rb
@@ -3,11 +3,10 @@ require 'package'
 class Php74 < Package
   description 'PHP is a popular general-purpose scripting language that is especially suited to web development.'
   homepage 'http://www.php.net/'
-  @_ver = '7.4.33'
-  version @_ver
+  version '7.4.33'
   license 'PHP-3.01'
   compatibility 'all'
-  source_url "https://www.php.net/distributions/php-#{@_ver}.tar.xz"
+  source_url "https://www.php.net/distributions/php-#{version}.tar.xz"
   source_sha256 '924846abf93bc613815c55dd3f5809377813ac62a9ec4eb3778675b82a27b927'
 
   binary_url({

--- a/packages/py2_setuptools.rb
+++ b/packages/py2_setuptools.rb
@@ -4,11 +4,10 @@ class Py2_setuptools < Package
   description 'Setuptools is the python build system from the Python Packaging Authority.'
   homepage 'https://setuptools.readthedocs.io/'
   # Newest python2 supported version as of 2021-04-24
-  @_ver = '44.1.1'
-  version @_ver
+  version '44.1.1'
   license 'MIT'
   compatibility 'all'
-  source_url "https://files.pythonhosted.org/packages/b2/40/4e00501c204b457f10fe410da0c97537214b2265247bc9a5bc6edd55b9e4/setuptools-#{@_ver}.zip"
+  source_url "https://files.pythonhosted.org/packages/b2/40/4e00501c204b457f10fe410da0c97537214b2265247bc9a5bc6edd55b9e4/setuptools-#{version}.zip"
   source_sha256 'c67aa55db532a0dadc4d2e20ba9961cbd3ccc84d544e9029699822542b5a476b'
 
   binary_url({

--- a/packages/rust.rb
+++ b/packages/rust.rb
@@ -3,8 +3,7 @@ require 'package'
 class Rust < Package
   description 'Rust is a systems programming language that runs blazingly fast, prevents segfaults, and guarantees thread safety.'
   homepage 'https://www.rust-lang.org/'
-  @_ver = '1.70.0'
-  version @_ver
+  version '1.70.0'
   license 'Apache-2.0 and MIT'
   compatibility 'all'
   source_url 'https://github.com/rust-lang/rustup.git'
@@ -39,15 +38,15 @@ class Rust < Package
     FileUtils.mkdir_p("#{CREW_DEST_PREFIX}/bin")
     FileUtils.mkdir_p("#{CREW_DEST_PREFIX}/share/cargo")
     FileUtils.mkdir_p("#{CREW_DEST_PREFIX}/share/rustup")
-    system "RUSTFLAGS='-Clto=thin' bash ./rustup-init.sh -y --no-modify-path --default-host #{default_host} --default-toolchain #{@_ver} --profile minimal"
+    system "RUSTFLAGS='-Clto=thin' bash ./rustup-init.sh -y --no-modify-path --default-host #{default_host} --default-toolchain #{version} --profile minimal"
     FileUtils.mkdir_p("#{CREW_DEST_PREFIX}/share/bash-completion/completions/")
-    FileUtils.install "#{CREW_DEST_PREFIX}/share/rustup/toolchains/#{@_ver}-#{default_host}/etc/bash_completion.d/cargo",
+    FileUtils.install "#{CREW_DEST_PREFIX}/share/rustup/toolchains/#{version}-#{default_host}/etc/bash_completion.d/cargo",
                       "#{CREW_DEST_PREFIX}/share/bash-completion/completions/cargo", mode: 0o644
-    FileUtils.rm("#{CREW_DEST_PREFIX}/share/rustup/toolchains/#{@_ver}-#{default_host}/etc/bash_completion.d/cargo")
+    FileUtils.rm("#{CREW_DEST_PREFIX}/share/rustup/toolchains/#{version}-#{default_host}/etc/bash_completion.d/cargo")
     FileUtils.touch "#{CREW_DEST_PREFIX}/share/bash-completion/completions/rustup"
-    FileUtils.mv("#{CREW_DEST_PREFIX}/share/rustup/toolchains/#{@_ver}-#{default_host}/share/man/",
+    FileUtils.mv("#{CREW_DEST_PREFIX}/share/rustup/toolchains/#{version}-#{default_host}/share/man/",
                  "#{CREW_DEST_PREFIX}/share/")
-    FileUtils.rm_rf("#{CREW_DEST_PREFIX}/share/rustup/toolchains/#{@_ver}-#{default_host}/share/doc/")
+    FileUtils.rm_rf("#{CREW_DEST_PREFIX}/share/rustup/toolchains/#{version}-#{default_host}/share/doc/")
     FileUtils.ln_sf("#{CREW_PREFIX}/share/cargo", "#{CREW_DEST_HOME}/.cargo")
     FileUtils.ln_sf("#{CREW_PREFIX}/share/rustup", "#{CREW_DEST_HOME}/.rustup")
 
@@ -80,7 +79,7 @@ class Rust < Package
   end
 
   def self.postinstall
-    system "rustup default #{@_ver}"
+    system "rustup default #{version}"
   end
 
   def self.remove

--- a/packages/s.rb
+++ b/packages/s.rb
@@ -3,19 +3,18 @@ require 'package'
 class S < Package
   description 'Open a web search in your terminal.'
   homepage 'https://github.com/zquestz/s/'
-  @_ver = '0.5.15'
-  version @_ver
+  version '0.5.15'
   license 'GPL-3+'
   compatibility 'all'
   case ARCH
   when 'aarch64', 'armv7l'
-    source_url "https://github.com/zquestz/s/releases/download/v#{@_ver}/s-linux_arm.zip"
+    source_url "https://github.com/zquestz/s/releases/download/v#{version}/s-linux_arm.zip"
     source_sha256 'ddffb211f117395a736f679a8a96cc726ac46c50fdfe1a6e2c4bb4494b970cd0'
   when 'i686'
-    source_url "https://github.com/zquestz/s/releases/download/v#{@_ver}/s-linux_386.zip"
+    source_url "https://github.com/zquestz/s/releases/download/v#{version}/s-linux_386.zip"
     source_sha256 '8724b0ea6ec0e8abedcdc87f2efccd12a848ff1267149f8ca14b46251649cffc'
   when 'x86_64'
-    source_url "https://github.com/zquestz/s/releases/download/v#{@_ver}/s-linux_amd64.zip"
+    source_url "https://github.com/zquestz/s/releases/download/v#{version}/s-linux_amd64.zip"
     source_sha256 '38c29001936f1758159cc935b3ab97d1dee75c35ceacd8bd5ada3837b306192f'
   end
 

--- a/packages/scdoc.rb
+++ b/packages/scdoc.rb
@@ -3,13 +3,12 @@ require 'package'
 class Scdoc < Package
   description 'A simple man page generator for POSIX systems written in C99'
   homepage 'https://git.sr.ht/~sircmpwn/scdoc/'
-  @_ver = '1.11.2'
-  version @_ver
+  version '1.11.2'
   license 'MIT'
   # source_url 'https://git.sr.ht/~sircmpwn/scdoc.git' # Git url with .git at the end returns 403 Forbidden
   # git_hashtag @_ver
   compatibility 'all'
-  source_url "https://git.sr.ht/~sircmpwn/scdoc/archive/#{@_ver}.tar.gz"
+  source_url "https://git.sr.ht/~sircmpwn/scdoc/archive/#{version}.tar.gz"
   source_sha256 'e9ff9981b5854301789a6778ee64ef1f6d1e5f4829a9dd3e58a9a63eacc2e6f0'
 
   binary_url({

--- a/packages/stack.rb
+++ b/packages/stack.rb
@@ -3,11 +3,10 @@ require 'package'
 class Stack < Package
   description 'The Haskell Tool Stack - Stack is a cross-platform program for developing Haskell projects. It is aimed at Haskellers both new and experienced.'
   homepage 'https://docs.haskellstack.org/'
-  @_ver = '2.9.3'
-  version @_ver
+  version '2.9.3'
   license 'BSD'
   compatibility 'all'
-  source_url "https://github.com/commercialhaskell/stack/releases/download/v#{@_ver}/stack-#{@_ver}-linux-x86_64.tar.gz"
+  source_url "https://github.com/commercialhaskell/stack/releases/download/v#{version}/stack-#{version}-linux-x86_64.tar.gz"
   source_sha256 '938f689dc45e2693ab1ca3ea215790b3786dfd531dcf6c0bf40842c24e579ae9'
 
   binary_url({

--- a/packages/unicode_character_database.rb
+++ b/packages/unicode_character_database.rb
@@ -3,11 +3,10 @@ require 'package'
 class Unicode_character_database < Package
   description 'Unicode Character Database'
   homepage 'https://www.unicode.org/'
-  @_ver = '13.0.0'
-  version @_ver
+  version '13.0.0'
   license 'Unicode-DFS-2015'
   compatibility 'all'
-  source_url "https://www.unicode.org/Public/zipped/#{@_ver}/UCD.zip"
+  source_url "https://www.unicode.org/Public/zipped/#{version}/UCD.zip"
   source_sha256 '2f76973b4d36ae45584f5a45ec65b47138932d777dd23a5669c89535ef3da951'
 
   binary_url({
@@ -26,7 +25,7 @@ class Unicode_character_database < Package
   depends_on 'libarchive' => :build
 
   def self.build
-    system "curl -Ls https://www.unicode.org/Public/zipped/#{@_ver}/Unihan.zip | bsdtar --no-same-owner --no-same-permissions -xf -"
+    system "curl -Ls https://www.unicode.org/Public/zipped/#{version}/Unihan.zip | bsdtar --no-same-owner --no-same-permissions -xf -"
   end
 
   def self.install

--- a/packages/unicode_emoji.rb
+++ b/packages/unicode_emoji.rb
@@ -3,8 +3,7 @@ require 'package'
 class Unicode_emoji < Package
   description 'Unicode Emoji Data Files'
   homepage 'https://www.unicode.org/emoji/'
-  @_ver = '13.1'
-  version @_ver
+  version '13.1'
   license 'unicode'
   compatibility 'all'
   source_url 'SKIP'
@@ -26,8 +25,8 @@ class Unicode_emoji < Package
 
   def self.install
     FileUtils.mkdir_p("#{CREW_DEST_PREFIX}/share/unicode/emoji")
-    system "curl -Lf https://www.unicode.org/Public/emoji/#{@_ver}/emoji-sequences.txt -o #{CREW_DEST_PREFIX}/share/unicode/emoji/emoji-sequences.txt"
-    system "curl -Lf https://www.unicode.org/Public/emoji/#{@_ver}/emoji-test.txt -o #{CREW_DEST_PREFIX}/share/unicode/emoji/emoji-test.txt"
-    system "curl -Lf https://www.unicode.org/Public/emoji/#{@_ver}/emoji-zwj-sequences.txt -o #{CREW_DEST_PREFIX}/share/unicode/emoji/emoji-zwj-sequences.txt"
+    system "curl -Lf https://www.unicode.org/Public/emoji/#{version}/emoji-sequences.txt -o #{CREW_DEST_PREFIX}/share/unicode/emoji/emoji-sequences.txt"
+    system "curl -Lf https://www.unicode.org/Public/emoji/#{version}/emoji-test.txt -o #{CREW_DEST_PREFIX}/share/unicode/emoji/emoji-test.txt"
+    system "curl -Lf https://www.unicode.org/Public/emoji/#{version}/emoji-zwj-sequences.txt -o #{CREW_DEST_PREFIX}/share/unicode/emoji/emoji-zwj-sequences.txt"
   end
 end


### PR DESCRIPTION
Following on from #8428, I am removing 27 uses of `@_ver` from packages that use it like this:
```
@_ver = '1.2.3'
version @_ver
...
@git_hash = "gopls/v#{@_ver}"
```
which now becomes:
```
version '1.2.3'
...
@git_hash = "gopls/v#{version}"
```

Tested and working on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=laver6 CREW_TESTING=1 crew update
```
