### PR TITLE
Remove pixz from install.sh and core.rb

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -345,7 +345,6 @@ crew update compatible
 
 echo_info "Installing core Chromebrew packages...\n"
 # We need these to install core.
-yes | crew install pixz
 yes | crew install core
 
 echo_info "\nRunning Bootstrap package postinstall scripts...\n"

--- a/packages/core.rb
+++ b/packages/core.rb
@@ -65,7 +65,6 @@ class Core < Package
   depends_on 'pcre'
   depends_on 'pcre2'
   depends_on 'perl'
-  depends_on 'pixz'
   depends_on 'popt'
   depends_on 'py3_wheel'
   depends_on 'python3'


### PR DESCRIPTION
Following up on #8916.

Tested and working on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```
exec bash --init-file <(curl -Ls https://raw.githubusercontent.com/Zopolis4/chromebrew/notpxcz/install.sh)
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=notpxcz crew update
```

