### PR TITLE
Rename some packages starting with b and c

### DIFF
--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -40,7 +40,8 @@ pkg_update_arr = [
   { pkg_name: 'acli', pkg_rename: 'acquia_cli', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' },
   { pkg_name: 'agrind', pkg_rename: 'angle_grinder', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' },
   { pkg_name: 'apriconv', pkg_rename: 'apr_iconv', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' },
-  { pkg_name: 'aprutil', pkg_rename: 'apr_util', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' }
+  { pkg_name: 'aprutil', pkg_rename: 'apr_util', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' },
+  { pkg_name: 'bz2', pkg_rename: 'bzip2', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' }
 ]
 
 pkg_update_arr.each do |pkg|

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -42,7 +42,8 @@ pkg_update_arr = [
   { pkg_name: 'apriconv', pkg_rename: 'apr_iconv', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' },
   { pkg_name: 'aprutil', pkg_rename: 'apr_util', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' },
   { pkg_name: 'bz2', pkg_rename: 'bzip2', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' },
-  { pkg_name: 'bz3', pkg_rename: 'bzip3', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' }
+  { pkg_name: 'bz3', pkg_rename: 'bzip3', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' },
+  { pkg_name: 'codium', pkg_rename: 'vscodium', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' }
 ]
 
 pkg_update_arr.each do |pkg|

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -41,7 +41,8 @@ pkg_update_arr = [
   { pkg_name: 'agrind', pkg_rename: 'angle_grinder', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' },
   { pkg_name: 'apriconv', pkg_rename: 'apr_iconv', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' },
   { pkg_name: 'aprutil', pkg_rename: 'apr_util', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' },
-  { pkg_name: 'bz2', pkg_rename: 'bzip2', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' }
+  { pkg_name: 'bz2', pkg_rename: 'bzip2', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' },
+  { pkg_name: 'bz3', pkg_rename: 'bzip3', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' }
 ]
 
 pkg_update_arr.each do |pkg|

--- a/packages/boost.rb
+++ b/packages/boost.rb
@@ -23,7 +23,7 @@ class Boost < Package
      x86_64: '892447b1c026b67f7d7c2e389be5953b2581db69bd0e44079fac9c3575e244f6'
   })
 
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'gcc_lib' # R
   depends_on 'glibc' # R
   depends_on 'icu4c' # R

--- a/packages/bzip2.rb
+++ b/packages/bzip2.rb
@@ -1,6 +1,6 @@
 require 'package'
 
-class Bz2 < Package
+class Bzip2 < Package
   description 'bzip2 is a freely available, patent free, high-quality data compressor.'
   homepage 'http://www.bzip.org/'
   version '1.0.8-1'

--- a/packages/bzip3.rb
+++ b/packages/bzip3.rb
@@ -1,6 +1,6 @@
 require 'package'
 
-class Bz3 < Package
+class Bzip3 < Package
   description 'bzip3 is a better and stronger spiritual successor to bzip2.'
   homepage 'https://github.com/kspalaiologos/bzip3'
   version '1.2.2'

--- a/packages/cmake.rb
+++ b/packages/cmake.rb
@@ -22,7 +22,7 @@ class Cmake < Package
      x86_64: 'f991e757d11a4156aac060d35912102bc81c6360501029f64604d3d7ed002d4d'
   })
 
-  depends_on 'bz2' => :build
+  depends_on 'bzip2' => :build
   depends_on 'cppdap' # R
   depends_on 'curl' # R
   depends_on 'expat' # R

--- a/packages/core.rb
+++ b/packages/core.rb
@@ -10,7 +10,7 @@ class Core < Package
   is_fake
 
   depends_on 'brotli'
-  depends_on 'bz2'
+  depends_on 'bzip2'
   depends_on 'c_ares'
   depends_on 'ca_certificates'
   depends_on 'crew_mvdir'

--- a/packages/di.rb
+++ b/packages/di.rb
@@ -2,7 +2,7 @@ require 'package'
 
 class Di < Package
   description 'DI is a disk information utility, displaying everything (and more) that your \'df\' command does.'
-  homepage 'http://gentoo.com/di/'
+  homepage 'https://diskinfo-di.sourceforge.io/'
   version '4.47.1'
   license 'ZLIB'
   compatibility 'all'

--- a/packages/dtrx.rb
+++ b/packages/dtrx.rb
@@ -23,7 +23,7 @@ class Dtrx < Package
   })
 
   depends_on 'binutils'
-  depends_on 'bz2'
+  depends_on 'bzip2'
   depends_on 'cabextract'
   depends_on 'cpio'
   depends_on 'lha'

--- a/packages/elfutils.rb
+++ b/packages/elfutils.rb
@@ -22,7 +22,7 @@ class Elfutils < Package
      x86_64: '9952fb6d9c22cde9ac9ceb45363d8bd5f8cca2a7ee61a66ccfb063e9e4dca32e'
   })
 
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'gcc_lib' # R
   depends_on 'glibc' # R
   depends_on 'libarchive' # R

--- a/packages/elinks.rb
+++ b/packages/elinks.rb
@@ -25,7 +25,7 @@ class Elinks < Package
   depends_on 'lzip'
   depends_on 'openssl' # R
   depends_on 'zlibpkg' # R
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'expat' # R
 
   def self.build

--- a/packages/ffmpeg.rb
+++ b/packages/ffmpeg.rb
@@ -22,7 +22,7 @@ class Ffmpeg < Package
 
   depends_on 'alsa_lib' # R
   depends_on 'avisynthplus' # ?
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'ccache' => :build
   depends_on 'chromaprint' # ?
   depends_on 'dav1d' # R

--- a/packages/filecmd.rb
+++ b/packages/filecmd.rb
@@ -22,7 +22,7 @@ class Filecmd < Package
      x86_64: '934e22a6546df52a0fba66589029a87d1e4fabefb5a32fd4326615670deb8631'
   })
 
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'gcc_lib' # R
   depends_on 'glibc' # R
   depends_on 'lzlib' # R Fixes checking lzlib.h usability... no

--- a/packages/freetype.rb
+++ b/packages/freetype.rb
@@ -22,7 +22,7 @@ class Freetype < Package
   })
 
   depends_on 'brotli' # R
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'expat' => :build
   depends_on 'gcc_lib' # R
   depends_on 'glib' => :build

--- a/packages/gimp.rb
+++ b/packages/gimp.rb
@@ -25,7 +25,7 @@ class Gimp < Package
   depends_on 'appstream_glib' # R
   depends_on 'at_spi2_core' => :build
   depends_on 'babl' # R
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'cairo' # R
   depends_on 'ffmpeg' => :build
   depends_on 'fontconfig' # R

--- a/packages/gnupg.rb
+++ b/packages/gnupg.rb
@@ -22,7 +22,7 @@ class Gnupg < Package
      x86_64: '479dad1509044aa77ebb3b6648ab54d0fcc298376df9b5fc960f4d1390b277f0'
   })
 
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'glibc' # R
   depends_on 'gnutls' # R
   depends_on 'libassuan' # R

--- a/packages/graphicsmagick.rb
+++ b/packages/graphicsmagick.rb
@@ -21,7 +21,7 @@ class Graphicsmagick < Package
   })
 
   depends_on 'brotli' # R
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'freetype' # R
   depends_on 'gcc_lib' # R
   depends_on 'ghostscript' => :build

--- a/packages/gstreamer.rb
+++ b/packages/gstreamer.rb
@@ -23,7 +23,7 @@ class Gstreamer < Package
 
   depends_on 'alsa_lib' # R
   depends_on 'at_spi2_core' # R
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'ca_certificates' => :build
   depends_on 'cairo' # R
   depends_on 'chromaprint' # R

--- a/packages/handbrake.rb
+++ b/packages/handbrake.rb
@@ -17,7 +17,7 @@ class Handbrake < Package
   })
 
   depends_on 'at_spi2_core' # R
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'expat' # R
   depends_on 'ffmpeg'
   depends_on 'freetype' # R

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -23,7 +23,7 @@ class Harfbuzz < Package
   })
 
   depends_on 'brotli' # R
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'chafa' # R
   depends_on 'expat' # R
   # depends_on 'fontconfig' # This pulls in freetype.

