### PR TITLE
Remove redundant postinstalls for gnome packages

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -400,8 +400,6 @@ def help(pkgName = nil)
       when 'git_fetchtags'
         puts "The 'git_fetchtags' property gets the repository tags."
         puts "Applicable only when 'source_url' is a git repository."
-      when 'gnome'
-        puts "Use the 'gnome' property for gnome specific packages."
       when 'is_fake'
         puts "Use the 'is_fake' property for packages that simply depend on other packages."
       when 'is_musl'
@@ -1040,15 +1038,6 @@ def post_install
     Dir.chdir post_install_tempdir do
       puts "Performing post-install for #{@pkg.name}...".lightblue
       @pkg.postinstall
-      if @pkg.gnome?
-        puts "Performing Gnome post-installs for #{@pkg.name}...".lightblue if @opt_verbose
-        # generate schemas
-        system "#{CREW_PREFIX}/bin/glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas" if @device[:installed_packages].any? { |elem| elem[:name] == 'glib' }
-        # update mime database
-        system "#{CREW_PREFIX}/bin/update-mime-database #{CREW_PREFIX}/share/mime" if @device[:installed_packages].any? { |elem| elem[:name] == 'shared_mime_info' }
-        # update icon cache, but only if gdk_pixbuf is already installed.
-        system "#{CREW_PREFIX}/bin/gtk-update-icon-cache -ft #{CREW_PREFIX}/share/icons/* || true" if @device[:installed_packages].any? { |elem| elem[:name] == 'gtk3' }
-      end
     end
   end
 end

--- a/packages/adwaita_icon_theme.rb
+++ b/packages/adwaita_icon_theme.rb
@@ -27,8 +27,6 @@ class Adwaita_icon_theme < Package
   depends_on 'vala' => :build
   depends_on 'xdg_base'
 
-  gnome
-
   def self.build
     # Need to make sure svg support is properly loaded otherwise build fails.
     system "env GDK_PIXBUF_MODULEDIR='#{CREW_LIB_PREFIX}/gdk-pixbuf-2.0/2.10.0/loaders' \

--- a/packages/at_spi2_core.rb
+++ b/packages/at_spi2_core.rb
@@ -35,8 +35,6 @@ class At_spi2_core < Package
   depends_on 'libxi' # R
   depends_on 'libxtst' # R
 
-  gnome
-
   def self.build
     system "mold -run meson setup #{CREW_MESON_OPTIONS} \
     builddir"

--- a/packages/atkmm.rb
+++ b/packages/atkmm.rb
@@ -29,8 +29,6 @@ class Atkmm < Package
   depends_on 'glib' # R
   depends_on 'libsigcplusplus3' # R
 
-  gnome
-
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     -Dbuild-documentation=false \

--- a/packages/atkmm16.rb
+++ b/packages/atkmm16.rb
@@ -29,8 +29,6 @@ class Atkmm16 < Package
   depends_on 'glib' # R
   depends_on 'libsigcplusplus' # R
 
-  gnome
-
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     -Dbuild-documentation=false \

--- a/packages/baobab.rb
+++ b/packages/baobab.rb
@@ -35,8 +35,6 @@ class Baobab < Package
   depends_on 'gtk4' # R
   depends_on 'libadwaita' # R
 
-  gnome
-
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"

--- a/packages/curtail.rb
+++ b/packages/curtail.rb
@@ -28,8 +28,6 @@ class Curtail < Package
   depends_on 'jpegoptim'
   depends_on 'libwebp'
 
-  gnome
-
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} build"
     system 'ninja -C build'

--- a/packages/dconf_editor.rb
+++ b/packages/dconf_editor.rb
@@ -29,8 +29,6 @@ class Dconf_editor < Package
   depends_on 'glibc' # R
   depends_on 'libhandy' # R
 
-  gnome
-
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
             builddir"

--- a/packages/epiphany.rb
+++ b/packages/epiphany.rb
@@ -54,8 +54,6 @@ class Epiphany < Package
   depends_on 'webkit2gtk_4_1' # R
   depends_on 'gcc_lib' # R
 
-  gnome
-
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
       builddir"

--- a/packages/evince.rb
+++ b/packages/evince.rb
@@ -51,8 +51,6 @@ class Evince < Package
   depends_on 'valgrind' => :build
   depends_on 'zlibpkg' # R
 
