### PR TITLE
Add --no-pager to meson configure lines

### DIFF
--- a/lib/buildsystems/meson.rb
+++ b/lib/buildsystems/meson.rb
@@ -8,7 +8,7 @@ class Meson < Package
     @crew_meson_options = @no_lto ? CREW_MESON_FNO_LTO_OPTIONS : CREW_MESON_OPTIONS
     @mold_linker_prefix_cmd = CREW_LINKER == 'mold' ? 'mold -run' : ''
     system "#{@mold_linker_prefix_cmd} meson setup #{@crew_meson_options} #{@meson_options} builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,5 +1,5 @@
 # Defines common constants used in different parts of crew
-CREW_VERSION = '1.36.1'
+CREW_VERSION = '1.36.2'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/packages/amtk.rb
+++ b/packages/amtk.rb
@@ -31,7 +31,7 @@ class Amtk < Package
     system "meson setup #{CREW_MESON_FNO_LTO_OPTIONS} \
     -Dc_args='-fuse-ld=lld' \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/at_spi2_core.rb
+++ b/packages/at_spi2_core.rb
@@ -38,7 +38,7 @@ class At_spi2_core < Package
   def self.build
     system "mold -run meson setup #{CREW_MESON_OPTIONS} \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/atkmm.rb
+++ b/packages/atkmm.rb
@@ -33,7 +33,7 @@ class Atkmm < Package
     system "meson setup #{CREW_MESON_OPTIONS} \
     -Dbuild-documentation=false \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/atkmm16.rb
+++ b/packages/atkmm16.rb
@@ -33,7 +33,7 @@ class Atkmm16 < Package
     system "meson setup #{CREW_MESON_OPTIONS} \
     -Dbuild-documentation=false \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/babl.rb
+++ b/packages/babl.rb
@@ -31,7 +31,7 @@ class Babl < Package
     system "meson setup #{CREW_MESON_OPTIONS} \
       -Denable-gir=true \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/baobab.rb
+++ b/packages/baobab.rb
@@ -38,7 +38,7 @@ class Baobab < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'mold -run samu -C builddir'
   end
 

--- a/packages/cairomm_1_0.rb
+++ b/packages/cairomm_1_0.rb
@@ -36,7 +36,7 @@ class Cairomm_1_0 < Package
     -Dbuild-examples=false \
     -Dbuild-tests=false \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/cairomm_1_16.rb
+++ b/packages/cairomm_1_16.rb
@@ -36,7 +36,7 @@ class Cairomm_1_16 < Package
     -Dbuild-examples=false \
     -Dbuild-tests=false \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/cantarell_fonts.rb
+++ b/packages/cantarell_fonts.rb
@@ -31,7 +31,7 @@ class Cantarell_fonts < Package
       -Duseprebuilt=true \
       -Dfontsdir=#{CREW_PREFIX}/share/fonts/opentype/cantarell \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/clutter_gtk.rb
+++ b/packages/clutter_gtk.rb
@@ -30,7 +30,7 @@ class Clutter_gtk < Package
 
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/colord.rb
+++ b/packages/colord.rb
@@ -39,7 +39,7 @@ class Colord < Package
 
   def self.build
     system "meson setup #{CREW_MESON_FNO_LTO_OPTIONS} -Dsystemd=false -Ddaemon_user=#{USER} builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/dav1d.rb
+++ b/packages/dav1d.rb
@@ -29,7 +29,7 @@ class Dav1d < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS.gsub('-mfpu=vfpv3-d16', '-mfpu=neon-fp16')} \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/dbus.rb
+++ b/packages/dbus.rb
@@ -41,7 +41,7 @@ class Dbus < Package
       -Dsystemd=disabled \
       -Dx11_autolaunch=enabled \
        builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "mold -run #{CREW_NINJA} -C builddir"
   end
 

--- a/packages/dconf.rb
+++ b/packages/dconf.rb
@@ -31,7 +31,7 @@ class Dconf < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/epiphany.rb
+++ b/packages/epiphany.rb
@@ -57,7 +57,7 @@ class Epiphany < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/evince.rb
+++ b/packages/evince.rb
@@ -58,7 +58,7 @@ class Evince < Package
       -Dps=enabled \
       -Dsystemduserunitdir=no \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "mold -run #{CREW_NINJA} -C builddir"
   end
 

