### PR TITLE
Add hurl package

### DIFF
--- a/manifest/x86_64/h/hurl.filelist
+++ b/manifest/x86_64/h/hurl.filelist
@@ -1,0 +1,4 @@
+/usr/local/bin/hurl
+/usr/local/bin/hurlfmt
+/usr/local/share/man/man1/hurl.1.zst
+/usr/local/share/man/man1/hurlfmt.1.zst

--- a/packages/hurl.rb
+++ b/packages/hurl.rb
@@ -1,0 +1,38 @@
+require 'package'
+
+class Hurl < Package
+  description 'Hurl is a command line tool that runs HTTP requests defined in a simple plain text format.'
+  homepage 'https://hurl.dev/'
+  version '4.1.0'
+  license 'Apache-2.0'
+  compatibility 'x86_64'
+  source_url 'https://github.com/Orange-OpenSource/hurl.git'
+  git_hashtag version
+
+  binary_url({
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/hurl/4.1.0_x86_64/hurl-4.1.0-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    x86_64: '59132b9e9ab44687e074a9417e8172a3e09653ac1256df9fa7dd38ecc5b341f0'
+  })
+
+  depends_on 'rust' => :build
+  depends_on 'curl'
+  depends_on 'libxml2'
+  depends_on 'openssl'
+
+  def self.build
+    system 'cargo build --release'
+  end
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    FileUtils.mkdir_p "#{CREW_DEST_MAN_PREFIX}/man1"
+    Dir.chdir 'target/release' do
+      FileUtils.install %w[hurl hurlfmt], "#{CREW_DEST_PREFIX}/bin", mode: 0o755
+    end
+    Dir.chdir 'docs/manual' do
+      FileUtils.install %w[hurl.1 hurlfmt.1], "#{CREW_DEST_MAN_PREFIX}/man1", mode: 0o644
+    end
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -3080,6 +3080,11 @@ url: https://github.com/hunspell/hunspell/releases
 activity: low
 ---
 kind: url
+name: hurl
+url: https://github.com/Orange-OpenSource/releases
+activity: medium
+---
+kind: url
 name: hwdata
 url: https://github.com/vcrhonek/hwdata/releases
 activity: high


### PR DESCRIPTION
Hurl is a command line tool that runs HTTP requests defined in a simple plain text format.

It can chain requests, capture values and evaluate queries on headers and body response. Hurl is very versatile: it can be used for both fetching data and testing HTTP sessions.

Hurl makes it easy to work with HTML content, REST / SOAP / GraphQL APIs, or any other XML / JSON based APIs.

See https://hurl.dev/.