### PR TITLE
update ncurses

### DIFF
--- a/manifest/armv7l/n/ncurses.filelist
+++ b/manifest/armv7l/n/ncurses.filelist
@@ -21,14 +21,12 @@
 /usr/local/include/ncurses/etip.h
 /usr/local/include/ncurses/form.h
 /usr/local/include/ncurses/menu.h
-/usr/local/include/ncurses/nc_tparm.h
 /usr/local/include/ncurses/ncurses_dll.h
 /usr/local/include/ncurses/ncurses.h
 /usr/local/include/ncurses/panel.h
 /usr/local/include/ncurses/termcap.h
 /usr/local/include/ncurses/term_entry.h
 /usr/local/include/ncurses/term.h
-/usr/local/include/ncurses/tic.h
 /usr/local/include/ncurses/unctrl.h
 /usr/local/include/ncursesw/cursesapp.h
 /usr/local/include/ncursesw/cursesf.h
@@ -41,14 +39,12 @@
 /usr/local/include/ncursesw/etip.h
 /usr/local/include/ncursesw/form.h
 /usr/local/include/ncursesw/menu.h
-/usr/local/include/ncursesw/nc_tparm.h
 /usr/local/include/ncursesw/ncurses_dll.h
 /usr/local/include/ncursesw/ncurses.h
 /usr/local/include/ncursesw/panel.h
 /usr/local/include/ncursesw/termcap.h
 /usr/local/include/ncursesw/term_entry.h
 /usr/local/include/ncursesw/term.h
-/usr/local/include/ncursesw/tic.h
 /usr/local/include/ncursesw/unctrl.h
 /usr/local/lib/libform.a
 /usr/local/lib/libform.so
@@ -199,6 +195,7 @@
 /usr/local/share/man/man3/curscr.3x.zst
 /usr/local/share/man/man3/curs_delch.3x.zst
 /usr/local/share/man/man3/curs_deleteln.3x.zst
+/usr/local/share/man/man3/curses.3x.zst
 /usr/local/share/man/man3/curses_trace.3x.zst
 /usr/local/share/man/man3/curses_version.3x.zst
 /usr/local/share/man/man3/curs_extend.3x.zst
@@ -435,7 +432,11 @@
 /usr/local/share/man/man3/in_wchnstr.3x.zst
 /usr/local/share/man/man3/in_wchstr.3x.zst
 /usr/local/share/man/man3/inwstr.3x.zst
+/usr/local/share/man/man3/is_cbreak.3x.zst
+/usr/local/share/man/man3/is_cbreak_sp.3x.zst
 /usr/local/share/man/man3/is_cleared.3x.zst
+/usr/local/share/man/man3/is_echo.3x.zst
+/usr/local/share/man/man3/is_echo_sp.3x.zst
 /usr/local/share/man/man3/isendwin.3x.zst
 /usr/local/share/man/man3/isendwin_sp.3x.zst
 /usr/local/share/man/man3/is_idcok.3x.zst
@@ -444,9 +445,13 @@
 /usr/local/share/man/man3/is_keypad.3x.zst
 /usr/local/share/man/man3/is_leaveok.3x.zst
 /usr/local/share/man/man3/is_linetouched.3x.zst
+/usr/local/share/man/man3/is_nl.3x.zst
+/usr/local/share/man/man3/is_nl_sp.3x.zst
 /usr/local/share/man/man3/is_nodelay.3x.zst
 /usr/local/share/man/man3/is_notimeout.3x.zst
 /usr/local/share/man/man3/is_pad.3x.zst
+/usr/local/share/man/man3/is_raw.3x.zst
+/usr/local/share/man/man3/is_raw_sp.3x.zst
 /usr/local/share/man/man3/is_scrollok.3x.zst
 /usr/local/share/man/man3/is_subwin.3x.zst
 /usr/local/share/man/man3/is_syncok.3x.zst
@@ -850,6 +855,8 @@
 /usr/local/share/man/man3/tigetstr_sp.3x.zst
 /usr/local/share/man/man3/timeout.3x.zst
 /usr/local/share/man/man3/tiparm.3x.zst
