### PR TITLE
libjpeg (turbo) => 3.0.0

### DIFF
--- a/manifest/armv7l/l/libjpeg.filelist
+++ b/manifest/armv7l/l/libjpeg.filelist
@@ -16,13 +16,13 @@
 /usr/local/lib/cmake/libjpeg-turbo/libjpeg-turboTargets-release.cmake
 /usr/local/lib/libjpeg.so
 /usr/local/lib/libjpeg.so.62
-/usr/local/lib/libjpeg.so.62.3.0
+/usr/local/lib/libjpeg.so.62.4.0
 /usr/local/lib/libturbojpeg.so
 /usr/local/lib/libturbojpeg.so.0
-/usr/local/lib/libturbojpeg.so.0.2.0
+/usr/local/lib/libturbojpeg.so.0.3.0
 /usr/local/lib/pkgconfig/libjpeg.pc
 /usr/local/lib/pkgconfig/libturbojpeg.pc
-/usr/local/share/doc/libjpeg-turbo/example.txt
+/usr/local/share/doc/libjpeg-turbo/example.c
 /usr/local/share/doc/libjpeg-turbo/libjpeg.txt
 /usr/local/share/doc/libjpeg-turbo/LICENSE.md
 /usr/local/share/doc/libjpeg-turbo/README.ijg

--- a/manifest/i686/l/libjpeg.filelist
+++ b/manifest/i686/l/libjpeg.filelist
@@ -16,13 +16,13 @@
 /usr/local/lib/cmake/libjpeg-turbo/libjpeg-turboTargets-release.cmake
 /usr/local/lib/libjpeg.so
 /usr/local/lib/libjpeg.so.62
-/usr/local/lib/libjpeg.so.62.3.0
+/usr/local/lib/libjpeg.so.62.4.0
 /usr/local/lib/libturbojpeg.so
 /usr/local/lib/libturbojpeg.so.0
-/usr/local/lib/libturbojpeg.so.0.2.0
+/usr/local/lib/libturbojpeg.so.0.3.0
 /usr/local/lib/pkgconfig/libjpeg.pc
 /usr/local/lib/pkgconfig/libturbojpeg.pc
-/usr/local/share/doc/libjpeg-turbo/example.txt
+/usr/local/share/doc/libjpeg-turbo/example.c
 /usr/local/share/doc/libjpeg-turbo/libjpeg.txt
 /usr/local/share/doc/libjpeg-turbo/LICENSE.md
 /usr/local/share/doc/libjpeg-turbo/README.ijg

--- a/manifest/x86_64/l/libjpeg.filelist
+++ b/manifest/x86_64/l/libjpeg.filelist
@@ -16,13 +16,13 @@
 /usr/local/lib64/cmake/libjpeg-turbo/libjpeg-turboTargets-release.cmake
 /usr/local/lib64/libjpeg.so
 /usr/local/lib64/libjpeg.so.62
-/usr/local/lib64/libjpeg.so.62.3.0
+/usr/local/lib64/libjpeg.so.62.4.0
 /usr/local/lib64/libturbojpeg.so
 /usr/local/lib64/libturbojpeg.so.0
-/usr/local/lib64/libturbojpeg.so.0.2.0
+/usr/local/lib64/libturbojpeg.so.0.3.0
 /usr/local/lib64/pkgconfig/libjpeg.pc
 /usr/local/lib64/pkgconfig/libturbojpeg.pc
-/usr/local/share/doc/libjpeg-turbo/example.txt
+/usr/local/share/doc/libjpeg-turbo/example.c
 /usr/local/share/doc/libjpeg-turbo/libjpeg.txt
 /usr/local/share/doc/libjpeg-turbo/LICENSE.md
 /usr/local/share/doc/libjpeg-turbo/README.ijg

--- a/packages/libjpeg.rb
+++ b/packages/libjpeg.rb
@@ -3,26 +3,28 @@ require 'package'
 class Libjpeg < Package
   description 'Libjpeg-turbo implements both the traditional libjpeg API as well as the less powerful but more straightforward TurboJPEG API.'
   homepage 'https://libjpeg-turbo.org'
-  version '2.1.5.1'
+  version '3.0.0'
   compatibility 'all'
   source_url 'https://github.com/libjpeg-turbo/libjpeg-turbo.git'
   git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libjpeg/2.1.5.1_armv7l/libjpeg-2.1.5.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libjpeg/2.1.5.1_armv7l/libjpeg-2.1.5.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libjpeg/2.1.5.1_i686/libjpeg-2.1.5.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libjpeg/2.1.5.1_x86_64/libjpeg-2.1.5.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libjpeg/3.0.0_armv7l/libjpeg-3.0.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libjpeg/3.0.0_armv7l/libjpeg-3.0.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libjpeg/3.0.0_i686/libjpeg-3.0.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libjpeg/3.0.0_x86_64/libjpeg-3.0.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '22e4475d2ff367b21b6608dfaadeab459957bf385df26f768309844223151c73',
-     armv7l: '22e4475d2ff367b21b6608dfaadeab459957bf385df26f768309844223151c73',
-       i686: 'b2ec21bc91a53d4d74640804a47c4d95d34f7f490c25f7134cc27cd18bcfcd48',
-     x86_64: '31c1dd4a5cf956c9552ca480aa67ed7c0c89ce0cbeaf2f807975f523a79509d1'
+    aarch64: '9b10ba35f72b7ba00f114b794d6095accdcaf6485423f674e8bba7c974464aa4',
+     armv7l: '9b10ba35f72b7ba00f114b794d6095accdcaf6485423f674e8bba7c974464aa4',
+       i686: '515a751b7160bddbc085de6b47df1503148ec1d76f527ae12fa4c9229992da8d',
+     x86_64: '0d26e82b4ff505b042d9928f0912046fcf4010671e0fbb81509e609eb12b6eb9'
   })
 
   depends_on 'yasm' => :build
   depends_on 'glibc' # R
+
+  no_env_options
 
   def self.build
     system "cmake \


### PR DESCRIPTION
- library names are unchanged.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=libjpeg3 CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
