### PR TITLE
Add CREW_ARCHIVE_DEST constant for use during builds

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1602,7 +1602,8 @@ def resolve_dependencies_and_build
       post_install
     end
     search origin, true
-    build_package Dir.pwd
+    abort "CREW_ARCHIVE_DEST (#{CREW_ARCHIVE_DEST}) is not writable!".lightred unless File.writable?(CREW_ARCHIVE_DEST)
+    build_package CREW_ARCHIVE_DEST
   rescue InstallError => e
     abort "#{@pkg.name} failed to build: #{e}".lightred
   ensure
@@ -1616,7 +1617,7 @@ def resolve_dependencies_and_build
   @resolve_dependencies_and_build = 0
 end
 
-def build_package(pwd)
+def build_package(crew_archive_dest)
   abort 'It is not possible to build a fake package'.lightred if @pkg.is_fake?
   abort 'It is not possible to build without source'.lightred unless @pkg.is_source?(@device[:architecture])
   abort "Unable to locate CREW_LOCAL_MANIFEST_PATH. Please try again in the chromebrew/release/#{ARCH} directory.".lightred if CREW_LOCAL_MANIFEST_PATH.empty?
@@ -1643,10 +1644,10 @@ def build_package(pwd)
 
   # build package from filelist, dlist and binary files in CREW_DEST_DIR
   puts 'Archiving...'
-  archive_package pwd
+  archive_package crew_archive_dest
 end
 
-def archive_package(pwd)
+def archive_package(crew_archive_dest)
   # Check to see that there is a working zstd
   if File.file?("#{CREW_PREFIX}/bin/zstd")
     @crew_prefix_zstd_available = File.file?("#{CREW_PREFIX}/bin/zstd") ? true : nil
@@ -1655,7 +1656,7 @@ def archive_package(pwd)
     puts 'Using xz to compress package. This may take some time.'.lightblue
     pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.tar.xz"
     Dir.chdir CREW_DEST_DIR do
-      system "tar c#{@verbose}Jf #{pwd}/#{pkg_name} *"
+      system "tar c#{@verbose}Jf #{crew_archive_dest}/#{pkg_name} *"
     end
   else
     puts 'Using zstd to compress package. This may take some time.'.lightblue
@@ -1667,11 +1668,11 @@ def archive_package(pwd)
       # Use nice so that user can (possibly) do other things during compression.
       if @crew_prefix_zstd_available
         puts 'Using standard zstd'.lightblue if @opt_verbose
-        system "tar c#{@verbose} * | nice -n 20 #{CREW_PREFIX}/bin/zstd -c -T0 --ultra -20 - > #{pwd}/#{pkg_name}"
+        system "tar c#{@verbose} * | nice -n 20 #{CREW_PREFIX}/bin/zstd -c -T0 --ultra -20 - > #{crew_archive_dest}/#{pkg_name}"
       end
     end
   end
-  system "sha256sum #{pwd}/#{pkg_name} > #{pwd}/#{pkg_name}.sha256"
+  system "sha256sum #{crew_archive_dest}/#{pkg_name} > #{crew_archive_dest}/#{pkg_name}.sha256"
 end
 
 def remove(pkgName)

--- a/bin/crew
+++ b/bin/crew
@@ -1617,7 +1617,7 @@ def resolve_dependencies_and_build
   @resolve_dependencies_and_build = 0
 end
 
-def build_package(crew_archive_dest)
+def build_package(CREW_ARCHIVE_DEST)
   abort 'It is not possible to build a fake package'.lightred if @pkg.is_fake?
   abort 'It is not possible to build without source'.lightred unless @pkg.is_source?(@device[:architecture])
   abort "Unable to locate CREW_LOCAL_MANIFEST_PATH. Please try again in the chromebrew/release/#{ARCH} directory.".lightred if CREW_LOCAL_MANIFEST_PATH.empty?
@@ -1644,10 +1644,10 @@ def build_package(crew_archive_dest)
 
   # build package from filelist, dlist and binary files in CREW_DEST_DIR
   puts 'Archiving...'
