### PR TITLE
Box 4.3.8 => 4.4.0

### DIFF
--- a/manifest/armv7l/b/box.filelist
+++ b/manifest/armv7l/b/box.filelist
@@ -1,0 +1,1 @@
+/usr/local/bin/box

--- a/packages/box.rb
+++ b/packages/box.rb
@@ -3,18 +3,17 @@ require 'package'
 class Box < Package
   description 'Fast, zero config application bundler with PHARs.'
   homepage 'https://github.com/box-project/box'
-  version '4.3.8'
+  version '4.4.0'
   license 'MIT'
-  compatibility 'all'
-  source_url 'https://github.com/box-project/box/releases/download/4.3.8/box.phar'
-  source_sha256 '83d63ddb24ecc97538356b90c320773d1aca2712d14813bd27bee3ba65cf3b18'
+  compatibility 'x86_64 aarch64 armv7l'
+  source_url 'https://github.com/box-project/box/releases/download/4.4.0/box.phar'
+  source_sha256 '5009ae580c4fc92f6a7d22e08d76798610d91f1afc2d0f1b391531cf28e93525'
 
   depends_on 'php81' unless File.exist? "#{CREW_PREFIX}/bin/php"
 
   no_compile_needed
 
   def self.install
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
     FileUtils.install 'box.phar', "#{CREW_DEST_PREFIX}/bin/box", mode: 0o755
   end
 end


### PR DESCRIPTION
i686 is no longer compatible since harfbuzz is a dependency and no binary is available.