--- a/packages/fcft.rb
+++ b/packages/fcft.rb
@@ -45,7 +45,7 @@ class Fcft < Package
       -Dgrapheme-shaping=enabled \
       -Drun-shaping=enabled \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'samu -C builddir'
   end
 

--- a/packages/folks.rb
+++ b/packages/folks.rb
@@ -42,7 +42,7 @@ class Folks < Package
     -Dtelepathy_backend=false \
     -Dtests=false \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/fontconfig.rb
+++ b/packages/fontconfig.rb
@@ -41,7 +41,7 @@ class Fontconfig < Package
       -Dlocalstatedir=#{CREW_PREFIX}/cache \
       -Dtests=disabled \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/fragments.rb
+++ b/packages/fragments.rb
@@ -40,7 +40,7 @@ class Fragments < Package
 
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/freetype.rb
+++ b/packages/freetype.rb
@@ -38,7 +38,7 @@ class Freetype < Package
     system "meson setup #{CREW_MESON_OPTIONS} \
       -Dharfbuzz=enabled \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'samu -C builddir'
   end
 

--- a/packages/fribidi.rb
+++ b/packages/fribidi.rb
@@ -30,7 +30,7 @@ class Fribidi < Package
       -Ddocs=false \
       -Dtests=false \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -v -C builddir'
   end
 

--- a/packages/fuse3.rb
+++ b/packages/fuse3.rb
@@ -33,7 +33,7 @@ class Fuse3 < Package
       -Dexamples=true \
       -Duseroot=false \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/gcab.rb
+++ b/packages/gcab.rb
@@ -37,7 +37,7 @@ class Gcab < Package
       -Dtests=false \
       -Dvapi=false \
        builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'mold -run samu -C builddir'
   end
 

--- a/packages/gcr_3.rb
+++ b/packages/gcr_3.rb
@@ -49,7 +49,7 @@ class Gcr_3 < Package
     system "meson setup #{CREW_MESON_OPTIONS} \
     -Dgtk_doc=false \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/gcr_4.rb
+++ b/packages/gcr_4.rb
@@ -46,7 +46,7 @@ class Gcr_4 < Package
     system "meson setup #{CREW_MESON_OPTIONS} \
     -Dgtk_doc=false \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/geany.rb
+++ b/packages/geany.rb
@@ -47,7 +47,7 @@ class Geany < Package
       -Dsocket=true \
       -Dvte=true \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/gedit.rb
+++ b/packages/gedit.rb
@@ -60,7 +60,7 @@ class Gedit < Package
     -Drequire_all_tests=false \
     -Duser_documentation=false \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/gegl.rb
+++ b/packages/gegl.rb
@@ -55,7 +55,7 @@ class Gegl < Package
       -Dlibjpeg=enabled \
       -Dlibpng=enabled \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/geoclue.rb
+++ b/packages/geoclue.rb
@@ -40,7 +40,7 @@ class Geoclue < Package
       -Dcdma-source=false \
       -Dmodem-gps-source=true \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/geocode_glib.rb
+++ b/packages/geocode_glib.rb
@@ -38,7 +38,7 @@ class Geocode_glib < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/geocode_glib2.rb
+++ b/packages/geocode_glib2.rb
@@ -39,7 +39,7 @@ class Geocode_glib2 < Package
     system "meson setup #{CREW_MESON_OPTIONS} \
       -Dsoup2=false \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/gexiv2.rb
+++ b/packages/gexiv2.rb
@@ -31,7 +31,7 @@ class Gexiv2 < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/gimp.rb
+++ b/packages/gimp.rb
@@ -93,7 +93,7 @@ class Gimp < Package
       #{CREW_MESON_OPTIONS} \
       -Dbug-report-url=https://github.com/chromebrew/chromebrew/issues \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/gjs.rb
+++ b/packages/gjs.rb
@@ -41,7 +41,7 @@ class Gjs < Package
     -Dprofiler=disabled \
     -Dreadline=disabled \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/glib.rb
+++ b/packages/glib.rb
@@ -41,7 +41,7 @@ class Glib < Package
     -Dman=false \
     -Dtests=false \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "mold -run #{CREW_NINJA} -C builddir"
   end
 

