### PR TITLE
Llvm17_build 17.0.1 => 17.0.2

### DIFF
--- a/manifest/i686/l/llvm17_build.filelist
+++ b/manifest/i686/l/llvm17_build.filelist
@@ -3897,6 +3897,8 @@
 /usr/local/lib/clang/17/include/cpuid.h
 /usr/local/lib/clang/17/include/crc32intrin.h
 /usr/local/lib/clang/17/include/cuda_wrappers/algorithm
+/usr/local/lib/clang/17/include/cuda_wrappers/bits/basic_string.h
+/usr/local/lib/clang/17/include/cuda_wrappers/bits/basic_string.tcc
 /usr/local/lib/clang/17/include/cuda_wrappers/bits/shared_ptr_base.h
 /usr/local/lib/clang/17/include/cuda_wrappers/cmath
 /usr/local/lib/clang/17/include/cuda_wrappers/complex
@@ -4144,7 +4146,7 @@
 /usr/local/lib/libclangSerialization.a
 /usr/local/lib/libclang.so
 /usr/local/lib/libclang.so.17
-/usr/local/lib/libclang.so.17.0.1
+/usr/local/lib/libclang.so.17.0.2
 /usr/local/lib/libclangStaticAnalyzerCheckers.a
 /usr/local/lib/libclangStaticAnalyzerCore.a
 /usr/local/lib/libclangStaticAnalyzerFrontend.a
@@ -4193,14 +4195,14 @@
 /usr/local/lib/liblldbIntelFeatures.so.17
 /usr/local/lib/liblldb.so
 /usr/local/lib/liblldb.so.17
-/usr/local/lib/liblldb.so.17.0.1
+/usr/local/lib/liblldb.so.17.0.2
 /usr/local/lib/liblldCOFF.a
 /usr/local/lib/liblldCommon.a
 /usr/local/lib/liblldELF.a
 /usr/local/lib/liblldMachO.a
 /usr/local/lib/liblldMinGW.a
 /usr/local/lib/liblldWasm.a
-/usr/local/lib/libLLVM-17.0.1.so
+/usr/local/lib/libLLVM-17.0.2.so
 /usr/local/lib/libLLVM-17.so
 /usr/local/lib/libLLVMAArch64AsmParser.a
 /usr/local/lib/libLLVMAArch64CodeGen.a

--- a/manifest/x86_64/l/llvm17_build.filelist
+++ b/manifest/x86_64/l/llvm17_build.filelist
@@ -3221,7 +3221,6 @@
 /usr/local/include/llvm/Support/ErrorOr.h
 /usr/local/include/llvm/Support/ExitCodes.h
 /usr/local/include/llvm/Support/ExtensibleRTTI.h
-/usr/local/include/llvm/Support/Extension.def
 /usr/local/include/llvm/Support/FileCollector.h
 /usr/local/include/llvm/Support/FileOutputBuffer.h
 /usr/local/include/llvm/Support/FileSystem.h
@@ -3897,6 +3896,8 @@
 /usr/local/lib64/clang/17/include/cpuid.h
 /usr/local/lib64/clang/17/include/crc32intrin.h
 /usr/local/lib64/clang/17/include/cuda_wrappers/algorithm
+/usr/local/lib64/clang/17/include/cuda_wrappers/bits/basic_string.h
+/usr/local/lib64/clang/17/include/cuda_wrappers/bits/basic_string.tcc
 /usr/local/lib64/clang/17/include/cuda_wrappers/bits/shared_ptr_base.h
 /usr/local/lib64/clang/17/include/cuda_wrappers/cmath
 /usr/local/lib64/clang/17/include/cuda_wrappers/complex
@@ -4146,7 +4147,7 @@
 /usr/local/lib64/libclangSerialization.a
 /usr/local/lib64/libclang.so
 /usr/local/lib64/libclang.so.17
