### PR TITLE
Add pre_configure_options to buildsystems/autotools

### DIFF
--- a/lib/buildsystems/autotools.rb
+++ b/lib/buildsystems/autotools.rb
@@ -2,10 +2,10 @@ require 'fileutils'
 require 'package'
 
 class Autotools < Package
-  property :configure_options
+  property :pre_configure_options, :configure_options
 
   def self.build
-    puts "Additional configure_options being used: #{@configure_options.nil? || @configure_options.empty? ? '<no configure_options>' : @configure_options}".orange
+    puts "Additional configure_options being used: #{@pre_configure_options.nil? || @pre_configure_options.empty? ? '<no pre_configure_options>' : @pre_configure_options} #{@configure_options.nil? || @configure_options.empty? ? '<no configure_options>' : @configure_options}".orange
     # Run autoreconf if necessary
     unless File.executable? './configure'
       if File.executable? './autogen.sh'
@@ -23,7 +23,7 @@ class Autotools < Package
       system 'filefix'
     end
     @mold_linker_prefix_cmd = CREW_LINKER == 'mold' ? 'mold -run ' : ''
-    system "#{@mold_linker_prefix_cmd}./configure #{CREW_OPTIONS} #{@configure_options}"
+    system "#{@pre_configure_options} #{@mold_linker_prefix_cmd}./configure #{CREW_OPTIONS} #{@configure_options}"
     system 'make'
   end
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
-CREW_VERSION = '1.37.9'
+CREW_VERSION = '1.38.0'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
Allows for adding env variables and such to the build environment for configure, e.g., 
`pre_configure_options "CXXFLAGS='#{CREW_ENV_OPTIONS_HASH['CXXFLAGS']} -I#{CREW_PREFIX}/share/gnulib/lib'"`

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/<Please_enter_the_name_of_your_repo>/chromebrew.git CREW_BRANCH=<Please_enter_the_branch_name_for_this_PR> crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
