### PR TITLE
Remove redundant use of `.to_s`

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1134,7 +1134,7 @@ def prepare_package(destdir)
     # locations.
     if File.exist?("#{CREW_DEST_PREFIX}/man")
       puts "Files in #{CREW_PREFIX}/man will be moved to #{CREW_MAN_PREFIX}.".orange
-      FileUtils.mkdir_p CREW_DEST_MAN_PREFIX.to_s
+      FileUtils.mkdir_p CREW_DEST_MAN_PREFIX
       FileUtils.mv Dir["#{CREW_DEST_PREFIX}/man/*"], "#{CREW_DEST_MAN_PREFIX}/"
       Dir.rmdir "#{CREW_DEST_PREFIX}/man" if Dir.empty?("#{CREW_DEST_PREFIX}/man")
     end
@@ -1146,7 +1146,7 @@ def prepare_package(destdir)
     end
     # Remove the "share/info/dir.*" file since it causes conflicts.
     FileUtils.rm_f Dir["#{CREW_DEST_PREFIX}/share/info/dir*"]
-    compress_doc CREW_DEST_MAN_PREFIX.to_s
+    compress_doc CREW_DEST_MAN_PREFIX
     compress_doc "#{CREW_DEST_PREFIX}/share/info"
 
     # Allow postbuild to override the filelist contents

--- a/lib/buildsystems/python.rb
+++ b/lib/buildsystems/python.rb
@@ -25,7 +25,7 @@ class Python < Package
 
   def self.install
     if File.file?('setup.py')
-      @py_setup_install_options = @no_svem ? PY_SETUP_INSTALL_OPTIONS_NO_SVEM.to_s : PY_SETUP_INSTALL_OPTIONS.to_s
+      @py_setup_install_options = @no_svem ? PY_SETUP_INSTALL_OPTIONS_NO_SVEM : PY_SETUP_INSTALL_OPTIONS
       puts "Python install options being used: #{@py_setup_install_options} #{@python_install_options}".orange
       system "MAKEFLAGS=-j#{CREW_NPROC} python3 setup.py install #{@py_setup_install_options} #{@python_install_options}"
     else

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -147,7 +147,7 @@ Dir.chdir CREW_LIB_PATH do
   @new_const_git_commit = `git log -n1 --oneline #{CREW_LIB_PATH}lib/const.rb`.chomp.split.first
 end
 
-unless @new_const_git_commit.to_s == CREW_CONST_GIT_COMMIT.to_s
+unless @new_const_git_commit == CREW_CONST_GIT_COMMIT
   puts 'Restarting crew update since there is an updated crew version.'.lightcyan
   puts "CREW_REPO=#{CREW_REPO} CREW_BRANCH=#{CREW_BRANCH} crew update".orange if @opt_verbose
   exec "CREW_REPO=#{CREW_REPO} CREW_BRANCH=#{CREW_BRANCH} crew update"

--- a/packages/a52.rb
+++ b/packages/a52.rb
@@ -2,11 +2,11 @@ require 'package'
 require_relative 'liba52'
 
 class A52 < Package
-  description Liba52.description.to_s
-  homepage Liba52.homepage.to_s
-  version Liba52.version.to_s
-  license Liba52.license.to_s
-  compatibility Liba52.compatibility.to_s
+  description Liba52.description
+  homepage Liba52.homepage
+  version Liba52.version
+  license Liba52.license
+  compatibility Liba52.compatibility
 
   is_fake
 

--- a/packages/arpack_ng.rb
+++ b/packages/arpack_ng.rb
@@ -56,7 +56,7 @@ class Arpack_ng < Package
              '-DMPI=ON',
              '..'
       system 'make'
-      system 'ld_default', old_ld.to_s
+      system 'ld_default', old_ld
     end
   end
 

--- a/packages/asciidoctor.rb
+++ b/packages/asciidoctor.rb
@@ -2,11 +2,11 @@ require 'package'
 require_relative 'ruby_asciidoctor'
 
 class Asciidoctor < Package
-  description Ruby_asciidoctor.description.to_s
-  homepage Ruby_asciidoctor.homepage.to_s
-  version Ruby_asciidoctor.version.to_s
-  license Ruby_asciidoctor.license.to_s
-  compatibility Ruby_asciidoctor.compatibility.to_s
+  description Ruby_asciidoctor.description
+  homepage Ruby_asciidoctor.homepage
+  version Ruby_asciidoctor.version
+  license Ruby_asciidoctor.license
+  compatibility Ruby_asciidoctor.compatibility
 
   is_fake
 

--- a/packages/at_spi2_atk.rb
+++ b/packages/at_spi2_atk.rb
@@ -2,11 +2,11 @@ require 'package'
 require_relative 'at_spi2_core'
 
 class At_spi2_atk < Package
-  description At_spi2_core.description.to_s
-  homepage At_spi2_core.homepage.to_s
-  version At_spi2_core.version.to_s
-  license At_spi2_core.license.to_s
-  compatibility At_spi2_core.compatibility.to_s
+  description At_spi2_core.description
+  homepage At_spi2_core.homepage
+  version At_spi2_core.version
+  license At_spi2_core.license
+  compatibility At_spi2_core.compatibility
 
   depends_on 'at_spi2_core'
 

--- a/packages/atk.rb
+++ b/packages/atk.rb
@@ -2,11 +2,11 @@ require 'package'
 require_relative 'at_spi2_core'
 
 class Atk < Package
-  description At_spi2_core.description.to_s
-  homepage At_spi2_core.homepage.to_s
-  version At_spi2_core.version.to_s
-  license At_spi2_core.license.to_s
-  compatibility At_spi2_core.compatibility.to_s
+  description At_spi2_core.description
+  homepage At_spi2_core.homepage
+  version At_spi2_core.version
+  license At_spi2_core.license
+  compatibility At_spi2_core.compatibility
 
   is_fake
 

--- a/packages/avocado.rb
+++ b/packages/avocado.rb
@@ -2,11 +2,11 @@ require 'package'
 require_relative 'avocado_framework'
 
 class Avocado < Package
-  description Avocado_framework.description.to_s
-  homepage Avocado_framework.homepage.to_s
-  version Avocado_framework.version.to_s
-  license Avocado_framework.license.to_s
-  compatibility Avocado_framework.compatibility.to_s
+  description Avocado_framework.description
+  homepage Avocado_framework.homepage
+  version Avocado_framework.version
+  license Avocado_framework.license
+  compatibility Avocado_framework.compatibility
 
   is_fake
 

--- a/packages/az.rb
+++ b/packages/az.rb
@@ -2,11 +2,11 @@ require 'package'
 require_relative 'py3_azure_cli'
 
 class Az < Package
-  description Py3_azure_cli.description.to_s
-  homepage Py3_azure_cli.homepage.to_s
-  version Py3_azure_cli.version.to_s
-  license Py3_azure_cli.license.to_s
-  compatibility Py3_azure_cli.compatibility.to_s
+  description Py3_azure_cli.description
+  homepage Py3_azure_cli.homepage
+  version Py3_azure_cli.version
+  license Py3_azure_cli.license
+  compatibility Py3_azure_cli.compatibility
 
   is_fake
 

--- a/packages/azure_cli.rb
+++ b/packages/azure_cli.rb
@@ -2,11 +2,11 @@ require 'package'
 require_relative 'py3_azure_cli'
 
 class Azure_cli < Package
-  description Py3_azure_cli.description.to_s
-  homepage Py3_azure_cli.homepage.to_s
-  version Py3_azure_cli.version.to_s
-  license Py3_azure_cli.license.to_s
-  compatibility Py3_azure_cli.compatibility.to_s
+  description Py3_azure_cli.description
+  homepage Py3_azure_cli.homepage
+  version Py3_azure_cli.version
+  license Py3_azure_cli.license
+  compatibility Py3_azure_cli.compatibility
 
   is_fake
 

--- a/packages/bitcoin_core.rb
+++ b/packages/bitcoin_core.rb
@@ -21,15 +21,15 @@ class Bitcoin_core < Package
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc"
-    FileUtils.mv 'bin/', CREW_DEST_PREFIX.to_s
-    FileUtils.mv 'share/', CREW_DEST_PREFIX.to_s
-    FileUtils.mv 'include/', CREW_DEST_PREFIX.to_s
+    FileUtils.mv 'bin/', CREW_DEST_PREFIX
+    FileUtils.mv 'share/', CREW_DEST_PREFIX
+    FileUtils.mv 'include/', CREW_DEST_PREFIX
     FileUtils.mv 'bitcoin.conf', "#{CREW_DEST_PREFIX}/etc"
     if ARCH == 'x86_64'
-      FileUtils.mkdir_p CREW_DEST_LIB_PREFIX.to_s
-      FileUtils.mv Dir['lib/*'], CREW_DEST_LIB_PREFIX.to_s
+      FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
+      FileUtils.mv Dir['lib/*'], CREW_DEST_LIB_PREFIX
     else
