### PR TITLE
Use same ExitMessage for all packages asking to source ~/.bashrc

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1058,12 +1058,12 @@ def pre_install(dest_dir)
 end
 
 def post_install
-  if @pkg.reload_source?
-    ExitMessage.add <<~SOURCE_BASHRC_EOT.lightblue
+  if @pkg.print_reload_bashrc?
+    ExitMessage.add <<~PRINT_RELOAD_BASHRC_EOT.lightblue
 
       To finish the installation, please execute the following:
       source ~/.bashrc
-    SOURCE_BASHRC_EOT
+    PRINT_RELOAD_BASHRC_EOT
   end
   # return unless the postinstall function was defined by the package recipe
   return unless @pkg.method(:postinstall).source_location[0].include?("#{@pkg.name}.rb")

--- a/bin/crew
+++ b/bin/crew
@@ -1058,6 +1058,12 @@ def pre_install(dest_dir)
 end
 
 def post_install
+  if @pkg.reload_source?
+    ExitMessage.add <<~SOURCE_BASHRC_EOT.lightblue
+      To finish the installation, please execute the following:
+      source ~/.bashrc
+    SOURCE_BASHRC_EOT
+  end
   # return unless the postinstall function was defined by the package recipe
   return unless @pkg.method(:postinstall).source_location[0].include?("#{@pkg.name}.rb")
 

--- a/bin/crew
+++ b/bin/crew
@@ -465,6 +465,8 @@ def help(pkgName = nil)
         puts "Use the 'no_zstd' property for the alternate xz compression algorithm."
       when 'patchelf'
         puts "Use the 'patchelf' property for patchelf execution."
+      when 'print_source_bashrc'
+        puts "Prints 'source ~/.bashrc' message at end of install."
       when 'run_tests'
         puts "Use the 'run_tests' property to execute make check tests."
       else
@@ -1058,12 +1060,12 @@ def pre_install(dest_dir)
 end
 
 def post_install
-  if @pkg.print_reload_bashrc?
-    ExitMessage.add <<~PRINT_RELOAD_BASHRC_EOT.lightblue
+  if @pkg.print_source_bashrc?
+    ExitMessage.add <<~PRINT_SOURCE_BASHRC_EOT.lightblue
 
       To finish the installation, please execute the following:
       source ~/.bashrc
-    PRINT_RELOAD_BASHRC_EOT
+    PRINT_SOURCE_BASHRC_EOT
   end
   # return unless the postinstall function was defined by the package recipe
   return unless @pkg.method(:postinstall).source_location[0].include?("#{@pkg.name}.rb")

--- a/bin/crew
+++ b/bin/crew
@@ -1060,6 +1060,7 @@ end
 def post_install
   if @pkg.reload_source?
     ExitMessage.add <<~SOURCE_BASHRC_EOT.lightblue
+
       To finish the installation, please execute the following:
       source ~/.bashrc
     SOURCE_BASHRC_EOT

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
-CREW_VERSION = '1.38.7'
+CREW_VERSION = '1.38.8'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -12,7 +12,7 @@ class Package
   boolean_property :conflicts_ok, :git_clone_deep, :git_fetchtags, :gnome, :is_fake, :is_musl, :is_static,
                    :no_compile_needed, :no_compress, :no_env_options, :no_fhs, :no_git_submodules,
                    :no_links, :no_lto, :no_patchelf, :no_shrink, :no_strip, :no_zstd, :patchelf,
-                   :print_reload_bashrc, :run_tests
+                   :print_source_bashrc, :run_tests
 
   create_placeholder :preflight,   # Function for checks to see if install should occur.
                      :patch,       # Function to perform patch operations prior to build from source.

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -11,7 +11,8 @@ class Package
 
   boolean_property :conflicts_ok, :git_clone_deep, :git_fetchtags, :gnome, :is_fake, :is_musl, :is_static,
                    :no_compile_needed, :no_compress, :no_env_options, :no_fhs, :no_git_submodules,
-                   :no_links, :no_lto, :no_patchelf, :no_shrink, :no_strip, :no_zstd, :patchelf, :run_tests
+                   :no_links, :no_lto, :no_patchelf, :no_shrink, :no_strip, :no_zstd, :patchelf, :reload_source,
+                   :run_tests
 
   create_placeholder :preflight,   # Function for checks to see if install should occur.
                      :patch,       # Function to perform patch operations prior to build from source.

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -11,8 +11,8 @@ class Package
 
   boolean_property :conflicts_ok, :git_clone_deep, :git_fetchtags, :gnome, :is_fake, :is_musl, :is_static,
                    :no_compile_needed, :no_compress, :no_env_options, :no_fhs, :no_git_submodules,
-                   :no_links, :no_lto, :no_patchelf, :no_shrink, :no_strip, :no_zstd, :patchelf, :reload_source,
-                   :run_tests
+                   :no_links, :no_lto, :no_patchelf, :no_shrink, :no_strip, :no_zstd, :patchelf,
+                   :print_reload_bashrc, :run_tests
 
   create_placeholder :preflight,   # Function for checks to see if install should occur.
                      :patch,       # Function to perform patch operations prior to build from source.

--- a/packages/antlr4.rb
+++ b/packages/antlr4.rb
@@ -24,7 +24,7 @@ class Antlr4 < Package
   })
 
   depends_on 'openjdk11'
-  reload_source
+  print_reload_bashrc
 
   def self.build
     @antlrenv = <<~ANTLR_EOF

--- a/packages/antlr4.rb
+++ b/packages/antlr4.rb
@@ -51,8 +51,7 @@ class Antlr4 < Package
   end
 
   def self.postinstall
-    puts "\nTo finish the installation, execute the following:".lightblue
-    puts 'source ~/.bashrc'.lightblue
-    puts "\nType 'antlr4' to get started.\n".lightblue
+    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
+    ExitMessage.add "\nType 'antlr4' to get started.\n".lightblue
   end
 end

