### PR TITLE
Minor improvements to Repology workflow and backend

### DIFF
--- a/.github/workflows/Repology.yml
+++ b/.github/workflows/Repology.yml
@@ -12,9 +12,8 @@ jobs:
         run: |
             sudo docker pull satmandu/crewbuild:amd64
             sudo docker run -t -v $(pwd):/usr/local/json satmandu/crewbuild:amd64 /bin/bash -c "
-            git clone https://github.com/chromebrew/chromebrew
-            cd chromebrew/tools
-            ruby json.rb
+            crew update
+            ruby ../tools/json.rb
             cp repology.json /usr/local/json"
       - name: Upload JSON arifact
         uses: actions/upload-artifact@v3

--- a/tools/json.rb
+++ b/tools/json.rb
@@ -10,7 +10,8 @@ output = Array.new
 
 Dir.glob('../packages/*.rb').each do |filename|
   pkg = Package.load_package(filename)
-  output << {name: File.basename(filename, '.rb'), description: pkg.description, homepage: pkg.homepage, version: pkg.version, license: pkg.license, compatibility: pkg.compatibility}
+  next if pkg.is_fake?
+  output << {name: File.basename(filename, '.rb').gsub("_","-"), description: pkg.description, homepage: pkg.homepage, version: pkg.version, license: pkg.license, compatibility: pkg.compatibility}
 end
 
 File.write('repology.json', JSON.generate(output))


### PR DESCRIPTION
Noticed this when working on a similar project just after the PR got merged.

Tested and working inside of an `x86_64` container.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=hindsought CREW_TESTING=1 crew update
```