-      FileUtils.mv 'lib/', CREW_DEST_PREFIX.to_s
+      FileUtils.mv 'lib/', CREW_DEST_PREFIX
     end
   end
 end

--- a/packages/brackets.rb
+++ b/packages/brackets.rb
@@ -43,7 +43,7 @@ class Brackets < Package
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
     FileUtils.mkdir_p "#{CREW_DEST_HOME}/.config/Brackets"
-    FileUtils.mv 'usr/share', CREW_DEST_PREFIX.to_s
+    FileUtils.mv 'usr/share', CREW_DEST_PREFIX
     FileUtils.mv 'opt/brackets', "#{CREW_DEST_PREFIX}/share"
     FileUtils.ln_s "#{CREW_PREFIX}/share/brackets/Brackets", "#{CREW_DEST_PREFIX}/bin/brackets"
     system "touch #{CREW_DEST_HOME}/.config/Brackets/window.ini"

--- a/packages/cairomm.rb
+++ b/packages/cairomm.rb
@@ -3,11 +3,11 @@ require_relative 'cairomm_1_0'
 require_relative 'cairomm_1_16'
 
 class Cairomm < Package
-  description Cairomm_1_0.description.to_s
-  homepage Cairomm_1_0.homepage.to_s
+  description Cairomm_1_0.description
+  homepage Cairomm_1_0.homepage
   version "#{Cairomm_1_0.version}+#{Cairomm_1_16.version}"
-  license Cairomm_1_0.license.to_s
-  compatibility Cairomm_1_0.compatibility.to_s
+  license Cairomm_1_0.license
+  compatibility Cairomm_1_0.compatibility
 
   is_fake
 

--- a/packages/composer.rb
+++ b/packages/composer.rb
@@ -18,7 +18,7 @@ class Composer < Package
   def self.preinstall
     if Dir.exist?("#{HOME}/.config") && !File.symlink?("#{HOME}/.config")
       # Save any existing configuration
-      FileUtils.cp_r "#{HOME}/.config", CREW_PREFIX.to_s, remove_destination: true unless Dir.empty? "#{HOME}/.config"
+      FileUtils.cp_r "#{HOME}/.config", CREW_PREFIX, remove_destination: true unless Dir.empty? "#{HOME}/.config"
     else
       # Remove the symlink, if it exists
       FileUtils.rm_f "#{HOME}/.config"

--- a/packages/crystal.rb
+++ b/packages/crystal.rb
@@ -14,8 +14,8 @@ class Crystal < Package
   print_source_bashrc
 
   def self.install
-    FileUtils.mkdir_p CREW_DEST_PREFIX.to_s
-    FileUtils.mv %w[bin lib share], CREW_DEST_PREFIX.to_s
+    FileUtils.mkdir_p CREW_DEST_PREFIX
+    FileUtils.mv %w[bin lib share], CREW_DEST_PREFIX
     bashcomp = <<~EOF
       # Crystal bash completion
       source "#{CREW_PREFIX}/share/bash-completion/completions/crystal"

--- a/packages/desktop_file_utilities.rb
+++ b/packages/desktop_file_utilities.rb
@@ -2,11 +2,11 @@ require 'package'
 require_relative 'desktop_file_utils'
 
 class Desktop_file_utilities < Package
-  description Desktop_file_utils.description.to_s
-  homepage Desktop_file_utils.homepage.to_s
-  version Desktop_file_utils.version.to_s
-  license Desktop_file_utils.license.to_s
-  compatibility Desktop_file_utils.compatibility.to_s
+  description Desktop_file_utils.description
+  homepage Desktop_file_utils.homepage
+  version Desktop_file_utils.version
+  license Desktop_file_utils.license
+  compatibility Desktop_file_utils.compatibility
 
   is_fake
 

--- a/packages/dexed.rb
+++ b/packages/dexed.rb
@@ -43,12 +43,12 @@ class Dexed < Package
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
-    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX.to_s
+    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
     FileUtils.mkdir_p "#{CREW_DEST_HOME}/.config/dexed"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/pixmaps"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/applications"
     FileUtils.install %w[dcd-client dcd-server dexed dscanner], "#{CREW_DEST_PREFIX}/bin", mode: 0o755
-    FileUtils.install 'libdexed-d.so', CREW_DEST_LIB_PREFIX.to_s, mode: 0o644
+    FileUtils.install 'libdexed-d.so', CREW_DEST_LIB_PREFIX, mode: 0o644
     FileUtils.install 'dexed.png', "#{CREW_DEST_PREFIX}/share/pixmaps", mode: 0o644
     FileUtils.install 'compilerspaths.txt', "#{CREW_DEST_HOME}/.config/dexed", mode: 0o644
     FileUtils.install 'dexed.desktop', "#{CREW_DEST_PREFIX}/share/applications", mode: 0o644

--- a/packages/dmd.rb
+++ b/packages/dmd.rb
@@ -71,20 +71,20 @@ class Dmd < Package
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc"
-    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX.to_s
+    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
     FileUtils.mkdir_p "#{CREW_DEST_MAN_PREFIX}/man1"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/include/phobos"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/include/dmd/druntime"
     FileUtils.install 'dmd/generated/linux/release/64/dmd', "#{CREW_DEST_PREFIX}/bin", mode: 0o755
     FileUtils.cp_r 'dmd/druntime/import', "#{CREW_DEST_PREFIX}/include/dmd/druntime"
     FileUtils.install 'dmd.conf', "#{CREW_DEST_PREFIX}/etc", mode: 0o644
-    FileUtils.cp_r 'dmd/compiler/docs/man/man5', CREW_DEST_MAN_PREFIX.to_s
+    FileUtils.cp_r 'dmd/compiler/docs/man/man5', CREW_DEST_MAN_PREFIX
     Dir.chdir 'dmd/generated/linux/release/64/host_dmd-2.095.0/dmd2/man/man1' do
       FileUtils.install 'dmd.1', "#{CREW_DEST_MAN_PREFIX}/man1", mode: 0o644
     end
     Dir.chdir 'phobos/generated/linux/release/64' do
       libraries = %w[libphobos2.a libphobos2.so libphobos2.so.0.102 libphobos2.so.0.102.1]
-      FileUtils.install libraries, CREW_DEST_LIB_PREFIX.to_s, mode: 0o644
+      FileUtils.install libraries, CREW_DEST_LIB_PREFIX, mode: 0o644
     end
     FileUtils.cp_r ['phobos/etc', 'phobos/std'], "#{CREW_DEST_PREFIX}/include/phobos"
     Dir.chdir 'tools/generated/linux/64' do

--- a/packages/elixir.rb
+++ b/packages/elixir.rb
@@ -20,11 +20,11 @@ class Elixir < Package
     FileUtils.rm_f Dir['bin/*.bat']
     FileUtils.rm_f Dir['man/*.1.in']
     # Prepare destination directories
-    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX.to_s
+    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
     FileUtils.mkdir_p "#{CREW_DEST_MAN_PREFIX}/man1"
     # Add relevant files
-    FileUtils.cp_r 'bin/', CREW_DEST_PREFIX.to_s
-    FileUtils.cp_r Dir['lib/mix/lib/*'], CREW_DEST_LIB_PREFIX.to_s
+    FileUtils.cp_r 'bin/', CREW_DEST_PREFIX
+    FileUtils.cp_r Dir['lib/mix/lib/*'], CREW_DEST_LIB_PREFIX
     FileUtils.cp_r Dir['man/*'], "#{CREW_DEST_MAN_PREFIX}/man1"
   end
 end

--- a/packages/gcc.rb
+++ b/packages/gcc.rb
@@ -3,10 +3,10 @@ require_relative 'gcc_build'
 
 class Gcc < Package
   description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, and Go.'
-  homepage Gcc_build.homepage.to_s
-  version Gcc_build.version.to_s
+  homepage Gcc_build.homepage
+  version Gcc_build.version
   license Gcc_build.license
-  compatibility Gcc_build.compatibility.to_s
+  compatibility Gcc_build.compatibility
 
   is_fake
 

--- a/packages/gcc_dev.rb
+++ b/packages/gcc_dev.rb
@@ -8,7 +8,7 @@ class Gcc_dev < Package
   license Gcc_build.license
   # When upgrading gcc_build, be sure to upgrade gcc_lib, gcc_dev, and libssp in tandem.
   puts "#{self} version differs from gcc version #{Gcc_build.version}".orange if version.to_s.gsub(/-.*/,
-                                                                                                   '') != Gcc_build.version.to_s
+                                                                                                   '') != Gcc_build.version
   compatibility 'all'
   source_url 'SKIP'
 

