### PR TITLE
Add no_lto

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -429,11 +429,12 @@ def help(pkgName = nil)
         puts "Use the 'no_shrink' property to bypass upx binary compression."
       when 'no_strip'
         puts "Use the 'no_strip' property to bypass strip execution."
+      when 'no_lto'
+        puts "Use the 'no_lto' property to bypass lto usage."
       when 'no_zstd'
         puts "Use the 'no_zstd' property for the alternate xz compression algorithm."
       when 'patchelf'
         puts "Use the 'patchelf' property for patchelf execution."
-        puts 'This is the default and for most cases is not needed.'
       else
         abort "Help for the '#{ARGV[2]}' property is not available.".lightred
       end

--- a/lib/buildsystems/autotools.rb
+++ b/lib/buildsystems/autotools.rb
@@ -21,7 +21,7 @@ class Autotools < Package
         system 'autoreconf -fiv'
       end
     end
-    system "./configure #{CREW_OPTIONS} #{@configure_options}"
+    system "./configure CREW_OPTIONS #{@configure_options}"
     system 'make'
   end
 

--- a/lib/buildsystems/autotools.rb
+++ b/lib/buildsystems/autotools.rb
@@ -21,7 +21,7 @@ class Autotools < Package
         system 'autoreconf -fiv'
       end
     end
-    system "./configure CREW_OPTIONS #{@configure_options}"
+    system "./configure #{CREW_OPTIONS} #{@configure_options}"
     system 'make'
   end
 

--- a/lib/buildsystems/cmake.rb
+++ b/lib/buildsystems/cmake.rb
@@ -11,7 +11,8 @@ class CMake < Package
   end
 
   def self.build
-    system "cmake -B builddir -G Ninja #{CREW_CMAKE_OPTIONS} #{@cmake_options}"
+    @crew_cmake_options = no_lto ? CREW_CMAKE_FNO_LTO_OPTIONS : CREW_CMAKE_OPTIONS
+    system "cmake -B builddir -G Ninja #{@crew_cmake_options} #{@cmake_options}"
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/lib/buildsystems/meson.rb
+++ b/lib/buildsystems/meson.rb
@@ -11,7 +11,9 @@ class Meson < Package
   end
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} #{@meson_options} builddir"
+    @crew_meson_options = no_lto ? CREW_MESON_FNO_LTO_OPTIONS : CREW_MESON_OPTIONS
+    system "meson #{@crew_meson_options} #{@meson_options} builddir"
+    system 'meson configure builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -2,7 +2,7 @@ require 'fileutils'
 
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.34.5'
+CREW_VERSION = '1.34.6'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -11,7 +11,7 @@ class Package
 
   boolean_property = %i[conflicts_ok git_clone_deep git_fetchtags gnome is_fake is_musl is_static
                         no_compile_needed no_compress no_env_options no_fhs no_git_submodules
-                        no_links no_patchelf no_shrink no_strip no_lto no_zstd patchelf]
+                        no_links no_lto no_patchelf no_shrink no_strip no_zstd patchelf]
 
   create_placeholder :preflight,   # Function for checks to see if install should occur.
                      :patch,       # Function to perform patch operations prior to build from source.

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -11,7 +11,7 @@ class Package
 
   boolean_property = %i[conflicts_ok git_clone_deep git_fetchtags gnome is_fake is_musl is_static
                         no_compile_needed no_compress no_env_options no_fhs no_git_submodules
-                        no_links no_patchelf no_shrink no_strip no_zstd patchelf]
+                        no_links no_patchelf no_shrink no_strip no_lto no_zstd patchelf]
 
   create_placeholder :preflight,   # Function for checks to see if install should occur.
                      :patch,       # Function to perform patch operations prior to build from source.
@@ -267,6 +267,8 @@ class Package
   def self.system(*args, **opt_args)
     @crew_env_options_hash = if no_env_options?
                                { 'CREW_DISABLE_ENV_OPTIONS' => '1' }
+                             elsif no_lto?
+                               CREW_ENV_FNO_LTO_OPTIONS_HASH
                              else
                                CREW_ENV_OPTIONS_HASH
                              end

--- a/manifest/armv7l/x/xorg_proto.filelist
+++ b/manifest/armv7l/x/xorg_proto.filelist
@@ -132,7 +132,6 @@
 /usr/local/share/doc/xorgproto/dri2proto.txt
 /usr/local/share/doc/xorgproto/dri3proto.txt
 /usr/local/share/doc/xorgproto/fixesproto.txt
