### PR TITLE
Github Action Unit Test: Test Crew Update, crew upgrade, crew install vim

### DIFF
--- a/.github/workflows/Handoff.yml
+++ b/.github/workflows/Handoff.yml
@@ -54,3 +54,7 @@ jobs:
     needs: handoff
     if: contains(needs.handoff.outputs.category, 'YAML')
     uses: ./.github/workflows/YAMLlint.yml
+  test:
+    needs: handoff
+    if: contains(needs.handoff.outputs.category, 'Ruby')
+    uses: ./.github/workflows/Unit-Test.yml

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -1,0 +1,23 @@
+name: Run Unit Tests on PR
+
+on:
+  pull_request:
+    branches: [master]
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Dump github context
+        run:   echo "$GITHUB_CONTEXT"
+        shell: bash
+        env:
+         GITHUB_CONTEXT: ${{ toJson(github) }}
+      - name: get repository name
+        run: echo "REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
+      - name: Unit Tests
+        run: |
+            sudo docker pull satmandu/crewbuild:amd64
+            sudo docker run -t satmandu/crewbuild:amd64 sudo -i -u chronos /bin/bash -c "
+            CREW_REPO=https://github.com/${{  github.actor  }}/chromebrew.git CREW_BRANCH=$GITHUB_REF_NAME crew update && \
+            yes | crew install vim" >> $GITHUB_OUTPUT

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Unit Tests
         run: |
             sudo docker run -t satmandu/crewbuild:amd64 sudo -i -u chronos /bin/bash -c "
-            echo \"CREW_REPO is ${{  github.actor  }}\" \
-            echo \"CREW_BRANCH is ${{ github.head_ref }}\" \
+            echo \"CREW_REPO is ${{  github.actor  }}\" && \
+            echo \"CREW_BRANCH is ${{ github.head_ref }}\" && \
             CREW_REPO=https://github.com/${{  github.actor  }}/chromebrew.git CREW_BRANCH=${{ github.head_ref }} crew update && \
             yes | crew upgrade && \
             yes | crew install vim"

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -16,6 +16,8 @@ jobs:
       - name: Unit Tests
         run: |
             sudo docker run -t satmandu/crewbuild:amd64 sudo -i -u chronos /bin/bash -c "
+            echo \"CREW_REPO is ${{  github.actor  }}\" \
+            echo \"CREW_BRANCH is ${{ github.head_ref }}\" \
             CREW_REPO=https://github.com/${{  github.actor  }}/chromebrew.git CREW_BRANCH=${{ github.head_ref }} crew update && \
             yes | crew upgrade && \
             yes | crew install vim"

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -13,11 +13,10 @@ jobs:
         shell: bash
         env:
          GITHUB_CONTEXT: ${{ toJson(github) }}
-      - name: get repository name
-        run: echo "REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
       - name: Unit Tests
         run: |
             sudo docker pull satmandu/crewbuild:amd64
             sudo docker run -t satmandu/crewbuild:amd64 sudo -i -u chronos /bin/bash -c "
-            CREW_REPO=https://github.com/${{  github.actor  }}/chromebrew.git CREW_BRANCH=$GITHUB_REF_NAME crew update && \
+            CREW_REPO=https://github.com/${{  github.actor  }}/chromebrew.git CREW_BRANCH=${{ github.head_ref }} crew update && \
+            yes | crew upgrade && \
             yes | crew install vim" >> $GITHUB_OUTPUT

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -15,8 +15,7 @@ jobs:
          GITHUB_CONTEXT: ${{ toJson(github) }}
       - name: Unit Tests
         run: |
-            sudo docker pull satmandu/crewbuild:amd64
             sudo docker run -t satmandu/crewbuild:amd64 sudo -i -u chronos /bin/bash -c "
             CREW_REPO=https://github.com/${{  github.actor  }}/chromebrew.git CREW_BRANCH=${{ github.head_ref }} crew update && \
             yes | crew upgrade && \
-            yes | crew install vim" >> $GITHUB_OUTPUT
+            yes | crew install vim"

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
-CREW_VERSION = '1.38.9'
+CREW_VERSION = '1.38.10'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
- At the moment, this GitHub Action only does this:
```
CREW_REPO=https://github.com/${{  github.actor  }}/chromebrew.git CREW_BRANCH=${{ github.head_ref }} crew update && \
            yes | crew upgrade && \
            yes | crew install vim
```
- Would installing another package for this unit test make sense? I was just looking for a package that also pulls in dependencies, and vim seems like a likely package for people to install first anyways.
- It would also make sense to run all crew functions here, e.g. also do 
```
yes | crew remove vim &&
crew list compatible
...
crew whatprovides (some file) && \
crew const
...
```
- Do we also want to test a simple build? (Maybe that only makes sense if `bin/crew`, anything in `lib/`, or one of the packages in `buildessential.rb` is updated?)