-/usr/local/lib64/libclang.so.17.0.1
+/usr/local/lib64/libclang.so.17.0.2
 /usr/local/lib64/libclangStaticAnalyzerCheckers.a
 /usr/local/lib64/libclangStaticAnalyzerCore.a
 /usr/local/lib64/libclangStaticAnalyzerFrontend.a
@@ -4195,14 +4196,14 @@
 /usr/local/lib64/liblldbIntelFeatures.so.17
 /usr/local/lib64/liblldb.so
 /usr/local/lib64/liblldb.so.17
-/usr/local/lib64/liblldb.so.17.0.1
+/usr/local/lib64/liblldb.so.17.0.2
 /usr/local/lib64/liblldCOFF.a
 /usr/local/lib64/liblldCommon.a
 /usr/local/lib64/liblldELF.a
 /usr/local/lib64/liblldMachO.a
 /usr/local/lib64/liblldMinGW.a
 /usr/local/lib64/liblldWasm.a
-/usr/local/lib64/libLLVM-17.0.1.so
+/usr/local/lib64/libLLVM-17.0.2.so
 /usr/local/lib64/libLLVM-17.so
 /usr/local/lib64/libLLVMAArch64AsmParser.a
 /usr/local/lib64/libLLVMAArch64CodeGen.a

--- a/packages/llvm17_build.rb
+++ b/packages/llvm17_build.rb
@@ -3,7 +3,7 @@ require 'package'
 class Llvm17_build < Package
   description 'The LLVM Project is a collection of modular and reusable compiler and toolchain technologies. The optional packages clang, lld, lldb, polly, compiler-rt, libcxx, and libcxxabi are included.'
   homepage 'http://llvm.org/'
-  version '17.0.1'
+  version '17.0.2'
   license 'Apache-2.0-with-LLVM-exceptions, UoI-NCSA, BSD, public-domain, rc, Apache-2.0 and MIT'
   compatibility 'all'
   source_url 'https://github.com/llvm/llvm-project.git'
@@ -12,14 +12,14 @@ class Llvm17_build < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm17_build/17.0.1_armv7l/llvm17_build-17.0.1-chromeos-armv7l.tar.zst',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm17_build/17.0.1_armv7l/llvm17_build-17.0.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm17_build/17.0.1_i686/llvm17_build-17.0.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm17_build/17.0.1_x86_64/llvm17_build-17.0.1-chromeos-x86_64.tar.zst'
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm17_build/17.0.2_i686/llvm17_build-17.0.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/llvm17_build/17.0.2_x86_64/llvm17_build-17.0.2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
     aarch64: '61979034409fd18ce316c0cfb1a29a7a62d6a04f387b7ca726cb7dd2728b3da6',
      armv7l: '61979034409fd18ce316c0cfb1a29a7a62d6a04f387b7ca726cb7dd2728b3da6',
-       i686: '80dc613b746126b1b393aaef98078a245f7f25d89b65de1b599f755352e21996',
-     x86_64: 'eebc943cc0c7a7d5528c143a5c0188a16486408dad029123cf644b543be30b22'
+       i686: 'bb572a3774902633aa5b004499219b0f1bf3c9ddb8e17c6483ac7c2f38e3057d',
+     x86_64: '38ed0470685997c9c583995ec7428ec862afa13a5cb81f761ce5501a40c7cffa'
   })
 
   depends_on 'ocaml' => :build


