### PR TITLE
Util_linux 2.38.1 => 2.39.1

### DIFF
--- a/manifest/armv7l/u/util_linux.filelist
+++ b/manifest/armv7l/u/util_linux.filelist
@@ -10,6 +10,7 @@
 /usr/local/bin/column
 /usr/local/bin/dmesg
 /usr/local/bin/eject
+/usr/local/bin/fadvise
 /usr/local/bin/fallocate
 /usr/local/bin/fincore
 /usr/local/bin/findmnt
@@ -46,6 +47,7 @@
 /usr/local/bin/mountpoint
 /usr/local/bin/namei
 /usr/local/bin/nsenter
+/usr/local/bin/pipesz
 /usr/local/bin/prlimit
 /usr/local/bin/rename
 /usr/local/bin/renice
@@ -67,6 +69,7 @@
 /usr/local/bin/utmpdump
 /usr/local/bin/uuidgen
 /usr/local/bin/uuidparse
+/usr/local/bin/waitpid
 /usr/local/bin/wall
 /usr/local/bin/wdctl
 /usr/local/bin/whereis
@@ -105,15 +108,16 @@
 /usr/local/lib/pkgconfig/mount.pc
 /usr/local/lib/pkgconfig/smartcols.pc
 /usr/local/lib/pkgconfig/uuid.pc
-/usr/local/lib/python3.10/site-packages/libmount/__init__.py
-/usr/local/lib/python3.10/site-packages/libmount/__pycache__/__init__.cpython-310.opt-1.pyc
-/usr/local/lib/python3.10/site-packages/libmount/__pycache__/__init__.cpython-310.pyc
-/usr/local/lib/python3.10/site-packages/libmount/pylibmount.la
-/usr/local/lib/python3.10/site-packages/libmount/pylibmount.so
+/usr/local/lib/python3.11/site-packages/libmount/__init__.py
+/usr/local/lib/python3.11/site-packages/libmount/__pycache__/__init__.cpython-311.opt-1.pyc
+/usr/local/lib/python3.11/site-packages/libmount/__pycache__/__init__.cpython-311.pyc
+/usr/local/lib/python3.11/site-packages/libmount/pylibmount.la
+/usr/local/lib/python3.11/site-packages/libmount/pylibmount.so
 /usr/local/sbin/addpart
 /usr/local/sbin/agetty
 /usr/local/sbin/blkdiscard
 /usr/local/sbin/blkid
+/usr/local/sbin/blkpr
 /usr/local/sbin/blkzone
 /usr/local/sbin/blockdev
 /usr/local/sbin/cfdisk
@@ -173,6 +177,7 @@
 /usr/local/share/bash-completion/completions/delpart
 /usr/local/share/bash-completion/completions/dmesg
 /usr/local/share/bash-completion/completions/eject
+/usr/local/share/bash-completion/completions/fadvise
 /usr/local/share/bash-completion/completions/fallocate
 /usr/local/share/bash-completion/completions/fdisk
 /usr/local/share/bash-completion/completions/fincore
@@ -221,6 +226,7 @@
 /usr/local/share/bash-completion/completions/namei
 /usr/local/share/bash-completion/completions/nsenter
 /usr/local/share/bash-completion/completions/partx
+/usr/local/share/bash-completion/completions/pipesz
 /usr/local/share/bash-completion/completions/pivot_root
 /usr/local/share/bash-completion/completions/prlimit
 /usr/local/share/bash-completion/completions/raw
@@ -253,6 +259,7 @@
 /usr/local/share/bash-completion/completions/uuidd
 /usr/local/share/bash-completion/completions/uuidgen
 /usr/local/share/bash-completion/completions/uuidparse
+/usr/local/share/bash-completion/completions/waitpid
 /usr/local/share/bash-completion/completions/wall
 /usr/local/share/bash-completion/completions/wdctl
 /usr/local/share/bash-completion/completions/whereis
@@ -275,12 +282,15 @@
 /usr/local/share/locale/id/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/it/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/ja/LC_MESSAGES/util-linux.mo
+/usr/local/share/locale/ko/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/nl/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/pl/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/pt_BR/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/pt/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/ru/LC_MESSAGES/util-linux.mo
+/usr/local/share/locale/sk/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/sl/LC_MESSAGES/util-linux.mo
+/usr/local/share/locale/sr/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/sv/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/tr/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/uk/LC_MESSAGES/util-linux.mo
@@ -298,6 +308,7 @@
 /usr/local/share/man/man1/column.1.zst
 /usr/local/share/man/man1/dmesg.1.zst
 /usr/local/share/man/man1/eject.1.zst
