### PR TITLE
New package: crew-sudo

### DIFF
--- a/packages/crew_sudo.rb
+++ b/packages/crew_sudo.rb
@@ -24,7 +24,7 @@ class Crew_sudo < Package
     FileUtils.ln_s "#{path}/crew-sudo", "#{bindir}/sudo"
     FileUtils.ln_s "#{path}/crew-sudo", "#{bindir}/sudod"
 
-    FileUtils.cp 'autostart/crew-sudo.sh', envdir
+    FileUtils.cp 'autostart/crew-sudo.sh', "#{envdir}/crew_sudo"
   end
 
   def self.postinstall

--- a/packages/crew_sudo.rb
+++ b/packages/crew_sudo.rb
@@ -17,7 +17,7 @@ class Crew_sudo < Package
     envdir = File.join(CREW_DEST_PREFIX, 'etc/env.d')
     path   = File.join(CREW_PREFIX, 'lib/crew-sudo')
 
-    FileUtils.mkdir_p [bindir, File.join(CREW_DEST_DIR, path)]
+    FileUtils.mkdir_p [bindir, envdir, File.join(CREW_DEST_DIR, path)]
     FileUtils.cp_r Dir['*'], File.join(CREW_DEST_DIR, path)
 
     FileUtils.ln_s "#{path}/crew-sudo", "#{bindir}/crew-sudo"

--- a/packages/crew_sudo.rb
+++ b/packages/crew_sudo.rb
@@ -8,7 +8,7 @@ class Crew_sudo < Package
   compatibility 'all'
 
   source_url 'https://github.com/supechicken/crew-sudo.git'
-  git_hashtag 'v1.0'
+  git_hashtag '1.0'
 
   no_compile_needed
 

--- a/packages/crew_sudo.rb
+++ b/packages/crew_sudo.rb
@@ -30,7 +30,7 @@ class Crew_sudo < Package
   def self.postinstall
     warn <<~EOT.lightblue
 
-      In order to make sudo works properly, the crew-sudo daemon need to
+      In order to make sudo work properly, the crew-sudo daemon needs to
       start in the VT-2 shell every boot by:
 
         - Press Ctrl + Alt + -> to enter VT-2 shell

--- a/packages/crew_sudo.rb
+++ b/packages/crew_sudo.rb
@@ -17,7 +17,7 @@ class Crew_sudo < Package
     envdir = File.join(CREW_DEST_PREFIX, 'etc/env.d')
     path   = File.join(CREW_PREFIX, 'lib/crew-sudo')
 
-    FileUtils.mkdir_p bindir, File.join(CREW_DEST_DIR, path)
+    FileUtils.mkdir_p [bindir, File.join(CREW_DEST_DIR, path)]
     FileUtils.cp_r Dir['*'], File.join(CREW_DEST_DIR, path)
 
     FileUtils.ln_s "#{path}/crew-sudo", "#{bindir}/crew-sudo"

--- a/packages/crew_sudo.rb
+++ b/packages/crew_sudo.rb
@@ -10,6 +10,8 @@ class Crew_sudo < Package
   source_url 'https://github.com/supechicken/crew-sudo.git'
   git_hashtag 'v1.0'
 
+  no_compile_needed
+
   def self.install
     bindir = File.join(CREW_DEST_PREFIX, 'bin')
     envdir = File.join(CREW_DEST_PREFIX, 'etc/env.d')

--- a/packages/crew_sudo.rb
+++ b/packages/crew_sudo.rb
@@ -1,0 +1,41 @@
+require 'package'
+
+class Crew_sudo < Package
+  description 'Workaround for using sudo on ChromeOS crosh shell (ChromeOS v117+)'
+  homepage 'https://github.com/supechicken/crew-sudo'
+  version '1.0'
+  license 'GPL-3'
+  compatibility 'all'
+
+  source_url 'https://github.com/supechicken/crew-sudo.git'
+  git_hashtag 'v1.0'
+
+  def self.install
+    bindir = File.join(CREW_DEST_PREFIX, 'bin')
+    envdir = File.join(CREW_DEST_PREFIX, 'etc/env.d')
+    path   = File.join(CREW_PREFIX, 'lib/crew-sudo')
+
+    FileUtils.mkdir_p bindir, File.join(CREW_DEST_DIR, path)
+    FileUtils.cp_r Dir['*'], File.join(CREW_DEST_DIR, path)
+
+    FileUtils.ln_s "#{path}/crew-sudo", "#{bindir}/crew-sudo"
+    FileUtils.ln_s "#{path}/crew-sudo", "#{bindir}/sudo"
+    FileUtils.ln_s "#{path}/crew-sudo", "#{bindir}/sudod"
+
+    FileUtils.cp 'autostart/crew-sudo.sh', envdir
+  end
+
+  def self.postinstall
+    warn <<~EOT.lightblue
+
+      In order to make sudo works properly, the crew-sudo daemon need to
+      start in the VT-2 shell every boot by:
+
+        - Press Ctrl + Alt + -> to enter VT-2 shell
+        - Log in as 'chronos' user
+        - The daemon should start automatically now
+        - Press Ctrl + Alt + <- to switch back to ChromeOS UI
+
+      EOT
+  end
+end


### PR DESCRIPTION
`crew-sudo`: Workaround for using `sudo` on ChromeOS `crosh` shell (ChromeOS v117+)

See https://github.com/supechicken/crew-sudo for more information.

Might help #8779, and this package **needs further testing** :) (I will transfer this project to `chromebrew` org once it is ready)

### Usage
Run this in VT-2 shell first to start the sudo daemon
```shell
# the bashrc should do it automatically once you login the VT-2 shell
crew-sudo --daemon
```

And `sudo` should work in `crosh` now (be aware that the original `sudo` command is covered with `crew-sudo` now because of the `PATH` priority, but it should be fine in most cases)

---

Tested on `x86_64`

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/supechicken/chromebrew CREW_BRANCH=crew-sudo crew update
```