-/usr/local/share/doc/xorgproto/PM_spec
 /usr/local/share/doc/xorgproto/presentproto.txt
 /usr/local/share/doc/xorgproto/randrproto.txt
 /usr/local/share/doc/xorgproto/renderproto.txt

--- a/manifest/i686/x/xorg_proto.filelist
+++ b/manifest/i686/x/xorg_proto.filelist
@@ -132,7 +132,6 @@
 /usr/local/share/doc/xorgproto/dri2proto.txt
 /usr/local/share/doc/xorgproto/dri3proto.txt
 /usr/local/share/doc/xorgproto/fixesproto.txt
-/usr/local/share/doc/xorgproto/PM_spec
 /usr/local/share/doc/xorgproto/presentproto.txt
 /usr/local/share/doc/xorgproto/randrproto.txt
 /usr/local/share/doc/xorgproto/renderproto.txt

--- a/manifest/x86_64/x/xorg_proto.filelist
+++ b/manifest/x86_64/x/xorg_proto.filelist
@@ -132,7 +132,6 @@
 /usr/local/share/doc/xorgproto/dri2proto.txt
 /usr/local/share/doc/xorgproto/dri3proto.txt
 /usr/local/share/doc/xorgproto/fixesproto.txt
-/usr/local/share/doc/xorgproto/PM_spec
 /usr/local/share/doc/xorgproto/presentproto.txt
 /usr/local/share/doc/xorgproto/randrproto.txt
 /usr/local/share/doc/xorgproto/renderproto.txt

--- a/packages/cdparanoia.rb
+++ b/packages/cdparanoia.rb
@@ -27,7 +27,7 @@ class Cdparanoia < Package
 
   depends_on 'glibc'
 
-  no_env_options
+  no_lto
 
   def self.patch
     downloader 'https://raw.githubusercontent.com/archlinux/svntogit-packages/packages/cdparanoia/trunk/gcc.patch',
@@ -36,7 +36,7 @@ class Cdparanoia < Package
   end
 
   def self.build
-    system "#{CREW_ENV_FNO_LTO_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_OPTIONS}"
     system 'make -j1'
   end
 

--- a/packages/gnutls.rb
+++ b/packages/gnutls.rb
@@ -39,7 +39,7 @@ class Gnutls < Package
   depends_on 'zlibpkg' # R
   depends_on 'zstd' # R
 
-  no_env_options
+  no_lto
 
   def self.prebuild
     # Use IPv4 fallback if default connection fails.
@@ -54,7 +54,7 @@ class Gnutls < Package
 
   def self.build
     system './configure --help'
-    system "mold -run ./configure #{CREW_OPTIONS} #{CREW_ENV_FNO_LTO_OPTIONS} \
+    system "mold -run ./configure #{CREW_OPTIONS} \
       --enable-shared \
       --with-pic \
       --with-system-priority-file=#{CREW_PREFIX}/etc/gnutls/default-priorities \

--- a/packages/handbrake.rb
+++ b/packages/handbrake.rb
@@ -59,7 +59,7 @@ class Handbrake < Package
   depends_on 'xzutils' # R
   depends_on 'zlibpkg' # R
 
-  no_env_options
+  no_lto
 
   def self.patch
     Dir.chdir 'gtk' do
@@ -75,7 +75,7 @@ class Handbrake < Package
     FileUtils.ln_sf "#{CREW_LIB_PREFIX}/libfribidi.la", "#{CREW_PREFIX}/lib/"
 
     unless Dir.exist? 'x86_64-cros-linux-gnu'
-      system "#{CREW_ENV_FNO_LTO_OPTIONS} LDFLAGS='-L #{CREW_LIB_PREFIX}' ./configure #{CREW_OPTIONS} \
+      system "LDFLAGS+=' -L #{CREW_LIB_PREFIX}' ./configure #{CREW_OPTIONS} \
         --enable-x265 \
         --enable-numa \
         --enable-fdk-aac \

--- a/packages/libbsd.rb
+++ b/packages/libbsd.rb
@@ -24,12 +24,13 @@ class Libbsd < Package
 
   depends_on 'glibc' # R
   depends_on 'libmd' # R
+  no_lto
 
   def self.build
     FileUtils.mkdir_p 'm4'
     system 'autoupdate'
     system 'autoreconf -fiv'