+/usr/local/share/man/man1/fadvise.1.zst
 /usr/local/share/man/man1/fallocate.1.zst
 /usr/local/share/man/man1/fincore.1.zst
 /usr/local/share/man/man1/flock.1.zst
@@ -326,6 +337,7 @@
 /usr/local/share/man/man1/mountpoint.1.zst
 /usr/local/share/man/man1/namei.1.zst
 /usr/local/share/man/man1/nsenter.1.zst
+/usr/local/share/man/man1/pipesz.1.zst
 /usr/local/share/man/man1/prlimit.1.zst
 /usr/local/share/man/man1/rename.1.zst
 /usr/local/share/man/man1/renice.1.zst
@@ -345,6 +357,7 @@
 /usr/local/share/man/man1/utmpdump.1.zst
 /usr/local/share/man/man1/uuidgen.1.zst
 /usr/local/share/man/man1/uuidparse.1.zst
+/usr/local/share/man/man1/waitpid.1.zst
 /usr/local/share/man/man1/wall.1.zst
 /usr/local/share/man/man1/whereis.1.zst
 /usr/local/share/man/man3/libblkid.3.zst
@@ -367,6 +380,7 @@
 /usr/local/share/man/man8/agetty.8.zst
 /usr/local/share/man/man8/blkdiscard.8.zst
 /usr/local/share/man/man8/blkid.8.zst
+/usr/local/share/man/man8/blkpr.8.zst
 /usr/local/share/man/man8/blkzone.8.zst
 /usr/local/share/man/man8/blockdev.8.zst
 /usr/local/share/man/man8/cfdisk.8.zst

--- a/manifest/i686/u/util_linux.filelist
+++ b/manifest/i686/u/util_linux.filelist
@@ -10,6 +10,7 @@
 /usr/local/bin/column
 /usr/local/bin/dmesg
 /usr/local/bin/eject
+/usr/local/bin/fadvise
 /usr/local/bin/fallocate
 /usr/local/bin/fincore
 /usr/local/bin/findmnt
@@ -46,6 +47,7 @@
 /usr/local/bin/mountpoint
 /usr/local/bin/namei
 /usr/local/bin/nsenter
+/usr/local/bin/pipesz
 /usr/local/bin/prlimit
 /usr/local/bin/rename
 /usr/local/bin/renice
@@ -105,11 +107,11 @@
 /usr/local/lib/pkgconfig/mount.pc
 /usr/local/lib/pkgconfig/smartcols.pc
 /usr/local/lib/pkgconfig/uuid.pc
-/usr/local/lib/python3.10/site-packages/libmount/__init__.py
-/usr/local/lib/python3.10/site-packages/libmount/__pycache__/__init__.cpython-310.opt-1.pyc
-/usr/local/lib/python3.10/site-packages/libmount/__pycache__/__init__.cpython-310.pyc
-/usr/local/lib/python3.10/site-packages/libmount/pylibmount.la
-/usr/local/lib/python3.10/site-packages/libmount/pylibmount.so
+/usr/local/lib/python3.11/site-packages/libmount/__init__.py
+/usr/local/lib/python3.11/site-packages/libmount/__pycache__/__init__.cpython-311.opt-1.pyc
+/usr/local/lib/python3.11/site-packages/libmount/__pycache__/__init__.cpython-311.pyc
+/usr/local/lib/python3.11/site-packages/libmount/pylibmount.la
+/usr/local/lib/python3.11/site-packages/libmount/pylibmount.so
 /usr/local/sbin/addpart
 /usr/local/sbin/agetty
 /usr/local/sbin/blkdiscard
@@ -171,6 +173,7 @@
 /usr/local/share/bash-completion/completions/delpart
 /usr/local/share/bash-completion/completions/dmesg
 /usr/local/share/bash-completion/completions/eject
+/usr/local/share/bash-completion/completions/fadvise
 /usr/local/share/bash-completion/completions/fallocate
 /usr/local/share/bash-completion/completions/fdisk
 /usr/local/share/bash-completion/completions/fincore
@@ -219,6 +222,7 @@
 /usr/local/share/bash-completion/completions/namei
 /usr/local/share/bash-completion/completions/nsenter
 /usr/local/share/bash-completion/completions/partx
+/usr/local/share/bash-completion/completions/pipesz
 /usr/local/share/bash-completion/completions/pivot_root
 /usr/local/share/bash-completion/completions/prlimit
 /usr/local/share/bash-completion/completions/raw
@@ -273,12 +277,15 @@
 /usr/local/share/locale/id/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/it/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/ja/LC_MESSAGES/util-linux.mo
