### PR TITLE
Fix const.rb path extra forward slash

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -112,7 +112,7 @@ CREW_LOCAL_REPO_ROOT = repo_root
 
 # The following is used in fixup.rb to determine if crew update needs to
 # be run again.
-CREW_CONST_GIT_COMMIT = `git log -n1 --oneline #{CREW_LIB_PATH}/lib/const.rb`.chomp.split.first
+CREW_CONST_GIT_COMMIT = `git log -n1 --oneline #{CREW_LIB_PATH}lib/const.rb`.chomp.split.first
 
 CREW_LOCAL_REPO_BASE = CREW_LOCAL_REPO_ROOT.empty? ? '' : File.basename(CREW_LOCAL_REPO_ROOT)
 CREW_LOCAL_MANIFEST_PATH = if ENV['CREW_LOCAL_MANIFEST_PATH'].to_s.empty?

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
-CREW_VERSION = '1.37.6'
+CREW_VERSION = '1.37.7'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -135,7 +135,7 @@ end
 # Handle case of const.rb not yet defining CREW_CONST_GIT_COMMIT.
 CREW_CONST_GIT_COMMIT = '0000' unless defined?(CREW_CONST_GIT_COMMIT)
 
-@new_const_git_commit = `git log -n1 --oneline #{CREW_LIB_PATH}/lib/const.rb`.chomp.split.first
+@new_const_git_commit = `git log -n1 --oneline #{CREW_LIB_PATH}lib/const.rb`.chomp.split.first
 
 unless @new_const_git_commit.to_s == CREW_CONST_GIT_COMMIT.to_s
   puts 'Restarting crew update since there is an updated crew version.'.lightcyan

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -93,7 +93,7 @@ pkg_update_arr.each do |pkg|
       raise StandardError, 'Failed to replace pkg name...'.lightred unless @device[:installed_packages].any? { |elem| elem[:name] == pkg[:pkg_rename] }
       # Ok to write working device.json
       File.write "#{CREW_CONFIG_PATH}/device.json", JSON.pretty_generate(JSON.parse(@device.to_json))
-      puts "#{pkg[:pkg_name].capitalize} renamed to #{pkg[:pkg_rename].capitalize}".lightgreen
+      puts "#{pkg[:pkg_name].capitalize} renamed to #{pkg[:pkg_rename].capitalize}".lightgreen if @opt_verbose
     rescue StandardError => e
       puts 'Restoring old filelist, directorylist, and device.json...'.lightred
       FileUtils.mv new_filelist, old_filelist

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -93,7 +93,7 @@ pkg_update_arr.each do |pkg|
       raise StandardError, 'Failed to replace pkg name...'.lightred unless @device[:installed_packages].any? { |elem| elem[:name] == pkg[:pkg_rename] }
       # Ok to write working device.json
       File.write "#{CREW_CONFIG_PATH}/device.json", JSON.pretty_generate(JSON.parse(@device.to_json))
-      puts "#{pkg[:pkg_name].capitalize} renamed to #{pkg[:pkg_rename].capitalize}".lightgreen if @opt_verbose
+      puts "#{pkg[:pkg_name].capitalize} renamed to #{pkg[:pkg_rename].capitalize}".lightgreen
     rescue StandardError => e
       puts 'Restoring old filelist, directorylist, and device.json...'.lightred
       FileUtils.mv new_filelist, old_filelist


### PR DESCRIPTION


Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=const_trailing_slash crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