--- a/packages/gcc_lib.rb
+++ b/packages/gcc_lib.rb
@@ -8,7 +8,7 @@ class Gcc_lib < Package
   license Gcc_build.license
   # When upgrading gcc_build, be sure to upgrade gcc_lib, gcc_dev, and libssp in tandem.
   puts "#{self} version differs from gcc version #{Gcc_build.version}".orange if version.to_s.gsub(/-.*/,
-                                                                                                   '') != Gcc_build.version.to_s
+                                                                                                   '') != Gcc_build.version
   compatibility 'all'
   source_url 'SKIP'
 

--- a/packages/gcr.rb
+++ b/packages/gcr.rb
@@ -3,11 +3,11 @@ require_relative 'gcr_3'
 require_relative 'gcr_4'
 
 class Gcr < Package
-  description Gcr_3.description.to_s
-  homepage Gcr_3.homepage.to_s
+  description Gcr_3.description
+  homepage Gcr_3.homepage
   version "#{Gcr_3.version}+#{Gcr_4.version}"
-  license Gcr_3.license.to_s
-  compatibility Gcr_3.compatibility.to_s
+  license Gcr_3.license
+  compatibility Gcr_3.compatibility
 
   is_fake
 

--- a/packages/gh.rb
+++ b/packages/gh.rb
@@ -2,11 +2,11 @@ require 'package'
 require_relative 'github_cli'
 
 class Gh < Package
-  description Github_cli.description.to_s
-  homepage Github_cli.homepage.to_s
-  version Github_cli.version.to_s
-  license Github_cli.license.to_s
-  compatibility Github_cli.compatibility.to_s
+  description Github_cli.description
+  homepage Github_cli.homepage
+  version Github_cli.version
+  license Github_cli.license
+  compatibility Github_cli.compatibility
 
   is_fake
 

--- a/packages/github_cli.rb
+++ b/packages/github_cli.rb
@@ -24,6 +24,6 @@ class Github_cli < Package
 
   def self.install
     FileUtils.install 'bin/gh', "#{CREW_DEST_PREFIX}/bin/gh", mode: 0o755
-    FileUtils.mv 'share', CREW_DEST_PREFIX.to_s
+    FileUtils.mv 'share', CREW_DEST_PREFIX
   end
 end

--- a/packages/gl2ps.rb
+++ b/packages/gl2ps.rb
@@ -37,8 +37,8 @@ class Gl2ps < Package
     Dir.chdir 'build' do
       system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
       if ARCH == 'x86_64'
-        FileUtils.mkdir_p CREW_DEST_LIB_PREFIX.to_s
-        FileUtils.mv Dir.glob("#{CREW_DEST_PREFIX}/lib/*"), CREW_DEST_LIB_PREFIX.to_s
+        FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
+        FileUtils.mv Dir.glob("#{CREW_DEST_PREFIX}/lib/*"), CREW_DEST_LIB_PREFIX
       end
     end
   end

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -7,32 +7,32 @@ require_relative 'glibc_build235'
 
 class Glibc < Package
   description 'The GNU C Library project provides the core libraries for GNU/Linux systems.'
-  homepage Glibc_build235.homepage.to_s
+  homepage Glibc_build235.homepage
   license Glibc_build235.license
-  compatibility Glibc_build235.compatibility.to_s
+  compatibility Glibc_build235.compatibility
 
   is_fake
 
   case LIBC_VERSION
   when '2.23'
-    version Glibc_build223.version.to_s
-    compatibility Glibc_build223.compatibility.to_s
+    version Glibc_build223.version
+    compatibility Glibc_build223.compatibility
     depends_on 'glibc_build223'
   when '2.27'
-    version Glibc_build227.version.to_s
-    compatibility Glibc_build227.compatibility.to_s
+    version Glibc_build227.version
+    compatibility Glibc_build227.compatibility
     depends_on 'glibc_build227'
   when '2.32'
-    version Glibc_build232.version.to_s
-    compatibility Glibc_build232.compatibility.to_s
+    version Glibc_build232.version
+    compatibility Glibc_build232.compatibility
     depends_on 'glibc_build232'
   when '2.33'
-    version Glibc_build233.version.to_s
-    compatibility Glibc_build233.compatibility.to_s
+    version Glibc_build233.version
+    compatibility Glibc_build233.compatibility
     depends_on 'glibc_build233'
   when '2.35'
-    version Glibc_build235.version.to_s
-    compatibility Glibc_build235.compatibility.to_s
+    version Glibc_build235.version
+    compatibility Glibc_build235.compatibility
     depends_on 'glibc_lib235'
   end
 end

--- a/packages/glibc_dev.rb
+++ b/packages/glibc_dev.rb
@@ -4,20 +4,20 @@ require_relative 'glibc_build235'
 
 class Glibc_dev < Package
   description 'glibc: everything except what is in glibc_lib'
-  homepage Glibc.homepage.to_s
-  license Glibc.license.to_s
+  homepage Glibc.homepage
+  license Glibc.license
   source_url 'SKIP'
 
   is_fake
 
   case LIBC_VERSION
   when '2.35'
-    version Glibc_build235.version.to_s
-    compatibility Glibc_build235.compatibility.to_s
+    version Glibc_build235.version
+    compatibility Glibc_build235.compatibility
     depends_on 'glibc_dev235'
   else
-    version Glibc.version.to_s
-    compatibility Glibc.compatibility.to_s
+    version Glibc.version
+    compatibility Glibc.compatibility
     depends_on 'glibc'
   end
 end

--- a/packages/glibc_lib.rb
+++ b/packages/glibc_lib.rb
@@ -12,12 +12,12 @@ class Glibc_lib < Package
 
   case LIBC_VERSION
   when '2.35'
-    version Glibc_build235.version.to_s
-    compatibility Glibc_build235.compatibility.to_s
+    version Glibc_build235.version
+    compatibility Glibc_build235.compatibility
     depends_on 'glibc_lib235'
   else
-    version Glibc.version.to_s
-    compatibility Glibc.compatibility.to_s
+    version Glibc.version
+    compatibility Glibc.compatibility
     depends_on 'glibc'
   end
 end

--- a/packages/glibmm.rb
+++ b/packages/glibmm.rb
@@ -3,11 +3,11 @@ require_relative 'glibmm_2_4'
 require_relative 'glibmm_2_68'
 
 class Glibmm < Package
-  description Glibmm_2_4.description.to_s
-  homepage Glibmm_2_4.homepage.to_s
+  description Glibmm_2_4.description
+  homepage Glibmm_2_4.homepage
   version "#{Glibmm_2_4.version}+#{Glibmm_2_68.version}"
-  license Glibmm_2_4.license.to_s
-  compatibility Glibmm_2_4.compatibility.to_s
+  license Glibmm_2_4.license
+  compatibility Glibmm_2_4.compatibility
 
   is_fake
 

--- a/packages/google_cloud_sdk.rb
+++ b/packages/google_cloud_sdk.rb
@@ -2,11 +2,11 @@ require 'package'
 require_relative 'gcloud'
 
 class Google_cloud_sdk < Package
-  description Gcloud.description.to_s
-  homepage Gcloud.homepage.to_s
-  version Gcloud.version.to_s
-  license Gcloud.license.to_s
-  compatibility Gcloud.compatibility.to_s
+  description Gcloud.description
+  homepage Gcloud.homepage
+  version Gcloud.version
+  license Gcloud.license
+  compatibility Gcloud.compatibility
 
   is_fake
 

--- a/packages/gst_plugins_bad.rb
+++ b/packages/gst_plugins_bad.rb
@@ -3,10 +3,10 @@ require_relative 'gstreamer'
 
 class Gst_plugins_bad < Package
   description 'Multimedia graph framework - bad plugins'
-  homepage Gstreamer.homepage.to_s
-  version Gstreamer.version.to_s
-  license Gstreamer.license.to_s
-  compatibility Gstreamer.compatibility.to_s
+  homepage Gstreamer.homepage
+  version Gstreamer.version
+  license Gstreamer.license
+  compatibility Gstreamer.compatibility
 
   is_fake
 

--- a/packages/gst_plugins_base.rb
+++ b/packages/gst_plugins_base.rb
@@ -4,9 +4,9 @@ require_relative 'gstreamer'
 class Gst_plugins_base < Package
   description 'An essential, exemplary set of elements for GStreamer'
   homepage 'https://gstreamer.freedesktop.org/modules/gst-plugins-base.html'
-  version Gstreamer.version.to_s
-  license Gstreamer.license.to_s
-  compatibility Gstreamer.compatibility.to_s
+  version Gstreamer.version
+  license Gstreamer.license
+  compatibility Gstreamer.compatibility
 
   is_fake
 

--- a/packages/gst_plugins_good.rb
+++ b/packages/gst_plugins_good.rb
@@ -3,10 +3,10 @@ require_relative 'gstreamer'
 
 class Gst_plugins_good < Package
   description 'Multimedia graph framework - good plugins'