-  gnome
-
   def self.build
     system "mold -run meson setup #{CREW_MESON_OPTIONS} \
       -Dgtk_doc=false \
@@ -66,9 +64,5 @@ class Evince < Package
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
-  end
-
-  def self.postinstall
-    system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas/"
   end
 end

--- a/packages/folks.rb
+++ b/packages/folks.rb
@@ -31,7 +31,6 @@ class Folks < Package
   depends_on 'glibc' # R
   depends_on 'libxml2' # R
   depends_on 'readline' # R
-  gnome
 
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
@@ -49,9 +48,5 @@ class Folks < Package
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-  end
-
-  def self.postinstall
-    system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas/"
   end
 end

--- a/packages/fragments.rb
+++ b/packages/fragments.rb
@@ -38,8 +38,6 @@ class Fragments < Package
   depends_on 'transmission' # L
   depends_on 'zlibpkg' # R
 
-  gnome
-
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} builddir"
     system 'meson configure builddir'

--- a/packages/gcr_3.rb
+++ b/packages/gcr_3.rb
@@ -44,7 +44,6 @@ class Gcr_3 < Package
   depends_on 'harfbuzz' # R
 
   conflicts_ok # expected conflicts with gcr_4
-  gnome
 
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \

--- a/packages/gcr_4.rb
+++ b/packages/gcr_4.rb
@@ -42,8 +42,6 @@ class Gcr_4 < Package
   depends_on 'p11kit' # R
   depends_on 'gcc_lib' # R
 
-  gnome
-
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     -Dgtk_doc=false \

--- a/packages/gdk_pixbuf.rb
+++ b/packages/gdk_pixbuf.rb
@@ -42,8 +42,6 @@ class Gdk_pixbuf < Package
   depends_on 'libpng' # R
   depends_on 'zlibpkg' # R
 
-  gnome
-
   def self.build
     system "mold -run meson setup #{CREW_MESON_OPTIONS} \
       -Dinstalled_tests=false \

--- a/packages/gedit.rb
+++ b/packages/gedit.rb
@@ -67,8 +67,4 @@ class Gedit < Package
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
-
-  def self.postinstall
-    system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
-  end
 end

--- a/packages/geocode_glib.rb
+++ b/packages/geocode_glib.rb
@@ -30,7 +30,6 @@ class Geocode_glib < Package
   depends_on 'glib' # R
   depends_on 'glibc' # R
   depends_on 'libsoup2' # R
-  gnome
 
   def self.patch
     system "sed -i 's/gnome/Adwaita/' icons/meson.build"

--- a/packages/geocode_glib2.rb
+++ b/packages/geocode_glib2.rb
@@ -31,8 +31,6 @@ class Geocode_glib2 < Package
   depends_on 'glibc' # R
   depends_on 'gcc_lib' # R
 
-  gnome
-
   def self.patch
     system "sed -i 's/gnome/Adwaita/' icons/meson.build"
   end

--- a/packages/gimp.rb
+++ b/packages/gimp.rb
@@ -88,8 +88,6 @@ class Gimp < Package
   depends_on 'xzutils' # R
   depends_on 'zlibpkg' # R
 
-  gnome
-
   def self.build
     system "meson setup \
       #{CREW_MESON_OPTIONS} \

--- a/packages/gjs.rb
+++ b/packages/gjs.rb
@@ -32,7 +32,6 @@ class Gjs < Package
   depends_on 'glibc' # R
   depends_on 'harfbuzz' # R
   depends_on 'libffi' # R
-  gnome
 
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \

--- a/packages/glib.rb
+++ b/packages/glib.rb
@@ -33,7 +33,6 @@ class Glib < Package
   depends_on 'gcc_lib' # R
 
   no_strip if %w[aarch64 armv7l].include? ARCH
-  gnome
 
   def self.build
     system "mold -run meson setup #{CREW_MESON_OPTIONS.gsub('strip=true', 'strip=false')} \

--- a/packages/glib_networking.rb
+++ b/packages/glib_networking.rb
@@ -29,8 +29,6 @@ class Glib_networking < Package
   depends_on 'gsettings_desktop_schemas'
   depends_on 'libproxy'
 
-  gnome
-
   def self.build
     system "mold -run meson setup #{CREW_MESON_OPTIONS} \
       builddir"

--- a/packages/gnome_autoar.rb
+++ b/packages/gnome_autoar.rb
@@ -36,8 +36,6 @@ class Gnome_autoar < Package
   depends_on 'vala' => :build
   depends_on 'zlibpkg' # R
 
-  gnome
-
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"

