### PR TITLE
update krb, openldap, rebuild libcyrussasl

### DIFF
--- a/manifest/armv7l/k/krb5.filelist
+++ b/manifest/armv7l/k/krb5.filelist
@@ -122,6 +122,7 @@
 /usr/local/share/examples/krb5/services.append
 /usr/local/share/locale/de/LC_MESSAGES/mit-krb5.mo
 /usr/local/share/locale/en_US/LC_MESSAGES/mit-krb5.mo
+/usr/local/share/locale/ka/LC_MESSAGES/mit-krb5.mo
 /usr/local/share/man/man1/k5srvutil.1.zst
 /usr/local/share/man/man1/kadmin.1.zst
 /usr/local/share/man/man1/kdestroy.1.zst

--- a/manifest/i686/k/krb5.filelist
+++ b/manifest/i686/k/krb5.filelist
@@ -122,6 +122,7 @@
 /usr/local/share/examples/krb5/services.append
 /usr/local/share/locale/de/LC_MESSAGES/mit-krb5.mo
 /usr/local/share/locale/en_US/LC_MESSAGES/mit-krb5.mo
+/usr/local/share/locale/ka/LC_MESSAGES/mit-krb5.mo
 /usr/local/share/man/man1/k5srvutil.1.zst
 /usr/local/share/man/man1/kadmin.1.zst
 /usr/local/share/man/man1/kdestroy.1.zst

--- a/manifest/x86_64/k/krb5.filelist
+++ b/manifest/x86_64/k/krb5.filelist
@@ -122,6 +122,7 @@
 /usr/local/share/examples/krb5/services.append
 /usr/local/share/locale/de/LC_MESSAGES/mit-krb5.mo
 /usr/local/share/locale/en_US/LC_MESSAGES/mit-krb5.mo
+/usr/local/share/locale/ka/LC_MESSAGES/mit-krb5.mo
 /usr/local/share/man/man1/k5srvutil.1.zst
 /usr/local/share/man/man1/kadmin.1.zst
 /usr/local/share/man/man1/kdestroy.1.zst

--- a/packages/krb5.rb
+++ b/packages/krb5.rb
@@ -3,23 +3,23 @@ require 'package'
 class Krb5 < Package
   description 'Kerberos is a network authentication protocol.'
   homepage 'https://web.mit.edu/kerberos'
-  version '1.20.1-1'
+  version '1.21.1'
   license 'openafs-krb5-a, BSD, MIT, OPENLDAP, BSD-2, HPND, BSD-4, ISC, RSA, CC-BY-SA-3.0 and BSD-2 or GPL-2+ )'
   compatibility 'all'
-  source_url 'https://web.mit.edu/kerberos/dist/krb5/1.20/krb5-1.20.1.tar.gz'
-  source_sha256 '704aed49b19eb5a7178b34b2873620ec299db08752d6a8574f95d41879ab8851'
+  source_url 'https://web.mit.edu/kerberos/dist/krb5/1.21/krb5-1.21.1.tar.gz'
+  source_sha256 '7881c3aaaa1b329bd27dbc6bf2bf1c85c5d0b6c7358aff2b35d513ec2d50fa1f'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/krb5/1.20.1-1_armv7l/krb5-1.20.1-1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/krb5/1.20.1-1_armv7l/krb5-1.20.1-1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/krb5/1.20.1-1_i686/krb5-1.20.1-1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/krb5/1.20.1-1_x86_64/krb5-1.20.1-1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/krb5/1.21.1_armv7l/krb5-1.21.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/krb5/1.21.1_armv7l/krb5-1.21.1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/krb5/1.21.1_i686/krb5-1.21.1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/krb5/1.21.1_x86_64/krb5-1.21.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '80b1c0a265ce4a1ad7838189c010513aae8dd8b10578d98a8d7e56df66fc70ce',
-     armv7l: '80b1c0a265ce4a1ad7838189c010513aae8dd8b10578d98a8d7e56df66fc70ce',
-       i686: 'ed85e0ab5d700e98aa67e616b23c13734234255332cb6b51e6872238f3c2998e',
-     x86_64: 'e31008fe76d9db3740c6c874bb501cf5d716c7ceb5fe61e8f43a25b653042e8b'
+    aarch64: '78b5a484074f739462c78a9409fcde96eb76c004bd7a58500653b56995793c16',
+     armv7l: '78b5a484074f739462c78a9409fcde96eb76c004bd7a58500653b56995793c16',
+       i686: '85ba1f202022f6976e432d4fa36ab6ca814085df7680bef413ce58cd7081aa0a',
+     x86_64: '00397b5f6b16de46624146d8ddae4a81108984d6ffd38fc86af53b397f2cb5ab'
   })
 
   depends_on 'ccache' => :build

--- a/packages/libcyrussasl.rb
+++ b/packages/libcyrussasl.rb
@@ -1,25 +1,25 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Libcyrussasl < Package
+class Libcyrussasl < Autotools
   description 'Simple Authentication and Security Layer (SASL) is a specification that describes how authentication mechanisms can be plugged into an application protocol on the wire. Cyrus SASL is an implementation of SASL that makes it easy for application developers to integrate authentication mechanisms into their application in a generic way.'
   homepage 'https://www.cyrusimap.org/sasl'
