### PR TITLE
print_source_bashrc should be last

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1061,7 +1061,7 @@ end
 
 def post_install
   if @pkg.print_source_bashrc?
-    ExitMessage.add <<~PRINT_SOURCE_BASHRC_EOT.lightblue
+    ExitMessage.add <<~PRINT_SOURCE_BASHRC_EOT.lightblue, print_last: true
 
       To finish the installation, please execute the following:
       source ~/.bashrc

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
-CREW_VERSION = '1.38.8'
+CREW_VERSION = '1.38.9'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
- refactor missed this...

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=postinstall_last crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
