### PR TITLE
Remove all remaining usages of @_ver with simple assignments

### DIFF
--- a/packages/caja.rb
+++ b/packages/caja.rb
@@ -6,11 +6,10 @@ require 'package'
 class Caja < Package
   description 'Caja file manager for the MATE desktop'
   homepage 'https://mate-desktop.org'
-  @_ver = '1.27.0'
-  version @_ver
+  version '1.27.0'
   compatibility 'all'
   license 'GPL-2+ LGPL-2+'
-  source_url "https://pub.mate-desktop.org/releases/#{@_ver.rpartition('.')[0]}/caja-#{@_ver}.tar.xz"
+  source_url "https://pub.mate-desktop.org/releases/#{version.rpartition('.')[0]}/caja-#{version}.tar.xz"
   source_sha256 '82aa0cc7a50a844d686ac3d29ca1866033ba4fb0c03e198838161337301de6d5'
 
   depends_on 'exempi'

--- a/packages/exo.rb
+++ b/packages/exo.rb
@@ -3,11 +3,10 @@ require 'package'
 class Exo < Package
   description 'Extension library for the Xfce desktop environment'
   homepage 'https://xfce.org/'
-  @_ver = '4.16.2'
-  version @_ver
+  version '4.16.2'
   license 'Apache-2.0'
   compatibility 'all'
