### PR TITLE
Rebuild termcap with -fPIC, copy arch PKGBUILD format, remove static lib

### DIFF
--- a/manifest/armv7l/t/termcap.filelist
+++ b/manifest/armv7l/t/termcap.filelist
@@ -1,7 +1,8 @@
 /usr/local/include/termcap.h
-/usr/local/info/termcap.info-1.gz
-/usr/local/info/termcap.info-2.gz
-/usr/local/info/termcap.info-3.gz
-/usr/local/info/termcap.info-4.gz
-/usr/local/info/termcap.info.gz
-/usr/local/lib/libtermcap.a
+/usr/local/lib/libtermcap.so
+/usr/local/lib/libtermcap.so.1.3.1
+/usr/local/share/info/termcap.info-1.zst
+/usr/local/share/info/termcap.info-2.zst
+/usr/local/share/info/termcap.info-3.zst
+/usr/local/share/info/termcap.info-4.zst
+/usr/local/share/info/termcap.info.zst

--- a/manifest/i686/t/termcap.filelist
+++ b/manifest/i686/t/termcap.filelist
@@ -1,7 +1,8 @@
 /usr/local/include/termcap.h
-/usr/local/info/termcap.info-1.gz
-/usr/local/info/termcap.info-2.gz
-/usr/local/info/termcap.info-3.gz
-/usr/local/info/termcap.info-4.gz
-/usr/local/info/termcap.info.gz
-/usr/local/lib/libtermcap.a
+/usr/local/lib/libtermcap.so
+/usr/local/lib/libtermcap.so.1.3.1
+/usr/local/share/info/termcap.info-1.zst
+/usr/local/share/info/termcap.info-2.zst
+/usr/local/share/info/termcap.info-3.zst
+/usr/local/share/info/termcap.info-4.zst
+/usr/local/share/info/termcap.info.zst

--- a/manifest/x86_64/t/termcap.filelist
+++ b/manifest/x86_64/t/termcap.filelist
@@ -1,7 +1,8 @@
 /usr/local/include/termcap.h
-/usr/local/info/termcap.info-1.gz
-/usr/local/info/termcap.info-2.gz
-/usr/local/info/termcap.info-3.gz
-/usr/local/info/termcap.info-4.gz
-/usr/local/info/termcap.info.gz
-/usr/local/lib64/libtermcap.a
+/usr/local/lib64/libtermcap.so
+/usr/local/lib64/libtermcap.so.1.3.1
+/usr/local/share/info/termcap.info-1.zst
+/usr/local/share/info/termcap.info-2.zst
+/usr/local/share/info/termcap.info-3.zst
+/usr/local/share/info/termcap.info-4.zst
+/usr/local/share/info/termcap.info.zst

--- a/packages/termcap.rb
+++ b/packages/termcap.rb
@@ -1,36 +1,46 @@
+# Adapted from Arch Linux termcap PKGBUILD at:
+# https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=termcap
+
 require 'package'
 
 class Termcap < Package
-  description 'A library for sending terminal control codes.'
-  homepage 'https://www.gnu.org/software/termutils/'
-  version '1.3.1-1'
-  license 'GPL-2'
+  description 'Enables programs to use display computer terminals in a device-independent manner'
+  homepage 'http://www.catb.org/~esr/terminfo/'
+  version '1.3.1-2'
+  license 'GPL'
   compatibility 'all'
-  source_url 'https://ftpmirror.gnu.org/termcap/termcap-1.3.1.tar.gz'
+  source_url 'http://ftp.gnu.org/gnu/termcap/termcap-1.3.1.tar.gz'
   source_sha256 '91a0e22e5387ca4467b5bcb18edf1c51b930262fd466d5fda396dd9d26719100'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/termcap/1.3.1-1_armv7l/termcap-1.3.1-1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/termcap/1.3.1-1_armv7l/termcap-1.3.1-1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/termcap/1.3.1-1_i686/termcap-1.3.1-1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/termcap/1.3.1-1_x86_64/termcap-1.3.1-1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/termcap/1.3.1-2_armv7l/termcap-1.3.1-2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/termcap/1.3.1-2_armv7l/termcap-1.3.1-2-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/termcap/1.3.1-2_i686/termcap-1.3.1-2-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/termcap/1.3.1-2_x86_64/termcap-1.3.1-2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'c009c6ce4f03e6897c656f2e45a6d386ecbd06b78b766b054fa96a981611cc45',
-     armv7l: 'c009c6ce4f03e6897c656f2e45a6d386ecbd06b78b766b054fa96a981611cc45',
-       i686: '3bea54475c13ea40aba0a85152414699d32b60d525459afaf686d3fe0142ddc8',
-     x86_64: 'f57bd2e1b4cd1893ce97d3038c9fe8a67664ef448c8249b67148749da350542c'
+    aarch64: 'bff907606b3b1d932cbbba5d02a3503809da67519bc457589cf240c515d28b62',
+     armv7l: 'bff907606b3b1d932cbbba5d02a3503809da67519bc457589cf240c515d28b62',
+       i686: 'b2dafe673b2bb978fb429b9f7beb08a3ed09d19bb5ab391b8053b5dd2fe0ef94',
+     x86_64: '99b1526e3629184c0934ad301024400995173e2043a23d35f2f4ebc03127f640'
   })
 