+/usr/local/share/locale/ko/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/nl/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/pl/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/pt_BR/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/pt/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/ru/LC_MESSAGES/util-linux.mo
+/usr/local/share/locale/sk/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/sl/LC_MESSAGES/util-linux.mo
+/usr/local/share/locale/sr/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/sv/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/tr/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/uk/LC_MESSAGES/util-linux.mo
@@ -296,6 +303,7 @@
 /usr/local/share/man/man1/column.1.zst
 /usr/local/share/man/man1/dmesg.1.zst
 /usr/local/share/man/man1/eject.1.zst
+/usr/local/share/man/man1/fadvise.1.zst
 /usr/local/share/man/man1/fallocate.1.zst
 /usr/local/share/man/man1/fincore.1.zst
 /usr/local/share/man/man1/flock.1.zst
@@ -323,6 +331,7 @@
 /usr/local/share/man/man1/mountpoint.1.zst
 /usr/local/share/man/man1/namei.1.zst
 /usr/local/share/man/man1/nsenter.1.zst
+/usr/local/share/man/man1/pipesz.1.zst
 /usr/local/share/man/man1/prlimit.1.zst
 /usr/local/share/man/man1/rename.1.zst
 /usr/local/share/man/man1/renice.1.zst

--- a/manifest/x86_64/u/util_linux.filelist
+++ b/manifest/x86_64/u/util_linux.filelist
@@ -10,6 +10,7 @@
 /usr/local/bin/column
 /usr/local/bin/dmesg
 /usr/local/bin/eject
+/usr/local/bin/fadvise
 /usr/local/bin/fallocate
 /usr/local/bin/fincore
 /usr/local/bin/findmnt
@@ -47,6 +48,7 @@
 /usr/local/bin/mountpoint
 /usr/local/bin/namei
 /usr/local/bin/nsenter
+/usr/local/bin/pipesz
 /usr/local/bin/prlimit
 /usr/local/bin/rename
 /usr/local/bin/renice
@@ -68,6 +70,7 @@
 /usr/local/bin/utmpdump
 /usr/local/bin/uuidgen
 /usr/local/bin/uuidparse
+/usr/local/bin/waitpid
 /usr/local/bin/wall
 /usr/local/bin/wdctl
 /usr/local/bin/whereis
@@ -107,15 +110,16 @@
 /usr/local/lib64/pkgconfig/mount.pc
 /usr/local/lib64/pkgconfig/smartcols.pc
 /usr/local/lib64/pkgconfig/uuid.pc
-/usr/local/lib64/python3.10/site-packages/libmount/__init__.py
-/usr/local/lib64/python3.10/site-packages/libmount/__pycache__/__init__.cpython-310.opt-1.pyc
-/usr/local/lib64/python3.10/site-packages/libmount/__pycache__/__init__.cpython-310.pyc
-/usr/local/lib64/python3.10/site-packages/libmount/pylibmount.la
-/usr/local/lib64/python3.10/site-packages/libmount/pylibmount.so
+/usr/local/lib64/python3.11/site-packages/libmount/__init__.py
+/usr/local/lib64/python3.11/site-packages/libmount/__pycache__/__init__.cpython-311.opt-1.pyc
+/usr/local/lib64/python3.11/site-packages/libmount/__pycache__/__init__.cpython-311.pyc
+/usr/local/lib64/python3.11/site-packages/libmount/pylibmount.la
+/usr/local/lib64/python3.11/site-packages/libmount/pylibmount.so
 /usr/local/sbin/addpart
 /usr/local/sbin/agetty
 /usr/local/sbin/blkdiscard
 /usr/local/sbin/blkid
+/usr/local/sbin/blkpr
 /usr/local/sbin/blkzone
 /usr/local/sbin/blockdev
 /usr/local/sbin/cfdisk
@@ -175,6 +179,7 @@
 /usr/local/share/bash-completion/completions/delpart
 /usr/local/share/bash-completion/completions/dmesg
 /usr/local/share/bash-completion/completions/eject
+/usr/local/share/bash-completion/completions/fadvise
 /usr/local/share/bash-completion/completions/fallocate
 /usr/local/share/bash-completion/completions/fdisk
 /usr/local/share/bash-completion/completions/fincore
@@ -223,6 +228,7 @@
 /usr/local/share/bash-completion/completions/namei
 /usr/local/share/bash-completion/completions/nsenter
 /usr/local/share/bash-completion/completions/partx
+/usr/local/share/bash-completion/completions/pipesz
 /usr/local/share/bash-completion/completions/pivot_root
 /usr/local/share/bash-completion/completions/prlimit
 /usr/local/share/bash-completion/completions/raw
