### PR TITLE
Verbosely notify of additional buildsystems options being used.

### DIFF
--- a/lib/buildsystems/cmake.rb
+++ b/lib/buildsystems/cmake.rb
@@ -11,6 +11,7 @@ class CMake < Package
   end
 
   def self.build
+    puts "Additional cmake_options being used: #{@cmake_options}".orange
     @crew_cmake_options = no_lto ? CREW_CMAKE_FNO_LTO_OPTIONS : CREW_CMAKE_OPTIONS
     system "cmake -B builddir -G Ninja #{@crew_cmake_options} #{@cmake_options}"
     system "#{CREW_NINJA} -C builddir"

--- a/lib/buildsystems/meson.rb
+++ b/lib/buildsystems/meson.rb
@@ -11,6 +11,7 @@ class Meson < Package
   end
 
   def self.build
+    puts "Additional meson_options being used: #{@meson_options}".orange
     @crew_meson_options = no_lto ? CREW_MESON_FNO_LTO_OPTIONS : CREW_MESON_OPTIONS
     system "meson #{@crew_meson_options} #{@meson_options} builddir"
     system 'meson configure builddir'

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -2,7 +2,7 @@ require 'fileutils'
 
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.34.6'
+CREW_VERSION = '1.34.7'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
- Report additional build options in buildsystems builds, which are currently `meson_options` and `cmake_options`.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=meson-buildsystems-debug CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