--- a/packages/glib_networking.rb
+++ b/packages/glib_networking.rb
@@ -32,7 +32,7 @@ class Glib_networking < Package
   def self.build
     system "mold -run meson setup #{CREW_MESON_OPTIONS} \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/glibmm_2_4.rb
+++ b/packages/glibmm_2_4.rb
@@ -33,7 +33,7 @@ class Glibmm_2_4 < Package
     system "meson setup #{CREW_MESON_OPTIONS} \
     -Dbuild-documentation=false \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/glibmm_2_68.rb
+++ b/packages/glibmm_2_68.rb
@@ -31,7 +31,7 @@ class Glibmm_2_68 < Package
     system "meson setup #{CREW_MESON_OPTIONS} \
     -Dbuild-documentation=false \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/glmark2.rb
+++ b/packages/glmark2.rb
@@ -39,7 +39,7 @@ class Glmark2 < Package
       #{CREW_MESON_OPTIONS} \
       -Dflavors=drm-gl,drm-glesv2,wayland-gl,wayland-glesv2,x11-gl,x11-glesv2 \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/gnome_autoar.rb
+++ b/packages/gnome_autoar.rb
@@ -39,7 +39,7 @@ class Gnome_autoar < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "mold -run #{CREW_NINJA} -C builddir"
   end
 

--- a/packages/gnome_calculator.rb
+++ b/packages/gnome_calculator.rb
@@ -43,7 +43,7 @@ class Gnome_calculator < Package
 
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'samu -C builddir'
   end
 

--- a/packages/gnome_console.rb
+++ b/packages/gnome_console.rb
@@ -45,7 +45,7 @@ class Gnome_console < Package
   def self.build
     system "mold -run meson setup #{CREW_MESON_OPTIONS} \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "mold -run #{CREW_NINJA} -C builddir"
   end
 

--- a/packages/gnome_desktop.rb
+++ b/packages/gnome_desktop.rb
@@ -48,7 +48,7 @@ class Gnome_desktop < Package
     system "meson setup #{CREW_MESON_OPTIONS} \
     -Dsystemd=disabled \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/gnome_klotski.rb
+++ b/packages/gnome_klotski.rb
@@ -17,7 +17,7 @@ class Gnome_klotski < Package
 
   def self.build
     system "meson setup #{CREW_MESON_FNO_LTO_OPTIONS} builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/gnome_maps.rb
+++ b/packages/gnome_maps.rb
@@ -48,7 +48,7 @@ class Gnome_maps < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/gnome_mines.rb
+++ b/packages/gnome_mines.rb
@@ -18,7 +18,7 @@ class Gnome_mines < Package
 
   def self.build
     system "meson setup #{CREW_MESON_FNO_LTO_OPTIONS} builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/gnome_nibbles.rb
+++ b/packages/gnome_nibbles.rb
@@ -18,7 +18,7 @@ class Gnome_nibbles < Package
 
   def self.build
     system "meson setup #{CREW_MESON_FNO_LTO_OPTIONS} builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/gnome_online_accounts.rb
+++ b/packages/gnome_online_accounts.rb
@@ -36,7 +36,7 @@ class Gnome_online_accounts < Package
     system "meson setup #{CREW_MESON_OPTIONS} \
     -Dgtk_doc=true \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/gnome_session.rb
+++ b/packages/gnome_session.rb
@@ -49,7 +49,7 @@ class Gnome_session < Package
       -Dsystemd_session=disable \
       -Dsystemd_journal=false \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/gnome_settings_daemon.rb
+++ b/packages/gnome_settings_daemon.rb
@@ -64,7 +64,7 @@ class Gnome_settings_daemon < Package
     -Dsystemd=false \
     -Dcolord=false \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/gnome_shell.rb
+++ b/packages/gnome_shell.rb
@@ -45,7 +45,7 @@ class Gnome_shell < Package
     -Dnetworkmanager=false \
     -Dtests=false \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/gnome_sudoku.rb
+++ b/packages/gnome_sudoku.rb
@@ -18,7 +18,7 @@ class Gnome_sudoku < Package
 
   def self.build
     system "meson setup #{CREW_MESON_FNO_LTO_OPTIONS} builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/gnome_terminal.rb