@@ -255,6 +261,7 @@
 /usr/local/share/bash-completion/completions/uuidd
 /usr/local/share/bash-completion/completions/uuidgen
 /usr/local/share/bash-completion/completions/uuidparse
+/usr/local/share/bash-completion/completions/waitpid
 /usr/local/share/bash-completion/completions/wall
 /usr/local/share/bash-completion/completions/wdctl
 /usr/local/share/bash-completion/completions/whereis
@@ -277,12 +284,15 @@
 /usr/local/share/locale/id/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/it/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/ja/LC_MESSAGES/util-linux.mo
+/usr/local/share/locale/ko/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/nl/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/pl/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/pt_BR/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/pt/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/ru/LC_MESSAGES/util-linux.mo
+/usr/local/share/locale/sk/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/sl/LC_MESSAGES/util-linux.mo
+/usr/local/share/locale/sr/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/sv/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/tr/LC_MESSAGES/util-linux.mo
 /usr/local/share/locale/uk/LC_MESSAGES/util-linux.mo
@@ -300,6 +310,7 @@
 /usr/local/share/man/man1/column.1.zst
 /usr/local/share/man/man1/dmesg.1.zst
 /usr/local/share/man/man1/eject.1.zst
+/usr/local/share/man/man1/fadvise.1.zst
 /usr/local/share/man/man1/fallocate.1.zst
 /usr/local/share/man/man1/fincore.1.zst
 /usr/local/share/man/man1/flock.1.zst
@@ -328,6 +339,7 @@
 /usr/local/share/man/man1/mountpoint.1.zst
 /usr/local/share/man/man1/namei.1.zst
 /usr/local/share/man/man1/nsenter.1.zst
+/usr/local/share/man/man1/pipesz.1.zst
 /usr/local/share/man/man1/prlimit.1.zst
 /usr/local/share/man/man1/rename.1.zst
 /usr/local/share/man/man1/renice.1.zst
@@ -347,6 +359,7 @@
 /usr/local/share/man/man1/utmpdump.1.zst
 /usr/local/share/man/man1/uuidgen.1.zst
 /usr/local/share/man/man1/uuidparse.1.zst
+/usr/local/share/man/man1/waitpid.1.zst
 /usr/local/share/man/man1/wall.1.zst
 /usr/local/share/man/man1/whereis.1.zst
 /usr/local/share/man/man3/libblkid.3.zst
@@ -369,6 +382,7 @@
 /usr/local/share/man/man8/agetty.8.zst
 /usr/local/share/man/man8/blkdiscard.8.zst
 /usr/local/share/man/man8/blkid.8.zst
+/usr/local/share/man/man8/blkpr.8.zst
 /usr/local/share/man/man8/blkzone.8.zst
 /usr/local/share/man/man8/blockdev.8.zst
 /usr/local/share/man/man8/cfdisk.8.zst

--- a/packages/util_linux.rb
+++ b/packages/util_linux.rb
@@ -3,23 +3,23 @@ require 'package'
 class Util_linux < Package
   description 'essential linux tools'
   homepage 'https://www.kernel.org/pub/linux/utils/util-linux/'
-  version '2.38.1'
+  version '2.39.1-py3.11'
   license 'GPL-2, LGPL-2.1, BSD-4, MIT and public-domain'
   compatibility 'all'
-  source_url 'https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.38/util-linux-2.38.1.tar.xz'
-  source_sha256 '60492a19b44e6cf9a3ddff68325b333b8b52b6c59ce3ebd6a0ecaa4c5117e84f'
+  source_url 'https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.39/util-linux-2.39.1.tar.xz'
+  source_sha256 '890ae8ff810247bd19e274df76e8371d202cda01ad277681b0ea88eeaa00286b'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/util_linux/2.38.1_armv7l/util_linux-2.38.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/util_linux/2.38.1_armv7l/util_linux-2.38.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/util_linux/2.38.1_i686/util_linux-2.38.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/util_linux/2.38.1_x86_64/util_linux-2.38.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/util_linux/2.39.1_armv7l/util_linux-2.39.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/util_linux/2.39.1_armv7l/util_linux-2.39.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/util_linux/2.39.1_i686/util_linux-2.39.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/util_linux/2.39.1_x86_64/util_linux-2.39.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '43eb0bf0f2f25a6de16b6da2117488a2af3271f19a4f2eb8cbb3d24a35c98b14',
-     armv7l: '43eb0bf0f2f25a6de16b6da2117488a2af3271f19a4f2eb8cbb3d24a35c98b14',
-       i686: '7cf66b87e3d4441096fed54c8a4b5b9414eb49530bb1938af07757fac3baae02',
-     x86_64: 'ffbdb18c1d22d32605c2a8033f795ee97dc8a0adaf7a1f4e6c83a810c36becfe'
+    aarch64: '4ce6e57e3f5fab54f18764edc9edfd059faf94b45b8e43930aa5f6f879761794',
+     armv7l: '4ce6e57e3f5fab54f18764edc9edfd059faf94b45b8e43930aa5f6f879761794',
+       i686: '9b84a3f15cfa13ef60ae498d0cf9cf1d1ca04bef988da28973367a7b313104f8',
+     x86_64: 'eae35dd81597ed8506bec34aaa7b5050c26e55325110ca4b0567299896f623eb'
   })
 
   depends_on 'bz2' # R