-  homepage Gstreamer.homepage.to_s
-  version Gstreamer.version.to_s
-  license Gstreamer.license.to_s
-  compatibility Gstreamer.compatibility.to_s
+  homepage Gstreamer.homepage
+  version Gstreamer.version
+  license Gstreamer.license
+  compatibility Gstreamer.compatibility
 
   is_fake
 

--- a/packages/gtksourceview.rb
+++ b/packages/gtksourceview.rb
@@ -4,11 +4,11 @@ require_relative 'gtksourceview_4'
 require_relative 'gtksourceview_5'
 
 class Gtksourceview < Package
-  description Gtksourceview_3.description.to_s
-  homepage Gtksourceview_3.homepage.to_s
+  description Gtksourceview_3.description
+  homepage Gtksourceview_3.homepage
   version "#{Gtksourceview_3.version}+#{Gtksourceview_4.version}+#{Gtksourceview_5.version}"
-  license Gtksourceview_3.license.to_s
-  compatibility Gtksourceview_3.compatibility.to_s
+  license Gtksourceview_3.license
+  compatibility Gtksourceview_3.compatibility
 
   is_fake
 

--- a/packages/hunspell.rb
+++ b/packages/hunspell.rb
@@ -4,7 +4,7 @@ require_relative 'hunspell_en_us'
 class Hunspell < Package
   description 'Hunspell is a spell checker and morphological analyzer library'
   homepage 'https://hunspell.github.io/'
-  version Hunspell_en_us.version.to_s
+  version Hunspell_en_us.version
   license 'MPL-1.1, GPL-2 and LGPL-2.1'
   compatibility 'all'
 

--- a/packages/imagemagick.rb
+++ b/packages/imagemagick.rb
@@ -3,11 +3,11 @@ require_relative 'imagemagick6'
 require_relative 'imagemagick7'
 
 class Imagemagick < Package
-  description Imagemagick7.description.to_s
-  homepage Imagemagick7.homepage.to_s
+  description Imagemagick7.description
+  homepage Imagemagick7.homepage
   version "#{Imagemagick6.version}-#{Imagemagick7.version}"
-  license Imagemagick7.license.to_s
-  compatibility Imagemagick7.compatibility.to_s
+  license Imagemagick7.license
+  compatibility Imagemagick7.compatibility
 
   is_fake
 

--- a/packages/irrlicht.rb
+++ b/packages/irrlicht.rb
@@ -60,13 +60,13 @@ class Irrlicht < Package
   end
 
   def self.install
-    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX.to_s
+    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/include/irrlicht"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/libexec/irrlicht"
     FileUtils.cp Dir.glob('include/*'), "#{CREW_DEST_PREFIX}/include/irrlicht"
-    FileUtils.cp 'lib/Linux/libIrrlicht.a', CREW_DEST_LIB_PREFIX.to_s
-    FileUtils.cp 'lib/Linux/libIrrlicht.so.1.8.5', CREW_DEST_LIB_PREFIX.to_s
-    Dir.chdir CREW_DEST_LIB_PREFIX.to_s do
+    FileUtils.cp 'lib/Linux/libIrrlicht.a', CREW_DEST_LIB_PREFIX
+    FileUtils.cp 'lib/Linux/libIrrlicht.so.1.8.5', CREW_DEST_LIB_PREFIX
+    Dir.chdir CREW_DEST_LIB_PREFIX do
       FileUtils.symlink 'libIrrlicht.so.1.8.5', 'libIrrlicht.so.1.8'
       FileUtils.symlink 'libIrrlicht.so.1.8.5', 'libIrrlicht.so'
     end

--- a/packages/jobscheduler.rb
+++ b/packages/jobscheduler.rb
@@ -25,7 +25,7 @@ class Jobscheduler < Package
   depends_on 'jdk8'
 
   def self.install
-    FileUtils.mkdir_p CREW_DEST_PREFIX.to_s
+    FileUtils.mkdir_p CREW_DEST_PREFIX
     system "cp -r bin/ #{CREW_DEST_PREFIX}"
     system "cp -r lib/ #{CREW_DEST_PREFIX}"
     system "cp -r var_4445/ #{CREW_DEST_PREFIX}"

--- a/packages/julia.rb
+++ b/packages/julia.rb
@@ -21,7 +21,7 @@ class Julia < Package
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_LIB_PREFIX}/julia"
-    FileUtils.cp_r Dir['.'], CREW_DEST_PREFIX.to_s
+    FileUtils.cp_r Dir['.'], CREW_DEST_PREFIX
     if ARCH == 'x86_64'
       FileUtils.cd "#{CREW_DEST_PREFIX}/lib/julia" do
         system "find . -type f -exec ln -s #{CREW_PREFIX}/lib/julia/{} #{CREW_DEST_LIB_PREFIX}/julia/{} \\;"

--- a/packages/kr.rb
+++ b/packages/kr.rb
@@ -37,7 +37,7 @@ class Kr < Package
     FileUtils.mkdir_p "#{Dir.pwd}/go/src"
     system 'go get github.com/kryptco/kr'
     FileUtils.cd('go/src/github.com/kryptco/kr') do
-      ENV['PREFIX'] = CREW_PREFIX.to_s
+      ENV['PREFIX'] = CREW_PREFIX
       ENV['PWD'] = Dir.pwd
       system "git checkout tags/#{version}"
       system 'git submodule update --init --recursive'

--- a/packages/ldc.rb
+++ b/packages/ldc.rb
@@ -17,12 +17,12 @@ class Ldc < Package
   print_source_bashrc
 
   def self.install
-    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX.to_s
+    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/bash.d"
     FileUtils.rm Dir['lib/*.o', 'lib/*.a']
     Dir['lib/*'].each do |lib|
-      FileUtils.install lib, CREW_DEST_LIB_PREFIX.to_s, mode: 0o644
+      FileUtils.install lib, CREW_DEST_LIB_PREFIX, mode: 0o644
     end
     Dir['bin/*'].each do |bin|
       FileUtils.install bin, "#{CREW_DEST_PREFIX}/bin", mode: 0o755

--- a/packages/libb64.rb
+++ b/packages/libb64.rb
@@ -29,10 +29,10 @@ class Libb64 < Package
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
-    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX.to_s
+    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/include"
     FileUtils.install 'base64/base64', "#{CREW_DEST_PREFIX}/bin", mode: 0o755
-    FileUtils.install 'src/libb64.a', CREW_DEST_LIB_PREFIX.to_s, mode: 0o644
+    FileUtils.install 'src/libb64.a', CREW_DEST_LIB_PREFIX, mode: 0o644
     FileUtils.cp_r 'include/b64', "#{CREW_DEST_PREFIX}/include"
   end
 end

--- a/packages/libcurl.rb
+++ b/packages/libcurl.rb
@@ -2,11 +2,11 @@ require 'package'
 require_relative 'curl'
 
 class Libcurl < Package
-  description Curl.description.to_s
-  homepage Curl.homepage.to_s
-  version Curl.version.to_s
-  license Curl.license.to_s
-  compatibility Curl.compatibility.to_s
+  description Curl.description
+  homepage Curl.homepage
+  version Curl.version
+  license Curl.license
+  compatibility Curl.compatibility
 
   is_fake
 

--- a/packages/libharu.rb
+++ b/packages/libharu.rb
@@ -39,8 +39,8 @@ class Libharu < Package
     Dir.chdir 'build' do
       system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
       if ARCH == 'x86_64'
-        FileUtils.mkdir_p CREW_DEST_LIB_PREFIX.to_s
-        FileUtils.mv Dir.glob("#{CREW_DEST_PREFIX}/lib/*"), CREW_DEST_LIB_PREFIX.to_s
+        FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
+        FileUtils.mv Dir.glob("#{CREW_DEST_PREFIX}/lib/*"), CREW_DEST_LIB_PREFIX
       end
       FileUtils.rm_f "#{CREW_DEST_PREFIX}/INSTALL"
       FileUtils.rm_f "#{CREW_DEST_PREFIX}/README"

--- a/packages/libressl.rb
+++ b/packages/libressl.rb
@@ -4,9 +4,9 @@ require_relative 'openssl'
 class Libressl < Package
   description 'LibreSSL is a version of the TLS/crypto stack forked from OpenSSL in 2014, with goals of modernizing the codebase, improving security, and applying best practice development processes.'
   homepage 'https://www.libressl.org/'
-  version Openssl.version.to_s
-  license Openssl.license.to_s
-  compatibility Openssl.compatibility.to_s
+  version Openssl.version
+  license Openssl.license
+  compatibility Openssl.compatibility
 
   is_fake
 

