### PR TITLE
Add autojump package

### DIFF
--- a/manifest/armv7l/a/autojump.filelist
+++ b/manifest/armv7l/a/autojump.filelist
@@ -1,0 +1,11 @@
+/usr/local/bin/autojump
+/usr/local/bin/autojump_argparse.py
+/usr/local/bin/autojump_data.py
+/usr/local/bin/autojump_match.py
+/usr/local/bin/autojump_utils.py
+/usr/local/etc/env.d/autojump.sh
+/usr/local/share/autojump/autojump.bash
+/usr/local/share/autojump/autojump.fish
+/usr/local/share/autojump/autojump.zsh
+/usr/local/share/autojump/icon.png
+/usr/local/share/man/man1/autojump.1.zst

--- a/manifest/i686/a/autojump.filelist
+++ b/manifest/i686/a/autojump.filelist
@@ -1,0 +1,11 @@
+/usr/local/bin/autojump
+/usr/local/bin/autojump_argparse.py
+/usr/local/bin/autojump_data.py
+/usr/local/bin/autojump_match.py
+/usr/local/bin/autojump_utils.py
+/usr/local/etc/env.d/autojump.sh
+/usr/local/share/autojump/autojump.bash
+/usr/local/share/autojump/autojump.fish
+/usr/local/share/autojump/autojump.zsh
+/usr/local/share/autojump/icon.png
+/usr/local/share/man/man1/autojump.1.zst

--- a/manifest/x86_64/a/autojump.filelist
+++ b/manifest/x86_64/a/autojump.filelist
@@ -1,0 +1,11 @@
+/usr/local/bin/autojump
+/usr/local/bin/autojump_argparse.py
+/usr/local/bin/autojump_data.py
+/usr/local/bin/autojump_match.py
+/usr/local/bin/autojump_utils.py
+/usr/local/etc/env.d/autojump.sh
+/usr/local/share/autojump/autojump.bash
+/usr/local/share/autojump/autojump.fish
+/usr/local/share/autojump/autojump.zsh
+/usr/local/share/autojump/icon.png
+/usr/local/share/man/man1/autojump.1.zst

--- a/packages/autojump.rb
+++ b/packages/autojump.rb
@@ -1,0 +1,30 @@
+require 'package'
+
+class Autojump < Package
+  description 'A cd command that learns - easily navigate directories from the command line'
+  homepage 'https://github.com/wting/autojump'
+  version '22.5.3'
+  license 'GPL-3'
+  compatibility 'all'
+  source_url 'https://github.com/wting/autojump/archive/release-v22.5.3.tar.gz'
+  source_sha256 '00daf3698e17ac3ac788d529877c03ee80c3790472a85d0ed063ac3a354c37b1'
+
+  depends_on 'python3'
+
+  no_compile_needed
+
+  def self.build
+    File.write 'autojump.sh', <<~EOF
+      [[ -s #{CREW_PREFIX}/share/autojump/autojump.bash ]] && source #{CREW_PREFIX}/share/autojump/autojump.bash
+    EOF
+  end
+
+  def self.install
+    system "./install.py -p #{CREW_DEST_PREFIX}"
+    FileUtils.install 'autojump.sh', "#{CREW_DEST_PREFIX}/etc/env.d/autojump.sh", mode: 0o755
+  end
+
+  def self.postinstall
+    puts "\nType 'source ~/.bashrc' to finish the installation.\n".lightblue
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -385,6 +385,11 @@ url: https://ftp.gnu.org/gnu/autoconf
 activity: none
 ---
 kind: url
+name: autojump
+url: https://github.com/wting/autojump/tags
+activity: none
+---
+kind: url
 name: automake
 url: https://ftp.gnu.org/gnu/automake
 activity: medium


### PR DESCRIPTION
autojump is a faster way to navigate your filesystem. It works by maintaining a database of the directories you use the most from the command line.  See https://github.com/wting/autojump.  Tested on all architectures.