### PR TITLE
Add meson parameters to not put files outside /usr/local

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,5 +1,5 @@
 # Defines common constants used in different parts of crew
-CREW_VERSION = '1.36.0'
+CREW_VERSION = '1.36.1'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp
@@ -277,7 +277,9 @@ OPT
 CREW_MESON_OPTIONS = <<~OPT.chomp
   -Dprefix=#{CREW_PREFIX} \
   -Dlibdir=#{CREW_LIB_PREFIX} \
+  -Dlocalstatedir=#{CREW_PREFIX}/var/local \
   -Dmandir=#{CREW_MAN_PREFIX} \
+  -Dsharedstatedir=#{CREW_PREFIX}/var/local/lib \
   -Dbuildtype=release \
   -Db_lto=true \
   -Dstrip=true \
@@ -289,7 +291,9 @@ OPT
 CREW_MESON_FNO_LTO_OPTIONS = <<~OPT.chomp
   -Dprefix=#{CREW_PREFIX} \
   -Dlibdir=#{CREW_LIB_PREFIX} \
+  -Dlocalstatedir=#{CREW_PREFIX}/var/local \
   -Dmandir=#{CREW_MAN_PREFIX} \
+  -Dsharedstatedir=#{CREW_PREFIX}/var/local/lib \
   -Dbuildtype=release \
   -Db_lto=false \
   -Dstrip=true \


### PR DESCRIPTION
Need to avoid situations like this that default to putting files outside /usr/local:
```
  Directories                    Current Value                    Possible Values                  Description
-------------                  -------------                    ---------------                  -----------
bindir                         bin                                                               Executable directory
datadir                        share                                                             Data file directory
includedir                     include                                                           Header file directory
infodir                        share/info                                                        Info page directory
libdir                         lib                                                               Library directory
libexecdir                     libexec                                                           Library executable directory                                                                                 licensedir                                                                                       Licenses directory
localedir                      share/locale                                                      Locale data directory
localstatedir                  /var/local                                                        Localstate data directory
mandir                         share/man                                                         Manual page directory
prefix                         /usr/local                                                        Installation prefix                                                                                          sbindir                        sbin                                                              System executable directory
sharedstatedir                 /var/local/lib                                                    Architecture-independent data directory
sysconfdir                     etc                                                               Sysconf data directory    
```


Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=meson_options CREW_TESTING=1 crew update
```

