### PR TITLE
Crew updates

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1129,7 +1129,8 @@ def prepare_package(destdir)
     @pkg.postbuild
 
     # create file list
-    system "find .#{CREW_PREFIX} .#{HOME} -type f,l | cut -c2- | sort", out: 'filelist'
+    system "find .#{CREW_PREFIX} -type f,l | cut -c2- | sort", out: %w[filelist a] if Dir.exist?(CREW_DEST_PREFIX)
+    system "find .#{HOME} -type f,l | cut -c2- | sort", out: %w[filelist a] if Dir.exist?(CREW_DEST_HOME)
 
     if Dir.exist?(CREW_LOCAL_MANIFEST_PATH) && File.writable?(CREW_LOCAL_MANIFEST_PATH)
       FileUtils.mkdir_p "#{CREW_LOCAL_MANIFEST_PATH}/#{ARCH}/#{@pkg.name.chr.downcase}"
@@ -1173,7 +1174,8 @@ def prepare_package(destdir)
     # Remove CREW_PREFIX and HOME from the generated directorylist.
     @crew_prefix_escaped = CREW_PREFIX.gsub('/', '\/')
     @home_escaped = HOME.gsub('/', '\/')
-    system "find .#{CREW_PREFIX} .#{HOME} -type d | cut -c2- | sed '0,/#{@crew_prefix_escaped}/{/#{@crew_prefix_escaped}/d}' | sed '0,/#{@home_escaped}/{/#{@home_escaped}/d}' | sort", out: 'dlist'
+    system "find .#{CREW_PREFIX} -type d | cut -c2- | sed '0,/#{@crew_prefix_escaped}/{/#{@crew_prefix_escaped}/d}'| sort", out: %w[dlist a] if Dir.exist?(CREW_DEST_PREFIX)
+    system "find .#{HOME} -type d | cut -c2- | sed '0,/#{@home_escaped}/{/#{@home_escaped}/d}' | sort", out: %w[dlist a] if Dir.exist?(CREW_DEST_HOME)
 
     strip_dir destdir
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -118,7 +118,7 @@ CREW_MUSL_PREFIX      = File.join(CREW_PREFIX, '/share/musl/')
 CREW_DEST_MUSL_PREFIX = File.join(CREW_DEST_DIR, CREW_MUSL_PREFIX)
 MUSL_LIBC_VERSION     = `[ -x '#{CREW_MUSL_PREFIX}/lib/libc.so' ] && #{CREW_MUSL_PREFIX}/lib/libc.so 2>&1`[/\bVersion\s+\K\S+/]
 
-CREW_DEST_HOME          = CREW_DEST_DIR + HOME
+CREW_DEST_HOME          = File.join(CREW_DEST_DIR, HOME)
 CREW_CACHE_DIR          = ENV.fetch('CREW_CACHE_DIR', "#{HOME}/.cache/crewcache")
 CREW_CACHE_BUILD        = ENV.fetch('CREW_CACHE_BUILD', '0').eql?('1')
 CREW_CACHE_FAILED_BUILD = ENV.fetch('CREW_CACHE_FAILED_BUILD', '0').eql?('1')

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.40.0'
+CREW_VERSION = '1.40.1'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
- Fix `CREW_DEST_HOME` in `const.rb`:
```
chronos@mbp113-x86_64 /usr/local/lib/crew/packages $ crew const | grep DEST_HOME
CREW_DEST_HOME=/usr/local/tmp/crew/dest//home/chronos/user
```
It should be:
```
chronos@mbp113-x86_64 /usr/local/lib/crew/packages $ crew const | grep DEST_HOME
CREW_DEST_HOME=/usr/local/tmp/crew/dest/home/chronos/user
```
- have `prepare_package` only run `find` in `CREW_DEST_DIR` if the relevant dir exists.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/<Please_enter_the_name_of_your_repo>/chromebrew.git CREW_BRANCH=<Please_enter_the_branch_name_for_this_PR> crew update
```

I tested this with `test.rb`:
```ruby
require 'package'

class Test < Package
  description 'Test package'
  homepage 'https://example.com'
  version '1.0'
  license 'GPL-2+'
  compatibility 'all'
  source_url 'SKIP'

  binary_url({})
  binary_sha256({})
  no_fhs

  def self.install
    FileUtils.touch 'testfile'
    FileUtils.install 'testfile', "#{CREW_DEST_PREFIX}/tmp/testfile"
    FileUtils.install 'testfile', "#{CREW_DEST_HOME}/tmp/testfile"
  end
end
```