--- a/packages/icecream.rb
+++ b/packages/icecream.rb
@@ -27,7 +27,7 @@ class Icecream < Package
 
   depends_on 'acl' # R
   depends_on 'attr' # R
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'docbook2x' => :build
   depends_on 'gcc_lib' # R
   depends_on 'glibc' # R

--- a/packages/imagemagick7.rb
+++ b/packages/imagemagick7.rb
@@ -23,7 +23,7 @@ class Imagemagick7 < Package
     x86_64: 'ed0e5cdf87a45c8c01e501022e49d045df5bb6f0b3e74111f1131c00a418a350'
   })
 
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'flif' => :build
   depends_on 'fontconfig' => :build
   depends_on 'freeimage' => :build

--- a/packages/imlib2.rb
+++ b/packages/imlib2.rb
@@ -34,7 +34,7 @@ class Imlib2 < Package
   depends_on 'libxcb'
   depends_on 'libxext'
   depends_on 'protobuf_c'
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'expat' # R
   depends_on 'gcc_lib' # R
   depends_on 'gdk_pixbuf' # R

--- a/packages/irrlicht.rb
+++ b/packages/irrlicht.rb
@@ -28,7 +28,7 @@ class Irrlicht < Package
   depends_on 'libjpeg'
   depends_on 'libpng'
   depends_on 'dos2unix' => :build
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'gcc_lib' # R
   depends_on 'glibc' # R
   depends_on 'mesa' # R