--- a/packages/gnome_calculator.rb
+++ b/packages/gnome_calculator.rb
@@ -40,7 +40,6 @@ class Gnome_calculator < Package
   depends_on 'mpc' # R
   depends_on 'mpfr' # R
   depends_on 'gcc_lib' # R
-  gnome
 
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} builddir"
@@ -53,10 +52,6 @@ class Gnome_calculator < Package
   end
 
   def self.postinstall
-    system "update-mime-database #{CREW_PREFIX}/share/mime"
-    system 'gdk-pixbuf-query-loaders --update-cache'
-    system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
-
     puts <<~EOT.lightblue
 
       To use the graphical calculator, execute 'gnome-calculator'

--- a/packages/gnome_console.rb
+++ b/packages/gnome_console.rb
@@ -42,8 +42,6 @@ class Gnome_console < Package
   depends_on 'vulkan_headers' => :build
   depends_on 'vulkan_icd_loader' # R
 
-  gnome
-
   def self.build
     system "mold -run meson setup #{CREW_MESON_OPTIONS} \
     builddir"
@@ -53,9 +51,5 @@ class Gnome_console < Package
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
-  end
-
-  def self.postinstall
-    system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
   end
 end

--- a/packages/gnome_desktop.rb
+++ b/packages/gnome_desktop.rb
@@ -44,8 +44,6 @@ class Gnome_desktop < Package
   depends_on 'libseccomp' # R
   depends_on 'gcc_lib' # R
 
-  gnome
-
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     -Dsystemd=disabled \

--- a/packages/gnome_klotski.rb
+++ b/packages/gnome_klotski.rb
@@ -24,10 +24,4 @@ class Gnome_klotski < Package
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
-
-  def self.postinstall
-    system "update-mime-database #{CREW_PREFIX}/share/mime"
-    system 'gdk-pixbuf-query-loaders --update-cache'
-    system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
-  end
 end

--- a/packages/gnome_maps.rb
+++ b/packages/gnome_maps.rb
@@ -40,7 +40,6 @@ class Gnome_maps < Package
   depends_on 'glibc' # R
   depends_on 'libxml2' # R
   depends_on 'rest' # R
-  gnome
 
   def self.patch
     system "sed -i 's/geocode-glib-2.0/geocode-glib-1.0/g' meson.build"
@@ -55,9 +54,5 @@ class Gnome_maps < Package
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-  end
-
-  def self.postinstall
-    system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
   end
 end

--- a/packages/gnome_mines.rb
+++ b/packages/gnome_mines.rb
@@ -25,10 +25,4 @@ class Gnome_mines < Package
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
-
-  def self.postinstall
-    system "update-mime-database #{CREW_PREFIX}/share/mime"
-    system 'gdk-pixbuf-query-loaders --update-cache'
-    system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
-  end
 end

--- a/packages/gnome_nibbles.rb
+++ b/packages/gnome_nibbles.rb
@@ -25,10 +25,4 @@ class Gnome_nibbles < Package
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
-
-  def self.postinstall
-    system 'update-mime-database', "#{CREW_PREFIX}/share/mime"
-    system 'gdk-pixbuf-query-loaders', '--update-cache'
-    system 'glib-compile-schemas', "#{CREW_PREFIX}/share/glib-2.0/schemas"
-  end
 end

--- a/packages/gnome_session.rb
+++ b/packages/gnome_session.rb
@@ -43,8 +43,6 @@ class Gnome_session < Package
   depends_on 'libxcomposite' # R
   depends_on 'mesa' # R
 
-  gnome
-
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS}\
       -Dsystemd=false \

--- a/packages/gnome_settings_daemon.rb
+++ b/packages/gnome_settings_daemon.rb
@@ -58,7 +58,6 @@ class Gnome_settings_daemon < Package
   depends_on 'pango' # R
   depends_on 'pulseaudio' # R
   depends_on 'wayland' # R
-  gnome
 
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \

--- a/packages/gnome_sudoku.rb
+++ b/packages/gnome_sudoku.rb
@@ -25,10 +25,4 @@ class Gnome_sudoku < Package
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
   end
-
-  def self.postinstall
-    system "update-mime-database #{CREW_PREFIX}/share/mime"
-    system 'gdk-pixbuf-query-loaders --update-cache'
-    system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
-  end
 end

--- a/packages/gnome_terminal.rb
+++ b/packages/gnome_terminal.rb
@@ -37,8 +37,6 @@ class Gnome_terminal < Package
   depends_on 'vte' # R
   depends_on 'yelp_tools' => :build
 
