### PR TITLE
Add warnings for Grunt (AMD StoneyRidge) devices

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1467,7 +1467,7 @@ def resolve_dependencies_and_install
 
   # Warn of possible segfaults for older packages on AMD StoneyRidge platforms
   # Family 21 identifies AMD Bulldozer/Piledriver/Steamroller/Excavator µArchs
-   amd_str_warn = <<~EOT
+  amd_str_warn = <<~EOT
     Notice: You are running an AMD StoneyRidge device; due to some bugs some
     older packages may fail with a segmentation fault and need to be rebuilt.
 
@@ -1480,9 +1480,7 @@ def resolve_dependencies_and_install
     (2) Execute `echo 0 | sudo tee /proc/sys/kernel/randomize_va_space` to disable ASLR.
     Warning: Disabling ASLR may create security issues, use it at your own risk!
   EOT
-  if CREW_CPU_FAMILY == '21'
-    puts amd_str_warn.yellow
-  end
+  puts amd_str_warn.yellow if CREW_CPU_FAMILY == '21'
 
   puts "#{@pkg.name.capitalize} installed!".lightgreen
   @resolve_dependencies_and_install = 0

--- a/bin/crew
+++ b/bin/crew
@@ -1467,7 +1467,7 @@ def resolve_dependencies_and_install
 
   # Warn of possible segfaults for older packages on AMD StoneyRidge platforms
   # Family 21 identifies AMD Bulldozer/Piledriver/Steamroller/Excavator µArchs
-  amd_str_warn = <<~EOT
+  puts <<~EOT.yellow if CREW_IS_AMD && CPUINFO['cpu family'] == '21'
     Notice: You are running an AMD StoneyRidge device; due to some bugs some
     older packages may fail with a segmentation fault and need to be rebuilt.
 
@@ -1480,7 +1480,6 @@ def resolve_dependencies_and_install
     (2) Execute `echo 0 | sudo tee /proc/sys/kernel/randomize_va_space` to disable ASLR.
     Warning: Disabling ASLR may create security issues, use it at your own risk!
   EOT
-  puts amd_str_warn.yellow if CREW_CPU_FAMILY == '21'
 
   puts "#{@pkg.name.capitalize} installed!".lightgreen
   @resolve_dependencies_and_install = 0

--- a/bin/crew
+++ b/bin/crew
@@ -1464,6 +1464,26 @@ def resolve_dependencies_and_install
       FileUtils.mkdir_p "#{CREW_BREW_DIR}/dest" # this is a little ugly, feel free to find a better way
     end
   end
+
+  # Warn of possible segfaults for older packages on AMD StoneyRidge platforms
+  # Family 21 identifies AMD Bulldozer/Piledriver/Steamroller/Excavator µArchs
+   amd_str_warn = <<~EOT
+    Notice: You are running an AMD StoneyRidge device; due to some bugs some
+    older packages may fail with a segmentation fault and need to be rebuilt.
+
+    If this happens, please report them to:
+    https://github.com/chromebrew/chromebrew/issues
+
+    Otherwise, rebuilding from source (1) or disabling ASLR (2) usually solves the issue:
+    (1) Run `crew reinstall -s #{@pkg.name}` to rebuild the package from source,
+    __OR__
+    (2) Execute `echo 0 | sudo tee /proc/sys/kernel/randomize_va_space` to disable ASLR.
+    Warning: Disabling ASLR may create security issues, use it at your own risk!
+  EOT
+  if CREW_CPU_FAMILY == '21'
+    puts amd_str_warn.yellow
+  end
+
   puts "#{@pkg.name.capitalize} installed!".lightgreen
   @resolve_dependencies_and_install = 0
 end

--- a/install.sh
+++ b/install.sh
@@ -437,4 +437,13 @@ most is used by default
 You may wish to edit the ${CREW_PREFIX}/etc/env.d/02-editor file for an editor default.
 Chromebrew provides nano, vim and emacs as default TUI editor options."
 
+# The easiest way to distinguish StoneyRidge platorms is to check for the FMA4
+# instruction, as it was first introduced in Bulldozer and later dropped in Zen.
+if grep -s "fma4" /proc/cpuinfo ; then
+  echo_info "Notice: You are running an AMD StoneyRidge device; due to some bugs some"
+  echo_info "older packages may fail with a segmentation fault and need to be rebuilt.\n"
+  echo_info "If this happens, please report them to:"
+  echo_info "https://github.com/chromebrew/chromebrew/issues\n\n"
+fi
+
 echo_success "Chromebrew installed successfully and package lists updated."

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.39.2'
+CREW_VERSION = '1.39.3'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp
@@ -74,9 +74,6 @@ CREW_CPU_VENDOR = CPUINFO['vendor_id'] || 'unknown'
 # cpuinfo vendor_id.
 CREW_IS_AMD   = CREW_CPU_VENDOR.eql?('AuthenticAMD')
 CREW_IS_INTEL = %w[x86_64 i686].include?(ARCH) && %w[unknown GenuineIntel].include?(CREW_CPU_VENDOR)
-# Used to identify Grunt (AMD StoneyRidge, family 21) boards;
-# May also be used to identify other sub-variants, exp. AMD or ARM (using some other key).
-CREW_CPU_FAMILY = %w[x86_64 i686].include?(ARCH) ? CPUINFO['cpu family'] : ''
 
 # Use sane minimal defaults if in container and no override specified.
 if CREW_IN_CONTAINER && ENV['CREW_KERNEL_VERSION'].nil?

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -74,6 +74,9 @@ CREW_CPU_VENDOR = CPUINFO['vendor_id'] || 'unknown'
 # cpuinfo vendor_id.
 CREW_IS_AMD   = CREW_CPU_VENDOR.eql?('AuthenticAMD')
 CREW_IS_INTEL = %w[x86_64 i686].include?(ARCH) && %w[unknown GenuineIntel].include?(CREW_CPU_VENDOR)
+# Used to identify Grunt (AMD StoneyRidge, family 21) boards;
+# May also be used to identify other sub-variants, exp. AMD or ARM (using some other key).
+CREW_CPU_FAMILY = %w[x86_64 i686].include?(ARCH) ? CPUINFO['cpu family'] : ''
 
 # Use sane minimal defaults if in container and no override specified.
 if CREW_IN_CONTAINER && ENV['CREW_KERNEL_VERSION'].nil?


### PR DESCRIPTION
Fixes #8823

<!-- (let GitHub automatically close an issue when this pull request gets merged) -->

<!--
## Before you submit a pull request

This template is not necessary when you do simple things like updating packages to the latest version. But in doubt, it's always better so provide some information.
-->

## Description
Add a warning of possible broken packages if crew is installed or run on an AMD StoneyRidge device.
<!--
Provide a description, what your changes do and why they are important

Please link issues and other pull requests connected to this one.
-->

## Additional information
<!-- Mention things we might need to know. Like: -->
* Added a warning on `install.sh` at the end of the installation process, with a link to the GitHub page;
* Added a test on `lib/const.rb` to detect the CPU family;
* Added a warning on `bin/crew` at the end of the package installation routine, which also proposes alternate solutions (rebuilding from source and disabling ASLR).

As I am not familiar with the project, nor the style (or even the language :P), I don't know if that's the best place to put such a warning.
Also the warning may be a bit obnoxious as it is a bit verbose, as I tried to convey the information as exhaustively as possible. It may be a good idea to add some logic to disable or reduce it, but I didn't want to clutter the code too much.

Works properly:
- [x] `x86_64`
- [ ] `i686`
- [ ] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/Juma7C9/chromebrew.git CREW_BRANCH=grunt_warn crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->