### PR TITLE
qemu => 8.1.0

### DIFF
--- a/manifest/armv7l/q/qemu.filelist
+++ b/manifest/armv7l/q/qemu.filelist
@@ -73,9 +73,14 @@
 /usr/local/bin/qemu-x86_64
 /usr/local/bin/qemu-xtensa
 /usr/local/bin/qemu-xtensaeb
+/usr/local/include/fdt.h
+/usr/local/include/libfdt_env.h
+/usr/local/include/libfdt.h
 /usr/local/include/qemu-plugin.h
 /usr/local/libexec/qemu-bridge-helper
 /usr/local/libexec/virtfs-proxy-helper
+/usr/local/lib/libfdt.a
+/usr/local/lib/pkgconfig/libfdt.pc
 /usr/local/share/applications/qemu.desktop
 /usr/local/share/icons/hicolor/128x128/apps/qemu.png
 /usr/local/share/icons/hicolor/16x16/apps/qemu.png

--- a/manifest/x86_64/q/qemu.filelist
+++ b/manifest/x86_64/q/qemu.filelist
@@ -73,7 +73,12 @@
 /usr/local/bin/qemu-x86_64
 /usr/local/bin/qemu-xtensa
 /usr/local/bin/qemu-xtensaeb
+/usr/local/include/fdt.h
+/usr/local/include/libfdt_env.h
+/usr/local/include/libfdt.h
 /usr/local/include/qemu-plugin.h
+/usr/local/lib64/libfdt.a
+/usr/local/lib64/pkgconfig/libfdt.pc
 /usr/local/libexec/qemu-bridge-helper
 /usr/local/libexec/virtfs-proxy-helper
 /usr/local/share/applications/qemu.desktop

--- a/packages/qemu.rb
+++ b/packages/qemu.rb
@@ -27,6 +27,7 @@ class Qemu < Package
   depends_on 'fontconfig' # R
   depends_on 'gdk_pixbuf' # R
   depends_on 'glib' # R
+  depends_on 'glibc_lib' # R
   depends_on 'gtk3' # R
   depends_on 'harfbuzz' # R
   depends_on 'hicolor_icon_theme'
@@ -63,7 +64,6 @@ class Qemu < Package
   depends_on 'vte' # R
   depends_on 'zlibpkg' # R
   depends_on 'zstd' # R
-  depends_on 'glibc_lib' # R
 
   def self.preflight
     abort "Qemu requires glibc 2.35. The current glibc version is #{LIBC_VERSION}.".lightred unless Gem::Version.new(LIBC_VERSION.to_s) == Gem::Version.new('2.35')

--- a/packages/qemu.rb
+++ b/packages/qemu.rb
@@ -3,20 +3,20 @@ require 'package'
 class Qemu < Package
   description 'QEMU is a generic and open source machine emulator and virtualizer.'
   homepage 'http://www.qemu.org/'
-  version '8.0.4'
+  version '8.1.0'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://github.com/qemu/qemu.git'
   git_hashtag "v#{version}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qemu/8.0.4_armv7l/qemu-8.0.4-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qemu/8.0.4_armv7l/qemu-8.0.4-chromeos-armv7l.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qemu/8.0.4_x86_64/qemu-8.0.4-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qemu/8.1.0_armv7l/qemu-8.1.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qemu/8.1.0_armv7l/qemu-8.1.0-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qemu/8.1.0_x86_64/qemu-8.1.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '586505a2c455403b880629260e2ab15f51a4f9967c21ef7b32acbd68d1115101',
-     armv7l: '586505a2c455403b880629260e2ab15f51a4f9967c21ef7b32acbd68d1115101',
-     x86_64: 'b164a7c5f6d284827cd5bf3976446d3731c92380a441bfa80f7d2986f26888a4'
+    aarch64: '35e5a86f8c3dea83508f69f423a51a1291cd9cece4f6e13c02fa7c865917d139',
+     armv7l: '35e5a86f8c3dea83508f69f423a51a1291cd9cece4f6e13c02fa7c865917d139',
+     x86_64: '0443fab996ef671cbea33224ec80b14f7b5c6e3418219fcda27adc8074461acb'
   })
 
   depends_on 'alsa_lib' # R
@@ -63,6 +63,11 @@ class Qemu < Package
   depends_on 'vte' # R
   depends_on 'zlibpkg' # R
   depends_on 'zstd' # R
+  depends_on 'glibc_lib' # R
+
+  def self.preflight
+    abort "Qemu requires glibc 2.35. The current glibc version is #{LIBC_VERSION}.".lightred unless Gem::Version.new(LIBC_VERSION.to_s) == Gem::Version.new('2.35')
+  end
 
   def self.patch
     # Avoid linux/usbdevice_fs.h:88:9: error: unknown type name ‘u8’ error


### PR DESCRIPTION
- Still needs preinstall logic added to check for `LIBC_VERSION >= 2.35` because this was built on newer M113 containers.

Works properly:
- [x] `x86_64`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=qemu81 CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