--- a/packages/libssp.rb
+++ b/packages/libssp.rb
@@ -8,7 +8,7 @@ class Libssp < Package
   license 'GPL-3, LGPL-3, libgcc, FDL-1.2'
   # When upgrading gcc_build, be sure to upgrade gcc_lib, gcc_dev, and libssp in tandem.
   puts "#{self} version differs from gcc version #{Gcc_build.version}".orange if version.to_s.gsub(/-.*/,
-                                                                                                   '') != Gcc_build.version.to_s
+                                                                                                   '') != Gcc_build.version
   compatibility 'all'
   source_url 'https://github.com/gcc-mirror/gcc.git'
   git_hashtag "releases/gcc-#{version}"

--- a/packages/libstfl.rb
+++ b/packages/libstfl.rb
@@ -45,10 +45,10 @@ class Libstfl < Package
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    Dir.chdir CREW_DEST_PREFIX.to_s do
-      FileUtils.mv 'lib', CREW_DEST_LIB_PREFIX.to_s if CREW_LIB_SUFFIX.to_s == '64'
+    Dir.chdir CREW_DEST_PREFIX do
+      FileUtils.mv 'lib', CREW_DEST_LIB_PREFIX if CREW_LIB_SUFFIX.to_s == '64'
     end
-    Dir.chdir CREW_DEST_LIB_PREFIX.to_s do
+    Dir.chdir CREW_DEST_LIB_PREFIX do
       FileUtils.symlink 'libstfl.so.0.23', 'libstfl.so.0'
     end
   end

--- a/packages/libudev_stub.rb
+++ b/packages/libudev_stub.rb
@@ -40,7 +40,7 @@ class Libudev_stub < Package
     Dir.chdir "#{CREW_DEST_PREFIX}/bin" do
       system "ln -sf #{CREW_PREFIX}/bin/g++-7.3 g++-6"
     end
-    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX.to_s
+    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
     system "cp -r build/out/lib/* #{CREW_DEST_LIB_PREFIX}"
     system "install -Dm755 build/out/bin/libudev_test #{CREW_DEST_PREFIX}/bin/libudev_test"
   end

--- a/packages/libutp.rb
+++ b/packages/libutp.rb
@@ -28,10 +28,10 @@ class Libutp < Package
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
-    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX.to_s
+    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/include/utp"
     FileUtils.install %w[ucat ucat-static], "#{CREW_DEST_PREFIX}/bin", mode: 0o755
-    FileUtils.install %w[libutp.a libutp.so], CREW_DEST_LIB_PREFIX.to_s, mode: 0o644
+    FileUtils.install %w[libutp.a libutp.so], CREW_DEST_LIB_PREFIX, mode: 0o644
     FileUtils.install Dir['*.h'], "#{CREW_DEST_PREFIX}/include/utp", mode: 0o644
   end
 end

--- a/packages/libuuid.rb
+++ b/packages/libuuid.rb
@@ -4,9 +4,9 @@ require_relative 'util_linux'
 class Libuuid < Package
   description 'Portable UUID C library. Bundled with util_linux.'
   homepage 'https://sourceforge.net/projects/libuuid/'
-  version Util_linux.version.to_s
-  license Util_linux.license.to_s
-  compatibility Util_linux.compatibility.to_s
+  version Util_linux.version
+  license Util_linux.license
+  compatibility Util_linux.compatibility
 
   is_fake
 

--- a/packages/libxml2_python.rb
+++ b/packages/libxml2_python.rb
@@ -2,11 +2,11 @@ require 'package'
 require_relative 'py3_libxml2'
 
 class Libxml2_python < Package
-  description Py3_libxml2.description.to_s
-  homepage Py3_libxml2.homepage.to_s
-  version Py3_libxml2.version.to_s
-  license Py3_libxml2.license.to_s
-  compatibility Py3_libxml2.compatibility.to_s
+  description Py3_libxml2.description
+  homepage Py3_libxml2.homepage
+  version Py3_libxml2.version
+  license Py3_libxml2.license
+  compatibility Py3_libxml2.compatibility
 
   is_fake
 

--- a/packages/libxscrnsaver.rb
+++ b/packages/libxscrnsaver.rb
@@ -2,11 +2,11 @@ require 'package'
 require_relative 'libxss'
 
 class Libxscrnsaver < Package
-  description Libxss.description.to_s
-  homepage Libxss.homepage.to_s
-  version Libxss.version.to_s
-  license Libxss.license.to_s
-  compatibility Libxss.compatibility.to_s
+  description Libxss.description
+  homepage Libxss.homepage
+  version Libxss.version
+  license Libxss.license
+  compatibility Libxss.compatibility
 
   is_fake
 

--- a/packages/llvm.rb
+++ b/packages/llvm.rb
@@ -3,10 +3,10 @@ require_relative 'llvm17_build'
 
 class Llvm < Package
   description 'The LLVM Project is a collection of modular and reusable compiler and toolchain technologies. The optional packages clang, lld, lldb, polly, compiler-rt, libcxx, and libcxxabi are included.'
-  homepage Llvm17_build.homepage.to_s
-  version Llvm17_build.version.to_s
+  homepage Llvm17_build.homepage
+  version Llvm17_build.version
   license Llvm17_build.license
-  compatibility Llvm17_build.compatibility.to_s
+  compatibility Llvm17_build.compatibility
 
   is_fake
 

--- a/packages/llvm16_dev.rb
+++ b/packages/llvm16_dev.rb
@@ -6,7 +6,7 @@ class Llvm16_dev < Package
   homepage Llvm16_build.homepage
   version '16.0.6'
   # When upgrading llvm_build*, be sure to upgrade llvm_lib* and llvm_dev* in tandem.
-  puts "#{self} version differs from llvm version #{Llvm16_build.version}".orange if version != Llvm16_build.version.to_s
+  puts "#{self} version differs from llvm version #{Llvm16_build.version}".orange if version != Llvm16_build.version
   license Llvm16_build.license
   compatibility 'all'
   source_url 'SKIP'

--- a/packages/llvm16_lib.rb
+++ b/packages/llvm16_lib.rb
@@ -6,7 +6,7 @@ class Llvm16_lib < Package
   homepage Llvm16_build.homepage
   version '16.0.6'
   # When upgrading llvm_build*, be sure to upgrade llvm_lib* and llvm_dev* in tandem.
-  puts "#{self} version differs from llvm version #{Llvm16_build.version}".orange if version != Llvm16_build.version.to_s
+  puts "#{self} version differs from llvm version #{Llvm16_build.version}".orange if version != Llvm16_build.version
   license Llvm16_build.license
   compatibility 'all'
   source_url 'SKIP'

--- a/packages/llvm17_dev.rb
+++ b/packages/llvm17_dev.rb
@@ -6,7 +6,7 @@ class Llvm17_dev < Package
   homepage Llvm17_build.homepage
   version '17.0.4'
   # When upgrading llvm_build*, be sure to upgrade llvm_lib* and llvm_dev* in tandem.
-  puts "#{self} version differs from llvm version #{Llvm17_build.version}".orange if version != Llvm17_build.version.to_s
+  puts "#{self} version differs from llvm version #{Llvm17_build.version}".orange if version != Llvm17_build.version
   license Llvm17_build.license
   compatibility 'all'
   source_url 'SKIP'

--- a/packages/llvm17_lib.rb
+++ b/packages/llvm17_lib.rb
@@ -6,7 +6,7 @@ class Llvm17_lib < Package
   homepage Llvm17_build.homepage
   version '17.0.4'
   # When upgrading llvm_build*, be sure to upgrade llvm_lib* and llvm_dev* in tandem.
-  puts "#{self} version differs from llvm version #{Llvm17_build.version}".orange if version != Llvm17_build.version.to_s
+  puts "#{self} version differs from llvm version #{Llvm17_build.version}".orange if version != Llvm17_build.version
   license Llvm17_build.license
   compatibility 'all'
   source_url 'SKIP'

--- a/packages/llvm_build16.rb
+++ b/packages/llvm_build16.rb
@@ -3,10 +3,10 @@ require_relative 'llvm16_build'
 
 class Llvm_build16 < Package
   description 'The LLVM Project is a collection of modular and reusable compiler and toolchain technologies. The optional packages clang, lld, lldb, polly, compiler-rt, libcxx, and libcxxabi are included.'
-  homepage Llvm16_build.homepage.to_s
-  version Llvm16_build.version.to_s
+  homepage Llvm16_build.homepage
+  version Llvm16_build.version
   license Llvm16_build.license
-  compatibility Llvm16_build.compatibility.to_s
+  compatibility Llvm16_build.compatibility
 
   is_fake
 

--- a/packages/llvm_dev16.rb
+++ b/packages/llvm_dev16.rb
@@ -3,10 +3,10 @@ require_relative 'llvm16_build'
 
 class Llvm_dev16 < Package
   description 'The LLVM Project is a collection of modular and reusable compiler and toolchain technologies. The optional packages clang, lld, lldb, polly, compiler-rt, libcxx, and libcxxabi are included.'
