### PR TITLE
Remove all remaining non-revision usages of @_ver apart from metadata tags

### DIFF
--- a/packages/ltrace.rb
+++ b/packages/ltrace.rb
@@ -3,8 +3,7 @@ require 'package'
 class Ltrace < Package
   description 'ltrace intercepts and records dynamic library calls which are called by an executed process and the signals received by that process.'
   homepage 'https://www.ltrace.org/'
-  @_ver = '0.7.91'
-  version "#{@_ver}-ea8928"
+  version '0.7.91-ea8928'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://gitlab.com/cespedes/ltrace.git'

--- a/packages/pavucontrol.rb
+++ b/packages/pavucontrol.rb
@@ -3,8 +3,7 @@ require 'package'
 class Pavucontrol < Package
   description 'PulseAudio Volume Control'
   homepage 'https://freedesktop.org/software/pulseaudio/pavucontrol/'
-  @_ver = '4.0'
-  version "#{@_ver}-381b-1"
+  version "4.0-381b-1"
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://github.com/pulseaudio/pavucontrol/archive/381b708202e87e40347a57f8a627014199cde266.zip'


### PR DESCRIPTION
Removes the 2 remaining usages of `@_ver` which aren't metadata tags (unclear what to do with those, they will technically work with 8196 but thats not a great solution) or revisions or python packages.

5 other usages of `@_ver` remain, but these will require rebuilds and updates.

Tested and working on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=laver8 CREW_TESTING=1 crew update
```
