### PR TITLE
Add fileutils dependency to lib/const.rb

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 # Defines common constants used in different parts of crew
 
 CREW_VERSION = '1.34.5'


### PR DESCRIPTION
`lib/const.rb` needs `fileutils`, and this becomes apparent when trying to run any of the tests. I presume it worked fine in regular usage because whatever file that included it already had `fileutils` as a dependency.

Tested and working on `x86_64`.

```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=uangle CREW_TESTING=1 crew update
```
