### PR TITLE
crew: Retry `make` with single thread if failed

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,5 +1,5 @@
 # Defines common constants used in different parts of crew
-CREW_VERSION = '1.36.0'
+CREW_VERSION = '1.36.1'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -300,10 +300,10 @@ class Package
         Kernel.system(env, *cmd_args, **opt_args)
       end
     rescue RuntimeError => e
-      if modded_make_cmd
+      if modded_make_cmd && make_threads != 1
         # retry with single thread if command is `make` and is modified by crew
         make_threads = 1
-        warn "Command \"#{cmd_args.join(' ')}\" failed, retrying with \"-j1\"...".yellow
+        warn "Command \"#{cmd_args.map { |arg| arg.sub('<<<CREW_NPROC>>>', "-j#{make_threads}") } .join(' ')}\" failed, retrying with \"-j1\"...".yellow
         retry
       else
         # exit with error

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -302,8 +302,8 @@ class Package
     rescue RuntimeError => e
       if modded_make_cmd && make_threads != 1
         # retry with single thread if command is `make` and is modified by crew
-        make_threads = 1
         warn "Command \"#{cmd_args.map { |arg| arg.sub('<<<CREW_NPROC>>>', "-j#{make_threads}") } .join(' ')}\" failed, retrying with \"-j1\"...".yellow
+        make_threads = 1
         retry
       else
         # exit with error


### PR DESCRIPTION
Suggested by @satmandu:

> It would be nice to automatically retry commands which have a -j#{CREW_NPROC} passed to it which fail automatically with -j1 so we can see the command that failed...

Tested on `x86_64`

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/supechicken/chromebrew.git CREW_TESTING_BRANCH=retry_make CREW_TESTING=1 crew update
```
