### PR TITLE
Glib_networking 2.76.0 => 2.78.0

### DIFF
--- a/packages/glib_networking.rb
+++ b/packages/glib_networking.rb
@@ -1,25 +1,23 @@
-require 'package'
+require 'buildsystems/meson'
 
-class Glib_networking < Package
+class Glib_networking < Meson
   description 'Network extensions for GLib'
   homepage 'https://github.com/GNOME/glib-networking'
-  version '2.76.0'
+  version '2.78.0'
   license 'LGPL-2.1+'
-  compatibility 'all'
+  compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.gnome.org/GNOME/glib-networking.git'
   git_hashtag version
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib_networking/2.76.0_armv7l/glib_networking-2.76.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib_networking/2.76.0_armv7l/glib_networking-2.76.0-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib_networking/2.76.0_i686/glib_networking-2.76.0-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib_networking/2.76.0_x86_64/glib_networking-2.76.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib_networking/2.78.0_armv7l/glib_networking-2.78.0-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib_networking/2.78.0_armv7l/glib_networking-2.78.0-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glib_networking/2.78.0_x86_64/glib_networking-2.78.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '6aae918087e530ebfa96240e4fb62fbc6bb4bea47abd2729457d31557d2a9808',
-     armv7l: '6aae918087e530ebfa96240e4fb62fbc6bb4bea47abd2729457d31557d2a9808',
-       i686: '944bda7a386f5851ad861ed06cb54b0a3c7fc68e0af505f930a2bf801a359884',
-     x86_64: 'eba4a6f591b61f4258112e5a9a8c5f0c90019e0749398890ed33db281160ad1b'
+    aarch64: '0d2722140f2f0e71b7abac4acac2925ad798650f3307c2545a4cc4bfe21e599f',
+     armv7l: '0d2722140f2f0e71b7abac4acac2925ad798650f3307c2545a4cc4bfe21e599f',
+     x86_64: '7e778510957044f2fc5db7283cd171514983134a5bc1fe11337c77e7f5ffe108'
   })
 
   depends_on 'gcc_lib' # R
@@ -28,15 +26,4 @@ class Glib_networking < Package
   depends_on 'gnutls' # R
   depends_on 'gsettings_desktop_schemas'
   depends_on 'libproxy'
-
-  def self.build
-    system "mold -run meson setup #{CREW_MESON_OPTIONS} \
-      builddir"
-    system 'meson configure --no-pager builddir'
-    system "#{CREW_NINJA} -C builddir"
-  end
-
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
-  end
 end


### PR DESCRIPTION
Fixes /usr/local/lib/libproxy.so.1: version `LIBPROXY_0.4.16' not found (required by /usr/local/lib/gio/modules/libgiolibproxy.so)
Failed to load module: /usr/local/lib/gio/modules/libgiolibproxy.so

Unable to build for i686 since libproxy is a dependency and not compatible.