### PR TITLE
Add py3_ruff, modify pip logic to exclude extra packages

### DIFF
--- a/lib/buildsystems/pip.rb
+++ b/lib/buildsystems/pip.rb
@@ -17,6 +17,9 @@ class Pip < Package
     @py_pkg_versioned_pypi = `curl -Ls https://pypi.org/pypi/#{@py_pkg}/#{@py_pkg_version}/json`.chomp
     @py_pkg_versioned_pypi_hash = JSON.parse(@py_pkg_versioned_pypi)
     @py_pkg_deps = @py_pkg_versioned_pypi_hash['info']['requires_dist']
+    # We don't want extra packages listed in the dependency list, since
+    # those are optional.
+    @py_pkg_deps.reject! {|x| x.include?('extra ==')}
     unless @py_pkg_deps.to_s.empty?
       puts "Installing #{@py_pkg} python dependencies with pip...".orange
       @py_pkg_deps.each do |pip_dep|

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
-CREW_VERSION = '1.38.4'
+CREW_VERSION = '1.38.5'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/manifest/armv7l/p/py3_ruff.filelist
+++ b/manifest/armv7l/p/py3_ruff.filelist
@@ -1,0 +1,11 @@
+/usr/local/bin/ruff
+/usr/local/lib/python3.12/site-packages/ruff-0.1.3.dist-info/INSTALLER
+/usr/local/lib/python3.12/site-packages/ruff-0.1.3.dist-info/license_files/LICENSE
+/usr/local/lib/python3.12/site-packages/ruff-0.1.3.dist-info/METADATA
+/usr/local/lib/python3.12/site-packages/ruff-0.1.3.dist-info/RECORD
+/usr/local/lib/python3.12/site-packages/ruff-0.1.3.dist-info/REQUESTED
+/usr/local/lib/python3.12/site-packages/ruff-0.1.3.dist-info/WHEEL
+/usr/local/lib/python3.12/site-packages/ruff/__init__.py
+/usr/local/lib/python3.12/site-packages/ruff/__main__.py
+/usr/local/lib/python3.12/site-packages/ruff/__pycache__/__init__.cpython-312.pyc
+/usr/local/lib/python3.12/site-packages/ruff/__pycache__/__main__.cpython-312.pyc

--- a/manifest/i686/p/py3_ruff.filelist
+++ b/manifest/i686/p/py3_ruff.filelist
@@ -1,0 +1,11 @@
+/usr/local/bin/ruff
+/usr/local/lib/python3.12/site-packages/ruff-0.1.3.dist-info/INSTALLER
+/usr/local/lib/python3.12/site-packages/ruff-0.1.3.dist-info/license_files/LICENSE
+/usr/local/lib/python3.12/site-packages/ruff-0.1.3.dist-info/METADATA
+/usr/local/lib/python3.12/site-packages/ruff-0.1.3.dist-info/RECORD
+/usr/local/lib/python3.12/site-packages/ruff-0.1.3.dist-info/REQUESTED
+/usr/local/lib/python3.12/site-packages/ruff-0.1.3.dist-info/WHEEL
+/usr/local/lib/python3.12/site-packages/ruff/__init__.py
+/usr/local/lib/python3.12/site-packages/ruff/__main__.py
+/usr/local/lib/python3.12/site-packages/ruff/__pycache__/__init__.cpython-312.pyc
+/usr/local/lib/python3.12/site-packages/ruff/__pycache__/__main__.cpython-312.pyc

--- a/manifest/x86_64/p/py3_cffi.filelist
+++ b/manifest/x86_64/p/py3_cffi.filelist
@@ -3,7 +3,6 @@
 /usr/local/lib64/python3.12/site-packages/cffi-1.16.0.dist-info/LICENSE
 /usr/local/lib64/python3.12/site-packages/cffi-1.16.0.dist-info/METADATA
 /usr/local/lib64/python3.12/site-packages/cffi-1.16.0.dist-info/RECORD
-/usr/local/lib64/python3.12/site-packages/cffi-1.16.0.dist-info/REQUESTED
 /usr/local/lib64/python3.12/site-packages/cffi-1.16.0.dist-info/top_level.txt
 /usr/local/lib64/python3.12/site-packages/cffi-1.16.0.dist-info/WHEEL
 /usr/local/lib64/python3.12/site-packages/cffi/api.py

--- a/manifest/x86_64/p/py3_ruff.filelist
+++ b/manifest/x86_64/p/py3_ruff.filelist
@@ -1,0 +1,11 @@
+/usr/local/bin/ruff
+/usr/local/lib64/python3.12/site-packages/ruff-0.1.3.dist-info/INSTALLER
+/usr/local/lib64/python3.12/site-packages/ruff-0.1.3.dist-info/license_files/LICENSE
+/usr/local/lib64/python3.12/site-packages/ruff-0.1.3.dist-info/METADATA
+/usr/local/lib64/python3.12/site-packages/ruff-0.1.3.dist-info/RECORD
+/usr/local/lib64/python3.12/site-packages/ruff-0.1.3.dist-info/REQUESTED
+/usr/local/lib64/python3.12/site-packages/ruff-0.1.3.dist-info/WHEEL
+/usr/local/lib64/python3.12/site-packages/ruff/__init__.py
+/usr/local/lib64/python3.12/site-packages/ruff/__main__.py
+/usr/local/lib64/python3.12/site-packages/ruff/__pycache__/__init__.cpython-312.pyc
+/usr/local/lib64/python3.12/site-packages/ruff/__pycache__/__main__.cpython-312.pyc

