### PR TITLE
Use 'mold -run' in builtsystems when mold is CREW_LINKER

### DIFF
--- a/lib/buildsystems/autotools.rb
+++ b/lib/buildsystems/autotools.rb
@@ -28,7 +28,11 @@ class Autotools < Package
       puts 'Using filefix.'.orange
       system 'filefix'
     end
-    system "./configure #{CREW_OPTIONS} #{@configure_options}"
+    if CREW_LINKER == 'mold'
+      system "mold -run ./configure #{CREW_OPTIONS} #{@configure_options}"
+    else
+      system "./configure #{CREW_OPTIONS} #{@configure_options}"
+    end
     system 'make'
   end
 

--- a/lib/buildsystems/cmake.rb
+++ b/lib/buildsystems/cmake.rb
@@ -12,7 +12,11 @@ class CMake < Package
   def self.build
     puts "Additional cmake_options being used: #{@cmake_options.nil? || @cmake_options.empty? ? '<no cmake_options>' : @cmake_options}".orange
     @crew_cmake_options = no_lto ? CREW_CMAKE_FNO_LTO_OPTIONS : CREW_CMAKE_OPTIONS
-    system "cmake -B builddir -G Ninja #{@crew_cmake_options} #{@cmake_options}"
+    if CREW_LINKER == 'mold'
+      system "mold -run cmake -B builddir -G Ninja #{@crew_cmake_options} #{@cmake_options}"
+    else
+      system "cmake -B builddir -G Ninja #{@crew_cmake_options} #{@cmake_options}"
+    end
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/lib/buildsystems/meson.rb
+++ b/lib/buildsystems/meson.rb
@@ -12,7 +12,11 @@ class Meson < Package
   def self.build
     puts "Additional meson_options being used: #{@meson_options.nil? || @meson_options.empty? ? '<no meson_options>' : @meson_options}".orange
     @crew_meson_options = no_lto ? CREW_MESON_FNO_LTO_OPTIONS : CREW_MESON_OPTIONS
-    system "meson setup #{@crew_meson_options} #{@meson_options} builddir"
+    if CREW_LINKER == 'mold'
+      system "mold -run meson setup #{@crew_meson_options} #{@meson_options} builddir"
+    else
+      system "meson setup #{@crew_meson_options} #{@meson_options} builddir"
+    end
     system 'meson configure builddir'
     system "#{CREW_NINJA} -C builddir"
   end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,5 +1,5 @@
 # Defines common constants used in different parts of crew
-CREW_VERSION = '1.35.0'
+CREW_VERSION = '1.35.1'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
- Some buildsystems builds break when `mold -run` isn't used during configuration.
Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=mold_buildsystems CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
