### PR TITLE
webkit2gtk_4 => 2.42.1

### DIFF
--- a/manifest/armv7l/w/webkit2gtk_4.filelist
+++ b/manifest/armv7l/w/webkit2gtk_4.filelist
@@ -139,6 +139,7 @@
 /usr/local/include/webkitgtk-4.0/webkit/WebKitAutomationSession.h
 /usr/local/include/webkitgtk-4.0/webkit/WebKitBackForwardList.h
 /usr/local/include/webkitgtk-4.0/webkit/WebKitBackForwardListItem.h
+/usr/local/include/webkitgtk-4.0/webkit/WebKitClipboardPermissionRequest.h
 /usr/local/include/webkitgtk-4.0/webkit/WebKitColorChooserRequest.h
 /usr/local/include/webkitgtk-4.0/webkit/WebKitConsoleMessage.h
 /usr/local/include/webkitgtk-4.0/webkit/WebKitContextMenuActions.h
@@ -154,6 +155,7 @@
 /usr/local/include/webkitgtk-4.0/webkit/WebKitEnumTypes.h
 /usr/local/include/webkitgtk-4.0/webkit/WebKitError.h
 /usr/local/include/webkitgtk-4.0/webkit/WebKitFaviconDatabase.h
+/usr/local/include/webkitgtk-4.0/webkit/WebKitFeature.h
 /usr/local/include/webkitgtk-4.0/webkit/WebKitFileChooserRequest.h
 /usr/local/include/webkitgtk-4.0/webkit/WebKitFindController.h
 /usr/local/include/webkitgtk-4.0/webkit/WebKitFormSubmissionRequest.h
@@ -225,10 +227,10 @@
 /usr/local/lib/girepository-1.0/WebKit2WebExtension-4.0.typelib
 /usr/local/lib/libjavascriptcoregtk-4.0.so
 /usr/local/lib/libjavascriptcoregtk-4.0.so.18
-/usr/local/lib/libjavascriptcoregtk-4.0.so.18.22.14
+/usr/local/lib/libjavascriptcoregtk-4.0.so.18.23.10
 /usr/local/lib/libwebkit2gtk-4.0.so
 /usr/local/lib/libwebkit2gtk-4.0.so.37
-/usr/local/lib/libwebkit2gtk-4.0.so.37.63.5
+/usr/local/lib/libwebkit2gtk-4.0.so.37.67.4
 /usr/local/lib/pkgconfig/javascriptcoregtk-4.0.pc
 /usr/local/lib/pkgconfig/webkit2gtk-4.0.pc
 /usr/local/lib/pkgconfig/webkit2gtk-web-extension-4.0.pc

--- a/packages/webkit2gtk_4.rb
+++ b/packages/webkit2gtk_4.rb
@@ -3,26 +3,26 @@ require 'package'
 class Webkit2gtk_4 < Package
   description 'Web content engine for GTK'
   homepage 'https://webkitgtk.org'
-  version '2.40.5'
+  version '2.42.1'
   license 'LGPL-2+ and BSD-2'
   compatibility 'x86_64 aarch64 armv7l'
-  source_url 'https://webkitgtk.org/releases/webkitgtk-2.40.5.tar.xz'
-  source_sha256 '7de051a263668621d91a61a5eb1c3771d1a7cec900043d4afef06c326c16037f'
+  source_url 'https://webkitgtk.org/releases/webkitgtk-2.42.1.tar.xz'
+  source_sha256 '6f41fac9989d3ee51c08c48de1d439cdeddecbc757e34b6180987d99b16d2499'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.40.5_armv7l/webkit2gtk_4-2.40.5-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.40.5_armv7l/webkit2gtk_4-2.40.5-chromeos-armv7l.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.40.5_x86_64/webkit2gtk_4-2.40.5-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.42.1_armv7l/webkit2gtk_4-2.42.1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.42.1_armv7l/webkit2gtk_4-2.42.1-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/webkit2gtk_4/2.42.1_x86_64/webkit2gtk_4-2.42.1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '70bfc0c10ffc3f14017219eb948eb2f03d9d81590444560992014c76cfa19ec7',
-     armv7l: '70bfc0c10ffc3f14017219eb948eb2f03d9d81590444560992014c76cfa19ec7',
-     x86_64: '551e913aa035ed8c5ebfbe6226c935cce2fcb22c992597571fc45b0c58c7825d'
+    aarch64: 'dfc34529afd99bd8c619757b4b3d7b837b819a8554fe291f5e936b09ed447133',
+     armv7l: 'dfc34529afd99bd8c619757b4b3d7b837b819a8554fe291f5e936b09ed447133',
+     x86_64: '6349949a24e1fbae37cb576454602287e136efb305ac7cd506a0ae84c6d26d98'
   })
 
   depends_on 'at_spi2_core' # R
   depends_on 'cairo'
-  # depends_on 'ccache' => :build
+  depends_on 'ccache' => :build
   depends_on 'dav1d'
   depends_on 'enchant' # R
   depends_on 'fontconfig'
@@ -96,13 +96,13 @@ class Webkit2gtk_4 < Package
       # WEBKIT_PREPEND_GLOBAL_CXX_FLAGS(-Wno-nonnull)
       # endif ()
 
-      #+    # This triggers warnings in wtf/Packed.h, a header that is included in many places. It does not
-      #+    # respect ignore warning pragmas and we cannot easily suppress it for all affected files.
-      #+    # https://bugs.webkit.org/show_bug.cgi?id=226557
-      #+    if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "11.0")
-      #+        WEBKIT_PREPEND_GLOBAL_CXX_FLAGS(-Wno-stringop-overread)
-      #+    endif ()
-      #+
+      # +    # This triggers warnings in wtf/Packed.h, a header that is included in many places. It does not
+      # +    # respect ignore warning pragmas and we cannot easily suppress it for all affected files.
+      # +    # https://bugs.webkit.org/show_bug.cgi?id=226557
+      # +    if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "11.0")
+      # +        WEBKIT_PREPEND_GLOBAL_CXX_FLAGS(-Wno-stringop-overread)
+      # +    endif ()
+      # +
       ## -Wexpansion-to-defined produces false positives with GCC but not Clang
       ## https://bugs.webkit.org/show_bug.cgi?id=167643#c13
       # if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")


### PR DESCRIPTION
- filelist for x86_64 already updated...
Works properly:
- [x] `x86_64`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=webkit2gtk_4 CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
