### PR TITLE
Add download source option

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -41,19 +41,19 @@ DOC = <<~DOCOPT
     crew build [options] [-k|--keep] <name> ...
     crew const [options] [<name> ...]
     crew deps [options] [-t|--tree] [-b|--include-build-deps] [--exclude-buildessential] <name> ...
-    crew download [options] <name> ...
+    crew download [options] [-s|--source] <name> ...
     crew files [options] <name> ...
     crew help [<command>] [<subcommand>]
-    crew install [options] [-k|--keep] [-s|--build-from-source] [-S|--recursive-build] <name> ...
+    crew install [options] [-k|--keep] [-s|--source] [-S|--recursive-build] <name> ...
     crew list [options] (available|installed|compatible|incompatible)
     crew postinstall [options] <name> ...
     crew prop
-    crew reinstall [options] [-k|--keep] [-s|--build-from-source] [-S|--recursive-build] <name> ...
+    crew reinstall [options] [-k|--keep] [-s|--source] [-S|--recursive-build] <name> ...
     crew remove [options] <name> ...
     crew search [options] [<name> ...]
     crew sysinfo [options]
     crew update [options] [<compatible>]
-    crew upgrade [options] [-k|--keep] [-s|--build-from-source] [<name> ...]
+    crew upgrade [options] [-k|--keep] [-s|--source] [<name> ...]
     crew whatprovides [options] <pattern> ...
 
     -b --include-build-deps  Include build dependencies in output.