+++ b/packages/gnome_terminal.rb
@@ -46,7 +46,7 @@ class Gnome_terminal < Package
     -Dlocalstatedir=#{CREW_PREFIX}/var/local \
     -Dsharedstatedir=#{CREW_PREFIX}/var/local/lib \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/gnome_text_editor.rb
+++ b/packages/gnome_text_editor.rb
@@ -46,7 +46,7 @@ class Gnome_text_editor < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
             builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "mold -run #{CREW_NINJA} -C builddir"
   end
 

--- a/packages/gnome_weather.rb
+++ b/packages/gnome_weather.rb
@@ -35,7 +35,7 @@ class Gnome_weather < Package
     system "meson setup #{CREW_MESON_OPTIONS} \
     -Dsystemd=disabled \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/graphene.rb
+++ b/packages/graphene.rb
@@ -32,7 +32,7 @@ class Graphene < Package
       -Dinstalled_tests=false \
       -Dtests=false \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/gsettings_desktop_schemas.rb
+++ b/packages/gsettings_desktop_schemas.rb
@@ -29,7 +29,7 @@ class Gsettings_desktop_schemas < Package
 
   def self.build
     system "mold -run meson setup #{CREW_MESON_OPTIONS} builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/gst_editing_services.rb
+++ b/packages/gst_editing_services.rb
@@ -33,7 +33,7 @@ class Gst_editing_services < Package
       -Ddoc=disabled \
       -Dvalidate=disabled \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/gstreamer.rb
+++ b/packages/gstreamer.rb
@@ -138,7 +138,7 @@ class Gstreamer < Package
       -Dgpl=enabled \
       -Dtests=disabled \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     @counter = 1
     @counter_max = 20
     loop do

--- a/packages/gtk3.rb
+++ b/packages/gtk3.rb
@@ -85,7 +85,7 @@ class Gtk3 < Package
       -Dexamples=false \
       -Dgtk_doc=false \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
     @gtk3settings = <<~GTK3_CONFIG_HEREDOC
       [Settings]

--- a/packages/gtk4.rb
+++ b/packages/gtk4.rb
@@ -100,7 +100,7 @@ class Gtk4 < Package
       -Dvulkan=enabled \
       -Dprint-cups=auto \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
     File.write 'gtk4settings', <<~GTK4_CONFIG_HEREDOC
       [Settings]

--- a/packages/gtk_doc.rb
+++ b/packages/gtk_doc.rb
@@ -30,7 +30,7 @@ class Gtk_doc < Package
 
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/gtk_vnc.rb
+++ b/packages/gtk_vnc.rb
@@ -41,7 +41,7 @@ class Gtk_vnc < Package
     system "meson \
       #{CREW_MESON_OPTIONS} \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/gtkmm3.rb
+++ b/packages/gtkmm3.rb
@@ -38,7 +38,7 @@ class Gtkmm3 < Package
     -Dbuild-demos=false \
     -Dbuild-tests=false \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/gtkmm4.rb
+++ b/packages/gtkmm4.rb
@@ -30,7 +30,7 @@ class Gtkmm4 < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/gtksourceview_4.rb
+++ b/packages/gtksourceview_4.rb
@@ -50,7 +50,7 @@ class Gtksourceview_4 < Package
     system "meson setup #{CREW_MESON_OPTIONS} \
     -Db_asneeded=false \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'mold -run samu -C builddir'
   end
 

--- a/packages/gtksourceview_5.rb
+++ b/packages/gtksourceview_5.rb
@@ -50,7 +50,7 @@ class Gtksourceview_5 < Package
     system "meson setup #{CREW_MESON_OPTIONS} \
     -Db_asneeded=false \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'mold -run samu -C builddir'
   end
 

--- a/packages/gusb.rb
+++ b/packages/gusb.rb
@@ -40,7 +40,7 @@ class Gusb < Package
     -Dusb_ids=#{CREW_PREFIX}/share/hwdata/usb.ids \
     -Ddocs=false \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/gvfs.rb
