### PR TITLE
Rename some packages starting with a

### DIFF
--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -37,7 +37,8 @@ pkg_update_arr = [
   { pkg_name: 'qtx11extras', pkg_rename: 'qt5_x11extras', pkg_deprecated: nil, comments: nil },
   { pkg_name: 'qtchooser', pkg_rename: nil, pkg_deprecated: true, comments: "Doesn't work for newer Qt versions." },
   { pkg_name: 'acli', pkg_rename: 'acquia_cli', pkg_deprecated: nil, comments: "Renamed to better match upstream." },
-  { pkg_name: 'agrind', pkg_rename: 'angle_grinder', pkg_deprecated: nil, comments: "Renamed to better match upstream." }
+  { pkg_name: 'agrind', pkg_rename: 'angle_grinder', pkg_deprecated: nil, comments: "Renamed to better match upstream." },
+  { pkg_name: 'apriconv', pkg_rename: 'apr_iconv', pkg_deprecated: nil, comments: "Renamed to better match upstream." }
 ]
 
 pkg_update_arr.each do |pkg|

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -38,7 +38,8 @@ pkg_update_arr = [
   { pkg_name: 'qtchooser', pkg_rename: nil, pkg_deprecated: true, comments: "Doesn't work for newer Qt versions." },
   { pkg_name: 'acli', pkg_rename: 'acquia_cli', pkg_deprecated: nil, comments: "Renamed to better match upstream." },
   { pkg_name: 'agrind', pkg_rename: 'angle_grinder', pkg_deprecated: nil, comments: "Renamed to better match upstream." },
-  { pkg_name: 'apriconv', pkg_rename: 'apr_iconv', pkg_deprecated: nil, comments: "Renamed to better match upstream." }
+  { pkg_name: 'apriconv', pkg_rename: 'apr_iconv', pkg_deprecated: nil, comments: "Renamed to better match upstream." },
+  { pkg_name: 'aprutil', pkg_rename: 'apr_util', pkg_deprecated: nil, comments: "Renamed to better match upstream." }
 ]
 
 pkg_update_arr.each do |pkg|

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -35,7 +35,8 @@ pkg_update_arr = [
   { pkg_name: 'qtwebglplugin', pkg_rename: 'qt5_webglplugin', pkg_deprecated: nil, comments: nil },
   { pkg_name: 'qtwebsockets', pkg_rename: 'qt5_websockets', pkg_deprecated: nil, comments: nil },
   { pkg_name: 'qtx11extras', pkg_rename: 'qt5_x11extras', pkg_deprecated: nil, comments: nil },
-  { pkg_name: 'qtchooser', pkg_rename: nil, pkg_deprecated: true, comments: "Doesn't work for newer Qt versions." }
+  { pkg_name: 'qtchooser', pkg_rename: nil, pkg_deprecated: true, comments: "Doesn't work for newer Qt versions." },
+  { pkg_name: 'acli', pkg_rename: 'acquia_cli', pkg_deprecated: nil, comments: "Renamed to better match upstream." }
 ]
 
 pkg_update_arr.each do |pkg|

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -36,7 +36,8 @@ pkg_update_arr = [
   { pkg_name: 'qtwebsockets', pkg_rename: 'qt5_websockets', pkg_deprecated: nil, comments: nil },
   { pkg_name: 'qtx11extras', pkg_rename: 'qt5_x11extras', pkg_deprecated: nil, comments: nil },
   { pkg_name: 'qtchooser', pkg_rename: nil, pkg_deprecated: true, comments: "Doesn't work for newer Qt versions." },
-  { pkg_name: 'acli', pkg_rename: 'acquia_cli', pkg_deprecated: nil, comments: "Renamed to better match upstream." }
+  { pkg_name: 'acli', pkg_rename: 'acquia_cli', pkg_deprecated: nil, comments: "Renamed to better match upstream." },
+  { pkg_name: 'agrind', pkg_rename: 'angle_grinder', pkg_deprecated: nil, comments: "Renamed to better match upstream." }
 ]
 
 pkg_update_arr.each do |pkg|

--- a/packages/acquia_cli.rb
+++ b/packages/acquia_cli.rb
@@ -1,6 +1,6 @@
 require 'package'
 