--- a/packages/antlr4.rb
+++ b/packages/antlr4.rb
@@ -24,7 +24,7 @@ class Antlr4 < Package
   })
 
   depends_on 'openjdk11'
-  print_reload_bashrc
+  print_source_bashrc
 
   def self.build
     @antlrenv = <<~ANTLR_EOF

--- a/packages/antlr4.rb
+++ b/packages/antlr4.rb
@@ -24,6 +24,7 @@ class Antlr4 < Package
   })
 
   depends_on 'openjdk11'
+  reload_source
 
   def self.build
     @antlrenv = <<~ANTLR_EOF
@@ -51,7 +52,6 @@ class Antlr4 < Package
   end
 
   def self.postinstall
-    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
     ExitMessage.add "\nType 'antlr4' to get started.\n".lightblue
   end
 end

--- a/packages/autojump.rb
+++ b/packages/autojump.rb
@@ -12,6 +12,7 @@ class Autojump < Package
   depends_on 'python3'
 
   no_compile_needed
+  reload_source
 
   def self.build
     File.write 'autojump.sh', <<~EOF
@@ -22,9 +23,5 @@ class Autojump < Package
   def self.install
     system "./install.py -p #{CREW_DEST_PREFIX}"
     FileUtils.install 'autojump.sh', "#{CREW_DEST_PREFIX}/etc/env.d/autojump.sh", mode: 0o755
-  end
-
-  def self.postinstall
-    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 end

--- a/packages/autojump.rb
+++ b/packages/autojump.rb
@@ -25,6 +25,6 @@ class Autojump < Package
   end
 
   def self.postinstall
-    puts "\nType 'source ~/.bashrc' to finish the installation.\n".lightblue
+    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 end

--- a/packages/autojump.rb
+++ b/packages/autojump.rb
@@ -12,7 +12,7 @@ class Autojump < Package
   depends_on 'python3'
 
   no_compile_needed
-  reload_source
+  print_reload_bashrc
 
   def self.build
     File.write 'autojump.sh', <<~EOF

--- a/packages/autojump.rb
+++ b/packages/autojump.rb
@@ -12,7 +12,7 @@ class Autojump < Package
   depends_on 'python3'
 
   no_compile_needed
-  print_reload_bashrc
+  print_source_bashrc
 
   def self.build
     File.write 'autojump.sh', <<~EOF

--- a/packages/bluefish.rb
+++ b/packages/bluefish.rb
@@ -35,7 +35,7 @@ class Bluefish < Package
   depends_on 'mesa'
   depends_on 'xcb_util'
 
-  print_reload_bashrc
+  print_source_bashrc
 
   def self.build
     system 'filefix'

--- a/packages/bluefish.rb
+++ b/packages/bluefish.rb
@@ -35,6 +35,8 @@ class Bluefish < Package
   depends_on 'mesa'
   depends_on 'xcb_util'
 
+  reload_source
+
   def self.build
     system 'filefix'
     system "./configure #{CREW_OPTIONS}"
@@ -54,7 +56,6 @@ class Bluefish < Package
 
   def self.postinstall
     system "update-mime-database #{CREW_PREFIX}/share/mime"
-    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 
   def self.remove

--- a/packages/bluefish.rb
+++ b/packages/bluefish.rb
@@ -35,7 +35,7 @@ class Bluefish < Package
   depends_on 'mesa'
   depends_on 'xcb_util'
 
-  reload_source
+  print_reload_bashrc
 
   def self.build
     system 'filefix'

--- a/packages/bluefish.rb
+++ b/packages/bluefish.rb
@@ -54,8 +54,7 @@ class Bluefish < Package
 
   def self.postinstall
     system "update-mime-database #{CREW_PREFIX}/share/mime"
-    puts "\nTo complete the installation, execute the following:".lightblue
-    puts "source ~/.bashrc\n".lightblue
+    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 
   def self.remove

--- a/packages/composer.rb
+++ b/packages/composer.rb
@@ -34,7 +34,6 @@ class Composer < Package
 
   def self.postinstall
     FileUtils.ln_sf "#{CREW_PREFIX}/.config", "#{HOME}/.config"
-    puts "\nTo finish the installation, execute the following:".lightblue
-    puts "source ~/.bashrc\n".lightblue
+    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 end

--- a/packages/composer.rb
+++ b/packages/composer.rb
@@ -13,7 +13,7 @@ class Composer < Package
   depends_on 'xdg_base'
 
   no_compile_needed
-  print_reload_bashrc
+  print_source_bashrc
 
   def self.preinstall
     if Dir.exist?("#{HOME}/.config") && !File.symlink?("#{HOME}/.config")

--- a/packages/composer.rb
+++ b/packages/composer.rb
@@ -13,7 +13,7 @@ class Composer < Package
   depends_on 'xdg_base'
 
   no_compile_needed
-  reload_source
+  print_reload_bashrc
 
   def self.preinstall
     if Dir.exist?("#{HOME}/.config") && !File.symlink?("#{HOME}/.config")

--- a/packages/composer.rb
+++ b/packages/composer.rb
@@ -13,6 +13,7 @@ class Composer < Package
   depends_on 'xdg_base'
 
   no_compile_needed
+  reload_source
 
   def self.preinstall
     if Dir.exist?("#{HOME}/.config") && !File.symlink?("#{HOME}/.config")
@@ -34,6 +35,5 @@ class Composer < Package
 
   def self.postinstall
     FileUtils.ln_sf "#{CREW_PREFIX}/.config", "#{HOME}/.config"
-    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 end

--- a/packages/crystal.rb
+++ b/packages/crystal.rb
@@ -11,6 +11,8 @@ class Crystal < Package
 
   depends_on 'llvm16_lib' # R
 
+  reload_source
+
   def self.install
     FileUtils.mkdir_p CREW_DEST_PREFIX.to_s
     FileUtils.mv %w[bin lib share], CREW_DEST_PREFIX.to_s