+++ b/packages/gvfs.rb
@@ -58,7 +58,7 @@ class Gvfs < Package
     -Dtmpfilesdir=no \
     -Dudisks2=false \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -85,7 +85,7 @@ class Harfbuzz < Package
       -Dragel_subproject=true \
       -Dtests=disabled \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/igt_gpu_tools.rb
+++ b/packages/igt_gpu_tools.rb
@@ -38,7 +38,7 @@ class Igt_gpu_tools < Package
     -Doping=disabled \
     -Drunner=disabled \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/iputils.rb
+++ b/packages/iputils.rb
@@ -24,7 +24,7 @@ class Iputils < Package
 
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/json_glib.rb
+++ b/packages/json_glib.rb
@@ -29,7 +29,7 @@ class Json_glib < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/jsoncpp.rb
+++ b/packages/jsoncpp.rb
@@ -25,7 +25,7 @@ class Jsoncpp < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'samu -C builddir'
   end
 

--- a/packages/jsonrpc_glib.rb
+++ b/packages/jsonrpc_glib.rb
@@ -35,7 +35,7 @@ class Jsonrpc_glib < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'mold -run samu -C builddir'
   end
 

--- a/packages/libadwaita.rb
+++ b/packages/libadwaita.rb
@@ -45,7 +45,7 @@ class Libadwaita < Package
             -Dexamples=false \
             -Dgtk_doc=false \
             builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/libchamplain.rb
+++ b/packages/libchamplain.rb
@@ -32,7 +32,7 @@ class Libchamplain < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/libcloudproviders.rb
+++ b/packages/libcloudproviders.rb
@@ -34,7 +34,7 @@ class Libcloudproviders < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/libdazzle.rb
+++ b/packages/libdazzle.rb
@@ -34,7 +34,7 @@ class Libdazzle < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/libefl.rb
+++ b/packages/libefl.rb
@@ -91,7 +91,7 @@ class Libefl < Package
        -Dgstreamer=false \
        -Decore-imf-loaders-disabler=ibus,scim \
        builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'mold -run samu -C builddir'
   end
 

--- a/packages/libevdev.rb
+++ b/packages/libevdev.rb
@@ -29,7 +29,7 @@ class Libevdev < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/libglvnd.rb
+++ b/packages/libglvnd.rb
@@ -32,7 +32,7 @@ class Libglvnd < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'samu -C builddir'
   end
 

--- a/packages/libgnome_games_support.rb
+++ b/packages/libgnome_games_support.rb
@@ -15,7 +15,7 @@ class Libgnome_games_support < Package
 
   def self.build
     system "meson setup #{CREW_MESON_FNO_LTO_OPTIONS} builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/libgudev.rb
+++ b/packages/libgudev.rb
@@ -30,7 +30,7 @@ class Libgudev < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/libgweather.rb
+++ b/packages/libgweather.rb
@@ -41,7 +41,7 @@ class Libgweather < Package
     system "meson setup #{CREW_MESON_OPTIONS} \
     -Dsoup2=true \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/libgxps.rb
+++ b/packages/libgxps.rb
@@ -47,7 +47,7 @@ class Libgxps < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/libhandy.rb
+++ b/packages/libhandy.rb
@@ -36,7 +36,7 @@ class Libhandy < Package
   def self.build
     system "mold -run meson setup #{CREW_MESON_OPTIONS} \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "mold -run #{CREW_NINJA} -C builddir"
   end
 

--- a/packages/libinih.rb
+++ b/packages/libinih.rb
@@ -28,7 +28,7 @@ class Libinih < Package
       -Ddistro_install=true \
       -Dwith_INIReader=true \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/libinput.rb
+++ b/packages/libinput.rb
@@ -38,7 +38,7 @@ class Libinput < Package
       -Ddebug-gui=false \
       -Ddocumentation=false \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/libmediaart.rb
+++ b/packages/libmediaart.rb
@@ -38,7 +38,7 @@ class Libmediaart < Package
       -Dimage_library=gdk-pixbuf \
       -Dtests=false \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/libnotify.rb
+++ b/packages/libnotify.rb
@@ -32,7 +32,7 @@ class Libnotify < Package
     -Dtests=false \
     -Dgtk_doc=false \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'mold -run samu -C builddir'
   end
 