-  version '2.1.28-1'
+  version '2.1.28-2'
   license 'custom'
   compatibility 'all'
   source_url 'https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-2.1.28/cyrus-sasl-2.1.28.tar.gz'
   source_sha256 '7ccfc6abd01ed67c1a0924b353e526f1b766b21f42d4562ee635a8ebfc5bb38c'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcyrussasl/2.1.28-1_armv7l/libcyrussasl-2.1.28-1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcyrussasl/2.1.28-1_armv7l/libcyrussasl-2.1.28-1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcyrussasl/2.1.28-1_i686/libcyrussasl-2.1.28-1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcyrussasl/2.1.28-1_x86_64/libcyrussasl-2.1.28-1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcyrussasl/2.1.28-2_armv7l/libcyrussasl-2.1.28-2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcyrussasl/2.1.28-2_armv7l/libcyrussasl-2.1.28-2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcyrussasl/2.1.28-2_i686/libcyrussasl-2.1.28-2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcyrussasl/2.1.28-2_x86_64/libcyrussasl-2.1.28-2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '9fcab15850eaa1926182c9f5a0184eba152ebe7c11b1d532f88c1b69d58af3d2',
-     armv7l: '9fcab15850eaa1926182c9f5a0184eba152ebe7c11b1d532f88c1b69d58af3d2',
-       i686: '5dfe33f38a6de869fe1a07ba18bf65f6034cc2958629d297127c1fa5d77dac8d',
-     x86_64: 'b2b76d5cc971e651cb3d926c899cdc6eb259844b9df44f84eb7fac934bcfaa7f'
+    aarch64: '256fe21c3b7e90413a775ddbe4e84354a5b626af4155aa9610f676c49ea343d1',
+     armv7l: '256fe21c3b7e90413a775ddbe4e84354a5b626af4155aa9610f676c49ea343d1',
+       i686: '1dba7c51855286e740b042c05be01fcdddbd143ebc04cad955d4386a7a4c0797',
+     x86_64: '7bbcc424ee8c4f9175dd089112fd8305ca67a35a4a3262c562abef4b8d7fada4'
   })
 
   depends_on 'diffutils' => :build
@@ -30,21 +30,8 @@ class Libcyrussasl < Package
   depends_on 'linux_pam' # R
   depends_on 'openssl' # R
 
-  def self.patch
-    system 'filefix'
-  end
-
-  def self.build
-    system "mold -run ./configure \
-      #{CREW_OPTIONS} \
-      --enable-shared \
-      --with-configdir=#{CREW_PREFIX}/etc/sasl2 \
-      --with-cxx-shared \
-      --with-dbpath=#{CREW_PREFIX}/etc/sasldb2"
-    system 'make'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  configure_options "--enable-shared \
+        --with-configdir=#{CREW_PREFIX}/etc/sasl2 \
+        --with-cxx-shared \
+        --with-dbpath=#{CREW_PREFIX}/etc/sasldb2"
 end

--- a/packages/openldap.rb
+++ b/packages/openldap.rb
@@ -3,23 +3,23 @@ require 'package'
 class Openldap < Package
   description 'OpenLDAP Software is an open source implementation of the Lightweight Directory Access Protocol.'
   homepage 'https://www.openldap.org/'
-  version '2.6.4'
+  version '2.6.5'
   license 'OpenLDAP and GPL-2'
   compatibility 'all'
   source_url "https://openldap.org/software/download/OpenLDAP/openldap-release/openldap-#{version}.tgz"
-  source_sha256 'd51704e50178430c06cf3d8aa174da66badf559747a47d920bb54b2d4aa40991'
+  source_sha256 '2e27a8d4f4c2af8fe840b573271c20aa163e24987f9765214644290f5beb38d9'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.6.4_armv7l/openldap-2.6.4-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.6.4_armv7l/openldap-2.6.4-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.6.4_i686/openldap-2.6.4-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.6.4_x86_64/openldap-2.6.4-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.6.5_armv7l/openldap-2.6.5-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.6.5_armv7l/openldap-2.6.5-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.6.5_i686/openldap-2.6.5-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/openldap/2.6.5_x86_64/openldap-2.6.5-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'd7fb060b540a91e103aa4252e5ebaa3d219cb86372277f72e91b8d590c8c7592',
-     armv7l: 'd7fb060b540a91e103aa4252e5ebaa3d219cb86372277f72e91b8d590c8c7592',
-       i686: '6e4b3f2cb18c7eda1159ef59ef27120406557fc5513ed7edbb49708dfe744bc5',
-     x86_64: '1b78e492b4ba7924669f25da5b0a059f001d230bb50f5e614764ee4067ca77ef'
+    aarch64: '781f2fda0ed60b38d3c8ff065489e603e8d4cdab667ae4b7abcfce7038c67b35',
+     armv7l: '781f2fda0ed60b38d3c8ff065489e603e8d4cdab667ae4b7abcfce7038c67b35',
+       i686: '24ca397b5b1c03444022e59ac2cfd8a8ff027590312aab32236360bee38e86bf',
+     x86_64: '459f1d99ac6d8826418fe6403053d6f384453a84af675033e75625736e3680a4'
   })
 
   depends_on 'e2fsprogs' => :build


### PR DESCRIPTION
- Note that OpenLDAP 2.6.6 does not build...

Builds properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=krbsasl CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
