### PR TITLE
add tests to install sparse checkout

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -395,7 +395,7 @@ else
   git checkout -f "${BRANCH}"
 
   # Set sparse-checkout folders.
-  git sparse-checkout set packages "manifest/${USER_SPACE_ARCH}" lib bin crew tools
+  git sparse-checkout set packages "manifest/${USER_SPACE_ARCH}" lib bin crew tests tools
   git reset --hard origin/"${BRANCH}"
 fi
 echo -e "${RESET}"


### PR DESCRIPTION
This lets us use the tests dir in the GitHub actions in our containers.