+  depends_on 'glibc' # R
+
   def self.build
-    system "./configure #{CREW_OPTIONS}"
-    system 'make'
+    system 'gcc -fPIC -c termcap.c -DHAVE_STRING_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1'
+    system 'gcc -fPIC -c tparam.c -DHAVE_STRING_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1'
+    system 'gcc -fPIC -c version.c -DHAVE_STRING_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1'
+    system "gcc -shared -Wl,-soname,libtermcap.so \
+    -o libtermcap.so.1.3.1 termcap.o tparam.o version.o"
   end
 
   def self.install
-    system "install -Dm644 libtermcap.a #{CREW_DEST_LIB_PREFIX}/libtermcap.a"
-    system "ranlib #{CREW_DEST_LIB_PREFIX}/libtermcap.a"
-    system "install -Dm644 termcap.h #{CREW_DEST_PREFIX}/include/termcap.h"
-    system "for f in termcap.info*; do install -Dm644 $f #{CREW_DEST_PREFIX}/info/$f; done"
+    FileUtils.install 'libtermcap.so.1.3.1', "#{CREW_DEST_LIB_PREFIX}/libtermcap.so.1.3.1", mode: 0o755
+    FileUtils.ln_s "#{CREW_LIB_PREFIX}/libtermcap.so.1.3.1", "#{CREW_DEST_LIB_PREFIX}/libtermcap.so"
+    FileUtils.install 'termcap.h', "#{CREW_DEST_PREFIX}/include/termcap.h", mode: 0o644
+    Dir['termcap.info*'].each do |infofile|
+      FileUtils.install infofile, "#{CREW_DEST_PREFIX}/share/info/#{infofile}", mode: 0o644
+    end
   end
 end

--- a/packages/termcap.rb
+++ b/packages/termcap.rb
@@ -9,7 +9,7 @@ class Termcap < Package
   version '1.3.1-2'
   license 'GPL'
   compatibility 'all'
-  source_url 'http://ftp.gnu.org/gnu/termcap/termcap-1.3.1.tar.gz'
+  source_url 'https://ftpmirror.gnu.org/termcap/termcap-1.3.1.tar.gz'
   source_sha256 '91a0e22e5387ca4467b5bcb18edf1c51b930262fd466d5fda396dd9d26719100'
 
   binary_url({


### PR DESCRIPTION
- Note that `CREW_OPTIONS` does not work with the ancient configure script this package comes with.
- This package rebuild fixes this error during builds:
```
mold: error: /usr/local/lib64/libtermcap.a(tparam.o):(.text): R_X86_64_32 relocation at offset 0xa against symbol `.rodata' can not be used; recompile with -fPIC
mold: error: /usr/local/lib64/libtermcap.a(termcap.o):(.text): R_X86_64_32 relocation at offset 0xa against symbol `.rodata' can not be used; recompile with -fPIC
mold: error: /usr/local/lib64/libtermcap.a(tparam.o):(.text): R_X86_64_32 relocation at offset 0x14b against symbol `.bss' can not be used; recompile with -fPIC
mold: error: /usr/local/lib64/libtermcap.a(termcap.o):(.text): R_X86_64_32S relocation at offset 0x30b against symbol `.data' can not be used; recompile with -fPIC
mold: error: /usr/local/lib64/libtermcap.a(tparam.o):(.text): R_X86_64_32S relocation at offset 0x28d against symbol `.rodata' can not be used; recompile with -fPIC
mold: error: /usr/local/lib64/libtermcap.a(termcap.o):(.text): R_X86_64_32S relocation at offset 0x3af against symbol `.data' can not be used; recompile with -fPIC
mold: error: /usr/local/lib64/libtermcap.a(termcap.o):(.text): R_X86_64_32 relocation at offset 0x4fd against symbol `.rodata' can not be used; recompile with -fPIC
mold: error: /usr/local/lib64/libtermcap.a(termcap.o):(.text): R_X86_64_32 relocation at offset 0x549 against symbol `.rodata' can not be used; recompile with -fPIC
mold: error: /usr/local/lib64/libtermcap.a(termcap.o):(.text): R_X86_64_32 relocation at offset 0x56c against symbol `.rodata' can not be used; recompile with -fPIC
mold: error: /usr/local/lib64/libtermcap.a(termcap.o):(.text): R_X86_64_32 relocation at offset 0x5dc against symbol `.rodata' can not be used; recompile with -fPIC
mold: error: /usr/local/lib64/libtermcap.a(termcap.o):(.text): R_X86_64_32 relocation at offset 0x7dc against symbol `.rodata' can not be used; recompile with -fPIC
collect2: error: ld returned 1 exit status
```
Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=termcap crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
