### PR TITLE
rebuild jp2a

### DIFF
--- a/manifest/armv7l/j/jp2a.filelist
+++ b/manifest/armv7l/j/jp2a.filelist
@@ -1,3 +1,3 @@
 /usr/local/bin/jp2a
 /usr/local/etc/bash_completion.d/jp2a
-/usr/local/share/man/man1/jp2a.1.gz
+/usr/local/share/man/man1/jp2a.1.zst

--- a/manifest/i686/j/jp2a.filelist
+++ b/manifest/i686/j/jp2a.filelist
@@ -1,3 +1,3 @@
 /usr/local/bin/jp2a
 /usr/local/etc/bash_completion.d/jp2a
-/usr/local/share/man/man1/jp2a.1.gz
+/usr/local/share/man/man1/jp2a.1.zst

--- a/manifest/x86_64/j/jp2a.filelist
+++ b/manifest/x86_64/j/jp2a.filelist
@@ -1,3 +1,3 @@
 /usr/local/bin/jp2a
 /usr/local/etc/bash_completion.d/jp2a
-/usr/local/share/man/man1/jp2a.1.gz
+/usr/local/share/man/man1/jp2a.1.zst

--- a/packages/jp2a.rb
+++ b/packages/jp2a.rb
@@ -1,42 +1,38 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Jp2a < Package
+class Jp2a < Autotools
   description 'jp2a is a simple JPEG/PNG to ASCII converter.'
   homepage 'https://github.com/Talinx/jp2a'
-  version '1.1.1'
+  version '1.1.1-1'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://github.com/Talinx/jp2a/releases/download/v1.1.1/jp2a-1.1.1.tar.bz2'
   source_sha256 '3b91f26f79eca4e963b1b1ae2473722a706bf642218f20bfe4ade5333aebb106'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jp2a/1.1.1_armv7l/jp2a-1.1.1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jp2a/1.1.1_armv7l/jp2a-1.1.1-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jp2a/1.1.1_i686/jp2a-1.1.1-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jp2a/1.1.1_x86_64/jp2a-1.1.1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jp2a/1.1.1-1_armv7l/jp2a-1.1.1-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jp2a/1.1.1-1_armv7l/jp2a-1.1.1-1-chromeos-armv7l.tar.zst',
+       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jp2a/1.1.1-1_i686/jp2a-1.1.1-1-chromeos-i686.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/jp2a/1.1.1-1_x86_64/jp2a-1.1.1-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '5904d25a8d64927b4daf67d3c8982eeaf748b5e7f4c7b5aa547cad30a9394182',
-     armv7l: '5904d25a8d64927b4daf67d3c8982eeaf748b5e7f4c7b5aa547cad30a9394182',
-       i686: 'd036f8479acad0db26fe5b315b0d4f3266b6ab0ed1eb28972bf2c85fe38f8722',
-     x86_64: '261e542c36ee596b0682e4a949f4a5f8be73d65b610c8b477a08c878e6ce2c29'
+    aarch64: '9438a0ebd55061bcb22278bc446bd5b43923afd4bacd0850193dfd5f1886c702',
+     armv7l: '9438a0ebd55061bcb22278bc446bd5b43923afd4bacd0850193dfd5f1886c702',
+       i686: 'd577997a33292f4859a6609421b04834a5ec66cf5dd4dcb2977a0a593a954ca8',
+     x86_64: '43d23d90642210eee4eca270d1760af66320485d1309bb717391d400e3223015'
   })
 
-  depends_on 'libjpeg'
-  depends_on 'libpng'
-  depends_on 'termcap'
+  depends_on 'curl' # R
+  depends_on 'glibc' # R
+  depends_on 'libjpeg' # R
+  depends_on 'libpng' # R
+  depends_on 'ncurses' # R
+  depends_on 'termcap' # R
 
-  def self.build
-    system "./configure #{CREW_OPTIONS} \
-            --enable-curl"
-    system 'make'
-  end
+  pre_configure_options "CFLAGS='-lncurses -ltinfo -I#{CREW_PREFIX}/include/ncurses #{CREW_ENV_OPTIONS_HASH['CFLAGS']}' LDFLAGS='-L#{CREW_LIB_PREFIX} -lncurses -ltinfo #{CREW_ENV_OPTIONS_HASH['LDFLAGS']}'"
+  configure_options '--enable-curl'
 
   def self.check
     system 'make check || true'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end


### PR DESCRIPTION
- rebuild with shared `termcap`

Builds properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=jp2a crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
