### PR TITLE
mold rebuild to fix broken binary on x86_64

### DIFF
--- a/packages/mold.rb
+++ b/packages/mold.rb
@@ -13,16 +13,16 @@ class Mold < Package
   git_hashtag '0c6daad215d0b0d4f835e33366d41a9218212367'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.2_armv7l/mold-2.3.2-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.2_armv7l/mold-2.3.2-chromeos-armv7l.tar.zst',
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.2-0c6daad_i686/mold-2.3.2-0c6daad-chromeos-i686.tar.zst',
-  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.2-0c6daad_x86_64/mold-2.3.2-0c6daad-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.2-0c6daad_armv7l/mold-2.3.2-0c6daad-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.2-0c6daad_armv7l/mold-2.3.2-0c6daad-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.2-0c6daad_i686/mold-2.3.2-0c6daad-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.2-0c6daad_x86_64/mold-2.3.2-0c6daad-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'd3da641a7e37663a989bf0ecacecd37a7bf087fbbc199b5c8afc975c729f5647',
-     armv7l: 'd3da641a7e37663a989bf0ecacecd37a7bf087fbbc199b5c8afc975c729f5647',
-    i686: '91801098f4c2504f7dcc0d38c624224e0a63b8b252df1c5f1d33142e818c74e6',
-  x86_64: '5772b5cb14ca2dfa2946edf2c3f7c7fd5366256aabc0b2cd67bf71f997886ac9'
+    aarch64: '102538863a51e44bad2ebeb4014d679e013cec0a8a10f6e58cd1e1dfaa7e6a77',
+     armv7l: '102538863a51e44bad2ebeb4014d679e013cec0a8a10f6e58cd1e1dfaa7e6a77',
+       i686: '91801098f4c2504f7dcc0d38c624224e0a63b8b252df1c5f1d33142e818c74e6',
+     x86_64: '5772b5cb14ca2dfa2946edf2c3f7c7fd5366256aabc0b2cd67bf71f997886ac9'
   })
 
   depends_on 'gcc_lib' # R

--- a/packages/mold.rb
+++ b/packages/mold.rb
@@ -6,23 +6,23 @@ require 'package'
 class Mold < Package
   description 'A Modern Linker'
   homepage 'https://github.com/rui314/mold'
-  version '2.3.2'
+  version '2.3.2-0c6daad'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/rui314/mold.git'
-  git_hashtag "v#{version}"
+  git_hashtag '0c6daad215d0b0d4f835e33366d41a9218212367'
 
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.2_armv7l/mold-2.3.2-chromeos-armv7l.tar.zst',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.2_armv7l/mold-2.3.2-chromeos-armv7l.tar.zst',
        i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.2_i686/mold-2.3.2-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.2_x86_64/mold-2.3.2-chromeos-x86_64.tar.zst'
+    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.2-0c6daad_x86_64/mold-2.3.2-0c6daad-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
     aarch64: 'd3da641a7e37663a989bf0ecacecd37a7bf087fbbc199b5c8afc975c729f5647',
      armv7l: 'd3da641a7e37663a989bf0ecacecd37a7bf087fbbc199b5c8afc975c729f5647',
        i686: '63293b849ec265b40453fa3fbdde565e322bd56725079e24a27d80cfc7a82de2',
-     x86_64: 'c8bdc39c6c9a4b450508635c4eaa874b4aa21bd4338fb113cfa08ead8118bd31'
+    x86_64: '5772b5cb14ca2dfa2946edf2c3f7c7fd5366256aabc0b2cd67bf71f997886ac9'
   })
 
   depends_on 'gcc_lib' # R

--- a/packages/mold.rb
+++ b/packages/mold.rb
@@ -15,14 +15,14 @@ class Mold < Package
   binary_url({
     aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.2_armv7l/mold-2.3.2-chromeos-armv7l.tar.zst',
      armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.2_armv7l/mold-2.3.2-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.2_i686/mold-2.3.2-chromeos-i686.tar.zst',
-    x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.2-0c6daad_x86_64/mold-2.3.2-0c6daad-chromeos-x86_64.tar.zst'
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.2-0c6daad_i686/mold-2.3.2-0c6daad-chromeos-i686.tar.zst',
+  x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/mold/2.3.2-0c6daad_x86_64/mold-2.3.2-0c6daad-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
     aarch64: 'd3da641a7e37663a989bf0ecacecd37a7bf087fbbc199b5c8afc975c729f5647',
      armv7l: 'd3da641a7e37663a989bf0ecacecd37a7bf087fbbc199b5c8afc975c729f5647',
-       i686: '63293b849ec265b40453fa3fbdde565e322bd56725079e24a27d80cfc7a82de2',
-    x86_64: '5772b5cb14ca2dfa2946edf2c3f7c7fd5366256aabc0b2cd67bf71f997886ac9'
+    i686: '91801098f4c2504f7dcc0d38c624224e0a63b8b252df1c5f1d33142e818c74e6',
+  x86_64: '5772b5cb14ca2dfa2946edf2c3f7c7fd5366256aabc0b2cd67bf71f997886ac9'
   })
 
   depends_on 'gcc_lib' # R


### PR DESCRIPTION

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=mold_rebuild crew update ; crew upgrade mold
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
