### PR TITLE
Fix Chromebrew install

### DIFF
--- a/packages/py3_pyparsing.rb
+++ b/packages/py3_pyparsing.rb
@@ -4,27 +4,28 @@ class Py3_pyparsing < Package
   description 'The pyparsing module is an alternative approach to creating and executing simple grammars, vs. the traditional lex/yacc approach, or the use of regular expressions.'
   homepage 'https://github.com/pyparsing/pyparsing/'
   @_ver = '3.0.9'
-  version "#{@_ver}-py3.11"
+  version "#{@_ver}-py3.11-1"
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/pyparsing/pyparsing.git'
   git_hashtag "pyparsing_#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyparsing/3.0.9-py3.11_armv7l/py3_pyparsing-3.0.9-py3.11-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyparsing/3.0.9-py3.11_armv7l/py3_pyparsing-3.0.9-py3.11-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyparsing/3.0.9-py3.11_i686/py3_pyparsing-3.0.9-py3.11-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyparsing/3.0.9-py3.11_x86_64/py3_pyparsing-3.0.9-py3.11-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyparsing/3.0.9-py3.11-1_armv7l/py3_pyparsing-3.0.9-py3.11-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyparsing/3.0.9-py3.11-1_armv7l/py3_pyparsing-3.0.9-py3.11-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyparsing/3.0.9-py3.11-1_i686/py3_pyparsing-3.0.9-py3.11-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyparsing/3.0.9-py3.11-1_x86_64/py3_pyparsing-3.0.9-py3.11-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '939e0032145745843ca76b98e80e2f1fdb2747ed6fd9789e6bf92454eccb29ce',
-     armv7l: '939e0032145745843ca76b98e80e2f1fdb2747ed6fd9789e6bf92454eccb29ce',
-       i686: 'ffc073d888b238111adaaf1c7c9d87057cc6c7e53cd04972be0777cf446fd202',
-     x86_64: 'ed9b21c9b56086df2f7d8f31c3b6b7c5c9b2a6669140f2ef30c7c644c3334f79'
+    aarch64: 'fa3ace7330aadc1607fc5963121a5cb99fbe64872985635557502706571e5bcb',
+     armv7l: 'fa3ace7330aadc1607fc5963121a5cb99fbe64872985635557502706571e5bcb',
+       i686: 'd0dd29348de1376366c2baaf2771aef5a9dc21fd1f156e5619d2596940400be1',
+     x86_64: '5d0bfcea1cd42f37089de37c22441125a05d171bbda2ffba02a3bf6acfcf262b'
   })
 
   depends_on 'python3'
   depends_on 'py3_flit_core'
+  depends_on 'py3_pep517' => :build
 
   def self.build
     system "SETUPTOOLS_SCM_PRETEND_VERSION=#{@_ver} python3 -m build #{PY3_BUILD_OPTIONS}"


### PR DESCRIPTION
Fixes #8731 
- Rebuild and reupload accidentally replaced py3_pyparsing Python 3.11 packages.

Builds properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=install_fix CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