-  archive_package crew_archive_dest
+  archive_package CREW_ARCHIVE_DEST
 end
 
-def archive_package(crew_archive_dest)
+def archive_package(CREW_ARCHIVE_DEST)
   # Check to see that there is a working zstd
   if File.file?("#{CREW_PREFIX}/bin/zstd")
     @crew_prefix_zstd_available = File.file?("#{CREW_PREFIX}/bin/zstd") ? true : nil
@@ -1656,7 +1656,7 @@ def archive_package(crew_archive_dest)
     puts 'Using xz to compress package. This may take some time.'.lightblue
     pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.tar.xz"
     Dir.chdir CREW_DEST_DIR do
-      system "tar c#{@verbose}Jf #{crew_archive_dest}/#{pkg_name} *"
+      system "tar c#{@verbose}Jf #{CREW_ARCHIVE_DEST}/#{pkg_name} *"
     end
   else
     puts 'Using zstd to compress package. This may take some time.'.lightblue
@@ -1668,11 +1668,11 @@ def archive_package(crew_archive_dest)
       # Use nice so that user can (possibly) do other things during compression.
       if @crew_prefix_zstd_available
         puts 'Using standard zstd'.lightblue if @opt_verbose
-        system "tar c#{@verbose} * | nice -n 20 #{CREW_PREFIX}/bin/zstd -c -T0 --ultra -20 - > #{crew_archive_dest}/#{pkg_name}"
+        system "tar c#{@verbose} * | nice -n 20 #{CREW_PREFIX}/bin/zstd -c -T0 --ultra -20 - > #{CREW_ARCHIVE_DEST}/#{pkg_name}"
       end
     end
   end
-  system "sha256sum #{crew_archive_dest}/#{pkg_name} > #{crew_archive_dest}/#{pkg_name}.sha256"
+  system "sha256sum #{CREW_ARCHIVE_DEST}/#{pkg_name} > #{CREW_ARCHIVE_DEST}/#{pkg_name}.sha256"
 end
 
 def remove(pkgName)

--- a/bin/crew
+++ b/bin/crew
@@ -1617,7 +1617,7 @@ def resolve_dependencies_and_build
   @resolve_dependencies_and_build = 0
 end
 
-def build_package(CREW_ARCHIVE_DEST)
+def build_package(crew_archive_dest)
   abort 'It is not possible to build a fake package'.lightred if @pkg.is_fake?
   abort 'It is not possible to build without source'.lightred unless @pkg.is_source?(@device[:architecture])
   abort "Unable to locate CREW_LOCAL_MANIFEST_PATH. Please try again in the chromebrew/release/#{ARCH} directory.".lightred if CREW_LOCAL_MANIFEST_PATH.empty?
@@ -1644,10 +1644,10 @@ def build_package(CREW_ARCHIVE_DEST)
 
   # build package from filelist, dlist and binary files in CREW_DEST_DIR
   puts 'Archiving...'
-  archive_package CREW_ARCHIVE_DEST
+  archive_package crew_archive_dest
 end
 
-def archive_package(CREW_ARCHIVE_DEST)
+def archive_package(crew_archive_dest)
   # Check to see that there is a working zstd
   if File.file?("#{CREW_PREFIX}/bin/zstd")
     @crew_prefix_zstd_available = File.file?("#{CREW_PREFIX}/bin/zstd") ? true : nil
@@ -1656,7 +1656,7 @@ def archive_package(CREW_ARCHIVE_DEST)
     puts 'Using xz to compress package. This may take some time.'.lightblue
     pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.tar.xz"
     Dir.chdir CREW_DEST_DIR do
-      system "tar c#{@verbose}Jf #{CREW_ARCHIVE_DEST}/#{pkg_name} *"
+      system "tar c#{@verbose}Jf #{crew_archive_dest}/#{pkg_name} *"
     end
   else
     puts 'Using zstd to compress package. This may take some time.'.lightblue
