### PR TITLE
Rework CREW_TESTING_* variables and crew update process

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,7 +25,7 @@ Works properly:
 
 ### Run the following to get this pull request's changes locally for testing.
 ```
-CREW_TESTING_REPO=https://github.com/<Please_enter_the_name_of_your_repo>/chromebrew.git CREW_TESTING_BRANCH=<Please_enter_the_branch_name_for_this_PR> CREW_TESTING=1 crew update
+CREW_REPO=https://github.com/<Please_enter_the_name_of_your_repo>/chromebrew.git CREW_BRANCH=<Please_enter_the_branch_name_for_this_PR> crew update
 ```
 
 <!--

--- a/bin/crew
+++ b/bin/crew
@@ -625,15 +625,8 @@ def update
     system "git sparse-checkout set packages manifest/#{USER_SPACE_ARCH} lib bin crew tools"
     system 'git sparse-checkout reapply'
 
-    if CREW_TESTING == '1'
-      puts 'Updating crew from testing repository...'
-      system "git remote add testing #{CREW_TESTING_REPO} 2>/dev/null || git remote set-url testing #{CREW_TESTING_REPO}"
-      system "git fetch testing #{CREW_TESTING_BRANCH}"
-      system "git reset --hard testing/#{CREW_TESTING_BRANCH}"
-    else
-      system 'git fetch origin master'
-      system 'git reset --hard origin/master'
-    end
+    system "git fetch #{CREW_REPO} #{CREW_BRANCH}"
+    system 'git reset --hard FETCH_HEAD'
   end
 
   puts 'Package lists, crew, and library updated.'

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,5 +1,5 @@
 # Defines common constants used in different parts of crew
-CREW_VERSION = '1.36.4'
+CREW_VERSION = '1.36.5'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp
@@ -150,18 +150,9 @@ CREW_NOT_LINKS = !ENV['CREW_NOT_LINKS'].to_s.empty? # or use no_links
 CREW_NOT_STRIP = !ENV['CREW_NOT_STRIP'].to_s.empty? # or use no_strip
 CREW_NOT_SHRINK_ARCHIVE = !ENV['CREW_NOT_SHRINK_ARCHIVE'].to_s.empty? # or use no_shrink
 
-# Set testing constants from environment variables
-CREW_TESTING_REPO = ENV.fetch('CREW_TESTING_REPO', nil)
-if CREW_TESTING_REPO
-  CREW_TESTING_ACCOUNT = if CREW_TESTING_REPO.downcase.include?('https://github.com')
-                           CREW_TESTING_REPO.to_s.downcase.gsub('https://github.com/', '').gsub('/chromebrew.git', '')
-                         else
-                           ENV.fetch('CREW_TESTING_ACCOUNT', nil)
-                         end
-end
-CREW_TESTING_BRANCH = ENV.fetch('CREW_TESTING_BRANCH', nil)
-
-CREW_TESTING = CREW_TESTING_BRANCH.to_s.empty? || CREW_TESTING_REPO.to_s.empty? ? '0' : ENV.fetch('CREW_TESTING', nil)
+# Allow git constants to be set from environment variables (for testing)
+CREW_REPO = ENV.fetch('CREW_REPO', 'https://github.com/chromebrew/chromebrew.git')
+CREW_BRANCH = ENV.fetch('CREW_BRANCH', 'master')
 
 USER = `whoami`.chomp
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -100,11 +100,6 @@ CREW_DEST_LIB_PREFIX = CREW_DEST_DIR + CREW_LIB_PREFIX
 CREW_DEST_DLL_PREFIX = CREW_DEST_PREFIX + CREW_DLL_PREFIX
 CREW_DEST_MAN_PREFIX = CREW_DEST_DIR + CREW_MAN_PREFIX
 
-# GitHub constants.
-CREW_GITHUB_ACCOUNT = 'chromebrew'
-CREW_GITHUB_BRANCH = 'master'
-CREW_GITHUB_REPO = 'https://github.com/chromebrew/chromebrew.git'
-
 # Local constants for contributors.
 repo_root = `git rev-parse --show-toplevel 2> /dev/null`.chomp.to_s
 if repo_root.empty?


### PR DESCRIPTION
Was looking at the crew update code, thought the fetching could be done better-- it could. 
Looked at it some more, thought the testing setup could be done better-- it could. 

Also looked at the completely unused `CREW_GITHUB_*` variables, realised they were unused, deleted them.

Tested and working on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```
CREW_TESTING_REPO=https://github.com/Zopolis4/chromebrew.git CREW_TESTING_BRANCH=gofetch CREW_TESTING=1 crew update
```