-  gnome
-
   def self.build
     system "meson setup #{CREW_MESON_FNO_LTO_OPTIONS} \
     --default-library=both \
@@ -57,7 +55,6 @@ class Gnome_terminal < Package
   end
 
   def self.postinstall
-    system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
     puts 'gnome-terminal should be launched using "dbus-launch gnome-terminal"'.lightblue
   end
 end

--- a/packages/gnome_text_editor.rb
+++ b/packages/gnome_text_editor.rb
@@ -43,8 +43,6 @@ class Gnome_text_editor < Package
   depends_on 'vulkan_icd_loader' # R
   depends_on 'yelp_tools' => :build
 
-  gnome
-
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
             builddir"
@@ -54,9 +52,5 @@ class Gnome_text_editor < Package
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
-  end
-
-  def self.postinstall
-    system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas/"
   end
 end

--- a/packages/gnome_tweaks.rb
+++ b/packages/gnome_tweaks.rb
@@ -26,10 +26,4 @@ class Gnome_tweaks < Meson
   depends_on 'python3'
   depends_on 'libhandy'
   depends_on 'libnotify'
-
-  gnome
-
-  def self.postinstall
-    system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
-  end
 end

--- a/packages/gobject_introspection.rb
+++ b/packages/gobject_introspection.rb
@@ -27,6 +27,4 @@ class Gobject_introspection < Meson
   depends_on 'libffi' # R
   depends_on 'python3' # R
   depends_on 'py3_setuptools' => :build
-
-  gnome
 end

--- a/packages/gsettings_desktop_schemas.rb
+++ b/packages/gsettings_desktop_schemas.rb
@@ -27,8 +27,6 @@ class Gsettings_desktop_schemas < Package
   depends_on 'gobject_introspection' => :build
   # depends_on 'gtk4'
 
-  gnome
-
   def self.build
     system "mold -run meson setup #{CREW_MESON_OPTIONS} builddir"
     system 'meson configure builddir'
@@ -37,9 +35,5 @@ class Gsettings_desktop_schemas < Package
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
-  end
-
-  def self.postinstall
-    system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas/"
   end
 end

--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -68,7 +68,6 @@ class Gtk3 < Package
   depends_on 'wayland' # R
   depends_on 'xdg_base' # L
 
-  gnome
   no_fhs
 
   def self.patch

--- a/packages/gtk4.rb
+++ b/packages/gtk4.rb
@@ -75,7 +75,6 @@ class Gtk4 < Package
   depends_on 'xdg_base' # L
   depends_on 'zlibpkg' # R
 
-  gnome
   no_fhs
 
   def self.patch

--- a/packages/libadwaita.rb
+++ b/packages/libadwaita.rb
@@ -39,8 +39,6 @@ class Libadwaita < Package
   depends_on 'vulkan_headers' => :build
   depends_on 'vulkan_icd_loader' => :build
 
-  gnome
-
   def self.build
     system "mold -run meson setup #{CREW_MESON_OPTIONS} \
             -Dintrospection=enabled \

--- a/packages/libcloudproviders.rb
+++ b/packages/libcloudproviders.rb
@@ -31,8 +31,6 @@ class Libcloudproviders < Package
   depends_on 'glib' # R
   depends_on 'glibc' # R
 
-  gnome
-
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"

--- a/packages/libgweather.rb
+++ b/packages/libgweather.rb
@@ -36,7 +36,6 @@ class Libgweather < Package
   depends_on 'py3_gi_docgen' => :buuld
   depends_on 'py3_smartypants' => :build
   depends_on 'json_glib' # R
-  gnome
 
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \

--- a/packages/libmediaart.rb
+++ b/packages/libmediaart.rb
@@ -32,8 +32,6 @@ class Libmediaart < Package
   depends_on 'glib' # R
   depends_on 'glibc' # R
 
-  gnome
-
   def self.build
     system "meson \
       #{CREW_MESON_OPTIONS} \

--- a/packages/libpanel.rb
+++ b/packages/libpanel.rb
@@ -30,7 +30,6 @@ class Libpanel < Package
   depends_on 'py3_gi_docgen' => :build
   depends_on 'py3_smartypants' => :build
   depends_on 'vala' => :build
-  gnome
 
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \

--- a/packages/libpeas.rb
+++ b/packages/libpeas.rb
@@ -35,8 +35,6 @@ class Libpeas < Package
   depends_on 'py3_gi_docgen' # R
   depends_on 'python3' # R
 
