### PR TITLE
Crew update should exit if it fails

### DIFF
--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -17,8 +17,8 @@ jobs:
         run: |
             sudo docker run -t satmandu/crewbuild:amd64 sudo -i -u chronos /bin/bash -c "
             set -e && \
-            echo \"CREW_REPO is ${{ github.head.repo.clone_url }}\" && \
+            echo \"CREW_REPO is ${{ github.event.pull_request.head.repo.clone_url }}\" && \
             echo \"CREW_BRANCH is ${{ github.head_ref }}\" && \
-            CREW_REPO=${{ github.head.repo.clone_url }} CREW_BRANCH=${{ github.head_ref }} crew update && \
+            CREW_REPO=${{ github.event.pull_request.head.repo.clone_url }} CREW_BRANCH=${{ github.head_ref }} crew update && \
             yes | crew upgrade && \
             yes | crew install vim"

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -16,8 +16,9 @@ jobs:
       - name: Unit Tests
         run: |
             sudo docker run -t satmandu/crewbuild:amd64 sudo -i -u chronos /bin/bash -c "
-            echo \"CREW_REPO is ${{  github.clone_url  }}\" && \
+            set -e && \
+            echo \"CREW_REPO is ${{ github.head.repo.clone_url }}\" && \
             echo \"CREW_BRANCH is ${{ github.head_ref }}\" && \
-            CREW_REPO=${{  github.clone_url  }} CREW_BRANCH=${{ github.head_ref }} crew update && \
+            CREW_REPO=${{ github.head.repo.clone_url }} CREW_BRANCH=${{ github.head_ref }} crew update && \
             yes | crew upgrade && \
             yes | crew install vim"

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Unit Tests
         run: |
             sudo docker run -t satmandu/crewbuild:amd64 sudo -i -u chronos /bin/bash -c "
-            echo \"CREW_REPO is ${{  github.actor  }}\" && \
+            echo \"CREW_REPO is ${{  github.clone_url  }}\" && \
             echo \"CREW_BRANCH is ${{ github.head_ref }}\" && \
-            CREW_REPO=https://github.com/${{  github.actor  }}/chromebrew.git CREW_BRANCH=${{ github.head_ref }} crew update && \
+            CREW_REPO=${{  github.clone_url  }} CREW_BRANCH=${{ github.head_ref }} crew update && \
             yes | crew upgrade && \
             yes | crew install vim"

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -20,4 +20,5 @@ jobs:
             echo \"CREW_BRANCH is ${{ github.head_ref }}\" && \
             CREW_REPO=${{ github.event.pull_request.head.repo.clone_url }} CREW_BRANCH=${{ github.head_ref }} crew update && \
             yes | crew upgrade && \
-            yes | crew install vim"
+            yes | crew install vim && \
+            yes | crew remove vim"

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -16,7 +16,6 @@ jobs:
       - name: Unit Tests
         run: |
             sudo docker run -t satmandu/crewbuild:amd64 sudo -i -u chronos /bin/bash -c "
-            set -e && \
             echo \"CREW_REPO is ${{ github.event.pull_request.head.repo.clone_url }}\" && \
             echo \"CREW_BRANCH is ${{ github.head_ref }}\" && \
             CREW_REPO=${{ github.event.pull_request.head.repo.clone_url }} CREW_BRANCH=${{ github.head_ref }} crew update && \

--- a/bin/crew
+++ b/bin/crew
@@ -660,8 +660,8 @@ def update
     system "git sparse-checkout set packages manifest/#{USER_SPACE_ARCH} lib bin crew tools"
     system 'git sparse-checkout reapply'
 
-    system "git fetch #{CREW_REPO} #{CREW_BRANCH}"
-    system 'git reset --hard FETCH_HEAD'
+    system "git fetch #{CREW_REPO} #{CREW_BRANCH}", exception: true
+    system 'git reset --hard FETCH_HEAD', exception: true
   end
 
   puts 'Package lists, crew, and library updated.'

--- a/bin/crew
+++ b/bin/crew
@@ -662,7 +662,6 @@ def update
 
     system "git fetch #{CREW_REPO} #{CREW_BRANCH}", exception: true
     system 'git reset --hard FETCH_HEAD', exception: true
-    exit 1
   end
 
   puts 'Package lists, crew, and library updated.'

--- a/bin/crew
+++ b/bin/crew
@@ -662,6 +662,7 @@ def update
 
     system "git fetch #{CREW_REPO} #{CREW_BRANCH}", exception: true
     system 'git reset --hard FETCH_HEAD', exception: true
+    exit 1
   end
 
   puts 'Package lists, crew, and library updated.'

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,6 +1,6 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
-CREW_VERSION = '1.38.10'
+CREW_VERSION = '1.38.11'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
- Make `crew` exit with errorcode if `crew update` fails.
- Make Github Action use the correct `CREW_REPO`.
- Make Github Action also test `crew remove vim`.
### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=fix_update crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
