### PR TITLE
Add lnav package

### DIFF
--- a/manifest/x86_64/l/lnav.filelist
+++ b/manifest/x86_64/l/lnav.filelist
@@ -1,0 +1,2 @@
+/usr/local/bin/lnav
+/usr/local/share/man/man1/lnav.1.zst

--- a/packages/lnav.rb
+++ b/packages/lnav.rb
@@ -1,0 +1,29 @@
+require 'buildsystems/autotools'
+
+class Lnav < Autotools
+  description 'An advanced log file viewer for the small-scale'
+  homepage 'https://lnav.org/'
+  version '0.11.2'
+  license 'BSD-2 Clause'
+  compatibility 'x86_64'
+  source_url 'https://github.com/tstack/lnav.git'
+  git_hashtag "v#{version}"
+
+  binary_url({
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/lnav/0.11.2_x86_64/lnav-0.11.2-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    x86_64: 'a3da030ad5690e7f447b58530966820e38e3d85bdb145d7fa77d02898fbb3453'
+  })
+
+  depends_on 'gcc' => :build
+  depends_on 'pcre2' # R
+  depends_on 'sqlite' # R
+  depends_on 'ncurses' # R
+  depends_on 'readline' # R
+  depends_on 'zlibpkg' # R
+  depends_on 'bz2' # R
+  depends_on 'libcurl' # R
+  depends_on 'libarchive' # R
+  depends_on 'wireshark' # R
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -5191,6 +5191,11 @@ url: https://git.openldap.org/openldap/openldap/-/tags
 activity: high
 ---
 kind: url
+name: lnav
+url: https://github.com/tstack/lnav/releases
+activity: high
+---
+kind: url
 name: log4c
 url: https://sourceforge.net/projects/log4c/files/log4c/
 activity: none


### PR DESCRIPTION
An advanced log file viewer for the small-scale
Watch and analyze your log files from a terminal.
No server. No setup. Still featureful.
See https://lnav.org/.