### PR TITLE
fix ambiguous argument '../lib/const.rb' error

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -110,10 +110,11 @@ if repo_root.empty?
 end
 CREW_LOCAL_REPO_ROOT = repo_root
 
+# The following is used in fixup.rb to determine if crew update needs to
+# be run again.
 CREW_CONST_GIT_COMMIT = `git log -n1 --oneline #{CREW_LOCAL_REPO_ROOT}/lib/const.rb`.chomp.split.first
 
 CREW_LOCAL_REPO_BASE = CREW_LOCAL_REPO_ROOT.empty? ? '' : File.basename(CREW_LOCAL_REPO_ROOT)
-
 CREW_LOCAL_MANIFEST_PATH = if ENV['CREW_LOCAL_MANIFEST_PATH'].to_s.empty?
                              "#{CREW_LOCAL_REPO_ROOT}/manifest"
                            else

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,8 +1,6 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
-CREW_VERSION = '1.37.2'
-
-CREW_CONST_GIT_COMMIT = `git log -n1 --oneline ../lib/const.rb`.chomp.split.first
+CREW_VERSION = '1.37.3'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp
@@ -111,7 +109,11 @@ if repo_root.empty?
   end
 end
 CREW_LOCAL_REPO_ROOT = repo_root
+
+CREW_CONST_GIT_COMMIT = `git log -n1 --oneline #{CREW_LOCAL_REPO_ROOT}/lib/const.rb`.chomp.split.first
+
 CREW_LOCAL_REPO_BASE = CREW_LOCAL_REPO_ROOT.empty? ? '' : File.basename(CREW_LOCAL_REPO_ROOT)
+
 CREW_LOCAL_MANIFEST_PATH = if ENV['CREW_LOCAL_MANIFEST_PATH'].to_s.empty?
                              "#{CREW_LOCAL_REPO_ROOT}/manifest"
                            else

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -126,14 +126,14 @@ pkg_update_arr.each do |pkg|
   end
 end
 
-# Restart crew update if the git commit of ../lib/const.rb loaded in 
+# Restart crew update if the git commit of ../lib/const.rb loaded in
 # const.rb is different from the git commit of the potentially updated
 # ../lib/const.rb loaded here after a git pull.
 
 # Handle case of const.rb not yet defining CREW_CONST_GIT_COMMIT.
 CREW_CONST_GIT_COMMIT = '0000' unless defined?(CREW_CONST_GIT_COMMIT)
 
-@new_const_git_commit = `git log -n1 --oneline ../lib/const.rb`.chomp.split.first
+@new_const_git_commit = `git log -n1 --oneline #{CREW_LOCAL_REPO_ROOT}/lib/const.rb`.chomp.split.first
 
 unless @new_const_git_commit.to_s == CREW_CONST_GIT_COMMIT.to_s
   puts 'Restarting crew update since there is an updated crew version.'.lightcyan

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -126,9 +126,9 @@ pkg_update_arr.each do |pkg|
   end
 end
 
-# Restart crew update if the git commit of ../lib/const.rb loaded in
-# const.rb is different from the git commit of the potentially updated
-# ../lib/const.rb loaded here after a git pull.
+# Restart crew update if the git commit of const.rb loaded in const.rb
+# is different from the git commit of the potentially updated const.rb
+# loaded here after a git pull.
 
 # Handle case of const.rb not yet defining CREW_CONST_GIT_COMMIT.
 CREW_CONST_GIT_COMMIT = '0000' unless defined?(CREW_CONST_GIT_COMMIT)


### PR DESCRIPTION
- Use absolute path for const.rb in check for git commit.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=const_git crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
