### PR TITLE
rubocop => 1.56.4, also rebuild py3_pyproject_hooks, py3_build for Python 3.11

### DIFF
--- a/packages/py3_build.rb
+++ b/packages/py3_build.rb
@@ -4,27 +4,28 @@ class Py3_build < Package
   description 'Python build is a simple, correct PEP 517 build frontend.'
   homepage 'https://pypa-build.readthedocs.io/'
   @_ver = '0.9.0'
-  version "#{@_ver}-py3.11"
+  version "#{@_ver}-1-py3.11"
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/pypa/build.git'
   git_hashtag @_ver
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_build/0.9.0-py3.11_armv7l/py3_build-0.9.0-py3.11-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_build/0.9.0-py3.11_armv7l/py3_build-0.9.0-py3.11-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_build/0.9.0-py3.11_i686/py3_build-0.9.0-py3.11-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_build/0.9.0-py3.11_x86_64/py3_build-0.9.0-py3.11-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_build/0.9.0-1-py3.11_armv7l/py3_build-0.9.0-1-py3.11-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_build/0.9.0-1-py3.11_armv7l/py3_build-0.9.0-1-py3.11-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_build/0.9.0-1-py3.11_i686/py3_build-0.9.0-1-py3.11-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_build/0.9.0-1-py3.11_x86_64/py3_build-0.9.0-1-py3.11-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '9b0448006c3e4f6453bfcae30472f50a4e68848d6ae322dae9b5335c4274cb71',
-     armv7l: '9b0448006c3e4f6453bfcae30472f50a4e68848d6ae322dae9b5335c4274cb71',
-       i686: '9048410e94aef4feb6950fa7574c0082c1c39a030aa79bd99ae731a58c01c1df',
-     x86_64: 'd98e8bf6a856a84306eb4c29a6858307625cbc0f4eaa4a4344e5d9506406e5e3'
+    aarch64: 'a9c9fcf17177e0cacf41eb187891ca499122eacd8324ddeb65ce9f71647116bf',
+     armv7l: 'a9c9fcf17177e0cacf41eb187891ca499122eacd8324ddeb65ce9f71647116bf',
+       i686: 'fdc59807e7f84c345889f3afb67a1f452950d8bd873323b3b9f3f1ec329931d6',
+     x86_64: '021cc30ea7a0f270d330f8c08d1f70024be19349d874aff6541c88c332edd847'
   })
 
   depends_on 'python3'
   depends_on 'py3_packaging'
+  depends_on 'py3_pep517' => :build
   depends_on 'py3_pyproject_hooks'
   depends_on 'py3_tomli'
 

--- a/packages/py3_pyproject_hooks.rb
+++ b/packages/py3_pyproject_hooks.rb
@@ -4,26 +4,27 @@ class Py3_pyproject_hooks < Package
   description 'This package contains wrappers to call hooks on build backends for pyproject.toml -based projects'
   homepage 'https://pyproject-hooks.readthedocs.io/'
   @_ver = '1.0.0'
-  version "#{@_ver}-py3.11"
+  version "#{@_ver}-1-py3.11"
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/pypa/pyproject-hooks.git'
   git_hashtag "v#{@_ver}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyproject_hooks/1.0.0-py3.11_armv7l/py3_pyproject_hooks-1.0.0-py3.11-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyproject_hooks/1.0.0-py3.11_armv7l/py3_pyproject_hooks-1.0.0-py3.11-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyproject_hooks/1.0.0-py3.11_i686/py3_pyproject_hooks-1.0.0-py3.11-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyproject_hooks/1.0.0-py3.11_x86_64/py3_pyproject_hooks-1.0.0-py3.11-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyproject_hooks/1.0.0-1-py3.11_armv7l/py3_pyproject_hooks-1.0.0-1-py3.11-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyproject_hooks/1.0.0-1-py3.11_armv7l/py3_pyproject_hooks-1.0.0-1-py3.11-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyproject_hooks/1.0.0-1-py3.11_i686/py3_pyproject_hooks-1.0.0-1-py3.11-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_pyproject_hooks/1.0.0-1-py3.11_x86_64/py3_pyproject_hooks-1.0.0-1-py3.11-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '21f517d2022987ada64860830426cb7f7a769e405d42cb381f24063629433e55',
-     armv7l: '21f517d2022987ada64860830426cb7f7a769e405d42cb381f24063629433e55',
-       i686: '3de0b5be888db9484499d5083ed1011908945e36603fff4a2386869a5ba897ce',
-     x86_64: 'bc0168df62eb6b2c238a49bbfa289cdb1e3941648e8d6427552a9270fefc6579'
+    aarch64: '5ba916f355743f059f8113e6d7eb984b6e554309400f8c2ec746c1a2d6f1b281',
+     armv7l: '5ba916f355743f059f8113e6d7eb984b6e554309400f8c2ec746c1a2d6f1b281',
+       i686: '504a11525def81a601f669747fe09ed34a73460eb75436ddf3e8cd7654832104',
+     x86_64: 'ae826e30b3b8dbf8778ed068f30118444958c0b7af2f1dd45d23dac0bc1ee07f'
   })
 
   depends_on 'python3'
+  depends_on 'py3_pep517' => :build
   depends_on 'py3_tomli'
 
   def self.build

--- a/packages/ruby_rubocop.rb
+++ b/packages/ruby_rubocop.rb
@@ -6,10 +6,10 @@ require 'package'
 class Ruby_rubocop < Package
   description 'A Ruby static code analyzer and formatter'
   homepage 'https://rubocop.org'
-  version '1.52.1-ruby-3.2'
+  version '1.56.4-ruby-3.2'
   compatibility 'all'
   source_url 'https://github.com/chromebrew/chromebrew/raw/master/.rubocop.yml'
-  source_sha256 'c25faeecdbc465ef97e5a9d94ca46a64af5a68c2d17d8de7ba622377d22b805c'
+  source_sha256 'ef0331bf6c4b032233f587b3fd74b688d9c1bd6cce32390dfca977bc92ef4968'
 
   depends_on 'libyaml'
   depends_on 'ruby'


### PR DESCRIPTION
Fixes #8741 #8745 #8746

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=rubocop CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
