### PR TITLE
Platformsh 4.10.3 => 4.10.4

### DIFF
--- a/packages/platformsh.rb
+++ b/packages/platformsh.rb
@@ -3,11 +3,11 @@ require 'package'
 class Platformsh < Package
   description 'The unified tool for managing your Platform.sh services from the command line.'
   homepage 'https://docs.platform.sh/overview/cli.html'
-  version '4.10.3'
+  version '4.10.4'
   license 'MIT'
-  compatibility 'all'
-  source_url 'https://github.com/platformsh/legacy-cli/releases/download/v4.10.3/platform.phar'
-  source_sha256 '5637426951cd219844f1ab4ec0685d3b597277141064a74a619f3baa93a3f7fb'
+  compatibility 'x86_64 aarch64 armv7l'
+  source_url 'https://github.com/platformsh/legacy-cli/releases/download/v4.10.4/platform.phar'
+  source_sha256 '956155f62daf7665d9306db3514276291160b4ca9ed4f2ca8491cf407e050860'
 
   depends_on 'php81' unless File.exist? "#{CREW_PREFIX}/bin/php"
 


### PR DESCRIPTION
Removed i686 since it depends on harfbuzz which is no longer compatible.