### PR TITLE
Fix glibc_build dependency issues

### DIFF
--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -7,9 +7,9 @@ require_relative 'glibc_build235'
 
 class Glibc < Package
   description 'The GNU C Library project provides the core libraries for GNU/Linux systems.'
-  homepage Glibc_build.homepage.to_s
-  license Glibc_build.license
-  compatibility Glibc_build.compatibility.to_s
+  homepage Glibc_build235.homepage.to_s
+  license Glibc_build235.license
+  compatibility Glibc_build235.compatibility.to_s
 
   is_fake
 

--- a/packages/glibc_build233.rb
+++ b/packages/glibc_build233.rb
@@ -1,6 +1,6 @@
 require 'package'
 
-class Glibc_build < Package
+class Glibc_build233 < Package
   description 'The GNU C Library project provides the core libraries for GNU/Linux systems.'
   homepage 'https://www.gnu.org/software/libc/'
   license 'LGPL-2.1+, BSD, HPND, ISC, inner-net, rc, and PCRE'


### PR DESCRIPTION
Before, `glibc.rb` would look for a nonexistent `Glibc_build233` class.

Tested and working on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=2angle CREW_TESTING=1 crew update
```
