### PR TITLE
Fix sudo in Repology workflow and set it to run daily

### DIFF
--- a/.github/workflows/Repology.yml
+++ b/.github/workflows/Repology.yml
@@ -2,7 +2,7 @@ name: Generate Repology JSON
 
 on:
   schedule:
-    - cron: '0 0 * * 0'  # Every Sunday at midnight
+    - cron: '0 0 * * *'  # Every day at midnight
 jobs:
   generate:
     runs-on: ubuntu-latest
@@ -11,7 +11,7 @@ jobs:
       - name: Generate JSON
         run: |
             sudo docker pull satmandu/crewbuild:amd64
-            sudo docker run -t -v $(pwd):/usr/local/json satmandu/crewbuild:amd64 /bin/bash -c "
+            sudo docker run -t -v $(pwd):/usr/local/json satmandu/crewbuild:amd64 sudo -i -u chronos /bin/bash -c "
             crew update
             ruby ../tools/json.rb
             cp repology.json /usr/local/json"


### PR DESCRIPTION
Forgot about this since I changed the workflow to use crew, and crew can't run as root. 

Also set the workflow to run daily because it doesn't take too long and will give Repology more accurate information.