@@ -20,9 +22,5 @@ class Crystal < Package
     EOF
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/bash.d"
     File.write("#{CREW_DEST_PREFIX}/etc/bash.d/10-crystal", bashcomp)
-  end
-
-  def self.postinstall
-    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 end

--- a/packages/crystal.rb
+++ b/packages/crystal.rb
@@ -11,7 +11,7 @@ class Crystal < Package
 
   depends_on 'llvm16_lib' # R
 
-  reload_source
+  print_reload_bashrc
 
   def self.install
     FileUtils.mkdir_p CREW_DEST_PREFIX.to_s

--- a/packages/crystal.rb
+++ b/packages/crystal.rb
@@ -11,7 +11,7 @@ class Crystal < Package
 
   depends_on 'llvm16_lib' # R
 
-  print_reload_bashrc
+  print_source_bashrc
 
   def self.install
     FileUtils.mkdir_p CREW_DEST_PREFIX.to_s

--- a/packages/crystal.rb
+++ b/packages/crystal.rb
@@ -23,7 +23,6 @@ class Crystal < Package
   end
 
   def self.postinstall
-    puts "\nTo finish the installation, execute the following:".lightblue
-    puts "source ~/.bashrc\n".lightblue
+    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 end

--- a/packages/filezilla.rb
+++ b/packages/filezilla.rb
@@ -64,7 +64,6 @@ class Filezilla < Package
   end
 
   def self.postinstall
-    puts "\nTo complete the installation, execute the following:".lightblue
-    puts "source ~/.bashrc\n".lightblue
+    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 end

--- a/packages/filezilla.rb
+++ b/packages/filezilla.rb
@@ -46,7 +46,7 @@ class Filezilla < Package
   depends_on 'xdg_utils' => :build
   depends_on 'zlibpkg' # R
 
-  reload_source
+  print_reload_bashrc
 
   def self.patch
     system 'filefix'

--- a/packages/filezilla.rb
+++ b/packages/filezilla.rb
@@ -46,6 +46,8 @@ class Filezilla < Package
   depends_on 'xdg_utils' => :build
   depends_on 'zlibpkg' # R
 
+  reload_source
+
   def self.patch
     system 'filefix'
   end
@@ -61,9 +63,5 @@ class Filezilla < Package
       alias filezilla="WAYLAND_DISPLAY=wayland-0 DISPLAY='' GDK_BACKEND=wayland filezilla"
     FILEZILLA_EOF
     FileUtils.install 'filezilla', "#{CREW_DEST_PREFIX}/etc/env.d/10-filezilla", mode: 0o644
-  end
-
-  def self.postinstall
-    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 end

--- a/packages/filezilla.rb
+++ b/packages/filezilla.rb
@@ -46,7 +46,7 @@ class Filezilla < Package
   depends_on 'xdg_utils' => :build
   depends_on 'zlibpkg' # R
 
-  print_reload_bashrc
+  print_source_bashrc
 
   def self.patch
     system 'filefix'

--- a/packages/git_prompt.rb
+++ b/packages/git_prompt.rb
@@ -8,7 +8,7 @@ class Git_prompt < Package
   compatibility 'all'
   source_url 'SKIP'
 
-  reload_source
+  print_reload_bashrc
 
   def self.build
     system "curl -#LO https://raw.githubusercontent.com/git/git/v#{version}/contrib/completion/git-prompt.sh"

--- a/packages/git_prompt.rb
+++ b/packages/git_prompt.rb
@@ -8,6 +8,8 @@ class Git_prompt < Package
   compatibility 'all'
   source_url 'SKIP'
 
+  reload_source
+
   def self.build
     system "curl -#LO https://raw.githubusercontent.com/git/git/v#{version}/contrib/completion/git-prompt.sh"
     abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest(File.read('git-prompt.sh')) == '1fbced3fe345ec14f828ffb876e191d69457cccc807c70f54c9ba48cb2a6620e'
@@ -31,7 +33,6 @@ class Git_prompt < Package
   end
 
   def self.postinstall
-    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
     ExitMessage.add "\ncd /path/to/git/repo and you should see the branch displayed in the prompt\n".lightblue
   end
 end

--- a/packages/git_prompt.rb
+++ b/packages/git_prompt.rb
@@ -31,8 +31,7 @@ class Git_prompt < Package
   end
 
   def self.postinstall
-    puts "\nTo finish the installation, execute the following:".lightblue
-    puts 'source ~/.bashrc'.lightblue
-    puts "\ncd /path/to/git/repo and you should see the branch displayed in the prompt\n".lightblue
+    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
+    ExitMessage.add "\ncd /path/to/git/repo and you should see the branch displayed in the prompt\n".lightblue
   end
 end

--- a/packages/git_prompt.rb
+++ b/packages/git_prompt.rb
@@ -8,7 +8,7 @@ class Git_prompt < Package
   compatibility 'all'
   source_url 'SKIP'
 
-  print_reload_bashrc
+  print_source_bashrc
 
   def self.build
     system "curl -#LO https://raw.githubusercontent.com/git/git/v#{version}/contrib/completion/git-prompt.sh"

--- a/packages/krita.rb
+++ b/packages/krita.rb
@@ -14,7 +14,7 @@ class Krita < Package
   depends_on 'sommelier'
 
   no_compile_needed
-  print_reload_bashrc
+  print_source_bashrc
 
   def self.build
     krita = <<~EOF

--- a/packages/krita.rb
+++ b/packages/krita.rb
@@ -37,8 +37,7 @@ class Krita < Package
   end
 
   def self.postinstall
-    puts "\nTo finish the installation, execute the following:".lightblue
-    puts 'source ~/.bashrc'.lightblue
-    puts "\nAfter the above, type 'krita' to get started.\n".lightblue
+    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
+    ExitMessage.add "\nType 'krita' to get started.\n".lightblue
   end
 end