--- a/packages/py3_cffi.rb
+++ b/packages/py3_cffi.rb
@@ -3,11 +3,24 @@ require 'buildsystems/pip'
 class Py3_cffi < Pip
   description 'C Foreign Function Interface for Python calling C code.'
   homepage 'https://cffi.readthedocs.io/'
-  @_ver = '1.15.1'
+  @_ver = '1.16.0'
   version "#{@_ver}-py3.12"
   license 'MIT'
   compatibility 'all'
   source_url 'SKIP'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_cffi/1.16.0-py3.12_armv7l/py3_cffi-1.16.0-py3.12-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_cffi/1.16.0-py3.12_armv7l/py3_cffi-1.16.0-py3.12-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_cffi/1.16.0-py3.12_i686/py3_cffi-1.16.0-py3.12-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_cffi/1.16.0-py3.12_x86_64/py3_cffi-1.16.0-py3.12-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: 'be7b4b4dd95c644bffc6fc6b795996d48b050242f75e0bd6fe8d7b821e6eca71',
+     armv7l: 'be7b4b4dd95c644bffc6fc6b795996d48b050242f75e0bd6fe8d7b821e6eca71',
+       i686: 'a63cd7198f632e81164702064e4dccdaa0ad2512127f54ecdf5407402c80d40d',
+     x86_64: '735cad77a2e874ceeaabed1318300305dc5622f29907afb5a46041d963c981d5'
+  })
 
   depends_on 'gcc_lib' # R
   depends_on 'glibc' # R

--- a/packages/py3_codespell.rb
+++ b/packages/py3_codespell.rb
@@ -3,13 +3,14 @@ require 'buildsystems/pip'
 class Py3_codespell < Pip
   description 'Fix common misspellings in text files.'
   homepage 'https://github.com/codespell-project/codespell'
-  @_ver = '2.2.2'
+  @_ver = '2.2.6'
   version "#{@_ver}-py3.12"
   license 'GPL-2.0'
   compatibility 'all'
   source_url 'SKIP'
 
   depends_on 'python3'
+  depends_on 'py3_ruff' # R
 
   no_compile_needed
 

--- a/packages/py3_codespell.rb
+++ b/packages/py3_codespell.rb
@@ -10,7 +10,6 @@ class Py3_codespell < Pip
   source_url 'SKIP'
 
   depends_on 'python3'
-  depends_on 'py3_ruff' # R
 
   no_compile_needed
 

--- a/packages/py3_ruff.rb
+++ b/packages/py3_ruff.rb
@@ -1,0 +1,29 @@
+require 'buildsystems/pip'
+
+class Py3_ruff < Pip
+  description 'An extremely fast Python linter, written in Rust.'
+  homepage 'https://docs.astral.sh/ruff'
+  @_ver = '0.1.3'
+  version "#{@_ver}-py3.12"
+  license 'GPL-2.0'
+  compatibility 'all'
+  source_url 'SKIP'
+
+  binary_url({
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_ruff/0.1.3-py3.12_armv7l/py3_ruff-0.1.3-py3.12-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_ruff/0.1.3-py3.12_armv7l/py3_ruff-0.1.3-py3.12-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_ruff/0.1.3-py3.12_i686/py3_ruff-0.1.3-py3.12-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/py3_ruff/0.1.3-py3.12_x86_64/py3_ruff-0.1.3-py3.12-chromeos-x86_64.tar.zst'
+  })
+  binary_sha256({
+    aarch64: '2f0185feab87e3f37d36029ea1ea85dc003220406962929b3d60de7f0c36d5cc',
+     armv7l: '2f0185feab87e3f37d36029ea1ea85dc003220406962929b3d60de7f0c36d5cc',
+       i686: '1ca0f02816822fd9cb8bed5a7cf1de3278d754475869e12a057197fb844b65cc',
+     x86_64: '157ed52235826c56908cec1f699a1628322aba3d2e94366921a283e45937804e'
+  })
+
+  depends_on 'gcc_lib' # R
+  depends_on 'glibc' # R
+  depends_on 'python3'
+  depends_on 'rust' => :build
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -7066,6 +7066,11 @@ url: https://github.com/pypa/pip/releases
 activity: medium
 ---
 kind: url
+name: py3_ruff
+url: https://docs.astral.sh/ruff
+activity: medium
+---
+kind: url
 name: py3_setuptools
 url: https://github.com/pypa/setuptools/releases
 activity: medium


### PR DESCRIPTION
- Add `py3_cffi` build, since that takes forever on arm. (the filelists for this have mostly not changed.)
- removing the extra packages dramatically speeds up the py3 installs.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=py3_codespell crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