+/usr/local/share/man/man3/tiparm_s.3x.zst
+/usr/local/share/man/man3/tiscan_s.3x.zst
 /usr/local/share/man/man3/top_panel.3x.zst
 /usr/local/share/man/man3/top_row.3x.zst
 /usr/local/share/man/man3/touchline.3x.zst
@@ -2255,6 +2262,7 @@
 /usr/local/share/terminfo/l/linux-c
 /usr/local/share/terminfo/l/linux-c-nc
 /usr/local/share/terminfo/l/linux+decid
+/usr/local/share/terminfo/l/linux+kbs
 /usr/local/share/terminfo/l/linux-koi8
 /usr/local/share/terminfo/l/linux-koi8r
 /usr/local/share/terminfo/l/linux-lat
@@ -2768,6 +2776,7 @@
 /usr/local/share/terminfo/p/pty
 /usr/local/share/terminfo/p/putty
 /usr/local/share/terminfo/p/putty-256color
+/usr/local/share/terminfo/p/putty+cursor
 /usr/local/share/terminfo/p/putty+fnkeys
 /usr/local/share/terminfo/p/putty+fnkeys+esc
 /usr/local/share/terminfo/p/putty+fnkeys+linux
@@ -2846,6 +2855,8 @@
 /usr/local/share/terminfo/r/regent40
 /usr/local/share/terminfo/r/regent40+
 /usr/local/share/terminfo/r/regent60
+/usr/local/share/terminfo/r/report+da2
+/usr/local/share/terminfo/r/report+version
 /usr/local/share/terminfo/r/rt6221
 /usr/local/share/terminfo/r/rt6221-w
 /usr/local/share/terminfo/r/rtpc

--- a/manifest/i686/n/ncurses.filelist
+++ b/manifest/i686/n/ncurses.filelist
@@ -21,14 +21,12 @@
 /usr/local/include/ncurses/etip.h
 /usr/local/include/ncurses/form.h
 /usr/local/include/ncurses/menu.h
-/usr/local/include/ncurses/nc_tparm.h
 /usr/local/include/ncurses/ncurses_dll.h
 /usr/local/include/ncurses/ncurses.h
 /usr/local/include/ncurses/panel.h
 /usr/local/include/ncurses/termcap.h
 /usr/local/include/ncurses/term_entry.h
 /usr/local/include/ncurses/term.h
-/usr/local/include/ncurses/tic.h
 /usr/local/include/ncurses/unctrl.h
 /usr/local/include/ncursesw/cursesapp.h
 /usr/local/include/ncursesw/cursesf.h
@@ -41,14 +39,12 @@
 /usr/local/include/ncursesw/etip.h
 /usr/local/include/ncursesw/form.h
 /usr/local/include/ncursesw/menu.h
-/usr/local/include/ncursesw/nc_tparm.h
 /usr/local/include/ncursesw/ncurses_dll.h
 /usr/local/include/ncursesw/ncurses.h
 /usr/local/include/ncursesw/panel.h
 /usr/local/include/ncursesw/termcap.h
 /usr/local/include/ncursesw/term_entry.h
 /usr/local/include/ncursesw/term.h
-/usr/local/include/ncursesw/tic.h
 /usr/local/include/ncursesw/unctrl.h
 /usr/local/lib/libform.a
 /usr/local/lib/libform.so
@@ -199,6 +195,7 @@
 /usr/local/share/man/man3/curscr.3x.zst
 /usr/local/share/man/man3/curs_delch.3x.zst
 /usr/local/share/man/man3/curs_deleteln.3x.zst
+/usr/local/share/man/man3/curses.3x.zst
 /usr/local/share/man/man3/curses_trace.3x.zst
 /usr/local/share/man/man3/curses_version.3x.zst
 /usr/local/share/man/man3/curs_extend.3x.zst