--- a/packages/krita.rb
+++ b/packages/krita.rb
@@ -14,7 +14,7 @@ class Krita < Package
   depends_on 'sommelier'
 
   no_compile_needed
-  reload_source
+  print_reload_bashrc
 
   def self.build
     krita = <<~EOF

--- a/packages/krita.rb
+++ b/packages/krita.rb
@@ -9,11 +9,12 @@ class Krita < Package
   source_url 'https://download.kde.org/stable/krita/5.1.4/krita-5.1.4-x86_64.appimage'
   source_sha256 'f6678796cb98086b1e576aae4911e3d6b133cd0a4ec61a900ff5136a9f55917d'
 
-  no_compile_needed
-
   depends_on 'gtk3'
   depends_on 'gdk_base'
   depends_on 'sommelier'
+
+  no_compile_needed
+  reload_source
 
   def self.build
     krita = <<~EOF
@@ -37,7 +38,6 @@ class Krita < Package
   end
 
   def self.postinstall
-    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
     ExitMessage.add "\nType 'krita' to get started.\n".lightblue
   end
 end

--- a/packages/ldc.rb
+++ b/packages/ldc.rb
@@ -14,7 +14,7 @@ class Ldc < Package
   depends_on 'zlibpkg'
 
   no_compile_needed
-  print_reload_bashrc
+  print_source_bashrc
 
   def self.install
     FileUtils.mkdir_p CREW_DEST_LIB_PREFIX.to_s

--- a/packages/ldc.rb
+++ b/packages/ldc.rb
@@ -14,7 +14,7 @@ class Ldc < Package
   depends_on 'zlibpkg'
 
   no_compile_needed
-  no_compile_needed
+  reload_source
 
   def self.install
     FileUtils.mkdir_p CREW_DEST_LIB_PREFIX.to_s

--- a/packages/ldc.rb
+++ b/packages/ldc.rb
@@ -14,6 +14,7 @@ class Ldc < Package
   depends_on 'zlibpkg'
 
   no_compile_needed
+  no_compile_needed
 
   def self.install
     FileUtils.mkdir_p CREW_DEST_LIB_PREFIX.to_s
@@ -28,9 +29,5 @@ class Ldc < Package
     end
     FileUtils.install 'etc/ldc2.conf', "#{CREW_DEST_PREFIX}/etc", mode: 0o644
     FileUtils.install 'etc/bash_completion.d/ldc2', "#{CREW_DEST_PREFIX}/etc/bash.d", mode: 0o644
-  end
-
-  def self.postinstall
-    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 end

--- a/packages/ldc.rb
+++ b/packages/ldc.rb
@@ -31,7 +31,6 @@ class Ldc < Package
   end
 
   def self.postinstall
-    puts "\nTo finish the installation, execute the following:".lightblue
-    puts "source ~/.bashrc\n".lightblue
+    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 end

--- a/packages/ldc.rb
+++ b/packages/ldc.rb
@@ -14,7 +14,7 @@ class Ldc < Package
   depends_on 'zlibpkg'
 
   no_compile_needed
-  reload_source
+  print_reload_bashrc
 
   def self.install
     FileUtils.mkdir_p CREW_DEST_LIB_PREFIX.to_s

--- a/packages/mold.rb
+++ b/packages/mold.rb
@@ -33,6 +33,7 @@ class Mold < Package
   depends_on 'zstd' # R
 
   no_env_options
+  no_compile_needed
 
   def self.build
     # TBB build option due to
@@ -58,9 +59,5 @@ class Mold < Package
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
     FileUtils.install 'moldenv', "#{CREW_DEST_PREFIX}/etc/env.d/mold", mode: 0o644
-  end
-
-  def self.postinstall
-    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 end

--- a/packages/mold.rb
+++ b/packages/mold.rb
@@ -6,34 +6,33 @@ require 'package'
 class Mold < Package
   description 'A Modern Linker'
   homepage 'https://github.com/rui314/mold'
-  version '2.3.1'
+  version '2.3.2'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/rui314/mold.git'
   git_hashtag "v#{version}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.1_armv7l/mold-2.3.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.1_armv7l/mold-2.3.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.1_i686/mold-2.3.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.1_x86_64/mold-2.3.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.2_armv7l/mold-2.3.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.2_armv7l/mold-2.3.2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.2_i686/mold-2.3.2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.2_x86_64/mold-2.3.2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '5b7966e94dab6666e1e86ec0128209c26689fb306f98fb53e9463af99c5802c4',
-     armv7l: '5b7966e94dab6666e1e86ec0128209c26689fb306f98fb53e9463af99c5802c4',
-       i686: '9c588afe02c221a9e69806f2226308ea5bf6a7a8b7318f9d85a6bbc79bab688b',
-     x86_64: '7ab15db9f31bbe7b24168e9aff48e74c0e6d78d0e1080c41f9238fcfdf1882bf'
+    aarch64: 'd3da641a7e37663a989bf0ecacecd37a7bf087fbbc199b5c8afc975c729f5647',
+     armv7l: 'd3da641a7e37663a989bf0ecacecd37a7bf087fbbc199b5c8afc975c729f5647',
+       i686: '63293b849ec265b40453fa3fbdde565e322bd56725079e24a27d80cfc7a82de2',
+     x86_64: 'c8bdc39c6c9a4b450508635c4eaa874b4aa21bd4338fb113cfa08ead8118bd31'
   })
 
-  depends_on 'zlibpkg' # R
+  depends_on 'gcc_lib' # R
   depends_on 'glibc' # R
   depends_on 'openssl' # R
-  depends_on 'gcc_lib' # R
   depends_on 'xxhash' => :build
+  depends_on 'zlibpkg' # R
   depends_on 'zstd' # R
 
   no_env_options
-  no_compile_needed
   print_source_bashrc
 
   def self.build

