### PR TITLE
Improve logic for detecting package updates

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -665,18 +665,25 @@ def update
       puts "Package file for #{package[:name]} not found. :(".lightred if @opt_verbose
       next
     end
-    if package[:binary_sha256] && package[:binary_sha256] != @pkg.get_binary_sha256(@device[:architecture])
-      canBeUpdated += 1
-      puts "#{@pkg.name} could be updated (rebuild)"
-    end
-    if package[:version] != @pkg.version
-      canBeUpdated += 1
+    differentVersion = (package[:version] != @pkg.version)
+    hasSha = !(@pkg.get_binary_sha256(@device[:architecture]).to_s.empty? || package[:binary_sha256].to_s.empty?)
+    differentSha = hasSha && package[:binary_sha256] != @pkg.get_binary_sha256(@device[:architecture])
+
+    canBeUpdated += 1 if differentVersion || differentSha
+
+    if differentVersion && !differentSha && hasSha
+      canBeUpdated -= 1
+      puts "#{@pkg.name} has a version change but does not have updated binaries".yellow
+    elsif differentVersion
       puts "#{@pkg.name} could be updated from #{package[:version]} to #{@pkg.version}"
+    elsif !differentVersion && differentSha
+      puts "#{@pkg.name} could be updated (rebuild)"
     end
   end
 
   if canBeUpdated.positive?
-    puts "\nRun `crew upgrade` to update all packages or `crew upgrade <package1> [<package2> ...]` to update specific packages."
+    puts "\n#{canBeUpdated} packages can be updated."
+    puts 'Run `crew upgrade` to update all packages or `crew upgrade <package1> [<package2> ...]` to update specific packages.'
   else
     puts 'Your software is up to date.'.lightgreen
   end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.40.9'
+CREW_VERSION = '1.41.0'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
The previous logic had a number of issues, so I fixed them. I've also added a warning for when packages have updated versions but no updated binaries, and I'll be using this in 8414 (eventually). 

I also touched up the logic in the installer script.
### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=touchup crew update
```
