### PR TITLE
Meson buildsystem fix

### DIFF
--- a/lib/buildsystems/meson.rb
+++ b/lib/buildsystems/meson.rb
@@ -12,7 +12,7 @@ class Meson < Package
   def self.build
     puts "Additional meson_options being used: #{@meson_options.nil? || @meson_options.empty? ? '<no meson_options>' : @meson_options}".orange
     @crew_meson_options = no_lto ? CREW_MESON_FNO_LTO_OPTIONS : CREW_MESON_OPTIONS
-    system "meson #{@crew_meson_options} #{@meson_options} builddir"
+    system "meson setup #{@crew_meson_options} #{@meson_options} builddir"
     system 'meson configure builddir'
     system "#{CREW_NINJA} -C builddir"
   end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,5 +1,5 @@
 # Defines common constants used in different parts of crew
-CREW_VERSION = '1.34.9'
+CREW_VERSION = '1.35.0'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/packages/fragments.rb
+++ b/packages/fragments.rb
@@ -41,16 +41,16 @@ class Fragments < Package
   gnome
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} builddir"
+    system "meson setup #{CREW_MESON_OPTIONS} builddir"
     system 'meson configure builddir'
-    system 'samu -C builddir'
+    system "#{CREW_NINJA} -C builddir"
   end
 
   def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
+    system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
   end
 
   def self.check
-    system 'samu -C builddir test || true'
+    system "#{CREW_NINJA} -C builddir test || true"
   end
 end

--- a/packages/fuse3.rb
+++ b/packages/fuse3.rb
@@ -27,7 +27,7 @@ class Fuse3 < Package
   depends_on 'glibc' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Ddisable-mtab=true \
       -Dudevrulesdir=#{CREW_PREFIX}/etc/udev/rules.d/ \
       -Dexamples=true \

--- a/packages/libdecor.rb
+++ b/packages/libdecor.rb
@@ -33,7 +33,7 @@ class Libdecor < Package
   depends_on 'wayland' # R
 
   def self.build
-    system "meson #{CREW_MESON_OPTIONS} \
+    system "meson setup #{CREW_MESON_OPTIONS} \
       -Dlocalstatedir=#{CREW_PREFIX}/var \
       -Dsharedstatedir=#{CREW_PREFIX}/var/lib \
       builddir"


### PR DESCRIPTION
Fixes this message during meson builds:
```
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.
```


Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=meson_buildsystem  CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