@@ -435,7 +432,11 @@
 /usr/local/share/man/man3/in_wchnstr.3x.zst
 /usr/local/share/man/man3/in_wchstr.3x.zst
 /usr/local/share/man/man3/inwstr.3x.zst
+/usr/local/share/man/man3/is_cbreak.3x.zst
+/usr/local/share/man/man3/is_cbreak_sp.3x.zst
 /usr/local/share/man/man3/is_cleared.3x.zst
+/usr/local/share/man/man3/is_echo.3x.zst
+/usr/local/share/man/man3/is_echo_sp.3x.zst
 /usr/local/share/man/man3/isendwin.3x.zst
 /usr/local/share/man/man3/isendwin_sp.3x.zst
 /usr/local/share/man/man3/is_idcok.3x.zst
@@ -444,9 +445,13 @@
 /usr/local/share/man/man3/is_keypad.3x.zst
 /usr/local/share/man/man3/is_leaveok.3x.zst
 /usr/local/share/man/man3/is_linetouched.3x.zst
+/usr/local/share/man/man3/is_nl.3x.zst
+/usr/local/share/man/man3/is_nl_sp.3x.zst
 /usr/local/share/man/man3/is_nodelay.3x.zst
 /usr/local/share/man/man3/is_notimeout.3x.zst
 /usr/local/share/man/man3/is_pad.3x.zst
+/usr/local/share/man/man3/is_raw.3x.zst
+/usr/local/share/man/man3/is_raw_sp.3x.zst
 /usr/local/share/man/man3/is_scrollok.3x.zst
 /usr/local/share/man/man3/is_subwin.3x.zst
 /usr/local/share/man/man3/is_syncok.3x.zst
@@ -850,6 +855,8 @@
 /usr/local/share/man/man3/tigetstr_sp.3x.zst
 /usr/local/share/man/man3/timeout.3x.zst
 /usr/local/share/man/man3/tiparm.3x.zst
+/usr/local/share/man/man3/tiparm_s.3x.zst
+/usr/local/share/man/man3/tiscan_s.3x.zst
 /usr/local/share/man/man3/top_panel.3x.zst
 /usr/local/share/man/man3/top_row.3x.zst
 /usr/local/share/man/man3/touchline.3x.zst
@@ -2255,6 +2262,7 @@
 /usr/local/share/terminfo/l/linux-c
 /usr/local/share/terminfo/l/linux-c-nc
 /usr/local/share/terminfo/l/linux+decid
+/usr/local/share/terminfo/l/linux+kbs
 /usr/local/share/terminfo/l/linux-koi8
 /usr/local/share/terminfo/l/linux-koi8r
 /usr/local/share/terminfo/l/linux-lat
@@ -2768,6 +2776,7 @@
 /usr/local/share/terminfo/p/pty
 /usr/local/share/terminfo/p/putty
 /usr/local/share/terminfo/p/putty-256color
+/usr/local/share/terminfo/p/putty+cursor
 /usr/local/share/terminfo/p/putty+fnkeys
 /usr/local/share/terminfo/p/putty+fnkeys+esc
 /usr/local/share/terminfo/p/putty+fnkeys+linux
@@ -2846,6 +2855,8 @@
 /usr/local/share/terminfo/r/regent40
 /usr/local/share/terminfo/r/regent40+
 /usr/local/share/terminfo/r/regent60
+/usr/local/share/terminfo/r/report+da2
+/usr/local/share/terminfo/r/report+version
 /usr/local/share/terminfo/r/rt6221
 /usr/local/share/terminfo/r/rt6221-w
 /usr/local/share/terminfo/r/rtpc

--- a/manifest/x86_64/n/ncurses.filelist
+++ b/manifest/x86_64/n/ncurses.filelist
@@ -21,14 +21,12 @@
 /usr/local/include/ncurses/etip.h
 /usr/local/include/ncurses/form.h
 /usr/local/include/ncurses/menu.h
