### PR TITLE
Samu => Ninja rebuild

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,5 +1,5 @@
 # Defines common constants used in different parts of crew
-CREW_VERSION = '1.36.2'
+CREW_VERSION = '1.36.3'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp
@@ -303,10 +303,10 @@ CREW_MESON_FNO_LTO_OPTIONS = <<~OPT.chomp
 OPT
 
 # Use ninja or samurai
-CREW_NINJA = if ENV['CREW_NINJA'].to_s.downcase == 'ninja'
-               'ninja'
-             else
+CREW_NINJA = if ENV['CREW_NINJA'].to_s.downcase == 'samu'
                'samu'
+             else
+               'ninja'
              end
 
 # Cmake sometimes wants to use LIB_SUFFIX to install libs in LIB64, so specify such for x86_64

--- a/packages/ninja.rb
+++ b/packages/ninja.rb
@@ -1,44 +1,40 @@
-require 'package'
+require 'buildsystems/cmake'
 
-class Ninja < Package
+class Ninja < CMake
   description 'a small build system with a focus on speed'
   homepage 'https://ninja-build.org'
-  @_ver = '1.11.1'
-  version "#{@_ver}-1"
+  @_ver = '1.12.0'
+  version "#{@_ver}-885b4ef"
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://github.com/ninja-build/ninja.git'
-  git_hashtag "v#{@_ver}"
+  git_hashtag '885b4efb41c039789b81f0dc0d67c1ed0faea17c'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.11.1-1_armv7l/ninja-1.11.1-1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.11.1-1_armv7l/ninja-1.11.1-1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.11.1-1_i686/ninja-1.11.1-1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.11.1-1_x86_64/ninja-1.11.1-1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.12.0-885b4ef_armv7l/ninja-1.12.0-885b4ef-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.12.0-885b4ef_armv7l/ninja-1.12.0-885b4ef-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.12.0-885b4ef_i686/ninja-1.12.0-885b4ef-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/ninja/1.12.0-885b4ef_x86_64/ninja-1.12.0-885b4ef-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'e3e130403a43980cc2ef0a03adb9156a6dbd31b5718efb445681a2191dbc2b2a',
-     armv7l: 'e3e130403a43980cc2ef0a03adb9156a6dbd31b5718efb445681a2191dbc2b2a',
-       i686: '190004a05d176d485eb3f0919fef7baac98d5d78f571160022558aabdec1d6bf',
-     x86_64: '6ed13fed4d9f7332ce42b48e1da9411f0b9928ec9effb1d30817e342f5ef45d8'
+    aarch64: 'd3703cfe35dc9e4a52c9fe1a2fafe1545ea840b6934deb7e2f86ae5fe27dbc51',
+     armv7l: 'd3703cfe35dc9e4a52c9fe1a2fafe1545ea840b6934deb7e2f86ae5fe27dbc51',
+       i686: '323e22fbc63bfb38ec28113469b1f24a5249d17ca5b8a02f9660738c05aca011',
+     x86_64: '2dafb6d42eef4f788590c04f951a04d244e492a7e3d3867fc4ca959d8d4fd454'
   })
 
+  depends_on 'gcc_lib' # R
+  depends_on 'glibc' # R
   depends_on 're2c' => :build
-  depends_on 'samurai' => :build
 
-  def self.build
-    Dir.mkdir 'builddir'
-    Dir.chdir 'builddir' do
-      system "mold -run cmake \
-          #{CREW_CMAKE_OPTIONS} \
-          -Wdev \
-          -G Ninja \
-          .."
-      system 'mold -run samu'
-    end
-  end
-
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} samu -C builddir install"
+  def self.patch
+    puts 'Patching to use /proc/loadavg'.orange
+    downloader 'https://patch-diff.githubusercontent.com/raw/ninja-build/ninja/pull/2268.patch',
+               'a1c1f218ac1625ac1ba371c1d40f788e902a9f8bbbcfa76627bd21fdf2f4b79b'
+    system 'patch -p1 -i 2268.patch'
+    puts 'Patching to update status on edge finish'.orange
+    downloader 'https://patch-diff.githubusercontent.com/raw/ninja-build/ninja/pull/2312.patch',
+               '09608df70838e8af1a4dab69f735da071699cb10af2336dfe22f92451edbe886'
+    system 'patch -p1 -i 2312.patch'
   end
 end


### PR DESCRIPTION
- `samurai` hasn't been updated in ~ 3 years, and there are builds that are failing with it, e.g. `dia`.
- Updated `ninja` to use loadavg and also show threads being used with PRs on the ninja git repo.
- Tested by building re2c, which uses ninja for the build.
- ninja builds finish within ~ 30 seconds of samu builds.
- default `CREW_NINJA` is switched from `samu` to `ninja` in this PR.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/satmandu/chromebrew.git CREW_TESTING_BRANCH=ninja_rebuild CREW_TESTING=1 crew update
```
Example of new ninja output:
![image](https://github.com/chromebrew/chromebrew/assets/1096701/77c0e42f-3705-4181-a203-2a0555a7af63)
