### PR TITLE
Prepare package fix

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1173,7 +1173,7 @@ def prepare_package(destdir)
     # Remove CREW_PREFIX and HOME from the generated directorylist.
     @crew_prefix_escaped = CREW_PREFIX.gsub('/', '\/')
     @home_escaped = HOME.gsub('/', '\/')
-    system "find ./usr/local ./home/chronos/user -type d | cut -c2- | sed '0,/#{@crew_prefix_escaped}/{/#{@crew_prefix_escaped}/d}' | sed '0,/#{@home_escaped}/{/#{@home_escaped}/d}' | sort", out: 'dlist'
+    system "find .#{CREW_PREFIX} .#{HOME} -type d | cut -c2- | sed '0,/#{@crew_prefix_escaped}/{/#{@crew_prefix_escaped}/d}' | sed '0,/#{@home_escaped}/{/#{@home_escaped}/d}' | sort", out: 'dlist'
 
     strip_dir destdir
 

--- a/bin/crew
+++ b/bin/crew
@@ -1129,7 +1129,7 @@ def prepare_package(destdir)
     @pkg.postbuild
 
     # create file list
-    system "find .#{CREW_PREFIX} .#{HOME} -type f,l | cut -c2- | tail -n +2 | sort", out: 'filelist'
+    system "find .#{CREW_PREFIX} .#{HOME} -type f,l | cut -c2- | sort", out: 'filelist'
 
     if Dir.exist?(CREW_LOCAL_MANIFEST_PATH) && File.writable?(CREW_LOCAL_MANIFEST_PATH)
       FileUtils.mkdir_p "#{CREW_LOCAL_MANIFEST_PATH}/#{ARCH}/#{@pkg.name.chr.downcase}"
@@ -1170,6 +1170,7 @@ def prepare_package(destdir)
     abort 'Exiting due to above errors.'.lightred if @_errors
 
     # create directory list
+    # 'tail -n +2' is used here to remove /usr/local from the list
     system "find .#{CREW_PREFIX} .#{HOME} -type d | cut -c2- | tail -n +2 | sort", out: 'dlist'
 
     strip_dir destdir

--- a/bin/crew
+++ b/bin/crew
@@ -1170,8 +1170,10 @@ def prepare_package(destdir)
     abort 'Exiting due to above errors.'.lightred if @_errors
 
     # create directory list
-    # 'tail -n +2' is used here to remove /usr/local from the list
-    system "find .#{CREW_PREFIX} .#{HOME} -type d | cut -c2- | tail -n +2 | sort", out: 'dlist'
+    # Remove CREW_PREFIX and HOME from the generated directorylist.
+    @crew_prefix_escaped = CREW_PREFIX.gsub('/', '\/')
+    @home_escaped = HOME.gsub('/', '\/')
+    system "find ./usr/local ./home/chronos/user -type d | cut -c2- | sed '0,/#{@crew_prefix_escaped}/{/#{@crew_prefix_escaped}/d}' | sed '0,/#{@home_escaped}/{/#{@home_escaped}/d}' | sort", out: 'dlist'
 
     strip_dir destdir
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.39.9'
+CREW_VERSION = '1.40.0'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/manifest/armv7l/w/weston.filelist
+++ b/manifest/armv7l/w/weston.filelist
@@ -56,6 +56,7 @@
 /usr/local/include/neatvnc.h
 /usr/local/include/weston/weston.h
 /usr/local/libexec/weston-desktop-shell
+/usr/local/libexec/weston-keyboard
 /usr/local/libexec/weston-simple-im
 /usr/local/lib/libaml.so
 /usr/local/lib/libaml.so.0

--- a/manifest/x86_64/w/weston.filelist
+++ b/manifest/x86_64/w/weston.filelist
@@ -53,6 +53,7 @@
 /usr/local/include/libweston-13/libweston/windowed-output-api.h
 /usr/local/include/libweston-13/libweston/xwayland-api.h
 /usr/local/include/libweston-13/libweston/zalloc.h
+/usr/local/include/neatvnc.h
 /usr/local/include/weston/weston.h
 /usr/local/lib64/libaml.so
 /usr/local/lib64/libaml.so.0

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -3,7 +3,7 @@ require 'package'
 class Buildessential < Package
   description 'A collection of tools essential to compile and build software.'
   homepage 'SKIP'
-  version '1.25'
+  version '1.26'
   license 'GPL-3+'
   compatibility 'all'
 
@@ -28,6 +28,10 @@ class Buildessential < Package
 
   # Linkers
   depends_on 'mold'
+
+  # findutils is needed for the newer version
+  # of 'find' used by crew in 'prepare_package'
+  depends_on 'findutils'
 
   # typically required libraries & tools to configure packages
   # e.g. using "./autogen.sh"

--- a/packages/weston.rb
+++ b/packages/weston.rb
@@ -15,9 +15,9 @@ class Weston < Meson
      x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/weston/13.0.0_x86_64/weston-13.0.0-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '6bdc016e369c410e42adfd2e67d2e757c77b6d31036081cbbcb5d2e1c189efbf',
-     armv7l: '6bdc016e369c410e42adfd2e67d2e757c77b6d31036081cbbcb5d2e1c189efbf',
-     x86_64: '1472d72e07bcf37651bee693f50c33f02cd3829d58581e9ef8e3d32480305dcb'
+    aarch64: '463fafa09122de01bf4c8dbba4eb157ae9741aa0aec68561e3ef03878d262161',
+     armv7l: '463fafa09122de01bf4c8dbba4eb157ae9741aa0aec68561e3ef03878d262161',
+     x86_64: 'daacfeb06185e4ff3a0fef2b7845a7b4f2528a02d1569957d5a61a70cc3e5bd2'
   })
 
   depends_on 'cairo' # R


### PR DESCRIPTION
- filelist generation was broken because I was using the same logic from dlist generation. That has been fixed.
- dlist generation now uses sed to remove the specific lines we don't want, instead of just removing the top line. We want specific removals since there could be packages with both `HOME` and `CREW_PREFIX` files.
- Also rebuilds `weston` to have the missing files in its filelist.
- Adds `findutils` to `buildessential` since the `find` in i686 is too old to have the functionality we are using.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=prepare_package_fix crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