--- a/packages/libarchive.rb
+++ b/packages/libarchive.rb
@@ -25,7 +25,7 @@ class Libarchive < Package
 
   depends_on 'acl' # R
   depends_on 'attr' # R
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'glibc' # R
   depends_on 'icu4c' # R
   depends_on 'libxml2' # R

--- a/packages/libewf.rb
+++ b/packages/libewf.rb
@@ -22,7 +22,7 @@ class Libewf < Package
      x86_64: '383f9c811cddf2c957588c265f7fb31075a4b3fce94e6c4d324f1fd1dd31fc13'
   })
 
-  depends_on 'bz2'
+  depends_on 'bzip2'
   depends_on 'py3_six'
   depends_on 'util_linux'
 

--- a/packages/libgsf.rb
+++ b/packages/libgsf.rb
@@ -24,7 +24,7 @@ class Libgsf < Package
 
   depends_on 'gdk_pixbuf'
   depends_on 'gtk_doc'
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'gcc_lib' # R
   depends_on 'glib' # R
   depends_on 'glibc' # R

--- a/packages/librsync.rb
+++ b/packages/librsync.rb
@@ -24,7 +24,7 @@ class Librsync < Package
   })
 
   depends_on 'cmake' => :build
-  depends_on 'bz2'
+  depends_on 'bzip2'
   depends_on 'perl'
   depends_on 'popt'
   depends_on 'zlibpkg'

--- a/packages/libzip.rb
+++ b/packages/libzip.rb
@@ -22,7 +22,7 @@ class Libzip < Package
       x86_64: 'dd16146327e8c8a91d0cdd5b1f2c776657bda33697c2a9e216e6804c115ac06c'
   })
 
-  depends_on 'bz2'
+  depends_on 'bzip2'
 
   def self.build
     Dir.mkdir 'builddir'

--- a/packages/links.rb
+++ b/packages/links.rb
@@ -23,7 +23,7 @@ class Links < Package
   })
 
   depends_on 'brotli' # R
-  depends_on 'bz2'
+  depends_on 'bzip2'
   depends_on 'glibc' # R
   depends_on 'libbsd' # R
   depends_on 'libjpeg'

--- a/packages/lnav.rb
+++ b/packages/lnav.rb
@@ -22,7 +22,7 @@ class Lnav < Autotools
   depends_on 'ncurses' # R
   depends_on 'readline' # R
   depends_on 'zlibpkg' # R
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'libcurl' # R
   depends_on 'libarchive' # R
   depends_on 'wireshark' # R

--- a/packages/ncdc.rb
+++ b/packages/ncdc.rb
@@ -24,7 +24,7 @@ class Ncdc < Package
 
   depends_on 'ncurses'
   depends_on 'zlibpkg'
-  depends_on 'bz2'
+  depends_on 'bzip2'
   depends_on 'sqlite'
   depends_on 'glib'
   depends_on 'gnutls'

--- a/packages/octave.rb
+++ b/packages/octave.rb
@@ -20,7 +20,7 @@ class Octave < Autotools
      x86_64: '7eeb3d979f6cf071419b4d5d981425bc284db80604d211897950a70934e9832f'
   })
 
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'curl' # R
   depends_on 'fontconfig' # R
   depends_on 'freetype' # R

--- a/packages/pcre2.rb
+++ b/packages/pcre2.rb
@@ -24,7 +24,7 @@ class Pcre2 < Package
 
   depends_on 'glibc' # R
   depends_on 'readline' # R
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'zlibpkg' # R
 
   def self.build

--- a/packages/php82.rb
+++ b/packages/php82.rb
@@ -23,7 +23,7 @@ class Php82 < Package
   depends_on 'aspell_en'
   depends_on 'aspell' # R
   depends_on 'brotli' # R
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'c_ares' # R
   depends_on 'curl' # R
   depends_on 'e2fsprogs' # R