--- a/packages/libnvme.rb
+++ b/packages/libnvme.rb
@@ -29,7 +29,7 @@ class Libnvme < Package
 
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/libpanel.rb
+++ b/packages/libpanel.rb
@@ -34,7 +34,7 @@ class Libpanel < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'mold -run samu -C builddir'
   end
 

--- a/packages/libpeas.rb
+++ b/packages/libpeas.rb
@@ -37,7 +37,7 @@ class Libpeas < Package
 
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/libportal.rb
+++ b/packages/libportal.rb
@@ -37,7 +37,7 @@ class Libportal < Package
     -Dportal-tests=false \
     -Dtests=false \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/libpsl.rb
+++ b/packages/libpsl.rb
@@ -29,7 +29,7 @@ class Libpsl < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'mold -run samu -C builddir'
   end
 

--- a/packages/libshumate.rb
+++ b/packages/libshumate.rb
@@ -42,7 +42,7 @@ class Libshumate < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/libsigcplusplus.rb
+++ b/packages/libsigcplusplus.rb
@@ -30,7 +30,7 @@ class Libsigcplusplus < Package
     -Dbuild-deprecated-api=true \
     -Dbuild-examples=false \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/libsigcplusplus3.rb
+++ b/packages/libsigcplusplus3.rb
@@ -29,7 +29,7 @@ class Libsigcplusplus3 < Package
     system "meson setup #{CREW_MESON_OPTIONS} \
     -Dbuild-examples=false \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/libsixel.rb
+++ b/packages/libsixel.rb
@@ -38,7 +38,7 @@ class Libsixel < Package
     system "meson setup #{CREW_MESON_OPTIONS} \
        -Dgdk-pixbuf2=enabled \
        builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'samu -C builddir'
   end
 

--- a/packages/libsoup.rb
+++ b/packages/libsoup.rb
@@ -44,7 +44,7 @@ class Libsoup < Package
       -Dsysprof=disabled \
       -Dintrospection=enabled \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/libsoup2.rb
+++ b/packages/libsoup2.rb
@@ -41,7 +41,7 @@ class Libsoup2 < Package
       -Dsysprof=disabled \
       -Dintrospection=enabled \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "sed -i 's#-R#-Wl,-rpath=#g' builddir/build.ninja"
     system 'mold -run samu -C builddir'
   end

--- a/packages/libva_intel_driver_hybrid.rb
+++ b/packages/libva_intel_driver_hybrid.rb
@@ -29,7 +29,7 @@ class Libva_intel_driver_hybrid < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
             -Denable_hybrid_codec=true builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/libva_utils.rb
+++ b/packages/libva_utils.rb
@@ -26,7 +26,7 @@ class Libva_utils < Package
 
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/libwpe.rb
+++ b/packages/libwpe.rb
@@ -29,7 +29,7 @@ class Libwpe < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/libxcvt.rb
+++ b/packages/libxcvt.rb
@@ -27,7 +27,7 @@ class Libxcvt < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/libxkbcommon.rb
+++ b/packages/libxkbcommon.rb
@@ -29,7 +29,7 @@ class Libxkbcommon < Package
     system "meson \
             #{CREW_MESON_OPTIONS} \
             builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/libxvmc.rb
+++ b/packages/libxvmc.rb
@@ -28,7 +28,7 @@ class Libxvmc < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
             builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/luajit_lgi.rb
+++ b/packages/luajit_lgi.rb
@@ -42,7 +42,7 @@ class Luajit_lgi < Package
     #-Dlua-bin=#{CREW_PREFIX}/bin/luajit \
     #-Dtests=false \
     # builddir"
-    # system 'meson configure builddir'
+    # system 'meson configure --no-pager builddir'
     # system 'mold -run samu -C builddir'
   end
 

--- a/packages/meld.rb
+++ b/packages/meld.rb
@@ -28,7 +28,7 @@ class Meld < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'mold -run samu -C builddir'
   end
 

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -75,7 +75,7 @@ class Mesa < Package
       -Dvulkan-drivers='#{@vulkan_drivers}' \
       -Dvideo-codecs='vc1dec,h264dec,h264enc,h265dec,h265enc' \
        builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "mold -run #{CREW_NINJA} -C builddir"
   end
 

