### PR TITLE
Update azure_cli package

### DIFF
--- a/lib/buildsystems/pip.rb
+++ b/lib/buildsystems/pip.rb
@@ -3,6 +3,8 @@ Encoding.default_internal = Encoding::UTF_8
 require 'package'
 
 class Pip < Package
+  property :pip_install_extras
+
   def self.install
     puts 'Checking for pip updates'.orange if @opt_verbose
     system 'python3 -s -m pip install -U pip', exception: false
@@ -16,5 +18,6 @@ class Pip < Package
       @destpath = "#{CREW_DEST_DIR.chomp('/')}#{@pip_path}"
       FileUtils.install @pip_path, @destpath
     end
+    eval @pip_install_extras
   end
 end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
-CREW_VERSION = '1.38.1'
+CREW_VERSION = '1.38.2'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/packages/az.rb
+++ b/packages/az.rb
@@ -1,7 +1,7 @@
 require 'package'
 require_relative 'py3_azure_cli'
 
-class Azure_cli < Package
+class Az < Package
   description Py3_azure_cli.description.to_s
   homepage Py3_azure_cli.homepage.to_s
   version Py3_azure_cli.version.to_s

--- a/packages/py3_azure_cli.rb
+++ b/packages/py3_azure_cli.rb
@@ -1,0 +1,28 @@
+require 'buildsystems/pip'
+
+class Py3_azure_cli < Pip
+  description 'Next generation multi-platform command line experience for Azure.'
+  homepage 'https://pypi.org/project/azure-cli/'
+  @_ver = '2.53.1'
+  version "#{@_ver}-py3.12"
+  license 'MIT'
+  compatibility 'all'
+  source_url 'SKIP'
+
+  depends_on 'python3'
+
+  no_compile_needed
+
+  pip_install_extras <<~EOF
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/bash.d/"
+    @azureenv = <<~AZUREEOF
+      # Microsoft Azure CLI bash completion
+      source #{CREW_PREFIX}/share/azure-cli/az.completion
+    AZUREEOF
+    File.write("#{CREW_DEST_PREFIX}/etc/bash.d/az", @azureenv)
+  EOF
+
+  def self.postinstall
+    puts "\nType 'source ~/.bashrc' to complete the installation.\n".lightblue
+  end
+end


### PR DESCRIPTION
- Add pip_install_extras property to buildsystems/pip
- Add py3_azure_cli package
- Add az fake package
- Convert azure_cli to a fake package

Tested and working.  We can probably include this logic in other buildsystems as well.