### PR TITLE
llvm & gcc packaging: do not run strip and shrink a second time

### DIFF
--- a/packages/gcc_dev.rb
+++ b/packages/gcc_dev.rb
@@ -35,6 +35,8 @@ class Gcc_dev < Package
   depends_on 'mpfr' # R
   depends_on 'zlibpkg' # R
   depends_on 'zstd' # R
+  no_shrink
+  no_strip
 
   def self.install
     puts 'Installing Gcc_build to pull files for build...'.lightblue

--- a/packages/gcc_lib.rb
+++ b/packages/gcc_lib.rb
@@ -27,6 +27,8 @@ class Gcc_lib < Package
 
   depends_on 'gcc_build' => :build
   depends_on 'glibc' # R
+  no_shrink
+  no_strip
 
   def self.install
     puts 'Installing Gcc_build to pull files for build...'.lightblue

--- a/packages/llvm17_dev.rb
+++ b/packages/llvm17_dev.rb
@@ -36,6 +36,8 @@ class Llvm17_dev < Package
   depends_on 'xzutils' # R
   depends_on 'zlibpkg' # R
   depends_on 'zstd' # R
+  no_shrink
+  no_strip
 
   def self.install
     puts 'Installing llvm17_build to pull files for build...'.lightblue

--- a/packages/llvm17_lib.rb
+++ b/packages/llvm17_lib.rb
@@ -33,6 +33,8 @@ class Llvm17_lib < Package
   depends_on 'ncurses' # R
   depends_on 'zlibpkg' # R
   depends_on 'zstd' # R
+  no_shrink
+  no_strip
 
   def self.install
     puts 'Installing llvm17_build to pull files for build...'.lightblue


### PR DESCRIPTION
- Realized as per https://github.com/upx/upx/issues/712#issuecomment-1728633564 that we were running strip and shrink a second time when doing the secondary packaging of llvm & GCC. Let us not do that.
- Not rebuilding binaries... but this is good to have for the next time we build updates to these...

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=llvm17_package_cleanup CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
