### PR TITLE
pip deps: handle nil case

### DIFF
--- a/lib/buildsystems/pip.rb
+++ b/lib/buildsystems/pip.rb
@@ -19,7 +19,7 @@ class Pip < Package
     @py_pkg_deps = @py_pkg_versioned_pypi_hash['info']['requires_dist']
     # We don't want extra packages listed in the dependency list, since
     # those are optional.
-    @py_pkg_deps.reject! {|x| x.include?('extra ==')}
+    @py_pkg_deps.reject! {|x| x.include?('extra ==')} unless @py_pkg_deps.to_s.empty?
     unless @py_pkg_deps.to_s.empty?
       puts "Installing #{@py_pkg} python dependencies with pip...".orange
       @py_pkg_deps.each do |pip_dep|

--- a/lib/buildsystems/pip.rb
+++ b/lib/buildsystems/pip.rb
@@ -29,7 +29,7 @@ class Pip < Package
       end
     end
     puts "Installing #{@py_pkg} python module. This may take a while...".lightblue
-    system "MAKEFLAGS=-j#{CREW_NPROC} python -s -m pip install -U #{@py_pkg}", exception: false
+    system "MAKEFLAGS=-j#{CREW_NPROC} python -s -m pip install -U #{@py_pkg} | grep -v 'Requirement already satisfied'", exception: false
     @pip_files = `python3 -s -m pip show -f #{@py_pkg}`.chomp
     @pip_files_base = @pip_files[/(?<=Location: ).*/, 0].concat('/')
     @pip_files_lines = @pip_files[/(?<=Files:\n)[\W|\w]*/, 0].split

--- a/lib/buildsystems/pip.rb
+++ b/lib/buildsystems/pip.rb
@@ -24,12 +24,12 @@ class Pip < Package
       puts "Installing #{@py_pkg} python dependencies with pip...".orange
       @py_pkg_deps.each do |pip_dep|
         @cleaned_py_dep = pip_dep[/[^;]+/]
-        puts "  Installing: #{@cleaned_py_dep}".gray
+        puts "——Installing: #{@cleaned_py_dep}".gray
         system "python3 -s -m pip install -U #{@cleaned_py_dep} | grep -v 'Requirement already satisfied'", exception: false
       end
     end
     puts "Installing #{@py_pkg} python module. This may take a while...".lightblue
-    system "MAKEFLAGS=-j#{CREW_NPROC} python -s -m pip install #{@py_pkg}", exception: false
+    system "MAKEFLAGS=-j#{CREW_NPROC} python -s -m pip install -U #{@py_pkg}", exception: false
     @pip_files = `python3 -s -m pip show -f #{@py_pkg}`.chomp
     @pip_files_base = @pip_files[/(?<=Location: ).*/, 0].concat('/')
     @pip_files_lines = @pip_files[/(?<=Files:\n)[\W|\w]*/, 0].split

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
-CREW_VERSION = '1.38.5'
+CREW_VERSION = '1.38.6'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
- installer is breaking on nil pip deps case.
- Also use em dash in Installing dialog, and further cleanup installs visually.
 
Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=reject crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