-  gnome
-
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} builddir"
     system 'meson configure builddir'

--- a/packages/librsvg.rb
+++ b/packages/librsvg.rb
@@ -43,8 +43,6 @@ class Librsvg < Package
   depends_on 'vala' => :build
   depends_on 'zlibpkg' # R
 
-  gnome
-
   def self.build
     system 'NOCONFIGURE=1 ./autogen.sh'
     system "mold -run ./configure \

--- a/packages/libsecret.rb
+++ b/packages/libsecret.rb
@@ -27,7 +27,6 @@ class Libsecret < Package
   depends_on 'vala' => :build
   depends_on 'glib' # R
   depends_on 'glibc' # R
-  gnome
 
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \

--- a/packages/libshumate.rb
+++ b/packages/libshumate.rb
@@ -39,8 +39,6 @@ class Libshumate < Package
   depends_on 'libsoup' # R
   depends_on 'sqlite' # R
 
-  gnome
-
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"

--- a/packages/libsoup.rb
+++ b/packages/libsoup.rb
@@ -38,8 +38,6 @@ class Libsoup < Package
   depends_on 'vala' => :build
   depends_on 'zlibpkg' # R
 
-  gnome
-
   def self.build
     system "mold -run meson setup #{CREW_MESON_OPTIONS} \
       -Dtests=false \

--- a/packages/libsoup2.rb
+++ b/packages/libsoup2.rb
@@ -35,8 +35,6 @@ class Libsoup2 < Package
   depends_on 'vala' => :build
   depends_on 'zlibpkg' # R
 
-  gnome
-
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
       -Dtests=false \

--- a/packages/meld.rb
+++ b/packages/meld.rb
@@ -24,7 +24,6 @@ class Meld < Package
 
   depends_on 'gtk3'
   depends_on 'gtksourceview_4'
-  gnome
 
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \

--- a/packages/nautilus.rb
+++ b/packages/nautilus.rb
@@ -55,8 +55,6 @@ class Nautilus < Package
   depends_on 'vulkan_headers' => :build
   depends_on 'vulkan_icd_loader' # R
 
-  gnome
-
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     -Ddocs=false \

--- a/packages/py3_gi_docgen.rb
+++ b/packages/py3_gi_docgen.rb
@@ -21,6 +21,4 @@ class Py3_gi_docgen < Pip
   no_compile_needed
   depends_on 'py3_toml'
   depends_on 'py3_typogrify'
-
-  gnome
 end

--- a/packages/rest.rb
+++ b/packages/rest.rb
@@ -43,7 +43,6 @@ class Rest < Package
   depends_on 'libxml2' # R
   depends_on 'pango' # R
   depends_on 'vulkan_icd_loader' # R
-  gnome
 
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \

--- a/packages/rhythmbox.rb
+++ b/packages/rhythmbox.rb
@@ -36,7 +36,6 @@ class Rhythmbox < Package
   end
 
   def self.postinstall
-    system "glib-compile-schemas #{CREW_PREFIX}/share/glib-2.0/schemas"
     puts "\nType 'rhythmbox' to get started.\n".lightblue
   end
 end

--- a/packages/shotwell.rb
+++ b/packages/shotwell.rb
@@ -38,8 +38,6 @@ class Shotwell < Meson
   depends_on 'sqlite' # R
   depends_on 'webkit2gtk' # R
 
-  gnome
-
   def self.postinstall
     puts "\nTo finish the installation, execute 'source ~/.bashrc'\n".lightblue
   end

--- a/packages/vala.rb
+++ b/packages/vala.rb
@@ -31,7 +31,6 @@ class Vala < Package
   depends_on 'glibc' # R
 
   git_fetchtags
-  gnome
 
   def self.build
     # Bootstrap vala

--- a/packages/vte.rb
+++ b/packages/vte.rb
@@ -40,7 +40,6 @@ class Vte < Package
   depends_on 'vulkan_icd_loader' # R
   depends_on 'zlibpkg' # R
 
-  gnome
   no_lto
 
   def self.build


### PR DESCRIPTION
As discussed. https://github.com/chromebrew/chromebrew/pull/6909#issuecomment-1760331636

This doesn't remove all the postinstalls for non-gnome packages, simply because I haven't looked through them yet to see if they do it themselves.

I'll probably do that later, but for this PR i just wanted to get it out of the door.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=gnomore CREW_TESTING=1 crew update
```