--- a/packages/mold.rb
+++ b/packages/mold.rb
@@ -34,6 +34,7 @@ class Mold < Package
 
   no_env_options
   no_compile_needed
+  reload_source
 
   def self.build
     # TBB build option due to

--- a/packages/mold.rb
+++ b/packages/mold.rb
@@ -34,7 +34,7 @@ class Mold < Package
 
   no_env_options
   no_compile_needed
-  print_reload_bashrc
+  print_source_bashrc
 
   def self.build
     # TBB build option due to

--- a/packages/mold.rb
+++ b/packages/mold.rb
@@ -61,7 +61,6 @@ class Mold < Package
   end
 
   def self.postinstall
-    puts "\nTo finish the installation, execute the following:".lightblue
-    puts "source ~/.bashrc\n".lightblue
+    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 end

--- a/packages/mold.rb
+++ b/packages/mold.rb
@@ -34,7 +34,7 @@ class Mold < Package
 
   no_env_options
   no_compile_needed
-  reload_source
+  print_reload_bashrc
 
   def self.build
     # TBB build option due to

--- a/packages/nvm.rb
+++ b/packages/nvm.rb
@@ -10,7 +10,7 @@ class Nvm < Package
   git_hashtag "v#{version}"
 
   no_compile_needed
-  print_reload_bashrc
+  print_source_bashrc
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/nvm"

--- a/packages/nvm.rb
+++ b/packages/nvm.rb
@@ -27,8 +27,7 @@ class Nvm < Package
       puts "\nNode.js 18.x and above requires GLIBC 2.28.".orange
       puts "ChromeOS is currently running GLIBC #{LIBC_VERSION}.".orange
     end
-    puts "\nTo finish the installation, execute the following:".lightblue
-    puts "source ~/.bashrc\n".lightblue
+    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 
   def self.remove

--- a/packages/nvm.rb
+++ b/packages/nvm.rb
@@ -10,6 +10,7 @@ class Nvm < Package
   git_hashtag "v#{version}"
 
   no_compile_needed
+  reload_source
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/nvm"
@@ -27,7 +28,6 @@ class Nvm < Package
       puts "\nNode.js 18.x and above requires GLIBC 2.28.".orange
       puts "ChromeOS is currently running GLIBC #{LIBC_VERSION}.".orange
     end
-    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 
   def self.remove

--- a/packages/nvm.rb
+++ b/packages/nvm.rb
@@ -10,7 +10,7 @@ class Nvm < Package
   git_hashtag "v#{version}"
 
   no_compile_needed
-  reload_source
+  print_reload_bashrc
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/nvm"

--- a/packages/openjdk11.rb
+++ b/packages/openjdk11.rb
@@ -22,6 +22,7 @@ class Openjdk11 < Package
 
   no_compile_needed
   no_shrink
+  reload_source
 
   def self.preflight
     jdkver = `java -version 2>&1`[/version "(.*?)"/, 1].to_s
@@ -54,9 +55,5 @@ class Openjdk11 < Package
       JAVA_HOME=#{CREW_PREFIX}
     EOF
     File.write("#{CREW_DEST_PREFIX}/etc/env.d/10-openjdk11", javaenv)
-  end
-
-  def self.postinstall
-    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 end

--- a/packages/openjdk11.rb
+++ b/packages/openjdk11.rb
@@ -22,7 +22,7 @@ class Openjdk11 < Package
 
   no_compile_needed
   no_shrink
-  print_reload_bashrc
+  print_source_bashrc
 
   def self.preflight
     jdkver = `java -version 2>&1`[/version "(.*?)"/, 1].to_s

--- a/packages/openjdk11.rb
+++ b/packages/openjdk11.rb
@@ -22,7 +22,7 @@ class Openjdk11 < Package
 
   no_compile_needed
   no_shrink
-  reload_source
+  print_reload_bashrc
 
   def self.preflight
     jdkver = `java -version 2>&1`[/version "(.*?)"/, 1].to_s

--- a/packages/openjdk11.rb
+++ b/packages/openjdk11.rb
@@ -57,6 +57,6 @@ class Openjdk11 < Package
   end
 
   def self.postinstall
-    puts "\nType 'source ~/.bashrc' to finish the installation.\n".lightblue
+    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 end

--- a/packages/openjdk17.rb
+++ b/packages/openjdk17.rb
@@ -22,6 +22,7 @@ class Openjdk17 < Package
 
   no_compile_needed
   no_shrink
+  reload_source
 
   def self.preflight
     jdkver = `java -version 2>&1`[/version "(.*?)"/, 1].to_s
@@ -54,9 +55,5 @@ class Openjdk17 < Package
       JAVA_HOME=#{CREW_PREFIX}
     EOF
     File.write("#{CREW_DEST_PREFIX}/etc/env.d/10-openjdk17", javaenv)
-  end
-
-  def self.postinstall
-    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 end

--- a/packages/openjdk17.rb
+++ b/packages/openjdk17.rb
@@ -57,6 +57,6 @@ class Openjdk17 < Package
   end
 
   def self.postinstall
-    puts "\nType 'source ~/.bashrc' to finish the installation.\n".lightblue
+    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 end

--- a/packages/openjdk17.rb
+++ b/packages/openjdk17.rb
@@ -22,7 +22,7 @@ class Openjdk17 < Package
 
   no_compile_needed
   no_shrink
-  reload_source
+  print_reload_bashrc
 
   def self.preflight
     jdkver = `java -version 2>&1`[/version "(.*?)"/, 1].to_s

--- a/packages/openjdk17.rb
+++ b/packages/openjdk17.rb
@@ -22,7 +22,7 @@ class Openjdk17 < Package
 
   no_compile_needed
   no_shrink
-  print_reload_bashrc
+  print_source_bashrc
 
   def self.preflight
     jdkver = `java -version 2>&1`[/version "(.*?)"/, 1].to_s

