### PR TITLE
restart crew update if there is a new crew version

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,5 +1,8 @@
+# lib/const.rb
 # Defines common constants used in different parts of crew
-CREW_VERSION = '1.37.1'
+CREW_VERSION = '1.37.2'
+
+CREW_CONST_GIT_COMMIT = `git log -n1 --oneline ../lib/const.rb`.chomp.split.first
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -135,7 +135,7 @@ NEW_CONST_GIT_COMMIT = `git log -n1 --oneline ../lib/const.rb`.chomp.split.first
 
 unless NEW_CONST_GIT_COMMIT.to_s == CREW_CONST_GIT_COMMIT.to_s
   puts 'Restarting crew update since there is an updated crew version'.lightcyan
-  puts "CREW_REPO=#{CREW_REPO} CREW_BRANCH=#{CREW_BRANCH} crew update".orange
+  puts "CREW_REPO=#{CREW_REPO} CREW_BRANCH=#{CREW_BRANCH} crew update".orange if @opt_verbose
   exec "CREW_REPO=#{CREW_REPO} CREW_BRANCH=#{CREW_BRANCH} crew update"
 end
 

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -1,3 +1,4 @@
+# lib/fixup.rb
 # Add fixups to be run during crew update here.
 
 # remove deprecated directory
@@ -36,10 +37,10 @@ pkg_update_arr = [
   { pkg_name: 'qtwebsockets', pkg_rename: 'qt5_websockets', pkg_deprecated: nil, comments: nil },
   { pkg_name: 'qtx11extras', pkg_rename: 'qt5_x11extras', pkg_deprecated: nil, comments: nil },
   { pkg_name: 'qtchooser', pkg_rename: nil, pkg_deprecated: true, comments: "Doesn't work for newer Qt versions." },
-  { pkg_name: 'acli', pkg_rename: 'acquia_cli', pkg_deprecated: nil, comments: "Renamed to better match upstream." },
-  { pkg_name: 'agrind', pkg_rename: 'angle_grinder', pkg_deprecated: nil, comments: "Renamed to better match upstream." },
-  { pkg_name: 'apriconv', pkg_rename: 'apr_iconv', pkg_deprecated: nil, comments: "Renamed to better match upstream." },
-  { pkg_name: 'aprutil', pkg_rename: 'apr_util', pkg_deprecated: nil, comments: "Renamed to better match upstream." }
+  { pkg_name: 'acli', pkg_rename: 'acquia_cli', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' },
+  { pkg_name: 'agrind', pkg_rename: 'angle_grinder', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' },
+  { pkg_name: 'apriconv', pkg_rename: 'apr_iconv', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' },
+  { pkg_name: 'aprutil', pkg_rename: 'apr_util', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' }
 ]
 
 pkg_update_arr.each do |pkg|
@@ -124,3 +125,17 @@ pkg_update_arr.each do |pkg|
     puts "#{pkg[:pkg_name].capitalize} not removed.".lightblue
   end
 end
+
+# Restart crew update if the git commit of ../lib/const.rb loaded in 
+# const.rb is different from the git commit of the potentially updated
+# ../lib/const.rb loaded here after a git pull.
+
+CREW_CONST_GIT_COMMIT = '0000' unless defined?(CREW_CONST_GIT_COMMIT)
+NEW_CONST_GIT_COMMIT = `git log -n1 --oneline ../lib/const.rb`.chomp.split.first
+
+unless NEW_CONST_GIT_COMMIT.to_s == CREW_CONST_GIT_COMMIT.to_s
+  puts 'Restarting crew update since there is an updated crew version'.lightcyan
+  puts "CREW_REPO=#{CREW_REPO} CREW_BRANCH=#{CREW_BRANCH} crew update".orange
+  exec "CREW_REPO=#{CREW_REPO} CREW_BRANCH=#{CREW_BRANCH} crew update"
+end
+

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -130,7 +130,9 @@ end
 # const.rb is different from the git commit of the potentially updated
 # ../lib/const.rb loaded here after a git pull.
 
+# Handle case of const.rb not yet defining CREW_CONST_GIT_COMMIT.
 CREW_CONST_GIT_COMMIT = '0000' unless defined?(CREW_CONST_GIT_COMMIT)
+
 NEW_CONST_GIT_COMMIT = `git log -n1 --oneline ../lib/const.rb`.chomp.split.first
 
 unless NEW_CONST_GIT_COMMIT.to_s == CREW_CONST_GIT_COMMIT.to_s

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -134,7 +134,7 @@ CREW_CONST_GIT_COMMIT = '0000' unless defined?(CREW_CONST_GIT_COMMIT)
 NEW_CONST_GIT_COMMIT = `git log -n1 --oneline ../lib/const.rb`.chomp.split.first
 
 unless NEW_CONST_GIT_COMMIT.to_s == CREW_CONST_GIT_COMMIT.to_s
-  puts 'Restarting crew update since there is an updated crew version'.lightcyan
+  puts 'Restarting crew update since there is an updated crew version.'.lightcyan
   puts "CREW_REPO=#{CREW_REPO} CREW_BRANCH=#{CREW_BRANCH} crew update".orange if @opt_verbose
   exec "CREW_REPO=#{CREW_REPO} CREW_BRANCH=#{CREW_BRANCH} crew update"
 end

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -133,9 +133,9 @@ end
 # Handle case of const.rb not yet defining CREW_CONST_GIT_COMMIT.
 CREW_CONST_GIT_COMMIT = '0000' unless defined?(CREW_CONST_GIT_COMMIT)
 
-NEW_CONST_GIT_COMMIT = `git log -n1 --oneline ../lib/const.rb`.chomp.split.first
+@new_const_git_commit = `git log -n1 --oneline ../lib/const.rb`.chomp.split.first
 
-unless NEW_CONST_GIT_COMMIT.to_s == CREW_CONST_GIT_COMMIT.to_s
+unless @new_const_git_commit.to_s == CREW_CONST_GIT_COMMIT.to_s
   puts 'Restarting crew update since there is an updated crew version.'.lightcyan
   puts "CREW_REPO=#{CREW_REPO} CREW_BRANCH=#{CREW_BRANCH} crew update".orange if @opt_verbose
   exec "CREW_REPO=#{CREW_REPO} CREW_BRANCH=#{CREW_BRANCH} crew update"


### PR DESCRIPTION

![image](https://github.com/chromebrew/chromebrew/assets/1096701/0c9e50a5-86f4-4c3e-af7c-b4f193e6ee5c)

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=fixupversion crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
