### PR TITLE
Update workflows to actions/checkout@v4

### DIFF
--- a/.github/workflows/Handoff.yml
+++ b/.github/workflows/Handoff.yml
@@ -9,7 +9,7 @@ jobs:
     outputs:
       category: ${{ steps.changed-file-extensions.outputs.category }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Get changed files

--- a/.github/workflows/Markdown-lint.yml
+++ b/.github/workflows/Markdown-lint.yml
@@ -5,9 +5,7 @@ jobs:
   markdown-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
       - name: Markdown-lint
         uses: bewuethr/mdl-action@v1
         with:

--- a/.github/workflows/Repology.yml
+++ b/.github/workflows/Repology.yml
@@ -7,7 +7,7 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Generate JSON
         run: |
             sudo docker pull satmandu/crewbuild:amd64

--- a/.github/workflows/Rubocop.yml
+++ b/.github/workflows/Rubocop.yml
@@ -5,9 +5,7 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
       - name: Rubocop
         uses: satmandu/Octocop@v0.0.3
         with:

--- a/.github/workflows/ShellCheck.yml
+++ b/.github/workflows/ShellCheck.yml
@@ -5,9 +5,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
       - name: ShellCheck
         uses: ludeeus/action-shellcheck@master
         with:

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -5,7 +5,7 @@ jobs:
   container_tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Dump github context
         run: echo "$GITHUB_CONTEXT"
         shell: bash

--- a/.github/workflows/YAMLlint.yml
+++ b/.github/workflows/YAMLlint.yml
@@ -5,9 +5,7 @@ jobs:
   yamllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
       - name: YAMLLint
         uses: ibiqlik/action-yamllint@v3
         with:


### PR DESCRIPTION
Along the way, remove unnecessary `fetch-depth: 0` settings-- this results in github fetching all the previous commit history, which is slower and unessecary in the majority of cases.