### PR TITLE
Detect rebuilds via changes in binary_sha256 when updating

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -655,6 +655,10 @@ def update
       puts "Package file for #{package[:name]} not found. :(".lightred if @opt_verbose
       next
     end
+    if package[:binary_sha256] && package[:binary_sha256] != @pkg.get_binary_sha256(@device[:architecture])
+      canBeUpdated += 1
+      puts "#{@pkg.name} could be updated (rebuild)"
+    end
     if package[:version] != @pkg.version
       canBeUpdated += 1
       puts "#{@pkg.name} could be updated from #{package[:version]} to #{@pkg.version}"
@@ -683,9 +687,12 @@ def upgrade(*pkgs, build_from_source: false)
         return false
       end
     end
-    pkgVer_latest    = Package.load_package(pkgFile, pkgName).version
-    pkgVer_installed = @device[:installed_packages].select { |pkg| pkg[:name] == pkgName } [0][:version]
+    pkgVer_latest     = Package.load_package(pkgFile, pkgName).version
+    pkgVer_installed  = @device[:installed_packages].select { |pkg| pkg[:name] == pkgName } [0][:version]
+    pkgHash_latest    = Package.load_package(pkgFile, pkgName).get_binary_sha256(@device[:architecture])
+    pkgHash_installed = @device[:installed_packages].select { |pkg| pkg[:name] == pkgName } [0][:binary_sha256]
 
+    return pkgHash_latest != pkgHash_installed unless !pkgHash_installed || pkgHash_latest == ''
     return pkgVer_latest != pkgVer_installed
   end
 
@@ -1566,7 +1573,7 @@ def install
   end
 
   # add to installed packages
-  @device[:installed_packages].push(name: @pkg.name, version: @pkg.version)
+  @device[:installed_packages].push(name: @pkg.name, version: @pkg.version, binary_sha256: @pkg.get_binary_sha256(@device[:architecture]))
   File.open("#{CREW_CONFIG_PATH}device.json.tmp", 'w') do |file|
     output = JSON.parse @device.to_json
     file.write JSON.pretty_generate(output)

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,5 +1,5 @@
 # Defines common constants used in different parts of crew
-CREW_VERSION = '1.35.4'
+CREW_VERSION = '1.35.5'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -244,6 +244,10 @@ class Package
     end
   end
 
+  def self.get_binary_sha256(architecture)
+    return @binary_sha256 && @binary_sha256.key?(architecture) ? @binary_sha256[architecture] : ''
+  end
+
   def self.get_extract_dir
     "#{name}.#{Time.now.utc.strftime('%Y%m%d%H%M%S')}.dir"
   end


### PR DESCRIPTION
I noticed that we sometimes bump the revision of a package for no other reason than a rebuild, i.e. 1c8249a. 

Now, rebuilt packages will simply be detected as needing an update, with no need to bump the revision of a package. 
Of course, in cases where we are patching the package or otherwise modifying it, a revision bump is still advisable.

Tested quite extensively on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=quintessence CREW_TESTING=1 crew update
```