-  homepage Llvm16_build.homepage.to_s
-  version Llvm16_build.version.to_s
+  homepage Llvm16_build.homepage
+  version Llvm16_build.version
   license Llvm16_build.license
-  compatibility Llvm16_build.compatibility.to_s
+  compatibility Llvm16_build.compatibility
 
   is_fake
 

--- a/packages/llvm_lib16.rb
+++ b/packages/llvm_lib16.rb
@@ -3,10 +3,10 @@ require_relative 'llvm16_build'
 
 class Llvm_lib16 < Package
   description 'The LLVM Project is a collection of modular and reusable compiler and toolchain technologies. The optional packages clang, lld, lldb, polly, compiler-rt, libcxx, and libcxxabi are included.'
-  homepage Llvm16_build.homepage.to_s
-  version Llvm16_build.version.to_s
+  homepage Llvm16_build.homepage
+  version Llvm16_build.version
   license Llvm16_build.license
-  compatibility Llvm16_build.compatibility.to_s
+  compatibility Llvm16_build.compatibility
 
   is_fake
 

--- a/packages/lzma.rb
+++ b/packages/lzma.rb
@@ -4,9 +4,9 @@ require_relative 'xzutils'
 class Lzma < Package
   description 'LZMA Utils are legacy data compression software with high compression ratio. Bundled with xzutils.'
   homepage 'https://tukaani.org/lzma/'
-  version Xzutils.version.to_s
-  license Xzutils.license.to_s
-  compatibility Xzutils.compatibility.to_s
+  version Xzutils.version
+  license Xzutils.license
+  compatibility Xzutils.compatibility
 
   is_fake
 

--- a/packages/minecraft.rb
+++ b/packages/minecraft.rb
@@ -21,7 +21,7 @@ class Minecraft < Package
   no_fhs
 
   def self.install
-    FileUtils.mkdir_p CREW_DEST_PREFIX.to_s
+    FileUtils.mkdir_p CREW_DEST_PREFIX
     FileUtils.cp_r '.', "#{CREW_DEST_PREFIX}/"
     FileUtils.mv "#{CREW_DEST_PREFIX}/bin/minecraft-launcher", "#{CREW_DEST_PREFIX}/bin/minecraft-launcher.elf"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/.config/.minecraft"

--- a/packages/musl_cc_toolchain.rb
+++ b/packages/musl_cc_toolchain.rb
@@ -35,7 +35,7 @@ class Musl_cc_toolchain < Package
       FileUtils.ln_sf 'libc.so', 'ld-musl-x86_64.so.1' if ARCH == 'x86_64'
       FileUtils.ln_sf 'libc.so', 'ld-musl-armhf.so.1' if ARCH == 'armv7l'
     end
-    Dir.chdir(CREW_DEST_MUSL_PREFIX.to_s) do
+    Dir.chdir(CREW_DEST_MUSL_PREFIX) do
       FileUtils.ln_sf 'lib', 'lib64' if ARCH == 'x86_64'
     end
   end

--- a/packages/musl_toolchain.rb
+++ b/packages/musl_toolchain.rb
@@ -2,11 +2,11 @@ require 'package'
 require_relative 'musl_cc_toolchain'
 
 class Musl_toolchain < Package
-  description Musl_cc_toolchain.description.to_s
-  homepage Musl_cc_toolchain.homepage.to_s
-  version Musl_cc_toolchain.version.to_s
-  license Musl_cc_toolchain.license.to_s
-  compatibility Musl_cc_toolchain.compatibility.to_s
+  description Musl_cc_toolchain.description
+  homepage Musl_cc_toolchain.homepage
+  version Musl_cc_toolchain.version
+  license Musl_cc_toolchain.license
+  compatibility Musl_cc_toolchain.compatibility
 
   is_fake
 

--- a/packages/netpbm.rb
+++ b/packages/netpbm.rb
@@ -46,7 +46,7 @@ class Netpbm < Package
     system "sed -i 's,/usr/bin/perl,#{CREW_PREFIX}/bin/perl,' #{CREW_DEST_PREFIX}/bin/manweb"
     system "sed -i 's,/etc/manweb.conf,#{CREW_PREFIX}/etc/manweb.conf,' #{CREW_DEST_PREFIX}/bin/manweb"
     FileUtils.mv "#{CREW_DEST_PREFIX}/man", "#{CREW_DEST_PREFIX}/share"
-    FileUtils.mv "#{CREW_DEST_PREFIX}/lib", CREW_DEST_LIB_PREFIX.to_s if ARCH == 'x86_64'
+    FileUtils.mv "#{CREW_DEST_PREFIX}/lib", CREW_DEST_LIB_PREFIX if ARCH == 'x86_64'
     FileUtils.rm_f '/tmp/netpbm'
   end
 end

--- a/packages/node.rb
+++ b/packages/node.rb
@@ -4,7 +4,7 @@ require_relative 'nodebrew'
 class Node < Package
   description 'As an asynchronous event driven JavaScript runtime, Node is designed to build scalable network applications.'
   homepage 'https://nodejs.org/en/'
-  version Nodebrew.version.to_s
+  version Nodebrew.version
   license 'Apache-1.1, Apache-2.0, BSD, BSD-2 and MIT'
   compatibility 'all'
 

--- a/packages/nspr.rb
+++ b/packages/nspr.rb
@@ -4,7 +4,7 @@ require_relative 'nss'
 class Nspr < Package
   description 'Netscape Portable Runtime (NSPR) provides a platform-neutral API for system level and libc-like functions.'
   homepage 'https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR'
-  version Nss.version.to_s
+  version Nss.version
   license 'MPL-2.0, GPL-2 or LGPL-2.1'
   compatibility 'all'
 

--- a/packages/openmp.rb
+++ b/packages/openmp.rb
@@ -9,7 +9,7 @@ class Openmp < Package
   homepage 'https://openmp.llvm.org/'
   version '17.0.4'
   # When upgrading llvm_build*, be sure to upgrade openmp in tandem.
-  puts "#{self} version differs from llvm version #{Llvm17_build.version}".orange if version != Llvm17_build.version.to_s
+  puts "#{self} version differs from llvm version #{Llvm17_build.version}".orange if version != Llvm17_build.version
   license 'Apache-2.0-with-LLVM-exceptions, UoI-NCSA, BSD, public-domain, rc, Apache-2.0 and MIT'
   compatibility 'all'
   source_url 'https://github.com/llvm/llvm-project.git'

--- a/packages/orc.rb
+++ b/packages/orc.rb
@@ -4,9 +4,9 @@ require_relative 'gstreamer'
 class Orc < Package
   description 'Optimized Inner Loop Runtime Compiler. Bundled with gstreamer.'
   homepage 'https://gitlab.freedesktop.org/gstreamer/orc'
-  version Gstreamer.version.to_s
-  license Gstreamer.license.to_s
-  compatibility Gstreamer.compatibility.to_s
+  version Gstreamer.version
+  license Gstreamer.license
+  compatibility Gstreamer.compatibility
 
   is_fake
 

--- a/packages/p7zip.rb
+++ b/packages/p7zip.rb
@@ -2,11 +2,11 @@ require 'package'
 require_relative 'pkg_7_zip'
 
 class P7zip < Package
-  description Pkg_7_zip.description.to_s
-  homepage Pkg_7_zip.homepage.to_s
-  version Pkg_7_zip.version.to_s
-  license Pkg_7_zip.license.to_s
-  compatibility Pkg_7_zip.compatibility.to_s
+  description Pkg_7_zip.description
+  homepage Pkg_7_zip.homepage
+  version Pkg_7_zip.version
+  license Pkg_7_zip.license
+  compatibility Pkg_7_zip.compatibility
 
   is_fake
 

--- a/packages/pandoc.rb
+++ b/packages/pandoc.rb
@@ -24,7 +24,7 @@ class Pandoc < Package
   })
 
   def self.install
-    FileUtils.mkdir_p CREW_DEST_PREFIX.to_s
+    FileUtils.mkdir_p CREW_DEST_PREFIX
     system "cp -r bin/ #{CREW_DEST_PREFIX}"
     system "cp -r share/ #{CREW_DEST_PREFIX}"
   end

--- a/packages/pangomm.rb
+++ b/packages/pangomm.rb
@@ -3,11 +3,11 @@ require_relative 'pangomm_1_4'
 require_relative 'pangomm_2_48'
 
 class Pangomm < Package
-  description Pangomm_1_4.description.to_s
-  homepage Pangomm_1_4.homepage.to_s
+  description Pangomm_1_4.description
+  homepage Pangomm_1_4.homepage
   version "#{Pangomm_1_4.version}+#{Pangomm_2_48.version}"
-  license Pangomm_1_4.license.to_s
-  compatibility Pangomm_1_4.compatibility.to_s
+  license Pangomm_1_4.license
+  compatibility Pangomm_1_4.compatibility
 
   is_fake
 

