### PR TITLE
libcue official release of 2.3.0, fixing CVE-2023-43641

### DIFF
--- a/manifest/armv7l/l/libcue.filelist
+++ b/manifest/armv7l/l/libcue.filelist
@@ -2,5 +2,5 @@
 /usr/local/include/libcue/libcue.h
 /usr/local/lib/libcue.so
 /usr/local/lib/libcue.so.2
-/usr/local/lib/libcue.so.2.2.1
+/usr/local/lib/libcue.so.2.3.0
 /usr/local/lib/pkgconfig/libcue.pc

--- a/manifest/i686/l/libcue.filelist
+++ b/manifest/i686/l/libcue.filelist
@@ -2,5 +2,5 @@
 /usr/local/include/libcue/libcue.h
 /usr/local/lib/libcue.so
 /usr/local/lib/libcue.so.2
-/usr/local/lib/libcue.so.2.2.1
+/usr/local/lib/libcue.so.2.3.0
 /usr/local/lib/pkgconfig/libcue.pc

--- a/manifest/x86_64/l/libcue.filelist
+++ b/manifest/x86_64/l/libcue.filelist
@@ -2,5 +2,5 @@
 /usr/local/include/libcue/libcue.h
 /usr/local/lib64/libcue.so
 /usr/local/lib64/libcue.so.2
-/usr/local/lib64/libcue.so.2.2.1
+/usr/local/lib64/libcue.so.2.3.0
 /usr/local/lib64/pkgconfig/libcue.pc

--- a/packages/libcue.rb
+++ b/packages/libcue.rb
@@ -3,34 +3,26 @@ require 'buildsystems/cmake'
 class Libcue < CMake
   description 'Parses so-called cue sheets and handles the parsed data.'
   homepage 'https://github.com/lipnitsk/libcue/'
-  @_ver = '2.2.1'
-  version "#{@_ver}-4"
+  version '2.3.0'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://github.com/lipnitsk/libcue.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag "v#{version}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcue/2.2.1-4_armv7l/libcue-2.2.1-4-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcue/2.2.1-4_armv7l/libcue-2.2.1-4-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcue/2.2.1-4_i686/libcue-2.2.1-4-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcue/2.2.1-4_x86_64/libcue-2.2.1-4-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcue/2.3.0_armv7l/libcue-2.3.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcue/2.3.0_armv7l/libcue-2.3.0-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcue/2.3.0_i686/libcue-2.3.0-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/libcue/2.3.0_x86_64/libcue-2.3.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '76ad8451342a57dd7548218e7c38e4c2f920cf5fb42e4a960af3f1087c6af5d1',
-     armv7l: '76ad8451342a57dd7548218e7c38e4c2f920cf5fb42e4a960af3f1087c6af5d1',
-       i686: '9930944eff65deda582302b2297b91e5d98c475e190b517170436081822ccf1d',
-     x86_64: '094867b36a144609576018b3ff71cfab8dc92c4c89c6d96fc5af41184ce1b449'
+    aarch64: '190e7b62104a8e93f2350104edf58f97f39d4b9b91e51a08ea25e46dee15df69',
+     armv7l: '190e7b62104a8e93f2350104edf58f97f39d4b9b91e51a08ea25e46dee15df69',
+       i686: '7b808b4565166d5001c095ea3558f9f41b3c0add889bcfbd13c9b973031ff586',
+     x86_64: '6364db5c3aaeaf790decdd8203821c1407886648eb2e5e2565cea4b2c7cdd83f'
   })
 
   depends_on 'glibc' # R
-
-  def self.patch
-    # CVE-2023-43641.patch from Arch at
-    # https://gitlab.archlinux.org/archlinux/packaging/packages/libcue/-/blob/main/CVE-2023-43641.patch?ref_type=heads
-    puts 'Patching for CVE-2023-43641.'.orange
-    system "sed -i 's,if (i > MAXINDEX) {,if (i < 0 || i > MAXINDEX) {,' cd.c"
-  end
 
   cmake_options '-DBUILD_SHARED_LIBS=ON'
 end


### PR DESCRIPTION
Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=libcue CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
