### PR TITLE
cairo: tee now enabled by default

### DIFF
--- a/packages/cairo.rb
+++ b/packages/cairo.rb
@@ -38,6 +38,5 @@ class Cairo < Meson
   conflicts_ok # because this overwrites the limited cairo from harfbuzz
 
   meson_options '-Dxlib-xcb=enabled \
-    -Dtee=enabled \
     -Dtests=disabled'
 end


### PR DESCRIPTION
Minor fix to package file as per changelog at https://gitlab.freedesktop.org/cairo/cairo/-/releases/1.18.0