### PR TITLE
Curl 8.1.2 => 8.2.0

### DIFF
--- a/manifest/armv7l/c/curl.filelist
+++ b/manifest/armv7l/c/curl.filelist
@@ -242,6 +242,7 @@
 /usr/local/share/man/man3/CURLOPT_FTP_USE_PRET.3.zst
 /usr/local/share/man/man3/CURLOPT_GSSAPI_DELEGATION.3.zst
 /usr/local/share/man/man3/CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS.3.zst
+/usr/local/share/man/man3/CURLOPT_HAPROXY_CLIENT_IP.3.zst
 /usr/local/share/man/man3/CURLOPT_HAPROXYPROTOCOL.3.zst
 /usr/local/share/man/man3/CURLOPT_HEADER.3.zst
 /usr/local/share/man/man3/CURLOPT_HEADERDATA.3.zst
@@ -285,7 +286,7 @@
 /usr/local/share/man/man3/CURLOPT_MAIL_AUTH.3.zst
 /usr/local/share/man/man3/CURLOPT_MAIL_FROM.3.zst
 /usr/local/share/man/man3/CURLOPT_MAIL_RCPT.3.zst
-/usr/local/share/man/man3/CURLOPT_MAIL_RCPT_ALLLOWFAILS.3.zst
+/usr/local/share/man/man3/CURLOPT_MAIL_RCPT_ALLOWFAILS.3.zst
 /usr/local/share/man/man3/CURLOPT_MAXAGE_CONN.3.zst
 /usr/local/share/man/man3/CURLOPT_MAXCONNECTS.3.zst
 /usr/local/share/man/man3/CURLOPT_MAXFILESIZE.3.zst
@@ -466,6 +467,8 @@
 /usr/local/share/man/man3/CURLOPT_XFERINFODATA.3.zst
 /usr/local/share/man/man3/CURLOPT_XFERINFOFUNCTION.3.zst
 /usr/local/share/man/man3/CURLOPT_XOAUTH2_BEARER.3.zst
+/usr/local/share/man/man3/curl_pushheader_byname.3.zst
+/usr/local/share/man/man3/curl_pushheader_bynum.3.zst
 /usr/local/share/man/man3/curl_share_cleanup.3.zst
 /usr/local/share/man/man3/curl_share_init.3.zst
 /usr/local/share/man/man3/curl_share_setopt.3.zst
@@ -502,3 +505,4 @@
 /usr/local/share/man/man3/libcurl-thread.3.zst
 /usr/local/share/man/man3/libcurl-tutorial.3.zst
 /usr/local/share/man/man3/libcurl-url.3.zst
+/usr/local/share/man/man3/libcurl-ws.3.zst

--- a/manifest/i686/c/curl.filelist
+++ b/manifest/i686/c/curl.filelist
@@ -242,6 +242,7 @@
 /usr/local/share/man/man3/CURLOPT_FTP_USE_PRET.3.zst
 /usr/local/share/man/man3/CURLOPT_GSSAPI_DELEGATION.3.zst
 /usr/local/share/man/man3/CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS.3.zst
+/usr/local/share/man/man3/CURLOPT_HAPROXY_CLIENT_IP.3.zst
 /usr/local/share/man/man3/CURLOPT_HAPROXYPROTOCOL.3.zst
 /usr/local/share/man/man3/CURLOPT_HEADER.3.zst
 /usr/local/share/man/man3/CURLOPT_HEADERDATA.3.zst
@@ -285,7 +286,7 @@
 /usr/local/share/man/man3/CURLOPT_MAIL_AUTH.3.zst
 /usr/local/share/man/man3/CURLOPT_MAIL_FROM.3.zst
 /usr/local/share/man/man3/CURLOPT_MAIL_RCPT.3.zst
-/usr/local/share/man/man3/CURLOPT_MAIL_RCPT_ALLLOWFAILS.3.zst
+/usr/local/share/man/man3/CURLOPT_MAIL_RCPT_ALLOWFAILS.3.zst
 /usr/local/share/man/man3/CURLOPT_MAXAGE_CONN.3.zst
 /usr/local/share/man/man3/CURLOPT_MAXCONNECTS.3.zst
 /usr/local/share/man/man3/CURLOPT_MAXFILESIZE.3.zst
@@ -466,6 +467,8 @@
 /usr/local/share/man/man3/CURLOPT_XFERINFODATA.3.zst
 /usr/local/share/man/man3/CURLOPT_XFERINFOFUNCTION.3.zst
 /usr/local/share/man/man3/CURLOPT_XOAUTH2_BEARER.3.zst
+/usr/local/share/man/man3/curl_pushheader_byname.3.zst
+/usr/local/share/man/man3/curl_pushheader_bynum.3.zst
 /usr/local/share/man/man3/curl_share_cleanup.3.zst
 /usr/local/share/man/man3/curl_share_init.3.zst
 /usr/local/share/man/man3/curl_share_setopt.3.zst
@@ -502,3 +505,4 @@
 /usr/local/share/man/man3/libcurl-thread.3.zst
 /usr/local/share/man/man3/libcurl-tutorial.3.zst
 /usr/local/share/man/man3/libcurl-url.3.zst
+/usr/local/share/man/man3/libcurl-ws.3.zst

--- a/manifest/x86_64/c/curl.filelist
+++ b/manifest/x86_64/c/curl.filelist
@@ -242,6 +242,7 @@
 /usr/local/share/man/man3/CURLOPT_FTP_USE_PRET.3.zst
 /usr/local/share/man/man3/CURLOPT_GSSAPI_DELEGATION.3.zst
 /usr/local/share/man/man3/CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS.3.zst