--- a/packages/openjdk21.rb
+++ b/packages/openjdk21.rb
@@ -12,7 +12,7 @@ class Openjdk21 < Package
 
   no_compile_needed
   no_shrink
-  print_reload_bashrc
+  print_source_bashrc
 
   def self.preflight
     jdkver = `java -version 2>&1`[/version "(.*?)"/, 1].to_s

--- a/packages/openjdk21.rb
+++ b/packages/openjdk21.rb
@@ -47,6 +47,6 @@ class Openjdk21 < Package
   end
 
   def self.postinstall
-    puts "\nType 'source ~/.bashrc' to finish the installation.\n".lightblue
+    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 end

--- a/packages/openjdk21.rb
+++ b/packages/openjdk21.rb
@@ -12,6 +12,7 @@ class Openjdk21 < Package
 
   no_compile_needed
   no_shrink
+  reload_source
 
   def self.preflight
     jdkver = `java -version 2>&1`[/version "(.*?)"/, 1].to_s
@@ -44,9 +45,5 @@ class Openjdk21 < Package
       JAVA_HOME=#{CREW_PREFIX}
     EOF
     File.write("#{CREW_DEST_PREFIX}/etc/env.d/10-openjdk21", javaenv)
-  end
-
-  def self.postinstall
-    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 end

--- a/packages/openjdk21.rb
+++ b/packages/openjdk21.rb
@@ -12,7 +12,7 @@ class Openjdk21 < Package
 
   no_compile_needed
   no_shrink
-  reload_source
+  print_reload_bashrc
 
   def self.preflight
     jdkver = `java -version 2>&1`[/version "(.*?)"/, 1].to_s

--- a/packages/postgres.rb
+++ b/packages/postgres.rb
@@ -38,7 +38,7 @@ class Postgres < Package
   depends_on 'tcl'
   depends_on 'zstd'
 
-  reload_source
+  print_reload_bashrc
 
   PGDATA = "#{CREW_PREFIX}/share/pgsql/data".freeze
 

--- a/packages/postgres.rb
+++ b/packages/postgres.rb
@@ -98,8 +98,7 @@ class Postgres < Package
     puts 'Connect to database: psql <dbname>'.lightblue
     puts
     puts "To configure, edit #{CREW_PREFIX}/etc/env.d/postgres".lightblue
-    puts "Remember to 'source ~/.bashrc' after changes".lightblue
-    puts
+    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 
   def self.remove

--- a/packages/postgres.rb
+++ b/packages/postgres.rb
@@ -38,6 +38,8 @@ class Postgres < Package
   depends_on 'tcl'
   depends_on 'zstd'
 
+  reload_source
+
   PGDATA = "#{CREW_PREFIX}/share/pgsql/data".freeze
 
   def self.patch
@@ -98,7 +100,6 @@ class Postgres < Package
     puts 'Connect to database: psql <dbname>'.lightblue
     puts
     puts "To configure, edit #{CREW_PREFIX}/etc/env.d/postgres".lightblue
-    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 
   def self.remove

--- a/packages/postgres.rb
+++ b/packages/postgres.rb
@@ -38,7 +38,7 @@ class Postgres < Package
   depends_on 'tcl'
   depends_on 'zstd'
 
-  print_reload_bashrc
+  print_source_bashrc
 
   PGDATA = "#{CREW_PREFIX}/share/pgsql/data".freeze
 

--- a/packages/py3_azure_cli.rb
+++ b/packages/py3_azure_cli.rb
@@ -25,6 +25,6 @@ class Py3_azure_cli < Pip
   EXTRAS_EOF
 
   def self.postinstall
-    puts "\nType 'source ~/.bashrc' to complete the installation.\n".lightblue
+    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 end

--- a/packages/py3_azure_cli.rb
+++ b/packages/py3_azure_cli.rb
@@ -14,7 +14,7 @@ class Py3_azure_cli < Pip
   depends_on 'rust' => :build
 
   no_compile_needed
-  print_reload_bashrc
+  print_source_bashrc
 
   pip_install_extras <<~EXTRAS_EOF
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/bash.d/"

--- a/packages/py3_azure_cli.rb
+++ b/packages/py3_azure_cli.rb
@@ -14,7 +14,7 @@ class Py3_azure_cli < Pip
   depends_on 'rust' => :build
 
   no_compile_needed
-  reload_source
+  print_reload_bashrc
 
   pip_install_extras <<~EXTRAS_EOF
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/bash.d/"

--- a/packages/py3_azure_cli.rb
+++ b/packages/py3_azure_cli.rb
@@ -14,6 +14,7 @@ class Py3_azure_cli < Pip
   depends_on 'rust' => :build
 
   no_compile_needed
+  reload_source
 
   pip_install_extras <<~EXTRAS_EOF
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/bash.d/"
@@ -23,8 +24,4 @@ class Py3_azure_cli < Pip
     AZUREEOF
     File.write("#{CREW_DEST_PREFIX}/etc/bash.d/az", @azureenv)
   EXTRAS_EOF
-
-  def self.postinstall
-    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
-  end
 end

--- a/packages/scbi.rb
+++ b/packages/scbi.rb
@@ -36,7 +36,7 @@ class Scbi < Package
   end
 
   def self.postinstall
-    puts "\nType 'source ~/.bashrc' to complete the installation.".lightblue
-    puts "\nTo view the User Guide, execute 'crew install zathura && zathura #{CREW_PREFIX}/share/scbi/scbi.pdf'.\n".lightblue
+    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
+    ExitMessage.add "\nTo view the User Guide, execute 'crew install zathura && zathura #{CREW_PREFIX}/share/scbi/scbi.pdf'.\n".lightblue
   end
 end

--- a/packages/scbi.rb
+++ b/packages/scbi.rb
@@ -15,7 +15,7 @@ class Scbi < Package
 
   no_compile_needed
   no_fhs