### PR DESCRIPTION
The arm build failed with the following:
```
[5344/7169] Linking CXX static library lib/libLLVMJITLink.a
[5345/7169] Linking CXX static library lib/libLLVMOrcJIT.a
[5346/7169] Linking CXX executable bin/lli-child-target
[5347/7169] Linking CXX shared library lib/libLLVM-17.so
samu: job failed: : && /usr/local/bin/clang++ -fPIC -fPIC -mfloat-abi=hard -mthumb -mfpu=vfpv3-d16 -march=armv7-a+fp -ccc-gcc-name armv7l-cros-linux-gnueabihf -flto=thin -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wc++98-compat-extra-semi -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -flto=thin -O3 -DNDEBUG  -Wl,-z,defs -Wl,-z,nodelete -flto=thin   -Wl,--gc-sections  -Xlinker -Bsymbolic-functions -shared -Wl,-soname,libLLVM-17.so -o lib/libLLVM-17.so tools/llvm-shlib/CMakeFiles/LLVM.dir/libllvm.cpp.o  -Wl,-rpath,"\$ORIGIN/../lib:"  -Wl,--version-script,/usr/local/tmp/crew/llvm17_build.20231003190943.dir/builddir/./lib/tools/llvm-shlib/simple_version_script.map  -Wl,--whole-archive  lib/libLLVMDemangle.a  lib/libLLVMSupport.a  lib/libLLVMCore.a  lib/libLLVMFuzzerCLI.a  lib/libLLVMFuzzMutate.a  lib/libLLVMFileCheck.a  lib/libLLVMInterfaceStub.a  lib/libLLVMIRPrinter.a  lib/libLLVMIRReader.a  lib/libLLVMCodeGenTypes.a  lib/libLLVMCodeGen.a  lib/libLLVMSelectionDAG.a  lib/libLLVMAsmPrinter.a  lib/libLLVMMIRParser.a  lib/libLLVMGlobalISel.a  lib/libLLVMBinaryFormat.a  lib/libLLVMBitReader.a  lib/libLLVMBitWriter.a  lib/libLLVMBitstreamReader.a  lib/libLLVMDWARFLinker.a  lib/libLLVMDWARFLinkerParallel.a  lib/libLLVMExtensions.a  lib/libLLVMFrontendHLSL.a  lib/libLLVMFrontendOpenACC.a  lib/libLLVMFrontendOpenMP.a  lib/libLLVMTransformUtils.a  lib/libLLVMInstrumentation.a  lib/libLLVMAggressiveInstCombine.a  lib/libLLVMInstCombine.a  lib/libLLVMScalarOpts.a  lib/libLLVMipo.a  lib/libLLVMVectorize.a  lib/libLLVMObjCARCOpts.a  lib/libLLVMCoroutines.a  lib/libLLVMCFGuard.a  lib/libLLVMLinker.a  lib/libLLVMAnalysis.a  lib/libLLVMLTO.a  lib/libLLVMMC.a  lib/libLLVMMCParser.a  lib/libLLVMMCDisassembler.a  lib/libLLVMMCA.a  lib/libLLVMObjCopy.a  lib/libLLVMObject.a  lib/libLLVMObjectYAML.a  lib/libLLVMOption.a  lib/libLLVMRemarks.a  lib/libLLVMDebugInfoDWARF.a  lib/libLLVMDebugInfoGSYM.a  lib/libLLVMDebugInfoLogicalView.a  lib/libLLVMDebugInfoMSF.a  lib/libLLVMDebugInfoCodeView.a  lib/libLLVMDebugInfoPDB.a  lib/libLLVMSymbolize.a  lib/libLLVMDebugInfoBTF.a  lib/libLLVMDWP.a  lib/libLLVMExecutionEngine.a  lib/libLLVMInterpreter.a  lib/libLLVMJITLink.a  lib/libLLVMMCJIT.a  lib/libLLVMOrcJIT.a  lib/libLLVMOrcShared.a  lib/libLLVMOrcTargetProcess.a  lib/libLLVMRuntimeDyld.a  lib/libLLVMTarget.a  lib/libLLVMAArch64CodeGen.a  lib/libLLVMAArch64AsmParser.a  lib/libLLVMAArch64Disassembler.a  lib/libLLVMAArch64Desc.a  lib/libLLVMAArch64Info.a  lib/libLLVMAArch64Utils.a  lib/libLLVMAMDGPUCodeGen.a  lib/libLLVMAMDGPUAsmParser.a  lib/libLLVMAMDGPUDisassembler.a  lib/libLLVMAMDGPUTargetMCA.a  lib/libLLVMAMDGPUDesc.a  lib/libLLVMAMDGPUInfo.a  lib/libLLVMAMDGPUUtils.a  lib/libLLVMARMCodeGen.a  lib/libLLVMARMAsmParser.a  lib/libLLVMARMDisassembler.a  lib/libLLVMARMDesc.a  lib/libLLVMARMInfo.a  lib/libLLVMARMUtils.a  lib/libLLVMAVRCodeGen.a  lib/libLLVMAVRAsmParser.a  lib/libLLVMAVRDisassembler.a  lib/libLLVMAVRDesc.a  lib/libLLVMAVRInfo.a  lib/libLLVMBPFCodeGen.a  lib/libLLVMBPFAsmParser.a  lib/libLLVMBPFDisassembler.a  lib/libLLVMBPFDesc.a  lib/libLLVMBPFInfo.a  lib/libLLVMHexagonCodeGen.a  lib/libLLVMHexagonAsmParser.a  lib/libLLVMHexagonDisassembler.a  lib/libLLVMHexagonDesc.a  lib/libLLVMHexagonInfo.a  lib/libLLVMLanaiCodeGen.a  lib/libLLVMLanaiAsmParser.a  lib/libLLVMLanaiDisassembler.a  lib/libLLVMLanaiDesc.a  lib/libLLVMLanaiInfo.a  lib/libLLVMLoongArchCodeGen.a  lib/libLLVMLoongArchAsmParser.a  lib/libLLVMLoongArchDisassembler.a  lib/libLLVMLoongArchDesc.a  lib/libLLVMLoongArchInfo.a  lib/libLLVMMipsCodeGen.a  lib/libLLVMMipsAsmParser.a  lib/libLLVMMipsDisassembler.a  lib/libLLVMMipsDesc.a  lib/libLLVMMipsInfo.a  lib/libLLVMMSP430CodeGen.a  lib/libLLVMMSP430Desc.a  lib/libLLVMMSP430Info.a  lib/libLLVMMSP430AsmParser.a  lib/libLLVMMSP430Disassembler.a  lib/libLLVMNVPTXCodeGen.a  lib/libLLVMNVPTXDesc.a  lib/libLLVMNVPTXInfo.a  lib/libLLVMPowerPCCodeGen.a  lib/libLLVMPowerPCAsmParser.a  lib/libLLVMPowerPCDisassembler.a  lib/libLLVMPowerPCDesc.a  lib/libLLVMPowerPCInfo.a  lib/libLLVMRISCVCodeGen.a  lib/libLLVMRISCVAsmParser.a  lib/libLLVMRISCVDisassembler.a  lib/libLLVMRISCVDesc.a  lib/libLLVMRISCVTargetMCA.a  lib/libLLVMRISCVInfo.a  lib/libLLVMSparcCodeGen.a  lib/libLLVMSparcAsmParser.a  lib/libLLVMSparcDisassembler.a  lib/libLLVMSparcDesc.a  lib/libLLVMSparcInfo.a  lib/libLLVMSystemZCodeGen.a  lib/libLLVMSystemZAsmParser.a  lib/libLLVMSystemZDisassembler.a  lib/libLLVMSystemZDesc.a  lib/libLLVMSystemZInfo.a  lib/libLLVMVECodeGen.a  lib/libLLVMVEAsmParser.a  lib/libLLVMVEDisassembler.a  lib/libLLVMVEInfo.a  lib/libLLVMVEDesc.a  lib/libLLVMWebAssemblyCodeGen.a  lib/libLLVMWebAssemblyAsmParser.a  lib/libLLVMWebAssemblyDisassembler.a  lib/libLLVMWebAssemblyDesc.a  lib/libLLVMWebAssemblyInfo.a  lib/libLLVMWebAssemblyUtils.a  lib/libLLVMX86CodeGen.a  lib/libLLVMX86AsmParser.a  lib/libLLVMX86Disassembler.a  lib/libLLVMX86TargetMCA.a  lib/libLLVMX86Desc.a  lib/libLLVMX86Info.a  lib/libLLVMXCoreCodeGen.a  lib/libLLVMXCoreDisassembler.a  lib/libLLVMXCoreDesc.a  lib/libLLVMXCoreInfo.a  lib/libLLVMAsmParser.a  lib/libLLVMLineEditor.a  lib/libLLVMProfileData.a  lib/libLLVMCoverage.a  lib/libLLVMPasses.a  lib/libLLVMTargetParser.a  lib/libLLVMTextAPI.a  lib/libLLVMDlltoolDriver.a  lib/libLLVMLibDriver.a  lib/libLLVMXRay.a  lib/libLLVMWindowsDriver.a  lib/libLLVMWindowsManifest.a  -Wl,--no-whole-archive  lib/libLLVMExtensions.a  lib/libPolly.a  lib/libPollyISL.a  /usr/local/lib/libffi.so  lib/libLLVMExecutionEngine.a  lib/libLLVMJITLink.a  lib/libLLVMOrcTargetProcess.a  lib/libLLVMOrcShared.a  lib/libLLVMRuntimeDyld.a  lib/libLLVMMIRParser.a  lib/libLLVMPasses.a  lib/libLLVMIRPrinter.a  lib/libLLVMCoroutines.a  lib/libLLVMMSP430Desc.a  lib/libLLVMMSP430Info.a  lib/libLLVMipo.a  lib/libLLVMFrontendOpenMP.a  lib/libLLVMVectorize.a  lib/libLLVMLinker.a  lib/libLLVMRISCVDesc.a  lib/libLLVMRISCVInfo.a  lib/libLLVMVEInfo.a  lib/libLLVMWebAssemblyDesc.a  lib/libLLVMWebAssemblyInfo.a  lib/libLLVMGlobalISel.a  lib/libLLVMInstrumentation.a  lib/libLLVMCFGuard.a  lib/libLLVMMCA.a  lib/libLLVMSelectionDAG.a  lib/libLLVMAsmPrinter.a  lib/libLLVMCodeGen.a  lib/libLLVMBitWriter.a  lib/libLLVMScalarOpts.a  lib/libLLVMAggressiveInstCombine.a  lib/libLLVMInstCombine.a  lib/libLLVMObjCARCOpts.a  lib/libLLVMTransformUtils.a  lib/libLLVMTarget.a  lib/libLLVMAnalysis.a  lib/libLLVMCodeGenTypes.a  lib/libLLVMMCDisassembler.a  /usr/local/lib/libedit.so  lib/libLLVMProfileData.a  lib/libLLVMSymbolize.a  lib/libLLVMDebugInfoDWARF.a  lib/libLLVMDebugInfoPDB.a  lib/libLLVMDebugInfoMSF.a  lib/libLLVMDebugInfoBTF.a  lib/libLLVMOption.a  lib/libLLVMObject.a  lib/libLLVMIRReader.a  lib/libLLVMAsmParser.a  lib/libLLVMBitReader.a  lib/libLLVMCore.a  lib/libLLVMRemarks.a  lib/libLLVMBitstreamReader.a  lib/libLLVMMCParser.a  lib/libLLVMMC.a  lib/libLLVMDebugInfoCodeView.a  lib/libLLVMTextAPI.a  lib/libLLVMBinaryFormat.a  lib/libLLVMTargetParser.a  lib/libLLVMSupport.a  lib/libLLVMDemangle.a  -lrt  -ldl  -lpthread  -lm  /usr/local/lib/libz.so  /usr/local/lib/libzstd.so  /usr/local/lib/libtinfo.so  /usr/local/lib/libxml2.so && :
/usr/local/bin/ld: fatal error: lib/libLLVM-17.so: mmap: failed to allocate 116140508 bytes for output file: Cannot allocate memory
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
samu: subcommand failed
Make iteration 1 of 20...
samu: entering directory 'builddir'
[1/1823] Linking CXX shared library lib/libLLVM-17.so
```