--- a/packages/mm_common.rb
+++ b/packages/mm_common.rb
@@ -26,7 +26,7 @@ class Mm_common < Package
     system "meson setup #{CREW_MESON_OPTIONS} \
     -Duse-network=true \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/mpv.rb
+++ b/packages/mpv.rb
@@ -83,7 +83,7 @@ class Mpv < Package
       hwdec-codecs=all
       fs=yes
     MPVCONF
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/mutter.rb
+++ b/packages/mutter.rb
@@ -45,7 +45,7 @@ class Mutter < Package
     -Dcogl_tests=true \
     -Dxwayland_path=#{CREW_PREFIX}/bin/Xwayland \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/nautilus.rb
+++ b/packages/nautilus.rb
@@ -61,7 +61,7 @@ class Nautilus < Package
     -Dpackagekit=false \
     -Dtests=headless \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "mold -run #{CREW_NINJA} -C builddir"
   end
 

--- a/packages/openh264.rb
+++ b/packages/openh264.rb
@@ -33,7 +33,7 @@ class Openh264 < Package
     system "mold -run meson setup #{CREW_MESON_OPTIONS} \
       -Dtests=disabled \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/opus.rb
+++ b/packages/opus.rb
@@ -38,7 +38,7 @@ class Opus < Package
       -Ddocs=disabled \
       -Dtests=disabled \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "mold -run #{CREW_NINJA} -C builddir"
   end
 

--- a/packages/pango.rb
+++ b/packages/pango.rb
@@ -46,7 +46,7 @@ class Pango < Package
       -Dlibthai=disabled \
       -Dgtk_doc=false \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/pangomm_1_4.rb
+++ b/packages/pangomm_1_4.rb
@@ -37,7 +37,7 @@ class Pangomm_1_4 < Package
     -Dmaintainer-mode=true \
     -Dbuild-documentation=false \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/pangomm_2_48.rb
+++ b/packages/pangomm_2_48.rb
@@ -37,7 +37,7 @@ class Pangomm_2_48 < Package
     -Dmaintainer-mode=true \
     -Dbuild-documentation=false \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/pax_utils.rb
+++ b/packages/pax_utils.rb
@@ -39,7 +39,7 @@ class Pax_utils < Package
             -Duse_libcap=enabled \
             -Duse_seccomp=true \
             builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "mold -run #{CREW_NINJA} -C builddir"
   end
 

--- a/packages/peek.rb
+++ b/packages/peek.rb
@@ -33,7 +33,7 @@ class Peek < Package
     system "mold -run meson setup #{CREW_MESON_OPTIONS} \
       -Dbuild-tests=false \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/pipewire.rb
+++ b/packages/pipewire.rb
@@ -87,7 +87,7 @@ class Pipewire < Package
       -Dvolume=auto \
       -Dvulkan=enabled \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/pixman.rb
+++ b/packages/pixman.rb
@@ -32,7 +32,7 @@ class Pixman < Package
     -Dlibpng=disabled \
     -Dtests=disabled \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/polkit.rb
+++ b/packages/polkit.rb
@@ -67,7 +67,7 @@ class Polkit < Package
     -Djs_engine=duktape \
     -Dos_type=gentoo \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/pulseaudio.rb
+++ b/packages/pulseaudio.rb
@@ -72,7 +72,7 @@ class Pulseaudio < Package
     -Dalsadatadir=#{CREW_PREFIX}/share/alsa-card-profile \
     -Dlocalstatedir=#{CREW_PREFIX}/var/run \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/rest.rb
+++ b/packages/rest.rb
@@ -47,7 +47,7 @@ class Rest < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'mold -run samu -C builddir'
   end
 

--- a/packages/rlottie.rb
+++ b/packages/rlottie.rb
@@ -24,7 +24,7 @@ class Rlottie < Package
 
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/seatd.rb
+++ b/packages/seatd.rb
@@ -33,7 +33,7 @@ class Seatd < Package
         -Dexamples=disabled \
         -Dserver=enabled \
         builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -130,7 +130,7 @@ class Sommelier < Package
           builddir
       BUILD
 
-      system 'meson configure builddir'
+      system 'meson configure --no-pager builddir'
       system "mold -run #{CREW_NINJA} -C builddir"
 
       FileUtils.mkdir_p 'builddir'