-  print_reload_bashrc
+  print_source_bashrc
 
   def self.patch
     # Set up destination locations.

--- a/packages/scbi.rb
+++ b/packages/scbi.rb
@@ -15,6 +15,7 @@ class Scbi < Package
 
   no_compile_needed
   no_fhs
+  reload_source
 
   def self.patch
     # Set up destination locations.
@@ -36,7 +37,6 @@ class Scbi < Package
   end
 
   def self.postinstall
-    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
     ExitMessage.add "\nTo view the User Guide, execute 'crew install zathura && zathura #{CREW_PREFIX}/share/scbi/scbi.pdf'.\n".lightblue
   end
 end

--- a/packages/scbi.rb
+++ b/packages/scbi.rb
@@ -15,7 +15,7 @@ class Scbi < Package
 
   no_compile_needed
   no_fhs
-  reload_source
+  print_reload_bashrc
 
   def self.patch
     # Set up destination locations.

--- a/packages/shotwell.rb
+++ b/packages/shotwell.rb
@@ -39,6 +39,6 @@ class Shotwell < Meson
   depends_on 'webkit2gtk' # R
 
   def self.postinstall
-    puts "\nTo finish the installation, execute 'source ~/.bashrc'\n".lightblue
+    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 end

--- a/packages/shotwell.rb
+++ b/packages/shotwell.rb
@@ -16,7 +16,7 @@ class Shotwell < Meson
     x86_64: '5cdee6e092952d82c60b26a8fd57446a96baebb43681bbc449e39138cc3d75cd'
   })
 
-  reload_source
+  print_reload_bashrc
 
   depends_on 'vala' => :build
   depends_on 'cairo' # R

--- a/packages/shotwell.rb
+++ b/packages/shotwell.rb
@@ -16,6 +16,8 @@ class Shotwell < Meson
     x86_64: '5cdee6e092952d82c60b26a8fd57446a96baebb43681bbc449e39138cc3d75cd'
   })
 
+  reload_source
+
   depends_on 'vala' => :build
   depends_on 'cairo' # R
   depends_on 'gcr' # R
@@ -37,8 +39,4 @@ class Shotwell < Meson
   depends_on 'json_glib' # R
   depends_on 'sqlite' # R
   depends_on 'webkit2gtk' # R
-
-  def self.postinstall
-    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
-  end
 end

--- a/packages/shotwell.rb
+++ b/packages/shotwell.rb
@@ -16,7 +16,7 @@ class Shotwell < Meson
     x86_64: '5cdee6e092952d82c60b26a8fd57446a96baebb43681bbc449e39138cc3d75cd'
   })
 
-  print_reload_bashrc
+  print_source_bashrc
 
   depends_on 'vala' => :build
   depends_on 'cairo' # R

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -44,6 +44,7 @@ class Sommelier < Package
   depends_on 'xwayland' # L
 
   no_shrink
+  reload_source
 
   def self.preflight
     return if File.socket?('/var/run/chrome/wayland-0') || CREW_IN_CONTAINER
@@ -465,7 +466,6 @@ class Sommelier < Package
         Removed old sommelier environment variables in ~/.bashrc.
         A backup of the original is stored in ~/.bashrc.#{@now}
       EOT0
-      ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
     end
 
     FileUtils.touch "#{HOME}/.sommelier.env" unless File.exist? "#{HOME}/.sommelier.env"

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -44,7 +44,7 @@ class Sommelier < Package
   depends_on 'xwayland' # L
 
   no_shrink
-  print_reload_bashrc
+  print_source_bashrc
 
   def self.preflight
     return if File.socket?('/var/run/chrome/wayland-0') || CREW_IN_CONTAINER

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -44,7 +44,7 @@ class Sommelier < Package
   depends_on 'xwayland' # L
 
   no_shrink
-  reload_source
+  print_reload_bashrc
 
   def self.preflight
     return if File.socket?('/var/run/chrome/wayland-0') || CREW_IN_CONTAINER

--- a/packages/sommelier.rb
+++ b/packages/sommelier.rb
@@ -464,9 +464,8 @@ class Sommelier < Package
 
         Removed old sommelier environment variables in ~/.bashrc.
         A backup of the original is stored in ~/.bashrc.#{@now}
-        To complete the installation, execute the following:
-        source ~/.bashrc
       EOT0
+      ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
     end
 
     FileUtils.touch "#{HOME}/.sommelier.env" unless File.exist? "#{HOME}/.sommelier.env"

--- a/packages/torbrowser.rb
+++ b/packages/torbrowser.rb
@@ -14,6 +14,7 @@ class Torbrowser < Package
 
   no_compile_needed
   no_shrink
+  reload_source
 
   def self.build
     tor = <<~EOF
@@ -37,7 +38,6 @@ class Torbrowser < Package
   end
 
   def self.postinstall
-    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
     print "\nSet Tor as your default browser? [Y/n]: "
     case $stdin.gets.chomp.downcase
     when '', 'y', 'yes'

--- a/packages/torbrowser.rb
+++ b/packages/torbrowser.rb
@@ -14,7 +14,7 @@ class Torbrowser < Package
 
   no_compile_needed
   no_shrink
-  print_reload_bashrc
+  print_source_bashrc
 
   def self.build
     tor = <<~EOF

--- a/packages/torbrowser.rb
+++ b/packages/torbrowser.rb
@@ -37,8 +37,7 @@ class Torbrowser < Package
   end
 
   def self.postinstall
-    puts "\nTo finish the installation, execute the following:".lightblue
-    puts 'source ~/.bashrc'.lightblue
+    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
     print "\nSet Tor as your default browser? [Y/n]: "
     case $stdin.gets.chomp.downcase
     when '', 'y', 'yes'

--- a/packages/torbrowser.rb
+++ b/packages/torbrowser.rb
@@ -14,7 +14,7 @@ class Torbrowser < Package
 
   no_compile_needed
   no_shrink