--- a/packages/python2.rb
+++ b/packages/python2.rb
@@ -22,7 +22,7 @@ class Python2 < Package
      x86_64: 'b733a3aa7b34b2737cc1cc433e3fe2ddb99c014837268fde3b5697f79da2510c'
   })
 
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'expat' # R
   depends_on 'glibc' # R
   depends_on 'libdb' # R

--- a/packages/python3.rb
+++ b/packages/python3.rb
@@ -23,7 +23,7 @@ class Python3 < Package
   })
 
   depends_on 'autoconf_archive' => :build
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'expat' # R
   depends_on 'gcc_lib' # R
   depends_on 'gdbm' # R

--- a/packages/qemu.rb
+++ b/packages/qemu.rb
@@ -51,7 +51,7 @@ class Qemu < Package
   depends_on 'pulseaudio' # R
   depends_on 'sdl2_image' # R
   depends_on 'snappy' # R
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'gcc_lib' # R
   depends_on 'glibc' # R
   depends_on 'gnutls' # R

--- a/packages/r.rb
+++ b/packages/r.rb
@@ -22,7 +22,7 @@ class R < Package
      x86_64: '2a5cfece8a24b8bad17ade73b2751cf23c1c9d5e1604addce436e45740400354'
   })
 
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'gcc_lib' # R
   depends_on 'glibc' # R
   depends_on 'glib' # R

--- a/packages/shotcut.rb
+++ b/packages/shotcut.rb
@@ -18,7 +18,7 @@ class Shotcut < Package
 
   depends_on 'acl' # R
   depends_on 'alsa_lib' # R
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'dav1d' # R
   depends_on 'dbus' # R
   depends_on 'elfutils' # R

--- a/packages/tcpflow.rb
+++ b/packages/tcpflow.rb
@@ -21,7 +21,7 @@ class Tcpflow < Package
   })
 
   depends_on 'boost' => :build
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'cairo' => :build
   depends_on 'cairo' # R
   depends_on 'expat' # R

--- a/packages/tesseract.rb
+++ b/packages/tesseract.rb
@@ -24,7 +24,7 @@ class Tesseract < Package
   depends_on 'asciidoc' => :build
   depends_on 'attr' => :build
   depends_on 'brotli' => :build
-  depends_on 'bz2' => :build
+  depends_on 'bzip2' => :build
   depends_on 'cairo' => :build
   depends_on 'c_ares' => :build
   depends_on 'curl' # R

--- a/packages/util_linux.rb
+++ b/packages/util_linux.rb
@@ -22,7 +22,7 @@ class Util_linux < Package
      x86_64: '3b6d221adae7b6533e3f586e28ecabc4d7fee6472e220b190a87b8c623961d75'
   })
 
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'eudev' if ARCH == 'x86_64' # (for libudev.h)
   depends_on 'filecmd' # R
   depends_on 'glibc' # R

--- a/packages/vscodium.rb
+++ b/packages/vscodium.rb
@@ -1,6 +1,6 @@
 require 'package'
 
-class Codium < Package
+class Vscodium < Package
   description 'VSCodium is Open Source Software Binaries of VSCode with a community-driven default configuration.'
   homepage 'https://vscodium.com/'
   version '1.83.1.23285'

--- a/packages/zip.rb
+++ b/packages/zip.rb
@@ -22,7 +22,7 @@ class Zip < Package
      x86_64: 'c78a63d3630f3dbf637127e1a5a08942fd1da213cde296d33e77823e8547a56c'
   })
 
-  depends_on 'bz2' # R
+  depends_on 'bzip2' # R
   depends_on 'glibc' # R
 
   # adapted from the homebrew recipe as seen at: https://github.com/Homebrew/homebrew-core/blob/master/Formula/zip.rb

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -1010,7 +1010,7 @@ url: http://codelobsteride.com/#download
 activity: medium
 ---
 kind: url
-name: codium
+name: vscodium
 url: https://github.com/VSCodium/vscodium/releases
 activity: high
 ---

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -700,7 +700,7 @@ url: https://launchpad.net/byobu/trunk
 activity: medium
 ---
 kind: url
-name: bz2
+name: bzip2
 url: http://www.bzip.org
 activity: none
 ---

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -705,7 +705,7 @@ url: http://www.bzip.org
 activity: none
 ---
 kind: url
-name: bz3
+name: bzip3
 url: https://github.com/kspalaiologos/bzip3/releases
 activity: medium
 ---


### PR DESCRIPTION
Renaming a few more of our packages to be more consistent with their upstream naming and how the majority of other distros name them, as well as to have them easily detectable by Anitya.

Tested and working on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=renesmbcd crew update
```