@@ -62,7 +62,7 @@ DOC = <<~DOCOPT
     -d --no-color            Disable colors even if standard out is a tty.
     -k --keep                Keep the `CREW_BREW_DIR` (#{CREW_BREW_DIR}) directory.
     -L --license             Display the crew license.
-    -s --build-from-source   Build from source even if pre-compiled binary exists.
+    -s --source              Build or download from source even if pre-compiled binary exists.
     -S --recursive-build     Build from source, including all dependencies, even if pre-compiled binaries exist.
     -v --verbose             Show extra information.
     -V --version             Display the crew version.
@@ -116,7 +116,7 @@ String.use_color = args['--color'] || !args['--no-color']
 
 @opt_keep      = args['--keep']
 @opt_verbose   = args['--verbose']
-@opt_src       = args['--build-from-source']
+@opt_source    = args['--source']
 @opt_recursive = args['--recursive-build']
 
 # Verbose options
@@ -349,8 +349,9 @@ def help(pkgName = nil)
   when 'download'
     puts <<~EOT
       Download package(s).
-      Usage: crew download [-v|--verbose] <package1> [<package2> ...]
+      Usage: crew download [-s|--source] [-v|--verbose] <package1> [<package2> ...]
       Download package(s) to `CREW_BREW_DIR` (#{CREW_BREW_DIR}), but don't install.
+      If `-s` or `--source` is present, the source will be downloaded instead of the binary.
       If `-v` or `--verbose` is present, extra information will be displayed.
     EOT
   when 'files'
@@ -362,10 +363,10 @@ def help(pkgName = nil)
   when 'install'
     puts <<~EOT
       Install package(s).
-      Usage: crew install [-k|--keep] [-s|--build-from-source] [-S|--recursive-build] [-v|--verbose] <package1> [<package2> ...]
+      Usage: crew install [-k|--keep] [-s|--source] [-S|--recursive-build] [-v|--verbose] <package1> [<package2> ...]
       The package(s) must have a valid name.  Use `crew search <pattern>` to search for packages to install.
       If `-k` or `--keep` is present, the `CREW_BREW_DIR` (#{CREW_BREW_DIR}) directory will remain.
-      If `-s` or `--build-from-source` is present, the package(s) will be compiled instead of installed via binary.
+      If `-s` or `--source` is present, the package(s) will be compiled instead of installed via binary.
       If `-S` or `--recursive-build` is present, the package(s), including all dependencies, will be compiled instead of installed via binary.
       If `-v` or `--verbose` is present, extra information will be displayed.
     EOT
@@ -446,9 +447,9 @@ def help(pkgName = nil)
   when 'reinstall'
     puts <<~EOT
       Remove and install package(s).
-      Usage: crew reinstall [-k|--keep] [-s|--build-from-source] [-S|--recursive-build] [-v|--verbose] <package1> [<package2> ...]
+      Usage: crew reinstall [-k|--keep] [-s|--source] [-S|--recursive-build] [-v|--verbose] <package1> [<package2> ...]
       If `-k` or `--keep` is present, the `CREW_BREW_DIR` (#{CREW_BREW_DIR}) directory will remain.
-      If `-s` or `--build-from-source` is present, the package(s) will be compiled instead of installed via binary.
+      If `-s` or `--source` is present, the package(s) will be compiled instead of installed via binary.
       If `-S` or `--recursive-build` is present, the package(s), including all dependencies, will be compiled instead of installed via binary.
       If `-v` or `--verbose` is present, extra information will be displayed.
     EOT
@@ -491,10 +492,10 @@ def help(pkgName = nil)
   when 'upgrade'
     puts <<~EOT
       Update package(s).
-      Usage: crew upgrade [-v|--verbose] [-s|--build-from-source] <package1> [<package2> ...]
+      Usage: crew upgrade [-v|--verbose] [-s|--source] <package1> [<package2> ...]
       If package(s) are omitted, all packages will be updated.  Otherwise, specific package(s) will be updated.
       Use `crew update` to update crew itself.
-      If `-s` or `--build-from-source` is present, the package(s) will be compiled instead of upgraded via binary.
+      If `-s` or `--source` is present, the package(s) will be compiled instead of upgraded via binary.
       If `-v` or `--verbose` is present, extra information will be displayed.
     EOT
   when 'whatprovides'
@@ -750,6 +751,7 @@ def upgrade(*pkgs, build_from_source: false)
 end
 
 def download
+  @pkg.build_from_source = true if @opt_source
   url = @pkg.get_url(@device[:architecture])
   source = @pkg.is_source?(@device[:architecture])
 
@@ -763,10 +765,10 @@ def download
 
   if !url
     abort "No precompiled binary or source is available for #{@device[:architecture]}.".lightred
-  elsif !source
-    puts 'Precompiled binary available, downloading...'
   elsif @pkg.build_from_source
     puts 'Downloading source...'
+  elsif !source
+    puts 'Precompiled binary available, downloading...'
   elsif url.casecmp?('SKIP')
     puts 'Skipping source download...'
   else
@@ -1869,7 +1871,7 @@ def install_command(args)
     @pkgName = name
     search @pkgName
     print_current_package true
-    @pkg.build_from_source = true if @opt_src || @opt_recursive || (CREW_BUILD_FROM_SOURCE == '1')
+    @pkg.build_from_source = true if @opt_source || @opt_recursive || (CREW_BUILD_FROM_SOURCE == '1')
     resolve_dependencies_and_install
   end
 end
@@ -1907,7 +1909,7 @@ def reinstall_command(args)
     @pkgName = name
     search @pkgName
     print_current_package
-    @pkg.build_from_source = true if @opt_src || @opt_recursive || (CREW_BUILD_FROM_SOURCE == '1')
+    @pkg.build_from_source = true if @opt_source || @opt_recursive || (CREW_BUILD_FROM_SOURCE == '1')
     next unless @pkgName
 
     @pkg.in_upgrade = true
@@ -1977,7 +1979,7 @@ def update_command(args)
   end
 end
 
-def upgrade_command(args) = upgrade(*args['<name>'], build_from_source: @opt_src)
+def upgrade_command(args) = upgrade(*args['<name>'], build_from_source: @opt_source)
 
 def whatprovides_command(args)
   args['<pattern>'].each do |name|

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,5 +1,5 @@
 # Defines common constants used in different parts of crew
-CREW_VERSION = '1.37.0'
+CREW_VERSION = '1.37.1'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
Currently, `crew download <package>` will download the source only if a binary is not available.  This PR adds a `-s` or `--source` option to download the source when a binary is available in the package.
```
chronos@mx-x86_64 /usr/local/tmp/crew $ crew download -s curl
curl: Command line tool and library for transferring data with URLs.
Downloading source...
Archive found in cache
chronos@mx-x86_64 /usr/local/tmp/crew $ ls
curl-8.4.0.tar.xz  dest
chronos@mx-x86_64 /usr/local/tmp/crew $ rm curl-8.4.0.tar.xz 
chronos@mx-x86_64 /usr/local/tmp/crew $ crew download curl
curl: Command line tool and library for transferring data with URLs.
Precompiled binary available, downloading...
Archive found in cache
chronos@mx-x86_64 /usr/local/tmp/crew $ ls
curl-8.4.0-chromeos-x86_64.tar.zst  dest
```