-  reload_source
+  print_reload_bashrc
 
   def self.build
     tor = <<~EOF

--- a/packages/transmission.rb
+++ b/packages/transmission.rb
@@ -48,7 +48,7 @@ class Transmission < Package
   depends_on 'xdg_base' # L
   depends_on 'pango' # R
 
-  print_reload_bashrc
+  print_source_bashrc
 
   def self.build
     system "cmake -B builddir -G Ninja \

--- a/packages/transmission.rb
+++ b/packages/transmission.rb
@@ -48,6 +48,8 @@ class Transmission < Package
   depends_on 'xdg_base' # L
   depends_on 'pango' # R
 
+  reload_source
+
   def self.build
     system "cmake -B builddir -G Ninja \
       #{CREW_CMAKE_OPTIONS} \
@@ -113,7 +115,6 @@ class Transmission < Package
     puts "\nTo start the gui client, execute 'transmission-gtk'".lightblue
     puts "\nTo start the daemon, execute 'starttransmission'".lightblue
     puts "\nTo stop the daemon, execute 'stoptransmission'".lightblue
-    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
     puts "\nConfiguration files are stored in #{HOME}/.config/transmission-daemon\n".lightblue
   end
 

--- a/packages/transmission.rb
+++ b/packages/transmission.rb
@@ -48,7 +48,7 @@ class Transmission < Package
   depends_on 'xdg_base' # L
   depends_on 'pango' # R
 
-  reload_source
+  print_reload_bashrc
 
   def self.build
     system "cmake -B builddir -G Ninja \

--- a/packages/transmission.rb
+++ b/packages/transmission.rb
@@ -113,7 +113,7 @@ class Transmission < Package
     puts "\nTo start the gui client, execute 'transmission-gtk'".lightblue
     puts "\nTo start the daemon, execute 'starttransmission'".lightblue
     puts "\nTo stop the daemon, execute 'stoptransmission'".lightblue
-    puts "\nTo finish the installation, execute 'source ~/.bashrc'".lightblue
+    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
     puts "\nConfiguration files are stored in #{HOME}/.config/transmission-daemon\n".lightblue
   end
 

--- a/packages/wine.rb
+++ b/packages/wine.rb
@@ -52,7 +52,7 @@ class Wine < Package
   depends_on 'xdg_base'
 
   no_lto
-  reload_source
+  print_reload_bashrc
 
   def self.build
     FileUtils.mkdir_p 'wine64-build'

--- a/packages/wine.rb
+++ b/packages/wine.rb
@@ -91,10 +91,8 @@ class Wine < Package
   end
 
   def self.postinstall
-    puts
-    puts "\nTo finish the installation, execute 'source ~/.bashrc'".lightblue
-    puts 'To run an application with wine, type `wine path/to/myexecutable.exe` or `wine path/to/myinstaller.msi`.'.lightblue
-    puts
+    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
+    ExitMessage.add 'To run an application with wine, type `wine path/to/myexecutable.exe` or `wine path/to/myinstaller.msi`.'.lightblue
   end
 
   def self.remove

--- a/packages/wine.rb
+++ b/packages/wine.rb
@@ -52,7 +52,7 @@ class Wine < Package
   depends_on 'xdg_base'
 
   no_lto
-  print_reload_bashrc
+  print_source_bashrc
 
   def self.build
     FileUtils.mkdir_p 'wine64-build'

--- a/packages/wine.rb
+++ b/packages/wine.rb
@@ -50,7 +50,9 @@ class Wine < Package
   depends_on 'sommelier'
   depends_on 'vkd3d'
   depends_on 'xdg_base'
+
   no_lto
+  reload_source
 
   def self.build
     FileUtils.mkdir_p 'wine64-build'
@@ -91,7 +93,6 @@ class Wine < Package
   end
 
   def self.postinstall
-    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
     ExitMessage.add 'To run an application with wine, type `wine path/to/myexecutable.exe` or `wine path/to/myinstaller.msi`.'.lightblue
   end
 

--- a/packages/zoxide.rb
+++ b/packages/zoxide.rb
@@ -43,6 +43,6 @@ class Zoxide < Package
   end
 
   def self.postinstall
-    puts "\nType 'source ~/.bashrc' to complete the installation.\n".lightblue
+    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 end

--- a/packages/zoxide.rb
+++ b/packages/zoxide.rb
@@ -20,7 +20,7 @@ class Zoxide < Package
   depends_on 'fzf'
 
   no_compile_needed
-  print_reload_bashrc
+  print_source_bashrc
 
   def self.build
     File.write 'zoxide.bash', <<~EOF

--- a/packages/zoxide.rb
+++ b/packages/zoxide.rb
@@ -20,7 +20,7 @@ class Zoxide < Package
   depends_on 'fzf'
 
   no_compile_needed
-  reload_source
+  print_reload_bashrc
 
   def self.build
     File.write 'zoxide.bash', <<~EOF

--- a/packages/zoxide.rb
+++ b/packages/zoxide.rb
@@ -20,6 +20,7 @@ class Zoxide < Package
   depends_on 'fzf'
 
   no_compile_needed
+  reload_source
 
   def self.build
     File.write 'zoxide.bash', <<~EOF
@@ -40,9 +41,5 @@ class Zoxide < Package
     FileUtils.install 'zoxide', "#{CREW_DEST_PREFIX}/bin/zoxide", mode: 0o755
     FileUtils.mv 'completions', "#{CREW_DEST_PREFIX}/share"
     FileUtils.mv 'man/man1', CREW_DEST_MAN_PREFIX.to_s
-  end
-
-  def self.postinstall
-    ExitMessage.add "\nTo finish the installation, please execute the following:\nsource ~/.bashrc".lightblue, print_last: true
   end
 end


### PR DESCRIPTION
- Multiple installs should now only list this message once.
- **Updates mold to 2.3.2.**

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=source_message crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