+/usr/local/share/man/man3/CURLOPT_HAPROXY_CLIENT_IP.3.zst
 /usr/local/share/man/man3/CURLOPT_HAPROXYPROTOCOL.3.zst
 /usr/local/share/man/man3/CURLOPT_HEADER.3.zst
 /usr/local/share/man/man3/CURLOPT_HEADERDATA.3.zst
@@ -285,7 +286,7 @@
 /usr/local/share/man/man3/CURLOPT_MAIL_AUTH.3.zst
 /usr/local/share/man/man3/CURLOPT_MAIL_FROM.3.zst
 /usr/local/share/man/man3/CURLOPT_MAIL_RCPT.3.zst
-/usr/local/share/man/man3/CURLOPT_MAIL_RCPT_ALLLOWFAILS.3.zst
+/usr/local/share/man/man3/CURLOPT_MAIL_RCPT_ALLOWFAILS.3.zst
 /usr/local/share/man/man3/CURLOPT_MAXAGE_CONN.3.zst
 /usr/local/share/man/man3/CURLOPT_MAXCONNECTS.3.zst
 /usr/local/share/man/man3/CURLOPT_MAXFILESIZE.3.zst
@@ -466,6 +467,8 @@
 /usr/local/share/man/man3/CURLOPT_XFERINFODATA.3.zst
 /usr/local/share/man/man3/CURLOPT_XFERINFOFUNCTION.3.zst
 /usr/local/share/man/man3/CURLOPT_XOAUTH2_BEARER.3.zst
+/usr/local/share/man/man3/curl_pushheader_byname.3.zst
+/usr/local/share/man/man3/curl_pushheader_bynum.3.zst
 /usr/local/share/man/man3/curl_share_cleanup.3.zst
 /usr/local/share/man/man3/curl_share_init.3.zst
 /usr/local/share/man/man3/curl_share_setopt.3.zst
@@ -502,3 +505,4 @@
 /usr/local/share/man/man3/libcurl-thread.3.zst
 /usr/local/share/man/man3/libcurl-tutorial.3.zst
 /usr/local/share/man/man3/libcurl-url.3.zst
+/usr/local/share/man/man3/libcurl-ws.3.zst

--- a/packages/curl.rb
+++ b/packages/curl.rb
@@ -3,23 +3,23 @@ require 'package'
 class Curl < Package
   description 'Command line tool and library for transferring data with URLs.'
   homepage 'https://curl.se/'
-  version '8.1.2'
+  version '8.2.0'
   license 'curl'
   compatibility 'all'
-  source_url 'https://curl.se/download/curl-8.1.2.tar.xz'
-  source_sha256 '31b1118eb8bfd43cd95d9a3f146f814ff874f6ed3999b29d94f4d1e7dbac5ef6'
+  source_url 'https://curl.se/download/curl-8.2.0.tar.xz'
+  source_sha256 '2859ec79e2cd96e976a99493547359b8001af1d1e21f3a3a3b846544ef54500f'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/8.1.2_armv7l/curl-8.1.2-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/8.1.2_armv7l/curl-8.1.2-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/8.1.2_i686/curl-8.1.2-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/8.1.2_x86_64/curl-8.1.2-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/8.2.0_armv7l/curl-8.2.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/8.2.0_armv7l/curl-8.2.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/8.2.0_i686/curl-8.2.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/curl/8.2.0_x86_64/curl-8.2.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'f61797ea0812422a343bb2de6d6be68ae4391630ea8552c9b6f93eb3021ce282',
-     armv7l: 'f61797ea0812422a343bb2de6d6be68ae4391630ea8552c9b6f93eb3021ce282',
-       i686: 'c72d008177000b151c28095477feae0d75056f76f97b20a687c6c02dbd610985',
-     x86_64: '4b664fdab78743015c37fbc11af00e34991097137ca955869629a77bd023822d'
+    aarch64: 'cc133fc3dcda93f89262785621981e8133d24d81a19ef240078d98ea0dde0aeb',
+     armv7l: 'cc133fc3dcda93f89262785621981e8133d24d81a19ef240078d98ea0dde0aeb',
+       i686: '6394bcef2bfede5378f510ad9af029cde45eed7927d38d7f09a1ffc7f5ead812',
+     x86_64: 'b2c5e1d3ebab0557a9f8c2f92d9a8608962e54b4fe40c25bbbd63df7a9f7027c'
   })
 
   depends_on 'brotli' # R


### PR DESCRIPTION
Tests passed as shown below:
```
$ for b in $(crew files curl|grep /usr/local/bin); do $b --version; done
curl 8.2.0 (x86_64-cros-linux-gnu) libcurl/8.2.0 OpenSSL/3.0.9 zlib/1.2.13 brotli/1.0.9 zstd/1.5.5 c-ares/1.18.1 libidn2/2.3.3 libpsl/0.21.1 (+libidn2/2.3.3) libssh/0.10.4/openssl/zlib nghttp2/1.52.0 OpenLDAP/2.6.4
Release-Date: 2023-07-19
Protocols: dict file ftp ftps gopher gophers http https imap imaps ldap ldaps mqtt pop3 pop3s rtsp scp sftp smb smbs smtp smtps telnet tftp
Features: alt-svc AsynchDNS brotli HSTS HTTP2 HTTPS-proxy IDN IPv6 Largefile libz NTLM NTLM_WB PSL SSL threadsafe TLS-SRP UnixSockets zstd
libcurl 8.2.0
```