### PR TITLE
Acquia_cli 2.15.1 => 2.20.1

### DIFF
--- a/packages/acli.rb
+++ b/packages/acli.rb
@@ -1,0 +1,14 @@
+require 'package'
+require_relative 'acquia_cli'
+
+class Acli < Package
+  description Acquia_cli.description
+  homepage Acquia_cli.homepage
+  version Acquia_cli.version
+  license Acquia_cli.license
+  compatibility Acquia_cli.compatibility
+
+  is_fake
+
+  depends_on 'acquia_cli'
+end

--- a/packages/acquia_cli.rb
+++ b/packages/acquia_cli.rb
@@ -3,11 +3,11 @@ require 'package'
 class Acquia_cli < Package
   description 'Acquia CLI - The official command-line tool for interacting with the Drupal Cloud Platform and services.'
   homepage 'https://github.com/acquia/cli'
-  version '2.15.1'
+  version '2.20.1'
   license 'GPL-2.0'
-  compatibility 'all'
-  source_url 'https://github.com/acquia/cli/releases/download/2.15.1/acli.phar'
-  source_sha256 '057e24cb711e0f011db4919d7c54d0de2dd38fe1905d19a5fbb94a76cbe9bade'
+  compatibility 'x86_64 aarch64 armv7l'
+  source_url 'https://github.com/acquia/cli/releases/download/2.20.1/acli.phar'
+  source_sha256 '55ffffae7b271151aa6c85472a8b2bf595840711ba51d941721c9e599a5ed028'
 
   depends_on 'php81' unless File.exist? "#{CREW_PREFIX}/bin/php"
 


### PR DESCRIPTION
Removed i686 since it depends on harfbuzz which is no longer compatible.