### PR TITLE
buildsystems/autotools: only run configure if Makefile does not exist

### DIFF
--- a/lib/buildsystems/autotools.rb
+++ b/lib/buildsystems/autotools.rb
@@ -5,7 +5,7 @@ class Autotools < Package
   property :pre_configure_options, :configure_options
 
   def self.build
-    unless File.file?('Makefile')
+    unless File.file?('Makefile') && CREW_CACHE_BUILD
       puts "Additional configure_options being used: #{@pre_configure_options.nil? || @pre_configure_options.empty? ? '<no pre_configure_options>' : @pre_configure_options} #{@configure_options.nil? || @configure_options.empty? ? '<no configure_options>' : @configure_options}".orange
       # Run autoreconf if necessary
       unless File.executable? './configure'

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
-CREW_VERSION = '1.38.0'
+CREW_VERSION = '1.38.1'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
- When restarting a cached build, it is useful not to run configure again if Makefile already exists, for instance when working with adjusting the install section during build testing.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=cached_autotools crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
