### PR TITLE
Update dtrx to 8.5.3, convert to pip buildsystem

### DIFF
--- a/packages/dtrx.rb
+++ b/packages/dtrx.rb
@@ -1,40 +1,17 @@
-require 'package'
+require 'buildsystems/pip'
 
-class Dtrx < Package
+class Dtrx < Pip
   description "An intelligent archive extraction tool for UNIX-like systems standing for 'Do The Right Extraction.'"
-  homepage 'https://brettcsmith.org/2007/dtrx/' # 404 Not Found
-  version '7.1'
-  license '' # Can't find license for project
+  homepage 'https://github.com/dtrx-py/dtrx/'
+  @_ver = '8.5.3'
+  version "#{@_ver}-py3.12"
+  license 'GPL-3+'
   compatibility 'all'
-  source_url 'https://brettcsmith.org/2007/dtrx/dtrx-7.1.tar.gz' # 404 Not Found
-  source_sha256 '1c9afe48e9d9d4a1caa4c9b0c50593c6fe427942716ce717d81bae7f8425ce97'
+  source_url 'SKIP'
 
-  binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dtrx/7.1_armv7l/dtrx-7.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dtrx/7.1_armv7l/dtrx-7.1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dtrx/7.1_i686/dtrx-7.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/dtrx/7.1_x86_64/dtrx-7.1-chromeos-x86_64.tar.xz'
-  })
-  binary_sha256({
-    aarch64: 'a607b05853dfa122ebdb852f28ac59b6142c99f7ee156a631b75bc5d82f797fa',
-     armv7l: 'a607b05853dfa122ebdb852f28ac59b6142c99f7ee156a631b75bc5d82f797fa',
-       i686: 'cdd735f6be940b2535b89226bfdeba5b65e92cbdfe0a828bceb7fc5787d872d7',
-     x86_64: '4817af93d2c30c4ced5c8fb5a4e0ebc7ebb51fb6fbfb2300380b27221b6b5c49'
-  })
+  binary_url({})
+  binary_sha256({})
 
-  depends_on 'binutils'
-  depends_on 'bzip2'
-  depends_on 'cabextract'
-  depends_on 'cpio'
-  depends_on 'lha'
-  depends_on 'python2'
-  depends_on 'unrar'
-  depends_on 'unshield'
-  depends_on 'unzip'
-
-  def self.install
-    system "python setup.py install --prefix=#{CREW_PREFIX}"
-    system "mkdir -p #{CREW_DEST_PREFIX}/bin"
-    system "cp #{CREW_PREFIX}/bin/dtrx #{CREW_DEST_PREFIX}/bin"
-  end
+  depends_on 'py3_unsupported_python' => :build
+  depends_on 'python3' => :build
 end

--- a/packages/py3_unsupported_python.rb
+++ b/packages/py3_unsupported_python.rb
@@ -1,0 +1,18 @@
+require 'buildsystems/pip'
+
+class Py3_unsupported_python < Pip
+  description 'This package can be used as a conditional dependency to indicate lack of support for particular versions of Python.'
+  homepage 'https://github.com/ntessore/unsupported-python'
+  @_ver = '1.0.0'
+  version "#{@_ver}-py3.12"
+  license 'GPL-3+'
+  compatibility 'all'
+  source_url 'SKIP'
+
+  binary_url({})
+  binary_sha256({})
+
+  depends_on 'python3' => :build
+
+  pre_configure_options 'ALLOW_UNSUPPORTED_PYTHON=3.12'
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -7116,6 +7116,11 @@ url: https://github.com/pypa/trove-classifiers/releases
 activity: medium
 ---
 kind: url
+name: py3_unsupported_python
+url: https://github.com/ntessore/unsupported-python/releases
+activity: none
+---
+kind: url
 name: py3_websockets
 url: https://github.com/python-websockets/websockets/tags
 activity: high


### PR DESCRIPTION
Tested on `x86_64`: building complains about `unsupported-python`, but seems to still work.

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=donetrx crew update
```