@@ -1668,11 +1668,11 @@ def archive_package(CREW_ARCHIVE_DEST)
       # Use nice so that user can (possibly) do other things during compression.
       if @crew_prefix_zstd_available
         puts 'Using standard zstd'.lightblue if @opt_verbose
-        system "tar c#{@verbose} * | nice -n 20 #{CREW_PREFIX}/bin/zstd -c -T0 --ultra -20 - > #{CREW_ARCHIVE_DEST}/#{pkg_name}"
+        system "tar c#{@verbose} * | nice -n 20 #{CREW_PREFIX}/bin/zstd -c -T0 --ultra -20 - > #{crew_archive_dest}/#{pkg_name}"
       end
     end
   end
-  system "sha256sum #{CREW_ARCHIVE_DEST}/#{pkg_name} > #{CREW_ARCHIVE_DEST}/#{pkg_name}.sha256"
+  system "sha256sum #{crew_archive_dest}/#{pkg_name} > #{crew_archive_dest}/#{pkg_name}.sha256"
 end
 
 def remove(pkgName)

--- a/lib/buildsystems/autotools.rb
+++ b/lib/buildsystems/autotools.rb
@@ -1,3 +1,4 @@
+require 'fileutils'
 require 'package'
 
 class Autotools < Package
@@ -21,6 +22,8 @@ class Autotools < Package
         system 'autoreconf -fiv'
       end
     end
+    abort "configure script not found!".lightred if File.file?('configure')
+    FileUtils.chmod('+x', 'configure')
     if `grep -q /usr/bin/file configure`
       puts 'Using filefix.'.orange
       system 'filefix'

--- a/lib/buildsystems/autotools.rb
+++ b/lib/buildsystems/autotools.rb
@@ -1,7 +1,6 @@
 require 'package'
 
 class Autotools < Package
-
   def self.configure_options(options = '')
     return (@configure_options = options if options)
   end
@@ -11,7 +10,7 @@ class Autotools < Package
   end
 
   def self.build
-    puts "Additional configure_options being used: #{if @configure_options.nil? or @configure_options.empty? ; '<no configure_options>' ; else ; @configure_options ; end}".orange
+    puts "Additional configure_options being used: #{@configure_options.nil? || @configure_options.empty? ? '<no configure_options>' : @configure_options}".orange
     # Run autoreconf if necessary
     unless File.executable? './configure'
       if File.executable? './autogen.sh'
@@ -21,6 +20,10 @@ class Autotools < Package
       else
         system 'autoreconf -fiv'
       end
+    end
+    if `grep -q /usr/bin/file configure`
+      puts 'Using filefix.'.orange
+      system 'filefix'
     end
     system "./configure #{CREW_OPTIONS} #{@configure_options}"
     system 'make'

--- a/lib/buildsystems/autotools.rb
+++ b/lib/buildsystems/autotools.rb
@@ -11,6 +11,7 @@ class Autotools < Package
   end
 
   def self.build
+    puts "Additional configure_options being used: #{if @configure_options.nil? or @configure_options.empty? ; '<no configure_options>' ; else ; @configure_options ; end}".orange
     # Run autoreconf if necessary
     unless File.executable? './configure'
       if File.executable? './autogen.sh'

--- a/lib/buildsystems/cmake.rb
+++ b/lib/buildsystems/cmake.rb
@@ -11,7 +11,7 @@ class CMake < Package
   end
 
   def self.build
-    puts "Additional cmake_options being used: #{@cmake_options}".orange
+    puts "Additional cmake_options being used: #{if @cmake_options.nil? or @cmake_options.empty? ; '<no cmake_options>' ; else ; @cmake_options ; end}".orange
     @crew_cmake_options = no_lto ? CREW_CMAKE_FNO_LTO_OPTIONS : CREW_CMAKE_OPTIONS
     system "cmake -B builddir -G Ninja #{@crew_cmake_options} #{@cmake_options}"
     system "#{CREW_NINJA} -C builddir"

