### PR TITLE
Fix no_lto detection in meson and cmake buildsystems

### DIFF
--- a/lib/buildsystems/cmake.rb
+++ b/lib/buildsystems/cmake.rb
@@ -11,9 +11,9 @@ class CMake < Package
 
   def self.build
     puts "Additional cmake_options being used: #{@cmake_options.nil? || @cmake_options.empty? ? '<no cmake_options>' : @cmake_options}".orange
-    @crew_cmake_options = no_lto ? CREW_CMAKE_FNO_LTO_OPTIONS : CREW_CMAKE_OPTIONS
-    @mold_linker_prefix_cmd = CREW_LINKER == 'mold' ? 'mold -run ' : ''
-    system "#{@mold_linker_prefix_cmd}cmake -B builddir -G Ninja #{@crew_cmake_options} #{@cmake_options}"
+    @crew_cmake_options = @no_lto ? CREW_CMAKE_FNO_LTO_OPTIONS : CREW_CMAKE_OPTIONS
+    @mold_linker_prefix_cmd = CREW_LINKER == 'mold' ? 'mold -run' : ''
+    system "#{@mold_linker_prefix_cmd} cmake -B builddir -G Ninja #{@crew_cmake_options} #{@cmake_options}"
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/lib/buildsystems/meson.rb
+++ b/lib/buildsystems/meson.rb
@@ -11,9 +11,9 @@ class Meson < Package
 
   def self.build
     puts "Additional meson_options being used: #{@meson_options.nil? || @meson_options.empty? ? '<no meson_options>' : @meson_options}".orange
-    @crew_meson_options = no_lto ? CREW_MESON_FNO_LTO_OPTIONS : CREW_MESON_OPTIONS
-    @mold_linker_prefix_cmd = CREW_LINKER == 'mold' ? 'mold -run ' : ''
-    system "#{@mold_linker_prefix_cmd}meson setup #{@crew_meson_options} #{@meson_options} builddir"
+    @crew_meson_options = @no_lto ? CREW_MESON_FNO_LTO_OPTIONS : CREW_MESON_OPTIONS
+    @mold_linker_prefix_cmd = CREW_LINKER == 'mold' ? 'mold -run' : ''
+    system "#{@mold_linker_prefix_cmd} meson setup #{@crew_meson_options} #{@meson_options} builddir"
     system 'meson configure builddir'
     system "#{CREW_NINJA} -C builddir"
   end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,5 +1,5 @@
 # Defines common constants used in different parts of crew
-CREW_VERSION = '1.35.1'
+CREW_VERSION = '1.35.2'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
Discovered this while working on some other stuff.

As an aside, setting `-DCMAKE_SHARED_LINKER_FLAGS` to `-fno_lto` breaks builds as `ar` interprets it as an argument. Not sure if this actually occurs after this fix though, or whether it was just in my specific environment, and so on. Just noting it here.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=flixesto CREW_TESTING=1 crew update
```