-/usr/local/include/ncurses/nc_tparm.h
 /usr/local/include/ncurses/ncurses_dll.h
 /usr/local/include/ncurses/ncurses.h
 /usr/local/include/ncurses/panel.h
 /usr/local/include/ncurses/termcap.h
 /usr/local/include/ncurses/term_entry.h
 /usr/local/include/ncurses/term.h
-/usr/local/include/ncurses/tic.h
 /usr/local/include/ncurses/unctrl.h
 /usr/local/include/ncursesw/cursesapp.h
 /usr/local/include/ncursesw/cursesf.h
@@ -41,14 +39,12 @@
 /usr/local/include/ncursesw/etip.h
 /usr/local/include/ncursesw/form.h
 /usr/local/include/ncursesw/menu.h
-/usr/local/include/ncursesw/nc_tparm.h
 /usr/local/include/ncursesw/ncurses_dll.h
 /usr/local/include/ncursesw/ncurses.h
 /usr/local/include/ncursesw/panel.h
 /usr/local/include/ncursesw/termcap.h
 /usr/local/include/ncursesw/term_entry.h
 /usr/local/include/ncursesw/term.h
-/usr/local/include/ncursesw/tic.h
 /usr/local/include/ncursesw/unctrl.h
 /usr/local/lib64/libform.a
 /usr/local/lib64/libform.so
@@ -198,6 +194,7 @@
 /usr/local/share/man/man3/curscr.3x.zst
 /usr/local/share/man/man3/curs_delch.3x.zst
 /usr/local/share/man/man3/curs_deleteln.3x.zst
+/usr/local/share/man/man3/curses.3x.zst
 /usr/local/share/man/man3/curses_trace.3x.zst
 /usr/local/share/man/man3/curses_version.3x.zst
 /usr/local/share/man/man3/curs_extend.3x.zst
@@ -434,7 +431,11 @@
 /usr/local/share/man/man3/in_wchnstr.3x.zst
 /usr/local/share/man/man3/in_wchstr.3x.zst
 /usr/local/share/man/man3/inwstr.3x.zst
+/usr/local/share/man/man3/is_cbreak.3x.zst
+/usr/local/share/man/man3/is_cbreak_sp.3x.zst
 /usr/local/share/man/man3/is_cleared.3x.zst
+/usr/local/share/man/man3/is_echo.3x.zst
+/usr/local/share/man/man3/is_echo_sp.3x.zst
 /usr/local/share/man/man3/isendwin.3x.zst
 /usr/local/share/man/man3/isendwin_sp.3x.zst
 /usr/local/share/man/man3/is_idcok.3x.zst
@@ -443,9 +444,13 @@
 /usr/local/share/man/man3/is_keypad.3x.zst
 /usr/local/share/man/man3/is_leaveok.3x.zst
 /usr/local/share/man/man3/is_linetouched.3x.zst
+/usr/local/share/man/man3/is_nl.3x.zst
+/usr/local/share/man/man3/is_nl_sp.3x.zst
 /usr/local/share/man/man3/is_nodelay.3x.zst
 /usr/local/share/man/man3/is_notimeout.3x.zst
 /usr/local/share/man/man3/is_pad.3x.zst
+/usr/local/share/man/man3/is_raw.3x.zst
+/usr/local/share/man/man3/is_raw_sp.3x.zst
 /usr/local/share/man/man3/is_scrollok.3x.zst
 /usr/local/share/man/man3/is_subwin.3x.zst
 /usr/local/share/man/man3/is_syncok.3x.zst
@@ -849,6 +854,8 @@
 /usr/local/share/man/man3/tigetstr_sp.3x.zst
 /usr/local/share/man/man3/timeout.3x.zst
 /usr/local/share/man/man3/tiparm.3x.zst
+/usr/local/share/man/man3/tiparm_s.3x.zst
+/usr/local/share/man/man3/tiscan_s.3x.zst
 /usr/local/share/man/man3/top_panel.3x.zst
 /usr/local/share/man/man3/top_row.3x.zst
 /usr/local/share/man/man3/touchline.3x.zst