@@ -37,6 +37,11 @@ class Util_linux < Package
 
   patchelf
   no_env_options
+
+  def self.patch
+    # Fix sys-utils/setarch.c:90:7: error: PER_LINUX_FDPIC undeclared here
+    system "sed -i 's,PER_LINUX_FDPIC,PER_LINUX_32BIT,' sys-utils/setarch.c" if ARCH == 'i686'
+  end
 
   def self.build
     system "./configure #{CREW_OPTIONS} \


### PR DESCRIPTION
Tests passed as shown below:
```
$ for b in $(crew files util_linux|grep /usr/local/bin); do $b --version; done
cal from util-linux 2.39.1
chfn from util-linux 2.39.1
chmem from util-linux 2.39.1
choom from util-linux 2.39.1
chrt from util-linux 2.39.1
chsh from util-linux 2.39.1
col from util-linux 2.39.1
colcrt from util-linux 2.39.1
colrm from util-linux 2.39.1
column from util-linux 2.39.1
dmesg from util-linux 2.39.1
eject from util-linux 2.39.1
fadvise from util-linux 2.39.1
fallocate from util-linux 2.39.1
fincore from util-linux 2.39.1
findmnt from util-linux 2.39.1
flock from util-linux 2.39.1
getopt from util-linux 2.39.1
hardlink from util-linux 2.39.1 (features: reflink, cryptoapi)
hexdump from util-linux 2.39.1
i386 from util-linux 2.39.1
ionice from util-linux 2.39.1
ipcmk from util-linux 2.39.1
ipcrm from util-linux 2.39.1
ipcs from util-linux 2.39.1
irqtop from util-linux 2.39.1
isosize from util-linux 2.39.1
last from util-linux 2.39.1
lastb from util-linux 2.39.1
linux32 from util-linux 2.39.1
linux64 from util-linux 2.39.1
logger from util-linux 2.39.1
login from util-linux 2.39.1
look from util-linux 2.39.1
lsblk from util-linux 2.39.1
lscpu from util-linux 2.39.1
lsfd from util-linux 2.39.1
lsipc from util-linux 2.39.1
lsirq from util-linux 2.39.1
lslocks from util-linux 2.39.1
lslogins from util-linux 2.39.1
lsmem from util-linux 2.39.1
lsns from util-linux 2.39.1
mcookie from util-linux 2.39.1
mesg from util-linux 2.39.1
more from util-linux 2.39.1
mount from util-linux 2.39.1 (libmount 2.39.1: btrfs, namespaces, assert, debug)
mountpoint from util-linux 2.39.1
namei from util-linux 2.39.1
nsenter from util-linux 2.39.1
pipesz from util-linux 2.39.1
prlimit from util-linux 2.39.1
rename from util-linux 2.39.1
renice from util-linux 2.39.1
rev from util-linux 2.39.1
script from util-linux 2.39.1
scriptlive from util-linux 2.39.1
scriptreplay from util-linux 2.39.1
setarch from util-linux 2.39.1
setpriv from util-linux 2.39.1
setsid from util-linux 2.39.1
setterm from util-linux 2.39.1
su from util-linux 2.39.1
taskset from util-linux 2.39.1
uclampset from util-linux 2.39.1
ul from util-linux 2.39.1
umount from util-linux 2.39.1 (libmount 2.39.1: btrfs, namespaces, assert, debug)
uname26 from util-linux 2.39.1
unshare from util-linux 2.39.1
utmpdump from util-linux 2.39.1
uuidgen from util-linux 2.39.1
uuidparse from util-linux 2.39.1
waitpid from util-linux 2.39.1
wall from util-linux 2.39.1
wdctl from util-linux 2.39.1
whereis from util-linux 2.39.1
x86_64 from util-linux 2.39.1
```