### PR TITLE
fix pipewire versioning

### DIFF
--- a/packages/pipewire.rb
+++ b/packages/pipewire.rb
@@ -2,14 +2,14 @@ require 'package'
 
 class Pipewire < Package
   description 'PipeWire is a project that aims to greatly improve handling of audio and video under Linux.'
-  homepage 'https://pipewire.org'
-  version = if Gem::Version.new(CREW_KERNEL_VERSION.to_s) < Gem::Version.new('3.9')
+  @_ver = if Gem::Version.new(CREW_KERNEL_VERSION.to_s) < Gem::Version.new('3.9')
               '0.3.29'
             elsif Gem::Version.new(CREW_KERNEL_VERSION.to_s) <= Gem::Version.new('5.4')
               '0.3.60'
             else
               '1.0.0'
             end
+  version @_ver
   compatibility 'all'
   license 'LGPL-2.1+'
   source_url 'https://gitlab.freedesktop.org/pipewire/pipewire.git'


### PR DESCRIPTION
- Fixes problem with builds not having correct version in the built package filename.

Works properly:
- [x] `x86_64`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=pipewire_versioning crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