@@ -2254,6 +2261,7 @@
 /usr/local/share/terminfo/l/linux-c
 /usr/local/share/terminfo/l/linux-c-nc
 /usr/local/share/terminfo/l/linux+decid
+/usr/local/share/terminfo/l/linux+kbs
 /usr/local/share/terminfo/l/linux-koi8
 /usr/local/share/terminfo/l/linux-koi8r
 /usr/local/share/terminfo/l/linux-lat
@@ -2767,6 +2775,7 @@
 /usr/local/share/terminfo/p/pty
 /usr/local/share/terminfo/p/putty
 /usr/local/share/terminfo/p/putty-256color
+/usr/local/share/terminfo/p/putty+cursor
 /usr/local/share/terminfo/p/putty+fnkeys
 /usr/local/share/terminfo/p/putty+fnkeys+esc
 /usr/local/share/terminfo/p/putty+fnkeys+linux
@@ -2845,6 +2854,8 @@
 /usr/local/share/terminfo/r/regent40
 /usr/local/share/terminfo/r/regent40+
 /usr/local/share/terminfo/r/regent60
+/usr/local/share/terminfo/r/report+da2
+/usr/local/share/terminfo/r/report+version
 /usr/local/share/terminfo/r/rt6221
 /usr/local/share/terminfo/r/rt6221-w
 /usr/local/share/terminfo/r/rtpc

--- a/packages/ncurses.rb
+++ b/packages/ncurses.rb
@@ -3,28 +3,27 @@ require 'package'
 class Ncurses < Package
   description 'The ncurses (new curses) library is a free software emulation of curses in System V Release 4.0 (SVr4), and more. — Wide character'
   homepage 'https://www.gnu.org/software/ncurses/'
-  version '6.4'
+  version '6.4-20230909'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://github.com/mirror/ncurses.git'
-  git_hashtag "v#{version}"
+  source_url 'https://invisible-island.net/archives/ncurses/current/ncurses-6.4-20230909.tgz'
+  source_sha256 'f859a4646974231a099a9339bbd66146dd4746a0dcbb802913c73335f8c750bb'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ncurses/6.4_armv7l/ncurses-6.4-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ncurses/6.4_armv7l/ncurses-6.4-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ncurses/6.4_i686/ncurses-6.4-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ncurses/6.4_x86_64/ncurses-6.4-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ncurses/6.4-20230909_armv7l/ncurses-6.4-20230909-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ncurses/6.4-20230909_armv7l/ncurses-6.4-20230909-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ncurses/6.4-20230909_i686/ncurses-6.4-20230909-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ncurses/6.4-20230909_x86_64/ncurses-6.4-20230909-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'b0a5264b54ebb2c794dd160bf80c15a53e7bf643729ffe6d52a7cee14a38ec17',
-     armv7l: 'b0a5264b54ebb2c794dd160bf80c15a53e7bf643729ffe6d52a7cee14a38ec17',
-       i686: 'c528b561ca5f8e2add713471bc7c08febb56f207f661047b86efb1566905919f',
-     x86_64: '8deeac491093d2413eb512daf8c0a98839e3e144ff282d94ec9566c59bd98aba'
+    aarch64: '5698eaefd29e5e1526baef7f8eb84d2c1a8e286df43b9b17d659eb8edc65b0e6',
+     armv7l: '5698eaefd29e5e1526baef7f8eb84d2c1a8e286df43b9b17d659eb8edc65b0e6',
+       i686: 'e5210cbf69eb819c659106ce34196df8a287fdbec55bdb2f6b4d4a4b402408d3',
+     x86_64: 'abe7e5d619073319c8e5f8963f6b64619a64a0e3c6cdf5eb9ee79776a1d21283'
   })
 
   depends_on 'gcc_lib' # R
   depends_on 'glibc' # R
-  no_patchelf
 
   def self.build
     # build libncurses


### PR DESCRIPTION
Addresses https://nvd.nist.gov/vuln/detail/CVE-2023-29491

@supechicken Note that this doesn't build without using `CREW_USE_CURL=1 crew build ncurses`

Builds properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=ncurses CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