--- a/lib/buildsystems/cmake.rb
+++ b/lib/buildsystems/cmake.rb
@@ -1,7 +1,6 @@
 require 'package'
 
 class CMake < Package
-
   def self.cmake_options(options = '')
     return (@cmake_options = options if options)
   end
@@ -11,7 +10,7 @@ class CMake < Package
   end
 
   def self.build
-    puts "Additional cmake_options being used: #{if @cmake_options.nil? or @cmake_options.empty? ; '<no cmake_options>' ; else ; @cmake_options ; end}".orange
+    puts "Additional cmake_options being used: #{@cmake_options.nil? || @cmake_options.empty? ? '<no cmake_options>' : @cmake_options}".orange
     @crew_cmake_options = no_lto ? CREW_CMAKE_FNO_LTO_OPTIONS : CREW_CMAKE_OPTIONS
     system "cmake -B builddir -G Ninja #{@crew_cmake_options} #{@cmake_options}"
     system "#{CREW_NINJA} -C builddir"

--- a/lib/buildsystems/meson.rb
+++ b/lib/buildsystems/meson.rb
@@ -11,7 +11,7 @@ class Meson < Package
   end
 
   def self.build
-    puts "Additional meson_options being used: #{@meson_options}".orange
+    puts "Additional meson_options being used: #{if @meson_options.nil? or @meson_options.empty? ; '<no meson_options>' ; else ; @meson_options ; end}".orange
     @crew_meson_options = no_lto ? CREW_MESON_FNO_LTO_OPTIONS : CREW_MESON_OPTIONS
     system "meson #{@crew_meson_options} #{@meson_options} builddir"
     system 'meson configure builddir'

--- a/lib/buildsystems/meson.rb
+++ b/lib/buildsystems/meson.rb
@@ -1,7 +1,6 @@
 require 'package'
 
 class Meson < Package
-
   def self.meson_options(options = '')
     return (@meson_options = options if options)
   end
@@ -11,7 +10,7 @@ class Meson < Package
   end
 
   def self.build
-    puts "Additional meson_options being used: #{if @meson_options.nil? or @meson_options.empty? ; '<no meson_options>' ; else ; @meson_options ; end}".orange
+    puts "Additional meson_options being used: #{@meson_options.nil? || @meson_options.empty? ? '<no meson_options>' : @meson_options}".orange
     @crew_meson_options = no_lto ? CREW_MESON_FNO_LTO_OPTIONS : CREW_MESON_OPTIONS
     system "meson #{@crew_meson_options} #{@meson_options} builddir"
     system 'meson configure builddir'

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -2,7 +2,7 @@ require 'fileutils'
 
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.34.7'
+CREW_VERSION = '1.34.8'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp
@@ -61,6 +61,8 @@ else
   CREW_PREFIX = ENV.fetch('CREW_PREFIX', nil)
   HOME = CREW_PREFIX + Dir.home
 end
+
+CREW_ARCHIVE_DEST = ENV.fetch('CREW_ARCHIVE_DEST', Dir.pwd)
 
 CREW_IN_CONTAINER = File.exist?('/.dockerenv') || !ENV['CREW_IN_CONTAINER'].to_s.empty?
 


### PR DESCRIPTION
`crew` currently builds package files in the dir that it was started from when `crew build` is invoked. This breaks packages that are referencing files in the `/usr/local/lib/crew/packages` dir. But invoking `crew build` in `/usr/local/crew/packages` also drops the built package files in `/usr/local/crew/packages`... which can be unwanted.

- This PR lets one set an ENV variable of `CREW_ARCHIVE_DEST` to specify where one wants those generated packages put. It falls back to `Dir.pwd`, the previous location.
- Add a check to bail out if `Dir.pwd` or `CREW_ARCHIVE_DEST` is not writable has also been added.
- Make `buildsystems` `{meson,make,configure}_options` messages more verbose.
- Add `filefix` to `buildsystems`' `autotools`.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=crew_build_dir CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