-  source_url "https://archive.xfce.org/src/xfce/exo/#{@_ver.rpartition('.')[0]}/exo-#{@_ver}.tar.bz2"
+  source_url "https://archive.xfce.org/src/xfce/exo/#{version.rpartition('.')[0]}/exo-#{version}.tar.bz2"
   source_sha256 '4e89f5536afbf1cb9191cceb720fb2764df1a4fae3459512b7320841ab5a9e9d'
 
   binary_url({

--- a/packages/gexiv2.rb
+++ b/packages/gexiv2.rb
@@ -3,12 +3,10 @@ require 'package'
 class Gexiv2 < Package
   description 'gexiv2 is a GObject wrapper around the Exiv2 photo metadata library.'
   homepage 'https://wiki.gnome.org/Projects/gexiv2/'
-  @_ver = '0.14.0'
-  @_ver_prelastdot = @_ver.rpartition('.')[0]
-  version @_ver
+  version '0.14.0'
   license 'LGPL-2.1+ and GPL-2'
   compatibility 'all'
-  source_url "https://download.gnome.org/sources/gexiv2/#{@_ver_prelastdot}/gexiv2-#{@_ver}.tar.xz"
+  source_url "https://download.gnome.org/sources/gexiv2/#{version.rpartition('.')[0]}/gexiv2-#{version}.tar.xz"
   source_sha256 'e58279a6ff20b6f64fa499615da5e9b57cf65ba7850b72fafdf17221a9d6d69e'
 
   binary_url({

--- a/packages/gfbgraph.rb
+++ b/packages/gfbgraph.rb
@@ -3,12 +3,10 @@ require 'package'
 class Gfbgraph < Package
   description 'GLib/GObject wrapper for the Facebook Graph API'
   homepage 'https://wiki.gnome.org/Projects/GFBGraph'
-  @_ver = '0.2.4'
-  @_ver_ = @_ver.gsub(/[.]/, '_')
-  version @_ver
+  version '0.2.4'
   license 'LGPL-2.1+'
   compatibility 'all'
-  source_url "https://gitlab.gnome.org/GNOME/libgfbgraph/-/archive/v_#{@_ver_}/libgfbgraph-v_#{@_ver_}.tar.bz2"
+  source_url "https://gitlab.gnome.org/GNOME/libgfbgraph/-/archive/v_#{version.gsub(/[.]/, '_')}/libgfbgraph-v_#{version.gsub(/[.]/, '_')}.tar.bz2"
   source_sha256 'e55bb497daabfcd7e68e216ac5c695f03319f660ff524d0b6659e42089853516'
 
   binary_url({

--- a/packages/gjs.rb
+++ b/packages/gjs.rb
@@ -2,9 +2,7 @@ require 'package'
 
 class Gjs < Package
   description 'Javascript Bindings for GNOME'
-  @_ver = '1.74.0'
-  @_ver_prelastdot = @_ver.rpartition('.')[0]
-  version @_ver
+  version '1.74.0'
   license 'MIT and MPL-1.1, LGPL-2+ or GPL-2+'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/gjs.git'

--- a/packages/gnome_desktop.rb
+++ b/packages/gnome_desktop.rb
@@ -3,13 +3,11 @@ require 'package'
 class Gnome_desktop < Package
   description 'Library with common API for various GNOME modules'
   homepage 'https://gitlab.gnome.org/GNOME/gnome-desktop'
-  @_ver = '43'
-  @_ver_prelastdot = @_ver.rpartition('.')[0]
-  version @_ver
+  version '43'
   license 'GPL-2+, LGPL-2+ and FDL-1.1+'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/gnome-desktop.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gnome_desktop/43_armv7l/gnome_desktop-43-chromeos-armv7l.tar.zst',

--- a/packages/gsound.rb
+++ b/packages/gsound.rb
@@ -3,11 +3,10 @@ require 'package'
 class Gsound < Package
   description 'GSound is a small library for playing system sounds.'
   homepage 'https://wiki.gnome.org/Projects/GSound'
-  @_ver = '1.0.2'
-  version @_ver
+  version '1.0.2'
   license 'LGPL-2.1+'
   compatibility 'all'
-  source_url "https://download.gnome.org/sources/gsound/#{@_ver.rpartition('.')[0]}/gsound-#{@_ver}.tar.xz"
+  source_url "https://download.gnome.org/sources/gsound/#{version.rpartition('.')[0]}/gsound-#{version}.tar.xz"
   source_sha256 'bba8ff30eea815037e53bee727bbd5f0b6a2e74d452a7711b819a7c444e78e53'
 
   binary_url({

--- a/packages/libchamplain.rb
+++ b/packages/libchamplain.rb
@@ -3,12 +3,10 @@ require 'package'
 class Libchamplain < Package
   description 'A map widget'
   homepage 'https://wiki.gnome.org/Projects/libchamplain'
-  @_ver = '0.12.20'
-  @_ver_ = @_ver.gsub(/[.]/, '_')
-  version @_ver
+  version '0.12.20'
   license 'LGPL-2.1+'
   compatibility 'all'
-  source_url "https://gitlab.gnome.org/GNOME/libchamplain/-/archive/LIBCHAMPLAIN_#{@_ver_}/libchamplain-LIBCHAMPLAIN_#{@_ver_}.tar.bz2"
+  source_url "https://gitlab.gnome.org/GNOME/libchamplain/-/archive/LIBCHAMPLAIN_#{version.gsub(/[.]/, '_')}/libchamplain-LIBCHAMPLAIN_#{version.gsub(/[.]/, '_')}.tar.bz2"
   source_sha256 'e2bfa2179a5ecbdde7fe18a0472e3b04137cb0873b4fe2de29da4c09f0b6e58d'
 
   binary_url({

--- a/packages/libcroco.rb
+++ b/packages/libcroco.rb
@@ -3,12 +3,10 @@ require 'package'
 class Libcroco < Package
   description 'Generic Cascading Style Sheet (CSS) parsing and manipulation toolkit.'
   homepage 'https://git.gnome.org/browse/libcroco/'
-  @_ver = '0.6.13'
-  @_ver_prelastdot = @_ver.rpartition('.')[0]
-  version @_ver
+  version '0.6.13'
   license 'LGPL-2'
   compatibility 'all'
-  source_url "http://ftp.gnome.org/pub/gnome/sources/libcroco/#{@_ver_prelastdot}/libcroco-#{@_ver}.tar.xz"
+  source_url "http://ftp.gnome.org/pub/gnome/sources/libcroco/#{version.rpartition('.')[0]}/libcroco-#{version}.tar.xz"
   source_sha256 '767ec234ae7aa684695b3a735548224888132e063f92db585759b422570621d4'
 
   binary_url({

--- a/packages/libexif.rb
+++ b/packages/libexif.rb
@@ -3,12 +3,10 @@ require 'package'
 class Libexif < Package
   description 'A library for parsing, editing, and saving EXIF data'
   homepage 'https://libexif.github.io/'
-  @_ver = '0.6.22'
-  @_ver_ = @_ver.gsub(/[.]/, '_')
+  version '0.6.22'
   license 'LGPL-2+'
-  version @_ver
   compatibility 'all'
-  source_url "https://github.com/libexif/libexif/releases/download/libexif-#{@_ver_}-release/libexif-#{@_ver}.tar.xz"
+  source_url "https://github.com/libexif/libexif/releases/download/libexif-#{version.gsub(/[.]/, '_')}-release/libexif-#{version}.tar.xz"
   source_sha256 '5048f1c8fc509cc636c2f97f4b40c293338b6041a5652082d5ee2cf54b530c56'
 
   binary_url({

--- a/packages/libgee.rb
+++ b/packages/libgee.rb
@@ -3,12 +3,10 @@ require 'package'
 class Libgee < Package
   description 'Libgee is an utility library providing GObject-based interfaces and classes for commonly used data structures.'
   homepage 'https://wiki.gnome.org/Projects/Libgee'
-  @_ver = '0.20.4'
-  @_ver_prelastdot = @_ver.rpartition('.')[0]
-  version @_ver
+  version '0.20.4'
   license 'LGPL-2.1+'
   compatibility 'all'
-  source_url "https://gitlab.gnome.org/GNOME/libgee/-/archive/#{@_ver}/libgee-#{@_ver}.tar.bz2"
+  source_url "https://gitlab.gnome.org/GNOME/libgee/-/archive/#{version}/libgee-#{version}.tar.bz2"
   source_sha256 'bf1e5840809e34e07b253e1363ec58c8844dac7400bc75c450e1c7aa13019c51'
 
   binary_url({

--- a/packages/libgnome_games_support.rb
+++ b/packages/libgnome_games_support.rb
@@ -3,11 +3,10 @@ require 'package'
 class Libgnome_games_support < Package
   description 'libgnome-games-support is a small library intended for internal use by GNOME Games.'
   homepage 'https://gitlab.gnome.org/GNOME/libgnome-games-support'
-  @_ver = '1.8.1'
-  version @_ver
+  version '1.8.1'
   license 'LGPL-3+'
   compatibility 'all'
-  source_url "https://download.gnome.org/sources/libgnome-games-support/#{@_ver.rpartition('.')[0]}/libgnome-games-support-#{@_ver}.tar.xz"
+  source_url "https://download.gnome.org/sources/libgnome-games-support/#{version.rpartition('.')[0]}/libgnome-games-support-#{version}.tar.xz"
   source_sha256 'c37b7acd3ba7eb12207f5d7bb020535fa5783b0bd897e51b2bd629ce119a413f'
 
   depends_on 'gtk3'

--- a/packages/libgphoto.rb
+++ b/packages/libgphoto.rb
@@ -3,12 +3,10 @@ require 'package'
 class Libgphoto < Package
   description 'The libgphoto2 camera access and control library.'
   homepage 'http://www.gphoto.org/'
-  @_ver = '2.5.27'
-  @_ver_ = @_ver.gsub(/[.]/, '_')
-  version @_ver
+  version '2.5.27'
   license 'GPL-2'
   compatibility 'all'
-  source_url "https://github.com/gphoto/libgphoto2/archive/libgphoto2-#{@_ver_}-release.tar.gz"
+  source_url "https://github.com/gphoto/libgphoto2/archive/libgphoto2-#{version.gsub(/[.]/, '_')}-release.tar.gz"
   source_sha256 '9ac1ab84fc5070d40194181efd0775044220c8d5cdee830386d528710e864ec9'
 
   binary_url({

--- a/packages/libgsf.rb
+++ b/packages/libgsf.rb
@@ -3,9 +3,7 @@ require 'package'
 class Libgsf < Package
   description 'The G Structured File Library'
   homepage 'https://gitlab.gnome.org/GNOME/libgsf'
-  @_ver = '1.14.50'
-  @_ver_prelastdot = @_ver.rpartition('.')[0]
-  version @_ver
+  version '1.14.50'
   license 'GPL-2 and LGPL-2'
   compatibility 'all'
   source_url 'https://gitlab.gnome.org/GNOME/libgsf.git'

--- a/packages/libproxy.rb
+++ b/packages/libproxy.rb
@@ -3,12 +3,11 @@ require 'package'
 class Libproxy < Package
   description 'libproxy is a library that provides automatic proxy configuration management.'
   homepage 'https://libproxy.github.io/libproxy/'
-  @_ver = '5d5e13ddc47a2a061c595c1356d7d07d78cf597f'
-  version @_ver[0, 7]
+  version '5d5e13ddc47a2a061c595c1356d7d07d78cf597f'
   license 'LGPL-2.1+'
   compatibility 'all'
   source_url 'https://github.com/libproxy/libproxy.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libproxy/5d5e13d_armv7l/libproxy-5d5e13d-chromeos-armv7l.tar.zst',

--- a/packages/libssh.rb
+++ b/packages/libssh.rb
@@ -3,12 +3,10 @@ require 'package'
 class Libssh < Package
   description 'libssh is a multiplatform C library implementing the SSHv2 and SSHv1 protocol on client and server side.'
   homepage 'https://www.libssh.org/'
-  @_ver = '0.10.4'
-  version @_ver
-  @_ver_prelastdot = @_ver.rpartition('.')[0]
+  version '0.10.4'
   license 'LGPL-2.1'
   compatibility 'all'
-  source_url "https://www.libssh.org/files/#{@_ver_prelastdot}/libssh-#{@_ver}.tar.xz"
+  source_url "https://www.libssh.org/files/#{version.rpartition('.')[0]}/libssh-#{version}.tar.xz"
   source_sha256 '07392c54ab61476288d1c1f0a7c557b50211797ad00c34c3af2bbc4dbc4bd97d'
 
   binary_url({

--- a/packages/musl_perl.rb
+++ b/packages/musl_perl.rb
@@ -3,11 +3,10 @@ require 'package'
 class Musl_perl < Package
   description 'Perl 5 is a highly capable, feature-rich programming language with over 29 years of development.'
   homepage 'https://www.perl.org/'
-  @_ver = '5.34.0'
-  version @_ver
+  version '5.34.0'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
-  source_url "http://www.cpan.org/src/5.0/perl-#{@_ver}.tar.gz"
+  source_url "http://www.cpan.org/src/5.0/perl-#{version}.tar.gz"
   source_sha256 '551efc818b968b05216024fb0b727ef2ad4c100f8cb6b43fab615fa78ae5be9a'
 
   binary_url({
@@ -28,10 +27,6 @@ class Musl_perl < Package
   depends_on 'musl_native_toolchain'
   depends_on 'musl_zlib' => :build
   depends_on 'musl_bz2' => :build
-
-  @perl_fullversion = @_ver.split('-')[0]
-
-  @perl_version = @_ver.rpartition('.')[0]
 
   def self.build
     load "#{CREW_LIB_PATH}lib/musl.rb"
@@ -88,7 +83,7 @@ EOF'
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     FileUtils.mkdir_p "#{CREW_DEST_MUSL_PREFIX}/lib"
-    FileUtils.ln_sf "#{CREW_MUSL_PREFIX}/lib/perl5/#{@perl_fullversion}/#{ARCH}-linux-thread-multi/CORE/libperl.so",
+    FileUtils.ln_sf "#{CREW_MUSL_PREFIX}/lib/perl5/#{version.split('-')[0]}/#{ARCH}-linux-thread-multi/CORE/libperl.so",
                     "#{CREW_DEST_MUSL_PREFIX}/lib/libperl.so"
     FileUtils.ln_sf "#{CREW_MUSL_PREFIX}/lib/libnsl.so.1", "#{CREW_DEST_MUSL_PREFIX}/lib/libnsl.so"
     system "install -Dm755 cpanm #{CREW_DEST_MUSL_PREFIX}/bin/cpanm"

--- a/packages/perl.rb
+++ b/packages/perl.rb
@@ -3,11 +3,10 @@ require 'package'
 class Perl < Package
   description 'Perl 5 is a highly capable, feature-rich programming language with over 29 years of development.'
   homepage 'https://www.perl.org/'
-  @_ver = '5.38.0'
-  version @_ver
+  version '5.38.0'
   license 'GPL-1+ or Artistic'
   compatibility 'all'
-  source_url "https://www.cpan.org/src/5.0/perl-#{@_ver}.tar.xz"
+  source_url "https://www.cpan.org/src/5.0/perl-#{version}.tar.xz"
   source_sha256 'eca551caec3bc549a4e590c0015003790bdd1a604ffe19cc78ee631d51f7072e'
 
   binary_url({
@@ -39,11 +38,11 @@ class Perl < Package
       -Dprefix=#{CREW_PREFIX} \
       -Dvendorprefix=#{CREW_PREFIX} \
       -Dprivlib=#{CREW_PREFIX}/share/perl5/core_perl \
-      -Darchlib=#{CREW_LIB_PREFIX}/perl5/#{@_ver}/core_perl \
+      -Darchlib=#{CREW_LIB_PREFIX}/perl5/#{version}/core_perl \
       -Dsitelib=#{CREW_PREFIX}/share/perl5/site_perl \
-      -Dsitearch=#{CREW_LIB_PREFIX}/perl5/#{@_ver}/site_perl \
+      -Dsitearch=#{CREW_LIB_PREFIX}/perl5/#{version}/site_perl \
       -Dvendorlib=#{CREW_PREFIX}/share/perl5/vendor_perl \
-      -Dvendorarch=#{CREW_LIB_PREFIX}/perl5/#{@_ver}/vendor_perl \
+      -Dvendorarch=#{CREW_LIB_PREFIX}/perl5/#{version}/vendor_perl \
       -Dcc=#{CREW_TGT}-gcc \
       -Doptimize='#{CREW_COMMON_FLAGS}' \
       -Dlldlflags='-shared #{CREW_LDFLAGS}' -Dldflags='#{CREW_LDFLAGS}' \
@@ -54,15 +53,13 @@ class Perl < Package
   end
 
   def self.install
-    @perl_fullversion = @_ver.split('-')[0]
-    @perl_version = @_ver.rpartition('.')[0]
 
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     # Make libperl symlinks into standard locations
-    libperl_so = "#{CREW_LIB_PREFIX}/perl5/#{@perl_fullversion}/core_perl/CORE/libperl.so"
-    FileUtils.ln_sf libperl_so, "#{CREW_DEST_LIB_PREFIX}/libperl.so.#{@_ver}" # e.g., libperl.so.5.34.1
-    FileUtils.ln_sf libperl_so, "#{CREW_DEST_LIB_PREFIX}/libperl.so.#{@_ver.sub(/\.\d$/, '')}" # e.g., libperl.so.5.34
-    FileUtils.ln_sf libperl_so, "#{CREW_DEST_LIB_PREFIX}/libperl.so#{@_ver.sub(/\.\d\.\d$/, '')}" # e.g., libperl.so.5
+    libperl_so = "#{CREW_LIB_PREFIX}/perl5/#{version.split('-')[0]}/core_perl/CORE/libperl.so"
+    FileUtils.ln_sf libperl_so, "#{CREW_DEST_LIB_PREFIX}/libperl.so.#{version}" # e.g., libperl.so.5.34.1
+    FileUtils.ln_sf libperl_so, "#{CREW_DEST_LIB_PREFIX}/libperl.so.#{version.sub(/\.\d$/, '')}" # e.g., libperl.so.5.34
+    FileUtils.ln_sf libperl_so, "#{CREW_DEST_LIB_PREFIX}/libperl.so#{version.sub(/\.\d\.\d$/, '')}" # e.g., libperl.so.5
     FileUtils.ln_sf libperl_so, "#{CREW_DEST_LIB_PREFIX}/libperl.so" # e.g., libperl.so
     # Consider adding this symlink to the glibc package
     FileUtils.ln_sf "#{CREW_LIB_PREFIX}/libnsl.so.1", "#{CREW_DEST_LIB_PREFIX}/libnsl.so"

--- a/packages/pipewire.rb
+++ b/packages/pipewire.rb
@@ -3,18 +3,17 @@ require 'package'
 class Pipewire < Package
   description 'PipeWire is a project that aims to greatly improve handling of audio and video under Linux.'
   homepage 'https://pipewire.org'
-  @_ver = if Gem::Version.new(CREW_KERNEL_VERSION.to_s) < Gem::Version.new('3.9')
+  version = if Gem::Version.new(CREW_KERNEL_VERSION.to_s) < Gem::Version.new('3.9')
             '0.3.29'
           elsif Gem::Version.new(CREW_KERNEL_VERSION.to_s) <= Gem::Version.new('5.4')
             '0.3.60'
           else
             '0.3.71'
           end
-  version @_ver
   compatibility 'all'
   license 'LGPL-2.1+'
   source_url 'https://gitlab.freedesktop.org/pipewire/pipewire.git'
-  git_hashtag @_ver
+  git_hashtag version
 
   if Gem::Version.new(CREW_KERNEL_VERSION.to_s) < Gem::Version.new('3.9')
     binary_url({

--- a/packages/tcl.rb
+++ b/packages/tcl.rb
@@ -3,12 +3,10 @@ require 'package'
 class Tcl < Package
   description 'Tcl (Tool Command Language) is a very powerful but easy to learn dynamic programming language, suitable for a very wide range of uses, including web and desktop applications, networking, administration, testing and many more.'
   homepage 'http://www.tcl.tk/'
-  @_ver = '8.6.13'
-  @_ver_prelastdot = @_ver.rpartition('.')[0]
-  version @_ver
+  version '8.6.13'
   license 'tcltk'
   compatibility 'all'
-  source_url "https://downloads.sourceforge.net/project/tcl/Tcl/#{@_ver}/tcl#{@_ver}-src.tar.gz"
+  source_url "https://downloads.sourceforge.net/project/tcl/Tcl/#{version}/tcl#{version}-src.tar.gz"
   source_sha256 '43a1fae7412f61ff11de2cfd05d28cfc3a73762f354a417c62370a54e2caf066'
 
   binary_url({
@@ -41,7 +39,7 @@ class Tcl < Package
     FileUtils.chdir('unix') do
       system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
       system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install-private-headers'
-      FileUtils.ln_s "#{CREW_PREFIX}/bin/tclsh#{@_ver_prelastdot}", "#{CREW_DEST_PREFIX}/bin/tclsh"
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/tclsh#{version.rpartition('.')[0]}", "#{CREW_DEST_PREFIX}/bin/tclsh"
     end
   end
 end

--- a/packages/thunar.rb
+++ b/packages/thunar.rb
@@ -3,11 +3,10 @@ require 'package'
 class Thunar < Package
   description 'Thunar File Manager'
   homepage 'https://docs.xfce.org/xfce/thunar/Start'
-  @_ver = '4.17.3'
-  version @_ver
+  version '4.17.3'
   license 'GPL-2+ and LGPL-2+'
   compatibility 'aarch64,armv7l,x86_64'
-  source_url "https://archive.xfce.org/src/xfce/thunar/#{@_ver.rpartition('.')[0]}/thunar-#{@_ver}.tar.bz2"
+  source_url "https://archive.xfce.org/src/xfce/thunar/#{version.rpartition('.')[0]}/thunar-#{version}.tar.bz2"
   source_sha256 '4580913d6c88003dbffc7e6d98a843ca0ae0fd1c5fa7b1e49fef565f33c7bea7'
 
   binary_url({

--- a/packages/tk.rb
+++ b/packages/tk.rb
@@ -3,12 +3,10 @@ require 'package'
 class Tk < Package
   description 'Tk is a graphical user interface toolkit that takes developing desktop applications to a higher level than conventional approaches.'
   homepage 'http://www.tcl.tk/'
-  @_ver = '8.6.13'
-  @_ver_prelastdot = @_ver.rpartition('.')[0]
-  version @_ver
+  version '8.6.13'
   license 'tcltk'
   compatibility 'all'
-  source_url "https://downloads.sourceforge.net/project/tcl/Tcl/#{@_ver}/tk#{@_ver}-src.tar.gz"
+  source_url "https://downloads.sourceforge.net/project/tcl/Tcl/#{version}/tk#{version}-src.tar.gz"
   source_sha256 '2e65fa069a23365440a3c56c556b8673b5e32a283800d8d9b257e3f584ce0675'
 
   binary_url({
@@ -51,7 +49,7 @@ class Tk < Package
   def self.install
     FileUtils.chdir('unix') do
       system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-      FileUtils.ln_s "#{CREW_PREFIX}/bin/wish#{@_ver_prelastdot}", "#{CREW_DEST_PREFIX}/bin/wish"
+      FileUtils.ln_s "#{CREW_PREFIX}/bin/wish#{version.rpartition('.')[0]}", "#{CREW_DEST_PREFIX}/bin/wish"
     end
   end
 end

--- a/packages/unicode_cldr.rb
+++ b/packages/unicode_cldr.rb
@@ -3,12 +3,10 @@ require 'package'
 class Unicode_cldr < Package
   description 'Unicode Common Locale Data Repository'
   homepage 'http://cldr.unicode.org/'
-  @_ver = '43.0'
-  @_ver_prelastdot = @_ver.rpartition('.')[0]
-  version @_ver
+  version '43.0'
   license 'unicode'
   compatibility 'all'
-  source_url "https://unicode.org/Public/cldr/#{@_ver_prelastdot}/cldr-common-#{@_ver}.zip"
+  source_url "https://unicode.org/Public/cldr/#{version.rpartition('.')[0]}/cldr-common-#{version}.zip"
   source_sha256 '7800dadb6a11e06ba1475f8c2830aa87e0749ed441c953d8deea60b4baeef592'
 
   no_compile_needed

--- a/packages/upower.rb
+++ b/packages/upower.rb
@@ -3,9 +3,7 @@ require 'package'
 class Upower < Package
   description 'Abstraction for enumerating power devices, listening to device events and querying history and statistics'
   homepage 'https://upower.freedesktop.org'
-  @_ver = '1.90.0'
-  @_ver_ = @_ver.gsub(/[.]/, '_')
-  version @_ver
+  version '1.90.0'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/upower/upower/-/archive/v1.90.0/upower-v1.90.0.tar.bz2'


### PR DESCRIPTION
Removes all the 24 remaining usages of @_ver with simple assignments-- that is, `version @_ver`.

For example, this:
```
@_ver = '1.2.3'
version @_ver
@_ver_prelastdot = @_ver.rpartition('.')[0]
...
source_url "https://download.gnome.org/sources/gexiv2/#{@_ver_prelastdot}/gexiv2-#{@_ver}.tar.xz"
```
would become this:
```
version '1.2.3'
...
source_url "https://download.gnome.org/sources/gexiv2/#{version.rpartition('.')[0]}/gexiv2-#{version}.tar.xz"
```
Tested and working on x86_64.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=laver7 CREW_TESTING=1 crew update
```