--- a/packages/spice_gtk.rb
+++ b/packages/spice_gtk.rb
@@ -57,7 +57,7 @@ class Spice_gtk < Package
     system "meson \
       #{CREW_MESON_OPTIONS} \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/spice_protocol.rb
+++ b/packages/spice_protocol.rb
@@ -29,7 +29,7 @@ class Spice_protocol < Package
     system "meson \
       #{CREW_MESON_OPTIONS} \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/tepl_5.rb
+++ b/packages/tepl_5.rb
@@ -34,7 +34,7 @@ class Tepl_5 < Package
 
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/tepl_6.rb
+++ b/packages/tepl_6.rb
@@ -33,7 +33,7 @@ class Tepl_6 < Package
 
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/tllist.rb
+++ b/packages/tllist.rb
@@ -27,7 +27,7 @@ class Tllist < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'samu -C builddir'
   end
 

--- a/packages/upower.rb
+++ b/packages/upower.rb
@@ -40,7 +40,7 @@ class Upower < Package
       -Dudevrulesdir=#{CREW_PREFIX}/etc/udev \
       -Dudevhwdbdir=#{CREW_PREFIX}/etc/udev \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/virglrenderer.rb
+++ b/packages/virglrenderer.rb
@@ -43,7 +43,7 @@ class Virglrenderer < Package
       -Drender-server-worker=minijail \
       -Dvideo=true \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/vte.rb
+++ b/packages/vte.rb
@@ -51,7 +51,7 @@ class Vte < Package
       -Dgir=false \
       -Dvapi=false
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/wayland.rb
+++ b/packages/wayland.rb
@@ -40,7 +40,7 @@ class Wayland < Package
       : "${GDK_BACKEND:=wayland}"
     WAYLAND_ENV_EOF
     system "meson setup #{CREW_MESON_OPTIONS} -Ddocumentation=false builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/wayland_protocols.rb
+++ b/packages/wayland_protocols.rb
@@ -28,7 +28,7 @@ class Wayland_protocols < Package
     system "meson setup #{CREW_MESON_OPTIONS} \
     -Dtests=false \
      builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'samu -C builddir'
   end
 

--- a/packages/waypipe.rb
+++ b/packages/waypipe.rb
@@ -33,7 +33,7 @@ class Waypipe < Package
   def self.build
     system "CC=clang LD=mold meson setup #{CREW_MESON_OPTIONS.gsub('-ffat-lto-objects', '').gsub('-fuse-ld=mold', '')} \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
   end
 

--- a/packages/weston.rb
+++ b/packages/weston.rb
@@ -72,7 +72,7 @@ class Weston < Package
         -Dsystemd=false \
         -Dxwayland-path=#{CREW_PREFIX}/bin/Xwayland \
         builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
     File.write 'weston.ini', <<~WESTON_INI_EOF
       [core]

--- a/packages/wlroots.rb
+++ b/packages/wlroots.rb
@@ -44,7 +44,7 @@ class Wlroots < Package
     system "meson setup #{CREW_MESON_OPTIONS} \
       -Dxwayland=enabled \
       builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/wpebackend_fdo.rb
+++ b/packages/wpebackend_fdo.rb
@@ -34,7 +34,7 @@ class Wpebackend_fdo < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/xorg_intel_driver.rb
+++ b/packages/xorg_intel_driver.rb
@@ -31,7 +31,7 @@ class Xorg_intel_driver < Package
             -Ddefault-dri=3 \
             -Dxvmc=false \
             builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'ninja -C builddir'
   end
 

--- a/packages/yelp_tools.rb
+++ b/packages/yelp_tools.rb
@@ -33,7 +33,7 @@ class Yelp_tools < Package
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \
     builddir"
-    system 'meson configure builddir'
+    system 'meson configure --no-pager builddir'
     system 'samu -C builddir'
   end
 


### PR DESCRIPTION
- Meson builds pause on `meson configure` to show the options being used, unless one is running `meson configure` from inside a script. But the pause halts the build until one pages through the options display. This adds the `--no-pager` option so that the options are still displayed, but the build isn't paused.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=meson_no_pager CREW_TESTING=1 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
