### PR TITLE
Fix autotools testing buildsystem error

### DIFF
--- a/lib/buildsystems/autotools.rb
+++ b/lib/buildsystems/autotools.rb
@@ -2,9 +2,7 @@ require 'fileutils'
 require 'package'
 
 class Autotools < Package
-  def self.configure_options(options = '')
-    return (@configure_options = options if options)
-  end
+  property :configure_options
 
   def self.build
     puts "Additional configure_options being used: #{@configure_options.nil? || @configure_options.empty? ? '<no configure_options>' : @configure_options}".orange
@@ -34,9 +32,7 @@ class Autotools < Package
   end
 
   def self.check
-    if run_tests
-      puts 'Testing with make check.'.orange
-      system 'make', 'check'
-    end
+    puts 'Testing with make check.'.orange if @run_tests
+    system 'make', 'check' if @run_tests
   end
 end

--- a/lib/buildsystems/cmake.rb
+++ b/lib/buildsystems/cmake.rb
@@ -1,13 +1,7 @@
 require 'package'
 
 class CMake < Package
-  def self.cmake_options(options = '')
-    return (@cmake_options = options if options)
-  end
-
-  def self.check?(bool = true)
-    return (@check = bool)
-  end
+  property :cmake_options
 
   def self.build
     puts "Additional cmake_options being used: #{@cmake_options.nil? || @cmake_options.empty? ? '<no cmake_options>' : @cmake_options}".orange
@@ -21,9 +15,8 @@ class CMake < Package
     system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
   end
 
-  if @check
-    def self.check
-      system "#{CREW_NINJA} -C builddir test"
-    end
+  def self.check
+    puts "Testing with #{CREW_NINJA} test.".orange if @run_tests
+    system "#{CREW_NINJA} -C builddir test" if @run_tests
   end
 end

--- a/lib/buildsystems/meson.rb
+++ b/lib/buildsystems/meson.rb
@@ -1,13 +1,7 @@
 require 'package'
 
 class Meson < Package
-  def self.meson_options(options = '')
-    return (@meson_options = options if options)
-  end
-
-  def self.check?(bool = true)
-    return (@check = bool)
-  end
+  property :meson_options
 
   def self.build
     puts "Additional meson_options being used: #{@meson_options.nil? || @meson_options.empty? ? '<no meson_options>' : @meson_options}".orange
@@ -22,9 +16,8 @@ class Meson < Package
     system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
   end
 
-  if @check
-    def self.check
-      system "#{CREW_NINJA} -C builddir test"
-    end
+  def self.check
+    puts "Testing with #{CREW_NINJA} test.".orange if @run_tests
+    system "#{CREW_NINJA} -C builddir test" if @run_tests
   end
 end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,5 +1,5 @@
 # Defines common constants used in different parts of crew
-CREW_VERSION = '1.35.5'
+CREW_VERSION = '1.35.6'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -9,9 +9,9 @@ class Package
            :binary_url, :binary_sha256, :source_url, :source_sha256,
            :git_branch, :git_hashtag
 
-  boolean_property = %i[conflicts_ok git_clone_deep git_fetchtags gnome is_fake is_musl is_static
-                        no_compile_needed no_compress no_env_options no_fhs no_git_submodules
-                        no_links no_lto no_patchelf no_shrink no_strip no_zstd patchelf run_tests]
+  boolean_property :conflicts_ok, :git_clone_deep, :git_fetchtags, :gnome, :is_fake, :is_musl, :is_static,
+                   :no_compile_needed, :no_compress, :no_env_options, :no_fhs, :no_git_submodules,
+                   :no_links, :no_lto, :no_patchelf, :no_shrink, :no_strip, :no_zstd, :patchelf, :run_tests
 
   create_placeholder :preflight,   # Function for checks to see if install should occur.
                      :patch,       # Function to perform patch operations prior to build from source.
@@ -141,26 +141,6 @@ class Package
     else
       # if this function is called outside of this function, return parsed dependencies only
       return expandedDeps.flatten
-    end
-  end
-
-  boolean_property.each do |prop|
-    self.class.__send__(:attr_reader, prop.to_s)
-    class_eval <<~EOT, __FILE__, __LINE__ + 1
-      def self.#{prop} (#{prop} = nil)
-        @#{prop} = true if #{prop}
-        !!@#{prop}
-      end
-    EOT
-    instance_eval <<~EOY, __FILE__, __LINE__ + 1
-      def self.#{prop}
-        @#{prop} = true
-      end
-    EOY
-    # Adds the symbol? method
-    define_singleton_method("#{prop}?") do
-      @prop = instance_variable_get("@#{prop}")
-      !!@prop
     end
   end
 

--- a/lib/package_helpers.rb
+++ b/lib/package_helpers.rb
@@ -22,6 +22,30 @@ def property(*properties)
   end
 end
 
+def boolean_property(*boolean_properties)
+  # boolean_property: if this exists in a package, it will return true
+  # Examples:
+  #   {prop_name}            # this will return #{prop_name} as true
+  boolean_properties.each do |prop|
+    class_eval <<~EOT, __FILE__, __LINE__ + 1
+      def self.#{prop} (#{prop} = nil)
+        @#{prop} = true if #{prop}
+        !!@#{prop}
+      end
+    EOT
+    instance_eval <<~EOY, __FILE__, __LINE__ + 1
+      def self.#{prop}
+        @#{prop} = true
+      end
+    EOY
+    # Adds the symbol? method
+    define_singleton_method("#{prop}?") do
+      @prop = instance_variable_get("@#{prop}")
+      !!@prop
+    end
+  end
+end
+
 def reload_constants
   warn_level = $VERBOSE
   $VERBOSE = nil

--- a/packages/libgit2.rb
+++ b/packages/libgit2.rb
@@ -31,5 +31,4 @@ class Libgit2 < CMake
 
   cmake_options '-DUSE_SSH=ON -DUSE_BUNDLED_ZLIB=OFF'
   # Tests #3 and #8 fail in containers
-  # run_tests
 end


### PR DESCRIPTION
Not really sure what happened here to cause an issue in the first place, but this seems to fix the testing issues in the autotools buildsystem. 

Tested on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=dediv CREW_TESTING=1 crew update
```
