### PR TITLE
terraform 1.6.2 => 1.6.4

### DIFF
--- a/packages/terraform.rb
+++ b/packages/terraform.rb
@@ -3,7 +3,7 @@ require 'package'
 class Terraform < Package
   description 'Terraform is a tool for building, changing, and combining infrastructure safely and efficiently.'
   homepage 'https://www.terraform.io/'
-  version '1.6.2'
+  version '1.6.4'
   license 'Apache-2.0, BSD-2, BSD-4, ECL-2.0, imagemagick, ISC, JSON, MIT, MIT-with-advertising, MPL-2.0 and unicode'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Terraform < Package
      x86_64: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_amd64.zip"
   })
   source_sha256({
-    aarch64: 'b0a5f94cc36b71d0eced8f82ac6a6db7a0e8c9753bf392ab0ddc7cddcd18035f',
-     armv7l: 'b0a5f94cc36b71d0eced8f82ac6a6db7a0e8c9753bf392ab0ddc7cddcd18035f',
-       i686: '38d7e0bd50684c35e087e2de436d2e27a3f8f63f4df473a2ce08e81a1cab302a',
-     x86_64: '107142241b12ff78b6eb9c419757d406a8714704f7928750a662ba19de055e98'
+    aarch64: '98a9dbe23cdee6b9a89f2c474eb2e1077f64e4e1e74e4356bc7539cc7d31985c',
+     armv7l: '98a9dbe23cdee6b9a89f2c474eb2e1077f64e4e1e74e4356bc7539cc7d31985c',
+       i686: '9204af46f2a0e12bccc0cdaa2077bf4bbce5090033b97c1978c92b9e88eb9f86',
+     x86_64: '569fc3d526dcf57eb5af4764843b87b36a7cb590fc50f94a07757c1189256775'
   })
 
   def self.install


### PR DESCRIPTION
## Description

Update terraform CLI to 1.6.4

## Additional information

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`