-    system "#{CREW_ENV_FNO_LTO_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libepoxy.rb
+++ b/packages/libepoxy.rb
@@ -1,27 +1,28 @@
 require 'buildsystems/meson'
 
-class Libepoxy < Package
+class Libepoxy < Meson
   description 'Epoxy is a library for handling OpenGL function pointer management for you'
   homepage 'https://github.com/anholt/libepoxy'
   version '1.5.10'
   license 'MIT'
-  compatibility 'all'
+  compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://github.com/anholt/libepoxy.git'
   git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libepoxy/1.5.5_armv7l/libepoxy-1.5.5-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libepoxy/1.5.5_armv7l/libepoxy-1.5.5-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libepoxy/1.5.5_i686/libepoxy-1.5.5-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libepoxy/1.5.5_x86_64/libepoxy-1.5.5-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libepoxy/1.5.10_armv7l/libepoxy-1.5.10-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libepoxy/1.5.10_armv7l/libepoxy-1.5.10-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libepoxy/1.5.10_x86_64/libepoxy-1.5.10-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'de87478a3eecf1b1ab3b23441b87ca0c81ee26af507b7223dffb51097aa15e07',
-     armv7l: 'de87478a3eecf1b1ab3b23441b87ca0c81ee26af507b7223dffb51097aa15e07',
-       i686: '39b1ca812fd683eda89f16a2b9f5be0a63425ea710f31abf5e9f208ba650b986',
-     x86_64: 'e2e6aeded9388b562742d958d047365157a7a4965a4b6147bc9178060a789bd6'
+    aarch64: '66b8a7eaa527e20d68e6e1834b4007b1f4b486bd6ad13bb31e46dc7287a75758',
+     armv7l: '66b8a7eaa527e20d68e6e1834b4007b1f4b486bd6ad13bb31e46dc7287a75758',
+     x86_64: '42b3fb3462233d166eac6af5755972df60042e06a3230a72357fe8c121ae8591'
   })
 
-  depends_on 'mesa'
-  depends_on 'python3'
+  depends_on 'mesa' => :build
+  depends_on 'python3' => :build
+  depends_on 'glibc' # R
+
+  no_lto
 end

--- a/packages/libepoxy.rb
+++ b/packages/libepoxy.rb
@@ -1,13 +1,13 @@
-require 'package'
+require 'buildsystems/meson'
 
 class Libepoxy < Package
   description 'Epoxy is a library for handling OpenGL function pointer management for you'
   homepage 'https://github.com/anholt/libepoxy'
-  version '1.5.5'
+  version '1.5.10'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://github.com/anholt/libepoxy/releases/download/1.5.5/libepoxy-1.5.5.tar.xz'
-  source_sha256 '261663db21bcc1cc232b07ea683252ee6992982276536924271535875f5b0556'
+  source_url 'https://github.com/anholt/libepoxy.git'
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libepoxy/1.5.5_armv7l/libepoxy-1.5.5-chromeos-armv7l.tar.xz',
@@ -24,14 +24,4 @@ class Libepoxy < Package
 
   depends_on 'mesa'
   depends_on 'python3'
-
-  def self.build
-    system "meson setup #{CREW_MESON_FNO_LTO_OPTIONS} builddir"
-    system 'meson configure builddir'
-    system 'ninja -C builddir'
-  end
-
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-  end
 end

--- a/packages/libsigsegv.rb
+++ b/packages/libsigsegv.rb
@@ -23,12 +23,11 @@ class Libsigsegv < Package
   })
 
   depends_on 'glibc' # R
-  no_env_options
+  no_lto
 
   def self.build
     system 'autoreconf -fiv'
-    # libsigsegv fails to build with LTO.
-    system "#{CREW_ENV_FNO_LTO_OPTIONS} ./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_OPTIONS} \
     --enable-shared \
     --enable-static \
     --enable-relocatable"

--- a/packages/tcl.rb
+++ b/packages/tcl.rb
@@ -27,13 +27,12 @@ class Tcl < Package
   depends_on 'glibc' # R
   depends_on 'zlibpkg' # R
 
-  no_env_options
+  no_lto
 
-  # tk breaks if tcl is built with lto
   def self.build
     FileUtils.chdir('unix') do
       @bit64 = ARCH == 'x86_64' ? 'enable' : 'disable'
