### PR TITLE
Add xclip package

### DIFF
--- a/manifest/armv7l/x/xclip.filelist
+++ b/manifest/armv7l/x/xclip.filelist
@@ -1,0 +1,7 @@
+/usr/local/bin/pbcopy
+/usr/local/bin/xclip
+/usr/local/bin/xclip-copyfile
+/usr/local/bin/xclip-cutfile
+/usr/local/bin/xclip-pastefile
+/usr/local/share/man/man1/xclip.1.zst
+/usr/local/share/man/man1/xclip-copyfile.1.zst

--- a/manifest/x86_64/x/xclip.filelist
+++ b/manifest/x86_64/x/xclip.filelist
@@ -1,0 +1,7 @@
+/usr/local/bin/pbcopy
+/usr/local/bin/xclip
+/usr/local/bin/xclip-copyfile
+/usr/local/bin/xclip-cutfile
+/usr/local/bin/xclip-pastefile
+/usr/local/share/man/man1/xclip.1.zst
+/usr/local/share/man/man1/xclip-copyfile.1.zst

--- a/packages/xclip.rb
+++ b/packages/xclip.rb
@@ -1,0 +1,36 @@
+require 'buildsystems/autotools'
+
+class Xclip < Autotools
+  description 'Command line interface to the X11 clipboard'
+  homepage 'https://github.com/astrand/xclip'
+  version '0.13'
+  license 'GPL-2'
+  compatibility 'x86_64 aarch64 armv7l'
+  source_url 'https://github.com/astrand/xclip.git'
+  git_hashtag version
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xclip/0.13_armv7l/xclip-0.13-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xclip/0.13_armv7l/xclip-0.13-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xclip/0.13_x86_64/xclip-0.13-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '3e1520b7cd5d82c87ee68d7777859046ede28f2cc9bacada0d06a4369f9c5dca',
+     armv7l: '3e1520b7cd5d82c87ee68d7777859046ede28f2cc9bacada0d06a4369f9c5dca',
+     x86_64: 'c01468f5fa173fca162424221aca0e1af2cb4b487aca53c14b6fc287c6e9c83e'
+  })
+
+  depends_on 'glibc' # R
+  depends_on 'libx11' # R
+  depends_on 'libxmu' # R
+
+  def self.install
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install.man'
+    File.write 'pbcopy.sh', <<~EOF
+      #!/bin/bash
+      xclip -i -sel c -f | xclip -i -sel p
+    EOF
+    FileUtils.install 'pbcopy.sh', "#{CREW_DEST_PREFIX}/bin/pbcopy", mode: 0o755
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -8911,6 +8911,11 @@ url: https://github.com/Airblader/xcb-util-xrm/releases
 activity: none
 ---
 kind: url
+name: xclip
+url: https://github.com/astrand/xclip/releases
+activity: none
+---
+kind: url
 name: xclock
 url: https://www.x.org/pub/individual/app/
 activity: low


### PR DESCRIPTION
xclip is a command line utility that is designed to run on any system with an
X11 implementation. It provides an interface to X selections ("the clipboard")
from the command line. It can read data from standard in or a file and place it
in an X selection for pasting into other X applications. xclip can also print
an X selection to standard out, which can then be redirected to a file or
another program.  See https://github.com/astrand/xclip.  Tested on arm and x86_64.