### PR TITLE
qt5_webchannel rebuild

### DIFF
--- a/packages/qt5_webchannel.rb
+++ b/packages/qt5_webchannel.rb
@@ -6,21 +6,21 @@ require 'buildsystems/qmake'
 class Qt5_webchannel < Qmake
   description 'Provides access to QObject or QML objects from HTML clients for seamless integration of Qt applications with HTML/JavaScript clients'
   homepage 'https://www.qt.io'
-  version '5.15.11-f84887c'
+  version '5.15.11-f84887c-1'
   license 'GPL3 LGPL3 FDL custom'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://invent.kde.org/qt/qt/qtwebchannel.git'
   git_hashtag 'f84887c1aee4ab04af375e639ae965c9ea2186a5' # from kde/5.15 branch
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qt5_webchannel/5.15.11-f84887c_armv7l/qt5_webchannel-5.15.11-f84887c-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qt5_webchannel/5.15.11-f84887c_armv7l/qt5_webchannel-5.15.11-f84887c-chromeos-armv7l.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qt5_webchannel/5.15.11-f84887c_x86_64/qt5_webchannel-5.15.11-f84887c-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qt5_webchannel/5.15.11-f84887c-1_armv7l/qt5_webchannel-5.15.11-f84887c-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qt5_webchannel/5.15.11-f84887c-1_armv7l/qt5_webchannel-5.15.11-f84887c-1-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/qt5_webchannel/5.15.11-f84887c-1_x86_64/qt5_webchannel-5.15.11-f84887c-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '379dd10cef54171ed23624632714751d98e4663bb4162c6c04a8117ce479508b',
-     armv7l: '379dd10cef54171ed23624632714751d98e4663bb4162c6c04a8117ce479508b',
-     x86_64: '88f6941f88078e1cac8d3fab3d78a78782f8727d7669a81bc2cbd413ee70642d'
+    aarch64: '90a95da431935e73b986f26185ea64f557341bc337dda5ecaffccc5b5120d462',
+     armv7l: '90a95da431935e73b986f26185ea64f557341bc337dda5ecaffccc5b5120d462',
+     x86_64: '504cb7151f15ca9dd4b27674477dcb7d1d6e4dfdbef7d0b7b3d59954352e961d'
   })
 
   depends_on 'gcc_lib' # R


### PR DESCRIPTION
- qt5_webchannel appeared to have a corrupted library, so this rebuilds it.

Works properly:
- [x] `x86_64`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=qt5_webchannel_rebuild crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