-      system "#{CREW_ENV_FNO_LTO_OPTIONS} ./configure #{CREW_OPTIONS} --#{@bit64}-64bit"
+      system "./configure #{CREW_OPTIONS} --#{@bit64}-64bit"
       system 'make'
     end
   end

--- a/packages/tk.rb
+++ b/packages/tk.rb
@@ -34,12 +34,12 @@ class Tk < Package
   depends_on 'tcl' # R
   depends_on 'zlibpkg' # R
 
-  no_env_options
+  no_lto
 
   def self.build
     FileUtils.chdir('unix') do
       @bit64 = ARCH == 'x86_64' ? 'enable' : 'disable'
-      system "#{CREW_ENV_FNO_LTO_OPTIONS} ./configure \
+      system "./configure \
           #{CREW_OPTIONS} \
           --with-tcl=#{CREW_LIB_PREFIX} \
           --enable-threads \

--- a/packages/vkd3d.rb
+++ b/packages/vkd3d.rb
@@ -29,9 +29,10 @@ class Vkd3d < Package
   depends_on 'spirv_tools' # R
   depends_on 'vulkan_headers' => :build
   depends_on 'vulkan_icd_loader' => :build
+  no_lto
 
   def self.build
-    system "#{CREW_ENV_FNO_LTO_OPTIONS} ./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_OPTIONS} \
             --with-xcb \
             --with-spirv-tools"
     system 'make'

--- a/packages/wine.rb
+++ b/packages/wine.rb
@@ -50,12 +50,13 @@ class Wine < Package
   depends_on 'sommelier'
   depends_on 'vkd3d'
   depends_on 'xdg_base'
+  no_lto
 
   def self.build
     FileUtils.mkdir_p 'wine64-build'
     Dir.chdir 'wine64-build' do
       unless File.file?('Makefile')
-        system "#{CREW_ENV_FNO_LTO_OPTIONS} ../configure #{CREW_OPTIONS} \
+        system "../configure #{CREW_OPTIONS} \
           --enable-win64 \
           --disable-maintainer-mode \
           --with-gstreamer \

--- a/packages/xorg_proto.rb
+++ b/packages/xorg_proto.rb
@@ -3,22 +3,22 @@ require 'buildsystems/meson'
 class Xorg_proto < Meson
   description 'The xorgproto package provides the header files required to build the X Window system, and to allow other applications to build against the installed X Window system.'
   homepage 'https://www.x.org/'
-  version '2022.2'
+  version '2023.2'
   license 'MIT'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/xorg/proto/xorgproto.git'
   git_hashtag "xorgproto-#{version}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_proto/2022.2_armv7l/xorg_proto-2022.2-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_proto/2022.2_armv7l/xorg_proto-2022.2-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_proto/2022.2_i686/xorg_proto-2022.2-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_proto/2022.2_x86_64/xorg_proto-2022.2-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_proto/2023.2_armv7l/xorg_proto-2023.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_proto/2023.2_armv7l/xorg_proto-2023.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_proto/2023.2_i686/xorg_proto-2023.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_proto/2023.2_x86_64/xorg_proto-2023.2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '4f29c3f12e684e8e3de289a0ca8810e763ddb96c3bf3a686baf0392d4d8ced66',
-     armv7l: '4f29c3f12e684e8e3de289a0ca8810e763ddb96c3bf3a686baf0392d4d8ced66',
-       i686: '0592845ac3053d91b8158bd186c629d2a0b372a95b5d0e30c06b71a5fffe4e95',
-     x86_64: '21802c99d382be50f69e613dee68e25821b6a09ba4b6833309899c76dce9789f'
+    aarch64: '135abd63058e542920a2125ff3d12f59f1f15b4e2ffd8051603e1d8d070aaafc',
+     armv7l: '135abd63058e542920a2125ff3d12f59f1f15b4e2ffd8051603e1d8d070aaafc',
+       i686: '58a8c851b381479f30e6cb24d3a0402d3990791dd823c297ab3de830e35302a5',
+     x86_64: '218d61ce750ba8f793e2f924baec49e65bd111fe9519a5b995dfb839f6f85501'
   })
 end


### PR DESCRIPTION
Fixes #8435

- updates `xorg_proto`
- updates `libepoxy` as an example meson package with `no_lto` set.
- adds `no_lto` to most packages using `CREW_ENV_FNO_LTO_OPTIONS`

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=no_lto CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