--- a/packages/parallel.rb
+++ b/packages/parallel.rb
@@ -3,10 +3,10 @@ require_relative 'moreutils'
 
 class Parallel < Package
   description 'Run multiple programs simultaneously. Bundled with moreutils.'
-  homepage Moreutils.homepage.to_s
-  version Moreutils.version.to_s
-  license Moreutils.license.to_s
-  compatibility Moreutils.compatibility.to_s
+  homepage Moreutils.homepage
+  version Moreutils.version
+  license Moreutils.license
+  compatibility Moreutils.compatibility
 
   is_fake
 

--- a/packages/perl_gcstring_linebreak.rb
+++ b/packages/perl_gcstring_linebreak.rb
@@ -4,7 +4,7 @@ require_relative 'perl_unicode_linebreak'
 class Perl_gcstring_linebreak < Package
   description 'UAX 14 Unicode Line Breaking Algorithm - Perl binding Unicode::LineBreak Unicode::GCString'
   homepage 'http://search.cpan.org/~nezumi/Unicode-LineBreak-2018.003/lib/Unicode/LineBreak.pod'
-  version Perl_unicode_linebreak.version.to_s
+  version Perl_unicode_linebreak.version
   license 'GPL-1+ or Artistic'
   compatibility 'all'
 

--- a/packages/perl_read_key.rb
+++ b/packages/perl_read_key.rb
@@ -4,7 +4,7 @@ require_relative 'perl_term_readkey'
 class Perl_read_key < Package
   description 'Term::ReadKey - A perl module for simple terminal control'
   homepage 'https://metacpan.org/pod/Term::ReadKey'
-  version Perl_term_readkey.version.to_s
+  version Perl_term_readkey.version
   license 'GPL-1+ or Artistic'
   compatibility 'all'
 

--- a/packages/perl_term_ansicolor.rb
+++ b/packages/perl_term_ansicolor.rb
@@ -4,7 +4,7 @@ require_relative 'perl'
 class Perl_term_ansicolor < Package
   description 'Character mode terminal access for Perl Term::ANSIColor'
   homepage 'https://metacpan.org/pod/Term::ANSIColor'
-  version Perl.version.to_s
+  version Perl.version
   license 'GPL-1+ or Artistic'
   compatibility 'all'
 

--- a/packages/perl_time_hires.rb
+++ b/packages/perl_time_hires.rb
@@ -4,7 +4,7 @@ require_relative 'perl'
 class Perl_time_hires < Package
   description 'High resolution alarm, sleep, gettimeofday, interval timers Time::HiRes'
   homepage 'https://metacpan.org/pod/Time::HiRes'
-  version Perl.version.to_s
+  version Perl.version
   license 'GPL-1+ or Artistic'
   compatibility 'all'
 

--- a/packages/perl_xml_sax_parserfactory.rb
+++ b/packages/perl_xml_sax_parserfactory.rb
@@ -4,7 +4,7 @@ require_relative 'perl_xml_sax'
 class Perl_xml_sax_parserfactory < Package
   description 'XML::SAX::ParserFactory is a factory class for providing an application with a Perl SAX2 XML parser.'
   homepage 'https://metacpan.org/pod/XML::SAX::ParserFactory'
-  version Perl_xml_sax.version.to_s
+  version Perl_xml_sax.version
   license 'GPL-1+ or Artistic'
   compatibility 'all'
 

--- a/packages/pkgsrc.rb
+++ b/packages/pkgsrc.rb
@@ -34,14 +34,14 @@ class Pkgsrc < Package
 --pkgdbdir=#{CREW_PREFIX}/pkg/pkgdb --sysconfdir=#{CREW_PREFIX}/pkg/etc --varbase=#{CREW_PREFIX}/pkg/var \
 --workdir=#{CREW_DEST_PREFIX} --cwrappers=no --prefer-pkgsrc=yes --make-jobs=#{CREW_NPROC}"
     end
-    FileUtils.mv "#{CREW_PREFIX}/pkg", CREW_DEST_PREFIX.to_s
+    FileUtils.mv "#{CREW_PREFIX}/pkg", CREW_DEST_PREFIX
     FileUtils.chdir "#{CREW_DEST_PREFIX}/bin" do
       system 'rm -f bmake nawk sed'
     end
     FileUtils.chdir "#{CREW_DEST_PREFIX}/sbin" do
       system 'rm -f *'
     end
-    FileUtils.chdir CREW_DEST_PREFIX.to_s do
+    FileUtils.chdir CREW_DEST_PREFIX do
       system "curl -#LO ftp://ftp.netbsd.org/pub/pkgsrc/pkgsrc-#{version}/pkgsrc-#{version}.tar.xz"
       abort 'Checksum mismatch. :/ Try again.'.lightred unless Digest::SHA256.hexdigest(File.read("pkgsrc-#{version}.tar.xz")) == '133d2f79115c87ad7dbf6f7ab604ddc0d09afe3b1d3c4cda5670c1fb758eb283'
       system "tar xvf pkgsrc-#{version}.tar.xz"

--- a/packages/pycairo.rb
+++ b/packages/pycairo.rb
@@ -2,11 +2,11 @@ require 'package'
 require_relative 'py3_pycairo'
 
 class Pycairo < Package
-  description Py3_pycairo.description.to_s
-  homepage Py3_pycairo.homepage.to_s
-  version Py3_pycairo.version.to_s
-  license Py3_pycairo.license.to_s
-  compatibility Py3_pycairo.compatibility.to_s
+  description Py3_pycairo.description
+  homepage Py3_pycairo.homepage
+  version Py3_pycairo.version
+  license Py3_pycairo.license
+  compatibility Py3_pycairo.compatibility
 
   is_fake
 

--- a/packages/python27.rb
+++ b/packages/python27.rb
@@ -3,9 +3,9 @@ require_relative 'python2'
 
 class Python27 < Package
   description 'A compatibility package for python2.'
-  homepage Python2.homepage.to_s
-  version Python2.version.to_s
-  compatibility Python2.compatibility.to_s
+  homepage Python2.homepage
+  version Python2.version
+  compatibility Python2.compatibility
 
   is_fake
 

--- a/packages/ragel.rb
+++ b/packages/ragel.rb
@@ -4,7 +4,7 @@ require_relative 'harfbuzz'
 class Ragel < Package
   description 'Ragel compiles executable finite state machines from regular languages. Now bundled with harfbuzz.'
   homepage 'https://www.colm.net/open-source/ragel/'
-  version Harfbuzz.version.to_s
+  version Harfbuzz.version
   license 'MIT' # Previously was GPL-2
   compatibility 'all'
 

--- a/packages/rkhunter.rb
+++ b/packages/rkhunter.rb
@@ -18,7 +18,7 @@ class Rkhunter < Package
   end
 
   def self.install
-    FileUtils.mkdir_p CREW_DEST_PREFIX.to_s
+    FileUtils.mkdir_p CREW_DEST_PREFIX
     system './installer.sh --install'
     system "sed -i 's,#{CREW_DEST_PREFIX},#{CREW_PREFIX},g' #{CREW_DEST_PREFIX}/etc/rkhunter.conf"
   end

--- a/packages/rubberband.rb
+++ b/packages/rubberband.rb
@@ -39,7 +39,7 @@ class Rubberband < Package
     system "sed -i '186d' Makefile"
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     if ARCH == 'x86_64'
-      Dir.chdir CREW_DEST_PREFIX.to_s do
+      Dir.chdir CREW_DEST_PREFIX do
         FileUtils.mv 'lib/', 'lib64/'
       end
     end

--- a/packages/signal_desktop.rb
+++ b/packages/signal_desktop.rb
@@ -26,7 +26,7 @@ class Signal_desktop < Package
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
-    FileUtils.mv 'usr/share', CREW_DEST_PREFIX.to_s
+    FileUtils.mv 'usr/share', CREW_DEST_PREFIX
     FileUtils.mv 'opt/Signal', "#{CREW_DEST_PREFIX}/share"
     FileUtils.ln_s "#{CREW_PREFIX}/share/Signal/signal-desktop", "#{CREW_DEST_PREFIX}/bin/signal-desktop"
   end

--- a/packages/six.rb
+++ b/packages/six.rb
@@ -2,11 +2,11 @@ require 'package'
 require_relative 'py3_six'
 
 class Six < Package
-  description Py3_six.description.to_s
-  homepage Py3_six.homepage.to_s
-  version Py3_six.version.to_s
-  license Py3_six.license.to_s
-  compatibility Py3_six.compatibility.to_s
+  description Py3_six.description
+  homepage Py3_six.homepage
+  version Py3_six.version
+  license Py3_six.license
+  compatibility Py3_six.compatibility
 
   is_fake
 

