### PR TITLE
Fix some unnoticed @_ver problems

### DIFF
--- a/packages/php80.rb
+++ b/packages/php80.rb
@@ -46,7 +46,7 @@ class Php80 < Package
 
   def self.preflight
     phpver = `php -v 2> /dev/null | head -1 | cut -d' ' -f2`.chomp
-    abort "PHP version #{phpver} already installed.".lightgreen if ARGV[0] != 'reinstall' && @_ver != phpver && !phpver.empty?
+    abort "PHP version #{phpver} already installed.".lightgreen if ARGV[0] != 'reinstall' && version != phpver && !phpver.empty?
   end
 
   def self.patch

--- a/packages/php81.rb
+++ b/packages/php81.rb
@@ -46,7 +46,7 @@ class Php81 < Package
 
   def self.preflight
     phpver = `php -v 2> /dev/null | head -1 | cut -d' ' -f2`.chomp
-    abort "PHP version #{phpver} already installed.".lightgreen if ARGV[0] != 'reinstall' && @_ver != phpver && !phpver.empty?
+    abort "PHP version #{phpver} already installed.".lightgreen if ARGV[0] != 'reinstall' && version != phpver && !phpver.empty?
   end
 
   def self.patch

--- a/packages/qemu.rb
+++ b/packages/qemu.rb
@@ -6,7 +6,7 @@ class Qemu < Package
   version '8.0.1'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://github.com/qemu/qemu.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qemu/8.0.1_armv7l/qemu-8.0.1-chromeos-armv7l.tar.zst',


### PR DESCRIPTION
Oops!

Tested and working on `x86_64`.

In regards to the wider consequences of this, namely that I've missed a few instances, I've now set up some sed scripts to check for errors like these, where there are remaining instances of `@_ver` despite my removal of the definition of @_ver.

As to why these errors did not show up in ruby, I am not sure.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=laver2.1 CREW_TESTING=1 crew update
```
