### PR TITLE
lib/package: Remove `reload_constants` and its usage

### DIFF
--- a/lib/package_helpers.rb
+++ b/lib/package_helpers.rb
@@ -45,10 +45,3 @@ def boolean_property(*boolean_properties)
     end
   end
 end
-
-def reload_constants
-  warn_level = $VERBOSE
-  $VERBOSE = nil
-  load "#{CREW_LIB_PATH}lib/const.rb"
-  $VERBOSE = warn_level
-end

--- a/packages/minecraft.rb
+++ b/packages/minecraft.rb
@@ -18,9 +18,9 @@ class Minecraft < Package
   depends_on 'libsecret'
   depends_on 'sommelier'
 
+  no_fhs
+
   def self.install
-    ENV['CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY'] = '1'
-    reload_constants
     FileUtils.mkdir_p CREW_DEST_PREFIX.to_s
     FileUtils.cp_r '.', "#{CREW_DEST_PREFIX}/"
     FileUtils.mv "#{CREW_DEST_PREFIX}/bin/minecraft-launcher", "#{CREW_DEST_PREFIX}/bin/minecraft-launcher.elf"

--- a/packages/php71.rb
+++ b/packages/php71.rb
@@ -35,6 +35,8 @@ class Php71 < Package
   depends_on 'tidy'
   depends_on 'unixodbc'
 
+  no_fhs
+
   def self.preflight
     phpver = `php -v 2> /dev/null | head -1 | cut -d' ' -f2`.chomp
     abort "PHP version #{phpver} already installed.".lightgreen if ARGV[0] != 'reinstall' && @_ver != phpver && !phpver.empty?
@@ -108,13 +110,7 @@ class Php71 < Package
     system 'make'
   end
 
-  def self.check
-    # system 'make', 'test'
-  end
-
   def self.install
-    ENV['CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY'] = '1'
-    reload_constants
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/log"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/tmp/run"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/init.d"

--- a/packages/php72.rb
+++ b/packages/php72.rb
@@ -36,6 +36,8 @@ class Php72 < Package
   depends_on 'tidy'
   depends_on 'unixodbc'
 
+  no_fhs
+
   def self.preflight
     phpver = `php -v 2> /dev/null | head -1 | cut -d' ' -f2`.chomp
     abort "PHP version #{phpver} already installed.".lightgreen if ARGV[0] != 'reinstall' && @_ver != phpver && !phpver.empty?
@@ -104,13 +106,7 @@ class Php72 < Package
     system 'make'
   end
 
-  def self.check
-    # system 'make', 'test'
-  end
-
   def self.install
-    ENV['CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY'] = '1'
-    reload_constants
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/log"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/tmp/run"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/init.d"

--- a/packages/php73.rb
+++ b/packages/php73.rb
@@ -36,6 +36,8 @@ class Php73 < Package
   depends_on 'unixodbc'
   depends_on 'py3_pygments'
 
+  no_fhs
+
   def self.preflight
     phpver = `php -v 2> /dev/null | head -1 | cut -d' ' -f2`.chomp
     abort "PHP version #{phpver} already installed.".lightgreen if ARGV[0] != 'reinstall' && @_ver != phpver && !phpver.empty?
@@ -107,13 +109,7 @@ class Php73 < Package
     system 'make'
   end
 
-  def self.check
-    # system 'make', 'test'
-  end
-
   def self.install
-    ENV['CREW_FHS_NONCOMPLIANCE_ONLY_ADVISORY'] = '1'
-    reload_constants
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/log"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/tmp/run"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/init.d"


### PR DESCRIPTION
Compared to `reload_constants`, the `no_*` package flags did the job nicely, so let's remove it for simplicity :)