### PR TITLE
Github_desktop 2.9.6-RC => 3.3.3-RC2

### DIFF
--- a/packages/github_desktop.rb
+++ b/packages/github_desktop.rb
@@ -3,20 +3,29 @@ require 'package'
 class Github_desktop < Package
   description 'GitHub Desktop is an open source Electron-based GitHub app'
   homepage 'https://desktop.github.com/'
-  version '2.9.6-RC'
+  version '3.3.3-RC2'
   license 'MIT'
-  compatibility 'x86_64'
-  source_url 'https://github.com/shiftkey/desktop/releases/download/release-2.9.6-linux1/GitHubDesktop-linux-2.9.6-linux1.AppImage'
-  source_sha256 'e5187e7c5a9ad1fa3c110c1ec60c9e7f75e0792c3670907741243f7cbea831b0'
-
-  binary_url({})
-  binary_sha256({})
+  compatibility 'x86_64 aarch64 armv7l'
+  source_url({
+    aarch64: 'https://github.com/shiftkey/desktop/releases/download/release-3.3.3-linux2/GitHubDesktop-linux-armv7l-3.3.3-linux2.AppImage',
+     armv7l: 'https://github.com/shiftkey/desktop/releases/download/release-3.3.3-linux2/GitHubDesktop-linux-armv7l-3.3.3-linux2.AppImage',
+     x86_64: 'https://github.com/shiftkey/desktop/releases/download/release-3.3.3-linux2/GitHubDesktop-linux-x86_64-3.3.3-linux2.AppImage'
+  })
+  source_sha256({
+    aarch64: '7080fd4b4e371e56b5bc49a0d66fe888f81884260283f181c0e33377810613b4',
+     armv7l: '7080fd4b4e371e56b5bc49a0d66fe888f81884260283f181c0e33377810613b4',
+     x86_64: 'c8b71fef885e903ff569273853c2848230a990e602d053b196443bdc3c7645a0'
+  })
 
   depends_on 'at_spi2_core'
   depends_on 'gdk_pixbuf'
   depends_on 'libcom_err'
   depends_on 'xdg_base'
-  depends_on 'sommelier'
+  depends_on 'gtk3'
+
+  no_compile_needed
+  no_shrink
+  no_strip # Fixes Syntax error: redirection unexpected (expecting ")")
 
   def self.build
     gd = <<~EOF


### PR DESCRIPTION
Tested on arm and x86_64.  Unable to install in arm container:
```
$ crew install github_desktop
github_desktop: GitHub Desktop is an open source Electron-based GitHub app
https://desktop.github.com/
Version: 3.3.3-RC2
License: MIT
Performing pre-flight checks...
No precompiled binary available for your platform, downloading source...
Cannot find cached archive. 😔 Will download.
Github_desktop archive downloaded.
Unpacking 'AppImage' archive, this may take a while...
../GitHubDesktop-linux-armv7l-3.3.3-linux2.AppImage: 1: ../GitHubDesktop-linux-armv7l-3.3.3-linux2.AppImage: Syntax error: word unexpected (expecting ")")
/usr/local/bin/crew:979:in `system': Command failed with exit 2: ../GitHubDesktop-linux-armv7l-3.3.3-linux2.AppImage (RuntimeError)
	from /usr/local/bin/crew:979:in `block in unpack'
	from /usr/local/bin/crew:949:in `chdir'
	from /usr/local/bin/crew:949:in `unpack'
	from /usr/local/bin/crew:1568:in `install'
	from /usr/local/bin/crew:1452:in `resolve_dependencies_and_install'
	from /usr/local/bin/crew:1926:in `block in install_command'
	from /usr/local/bin/crew:1921:in `each'
	from /usr/local/bin/crew:1921:in `install_command'
	from /usr/local/bin/crew:2055:in `<main>'
```
On arm Chromebook hardware the install worked but there was an error while executing github-desktop:
```
[9682:1119/110106.891643:ERROR:viz_main_impl.cc(186)] Exiting GPU process due to errors during initialization
[9739:1119/110107.247601:ERROR:gpu_memory_buffer_support_x11.cc(49)] dri3 extension not supported.
```