--- a/packages/stow.rb
+++ b/packages/stow.rb
@@ -2,11 +2,11 @@ require 'package'
 require_relative 'perl_stow'
 
 class Stow < Package
-  description Perl_stow.description.to_s
-  homepage Perl_stow.homepage.to_s
-  version Perl_stow.version.to_s
-  license Perl_stow.license.to_s
-  compatibility Perl_stow.compatibility.to_s
+  description Perl_stow.description
+  homepage Perl_stow.homepage
+  version Perl_stow.version
+  license Perl_stow.license
+  compatibility Perl_stow.compatibility
 
   depends_on 'perl_stow'
 

--- a/packages/tcpwrappers.rb
+++ b/packages/tcpwrappers.rb
@@ -42,7 +42,7 @@ class Tcpwrappers < Package
   end
 
   def self.install
-    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX.to_s
+    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/sbin"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/include"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/man/man3"

--- a/packages/tepl.rb
+++ b/packages/tepl.rb
@@ -3,11 +3,11 @@ require_relative 'tepl_5'
 require_relative 'tepl_6'
 
 class Tepl < Package
-  description Tepl_5.description.to_s
-  homepage Tepl_5.homepage.to_s
+  description Tepl_5.description
+  homepage Tepl_5.homepage
   version "#{Tepl_5.version}+#{Tepl_6.version}"
-  license Tepl_5.license.to_s
-  compatibility Tepl_5.compatibility.to_s
+  license Tepl_5.license
+  compatibility Tepl_5.compatibility
 
   is_fake
 

--- a/packages/texlive.rb
+++ b/packages/texlive.rb
@@ -63,7 +63,7 @@ class Texlive < Package
     end
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/env.d/"
     destpath = `echo #{CREW_DEST_PREFIX}/share/texlive/20*`.chomp
-    path = destpath.gsub(CREW_DEST_PREFIX.to_s, CREW_PREFIX.to_s)
+    path = destpath.gsub(CREW_DEST_PREFIX, CREW_PREFIX)
     @texliveenv = <<~TEXLIVEEOF
       # texlive configuration
       export PATH="$PATH:#{path}/bin/#{@archpath}"

--- a/packages/tilp.rb
+++ b/packages/tilp.rb
@@ -2,11 +2,11 @@ require 'package'
 require_relative 'tilp2'
 
 class Tilp < Package
-  description Tilp2.description.to_s
-  homepage Tilp2.homepage.to_s
-  version Tilp2.version.to_s
-  license Tilp2.license.to_s
-  compatibility Tilp2.compatibility.to_s
+  description Tilp2.description
+  homepage Tilp2.homepage
+  version Tilp2.version
+  license Tilp2.license
+  compatibility Tilp2.compatibility
 
   is_fake
 

--- a/packages/vamp_sdk.rb
+++ b/packages/vamp_sdk.rb
@@ -34,7 +34,7 @@ class Vamp_sdk < Package
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     if ARCH == 'x86_64'
-      Dir.chdir CREW_DEST_PREFIX.to_s do
+      Dir.chdir CREW_DEST_PREFIX do
         FileUtils.mv 'lib/', 'lib64/'
       end
     end

--- a/packages/webkit2gtk.rb
+++ b/packages/webkit2gtk.rb
@@ -2,11 +2,11 @@ require 'package'
 require_relative 'webkit2gtk_4'
 
 class Webkit2gtk < Package
-  description Webkit2gtk_4.description.to_s
-  homepage Webkit2gtk_4.homepage.to_s
-  version Webkit2gtk_4.version.to_s
-  license Webkit2gtk_4.license.to_s
-  compatibility Webkit2gtk_4.compatibility.to_s
+  description Webkit2gtk_4.description
+  homepage Webkit2gtk_4.homepage
+  version Webkit2gtk_4.version
+  license Webkit2gtk_4.license
+  compatibility Webkit2gtk_4.compatibility
 
   is_fake
 

--- a/packages/webkit2gtk_5.rb
+++ b/packages/webkit2gtk_5.rb
@@ -2,11 +2,11 @@ require 'package'
 require_relative 'webkitgtk_6'
 
 class Webkit2gtk_5 < Package
-  description Webkitgtk_6.description.to_s
-  homepage Webkitgtk_6.homepage.to_s
-  version Webkitgtk_6.version.to_s
-  license Webkitgtk_6.license.to_s
-  compatibility Webkitgtk_6.compatibility.to_s
+  description Webkitgtk_6.description
+  homepage Webkitgtk_6.homepage
+  version Webkitgtk_6.version
+  license Webkitgtk_6.license
+  compatibility Webkitgtk_6.compatibility
 
   is_fake
 

--- a/packages/wkhtmltox.rb
+++ b/packages/wkhtmltox.rb
@@ -16,11 +16,11 @@ class Wkhtmltox < Package
   })
 
   def self.install
-    FileUtils.mkdir_p CREW_DEST_PREFIX.to_s
-    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX.to_s
-    FileUtils.cp_r 'bin/', CREW_DEST_PREFIX.to_s
-    FileUtils.cp_r Dir.glob('lib/*'), CREW_DEST_LIB_PREFIX.to_s
-    FileUtils.cp_r 'share/', CREW_DEST_PREFIX.to_s
-    FileUtils.cp_r 'include/', CREW_DEST_PREFIX.to_s
+    FileUtils.mkdir_p CREW_DEST_PREFIX
+    FileUtils.mkdir_p CREW_DEST_LIB_PREFIX
+    FileUtils.cp_r 'bin/', CREW_DEST_PREFIX
+    FileUtils.cp_r Dir.glob('lib/*'), CREW_DEST_LIB_PREFIX
+    FileUtils.cp_r 'share/', CREW_DEST_PREFIX
+    FileUtils.cp_r 'include/', CREW_DEST_PREFIX
   end
 end

--- a/packages/xorg_lib.rb
+++ b/packages/xorg_lib.rb
@@ -3,10 +3,10 @@ require_relative 'libx11'
 
 class Xorg_lib < Package
   description 'A collection of xorg libraries.'
-  homepage Libx11.homepage.to_s
-  version Libx11.version.to_s
-  license Libx11.license.to_s
-  compatibility Libx11.compatibility.to_s
+  homepage Libx11.homepage
+  version Libx11.version
+  license Libx11.license
+  compatibility Libx11.compatibility
 
   is_fake
 

--- a/packages/yarn.rb
+++ b/packages/yarn.rb
@@ -13,8 +13,8 @@ class Yarn < Package
   depends_on 'nodebrew' unless node_version.to_s != ''
 
   def self.install
-    FileUtils.mkdir_p CREW_DEST_PREFIX.to_s
+    FileUtils.mkdir_p CREW_DEST_PREFIX
     FileUtils.rm_f ['bin/yarn.cmd', 'bin/yarnpkg.cmd']
-    FileUtils.cp_r ['bin/', 'lib/'], CREW_DEST_PREFIX.to_s
+    FileUtils.cp_r ['bin/', 'lib/'], CREW_DEST_PREFIX
   end
 end

--- a/packages/youtubedl.rb
+++ b/packages/youtubedl.rb
@@ -2,11 +2,11 @@ require 'package'
 require_relative 'youtube_dl'
 
 class Youtubedl < Package
-  description Youtube_dl.description.to_s
-  homepage Youtube_dl.homepage.to_s
-  version Youtube_dl.version.to_s
-  license Youtube_dl.license.to_s
-  compatibility Youtube_dl.compatibility.to_s
+  description Youtube_dl.description
+  homepage Youtube_dl.homepage
+  version Youtube_dl.version
+  license Youtube_dl.license
+  compatibility Youtube_dl.compatibility
 
   is_fake
 

--- a/packages/zoxide.rb
+++ b/packages/zoxide.rb
@@ -34,12 +34,12 @@ class Zoxide < Package
   end
 
   def self.install
-    FileUtils.mkdir_p CREW_DEST_MAN_PREFIX.to_s
+    FileUtils.mkdir_p CREW_DEST_MAN_PREFIX
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share"
     FileUtils.install 'zoxide.bash', "#{CREW_DEST_PREFIX}/etc/env.d/zoxide.bash", mode: 0o644
     FileUtils.install 'zoxide.init', "#{CREW_DEST_PREFIX}/etc/env.d/zoxide.init", mode: 0o644
     FileUtils.install 'zoxide', "#{CREW_DEST_PREFIX}/bin/zoxide", mode: 0o755
     FileUtils.mv 'completions', "#{CREW_DEST_PREFIX}/share"
-    FileUtils.mv 'man/man1', CREW_DEST_MAN_PREFIX.to_s
+    FileUtils.mv 'man/man1', CREW_DEST_MAN_PREFIX
   end
 end


### PR DESCRIPTION
Removed some unnecessary `.to_s` usage on variables which must be a string.

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/supechicken/chromebrew.git CREW_BRANCH=refactor-2 crew update
```
