### PR TITLE
Wireshark 4.0.6 => 4.0.7

### DIFF
--- a/manifest/armv7l/w/wireshark.filelist
+++ b/manifest/armv7l/w/wireshark.filelist
@@ -649,10 +649,10 @@
 /usr/local/include/wireshark/ws_version.h
 /usr/local/lib/libwireshark.so
 /usr/local/lib/libwireshark.so.16
-/usr/local/lib/libwireshark.so.16.0.6
+/usr/local/lib/libwireshark.so.16.0.7
 /usr/local/lib/libwiretap.so
 /usr/local/lib/libwiretap.so.13
-/usr/local/lib/libwiretap.so.13.0.6
+/usr/local/lib/libwiretap.so.13.0.7
 /usr/local/lib/libwsutil.so
 /usr/local/lib/libwsutil.so.14
 /usr/local/lib/libwsutil.so.14.0.0

--- a/manifest/i686/w/wireshark.filelist
+++ b/manifest/i686/w/wireshark.filelist
@@ -648,10 +648,10 @@
 /usr/local/include/wireshark/ws_version.h
 /usr/local/lib/libwireshark.so
 /usr/local/lib/libwireshark.so.16
-/usr/local/lib/libwireshark.so.16.0.6
+/usr/local/lib/libwireshark.so.16.0.7
 /usr/local/lib/libwiretap.so
 /usr/local/lib/libwiretap.so.13
-/usr/local/lib/libwiretap.so.13.0.6
+/usr/local/lib/libwiretap.so.13.0.7
 /usr/local/lib/libwsutil.so
 /usr/local/lib/libwsutil.so.14
 /usr/local/lib/libwsutil.so.14.0.0

--- a/manifest/x86_64/w/wireshark.filelist
+++ b/manifest/x86_64/w/wireshark.filelist
@@ -649,10 +649,10 @@
 /usr/local/include/wireshark/ws_version.h
 /usr/local/lib64/libwireshark.so
 /usr/local/lib64/libwireshark.so.16
-/usr/local/lib64/libwireshark.so.16.0.6
+/usr/local/lib64/libwireshark.so.16.0.7
 /usr/local/lib64/libwiretap.so
 /usr/local/lib64/libwiretap.so.13
-/usr/local/lib64/libwiretap.so.13.0.6
+/usr/local/lib64/libwiretap.so.13.0.7
 /usr/local/lib64/libwsutil.so
 /usr/local/lib64/libwsutil.so.14
 /usr/local/lib64/libwsutil.so.14.0.0

--- a/packages/wireshark.rb
+++ b/packages/wireshark.rb
@@ -6,22 +6,22 @@ require 'package'
 class Wireshark < Package
   description 'Network traffic and protocol analyzer/sniffer'
   homepage 'https://www.wireshark.org/'
-  version '4.0.6'
+  version '4.0.7'
   compatibility 'all'
   source_url 'https://github.com/wireshark/wireshark.git'
   git_hashtag "wireshark-#{version}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wireshark/4.0.6_armv7l/wireshark-4.0.6-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wireshark/4.0.6_armv7l/wireshark-4.0.6-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wireshark/4.0.6_i686/wireshark-4.0.6-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wireshark/4.0.6_x86_64/wireshark-4.0.6-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wireshark/4.0.7_armv7l/wireshark-4.0.7-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wireshark/4.0.7_armv7l/wireshark-4.0.7-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wireshark/4.0.7_i686/wireshark-4.0.7-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/wireshark/4.0.7_x86_64/wireshark-4.0.7-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '017257adc58efbfcb50a218505d0f36954d3ff25a475df7b3e34858c6f6b22b3',
-     armv7l: '017257adc58efbfcb50a218505d0f36954d3ff25a475df7b3e34858c6f6b22b3',
-       i686: '7b505459f5f8e8a98cb64c98e32190300e9ffbcb4f832528f8e3ca3d30c4eb92',
-     x86_64: 'd9a064f716807a3354ea0f09971e3c9a54a46dd5fa15add2e5e1719d3735437d'
+    aarch64: '151e5fc92876d26cf2961725549ccae7f2a30dbbac4775db855c332cad637dbf',
+     armv7l: '151e5fc92876d26cf2961725549ccae7f2a30dbbac4775db855c332cad637dbf',
+       i686: 'd4d44e2f452d3481cb2831f9ff223d1239dc92e9770da305bcd89230095e658b',
+     x86_64: '219be09a131409c6868478701b2f6c27093fcd89b0ab88d62139b7a7c938f784'
   })
 
   depends_on 'brotli' # R


### PR DESCRIPTION
Tests passed as shown below:
```
$ for b in $(crew files wireshark|grep /usr/local/bin); do $b -v 2>/dev/null|head -1; done
Capinfos (Wireshark) 4.0.7 (v4.0.7-0-g0ad1823cc090).
Captype (Wireshark) 4.0.7 (v4.0.7-0-g0ad1823cc090).
Dumpcap (Wireshark) 4.0.7 (v4.0.7-0-g0ad1823cc090).
Editcap (Wireshark) 4.0.7 (v4.0.7-0-g0ad1823cc090).
Mergecap (Wireshark) 4.0.7 (v4.0.7-0-g0ad1823cc090).
[init]
Rawshark (Wireshark) 4.0.7 (v4.0.7-0-g0ad1823cc090).
Reordercap (Wireshark) 4.0.7 (v4.0.7-0-g0ad1823cc090).
Sharkd (Wireshark) 4.0.7 (v4.0.7-0-g0ad1823cc090).
Text2pcap (Wireshark) 4.0.7 (v4.0.7-0-g0ad1823cc090).
TShark (Wireshark) 4.0.7 (v4.0.7-0-g0ad1823cc090).
```