### PR TITLE
Add exit code to crew.

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -128,16 +128,32 @@ class ExitMessage
   @messages = []
 
   def self.add(msg, print_last: false)
-    # add an option to allow important messages (like sommelier) to print at the bottom
+    # Use the print_last option to allow important messages (like sommelier) to print at the bottom
+    # Usage:
+    # ExitMessage.add 'Last Message', print_last: true
     @messages << [msg.lightcyan, print_last]
   end
 
-# print all messages
-  def self.print
-    # &:last represent to print_last
-    puts @messages.reject(&:last).map(&:first)
-    puts @messages.select(&:last).map(&:first)
+  def self.handle_messages(msg)
+    puts msg
+    # Delete printed message from array & only print each message once.
+    @messages.reject! {|x| x.include? msg }
   end
+
+  def self.print
+    # print first non-print_last messages, then print_last messages.
+    # &:last represent to print_last
+    handle_messages(@messages.reject(&:last).map(&:first).first) until @messages.reject(&:last).map(&:first).empty?
+    handle_messages(@messages.select(&:last).map(&:first).first) until @messages.select(&:last).map(&:first).empty?
+  end
+end
+
+at_exit do
+  unless $ERROR_INFO.nil? || ($ERROR_INFO.is_a?(SystemExit) && $ERROR_INFO.success?)
+    code = $ERROR_INFO.is_a?(SystemExit) ? $ERROR_INFO.status : 1
+  end
+  # Print exit messages.
+  ExitMessage.print
 end
 
 def load_json
@@ -2008,21 +2024,15 @@ def is_command(name) = !!!name[/^[-<]/]
 Signal.trap('INT') do
   if CREW_CACHE_FAILED_BUILD && CREW_CACHE_ENABLED && @pkg.in_build
     cache_build
-    abort 'The build was interrupted. The build directory was cached.'.lightred
+    ExitMessage.add 'The build was interrupted. The build directory was cached.'.lightred
+    exit 1
   end
-  abort 'Interrupted.'.lightred
+  ExitMessage.add 'Interrupted!'.lightred
+  exit 1
 end
 
 load_json
 command_name = args.select { |k, v| v && is_command(k) }.keys[0]
 send("#{command_name}_command", args)
 
-at_exit do
-  # Print exit messages.
-  ExitMessage.add 'Crew is exiting.' if @opt_verbose
-  ExitMessage.print
-  unless $ERROR_INFO.nil? || ($ERROR_INFO.is_a?(SystemExit) && $ERROR_INFO.success?)
-    code = $ERROR_INFO.is_a?(SystemExit) ? $ERROR_INFO.status : 1
-    print "failure with code #{code}"
-  end
-end
+ExitMessage.add 'Crew is exiting.' if @opt_verbose

--- a/bin/crew
+++ b/bin/crew
@@ -132,7 +132,8 @@ class ExitMessage
     @messages << [msg.lightcyan, print_last]
   end
 
-  def self.print # print all messages
+# print all messages
+  def self.print
     # &:last represent to print_last
     puts @messages.reject(&:last).map(&:first)
     puts @messages.select(&:last).map(&:first)
@@ -2016,6 +2017,12 @@ load_json
 command_name = args.select { |k, v| v && is_command(k) }.keys[0]
 send("#{command_name}_command", args)
 
-# Print exit messages.
-ExitMessage.add 'Crew is exiting.' if @opt_verbose
-ExitMessage.print
+at_exit do
+  # Print exit messages.
+  ExitMessage.add 'Crew is exiting.' if @opt_verbose
+  ExitMessage.print
+  unless $ERROR_INFO.nil? || ($ERROR_INFO.is_a?(SystemExit) && $ERROR_INFO.success?)
+    code = $ERROR_INFO.is_a?(SystemExit) ? $ERROR_INFO.status : 1
+    print "failure with code #{code}"
+  end
+end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
-CREW_VERSION = '1.38.6'
+CREW_VERSION = '1.38.7'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
- This tries to make sure there is a non-zero exit code for `crew` when something goes wrong so we can act upon a failure using the `at_exit` function, in case using something like `abort` doesn't automatically create an `exit 1` condition. (Feel free to help improve this!)
- This was adapted from https://stackoverflow.com/a/1154665/21935208
- Modifies the ExitMessage function to only print messages once.
- Modifies `Signal.trap('INT')` to use ExitMessage.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=crew_exit_code crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