-class Acli < Package
+class Acquia_cli < Package
   description 'Acquia CLI - The official command-line tool for interacting with the Drupal Cloud Platform and services.'
   homepage 'https://github.com/acquia/cli'
   version '2.15.1'

--- a/packages/angle_grinder.rb
+++ b/packages/angle_grinder.rb
@@ -1,6 +1,6 @@
 require 'package'
 
-class Agrind < Package
+class Angle_grinder < Package
   description 'Slice and dice logs on the command line'
   homepage 'https://github.com/rcoh/angle-grinder'
   version '0.19.2'

--- a/packages/apr_iconv.rb
+++ b/packages/apr_iconv.rb
@@ -1,6 +1,6 @@
 require 'package'
 
-class Apriconv < Package
+class Apr_iconv < Package
   description 'a portable implementation of the iconv() library'
   homepage 'http://apr.apache.org/'
   version '1.2.2'

--- a/packages/apr_util.rb
+++ b/packages/apr_util.rb
@@ -1,6 +1,6 @@
 require 'package'
 
-class Aprutil < Package
+class Apr_util < Package
   description 'APR-util provides a number of helpful abstractions on top of APR.'
   homepage 'http://apr.apache.org/'
   version '1.6.1'

--- a/packages/arping.rb
+++ b/packages/arping.rb
@@ -2,7 +2,7 @@ require 'package'
 
 class Arping < Package
   description 'ARP Ping'
-  homepage 'https://github.com/ThomasHabets/arping'
+  homepage 'https://www.habets.pp.se/synscan/programs_arping.html'
   version '2.21'
   license 'GPL-2'
   compatibility 'all'

--- a/packages/biew.rb
+++ b/packages/biew.rb
@@ -22,7 +22,7 @@ class Biew < Package
      x86_64: '140bc619e0495b7bbec4b3ca934ddb0e12cb46b793b27197dd677b73d4819ddd'
   })
 
-  depends_on 'apriconv'
+  depends_on 'apr_iconv'
   depends_on 'ncurses'
   depends_on 'slang'
 

--- a/packages/httpd.rb
+++ b/packages/httpd.rb
@@ -23,7 +23,7 @@ class Httpd < Package
   })
 
   depends_on 'apr'
-  depends_on 'aprutil'
+  depends_on 'apr_util'
   depends_on 'libtool'
   depends_on 'pcre'
   depends_on 'expat'

--- a/packages/libconfuse.rb
+++ b/packages/libconfuse.rb
@@ -22,7 +22,7 @@ class Libconfuse < Package
      x86_64: '697f525ada438cb1662374dc2ec820e2dd0133b339244ced2b56da0f098036e5'
   })
 
-  depends_on 'apriconv'
+  depends_on 'apr_iconv'
   depends_on 'intltool'
 
   def self.build

--- a/packages/serf.rb
+++ b/packages/serf.rb
@@ -23,7 +23,7 @@ class Serf < Package
   })
 
   depends_on 'scons'
-  depends_on 'aprutil'
+  depends_on 'apr_util'
   depends_on 'openssl'
 
   def self.build

--- a/packages/subversion.rb
+++ b/packages/subversion.rb
@@ -22,7 +22,7 @@ class Subversion < Package
      x86_64: 'c708bfe66744ccb19d7fcf463912a4b27c14fe854d9de83e49cb174baadf5d5e'
   })
 
-  depends_on 'aprutil'
+  depends_on 'apr_util'
   depends_on 'serf'
   depends_on 'sqlite'
 

--- a/packages/testdisk.rb
+++ b/packages/testdisk.rb
@@ -22,7 +22,7 @@ class Testdisk < Package
      x86_64: 'c861cb658e05fee9728239a404f4aaf87617fb19805f9ec2f183f6a9ff6205db'
   })
 
-  depends_on 'apriconv'
+  depends_on 'apr_iconv'
   depends_on 'compressdoc' => :build
   depends_on 'libjpeg'
   depends_on 'ncurses'


### PR DESCRIPTION
Renaming a few of our packages to be more consistent with their upstream naming and how the majority of other distros name them, as well as to have them easily detectable by Anitya.

Tested and working on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=renesma crew update
```
