### PR TITLE
terraform 1.6.4 => 1.6.5

### DIFF
--- a/packages/terraform.rb
+++ b/packages/terraform.rb
@@ -3,7 +3,7 @@ require 'package'
 class Terraform < Package
   description 'Terraform is a tool for building, changing, and combining infrastructure safely and efficiently.'
   homepage 'https://www.terraform.io/'
-  version '1.6.4'
+  version '1.6.5'
   license 'Apache-2.0, BSD-2, BSD-4, ECL-2.0, imagemagick, ISC, JSON, MIT, MIT-with-advertising, MPL-2.0 and unicode'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Terraform < Package
      x86_64: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_amd64.zip"
   })
   source_sha256({
-    aarch64: '98a9dbe23cdee6b9a89f2c474eb2e1077f64e4e1e74e4356bc7539cc7d31985c',
-     armv7l: '98a9dbe23cdee6b9a89f2c474eb2e1077f64e4e1e74e4356bc7539cc7d31985c',
-       i686: '9204af46f2a0e12bccc0cdaa2077bf4bbce5090033b97c1978c92b9e88eb9f86',
-     x86_64: '569fc3d526dcf57eb5af4764843b87b36a7cb590fc50f94a07757c1189256775'
+    aarch64: 'abc220cef21d0937878e42de5c3085bdd8b7ca2e135163bfeeac1881da148a4b',
+     armv7l: 'abc220cef21d0937878e42de5c3085bdd8b7ca2e135163bfeeac1881da148a4b',
+       i686: 'f82fc45597a574234cbaf2825ac26a02158191d5e581c425bdadde7294a2a120',
+     x86_64: 'f6404dc264aff75fc1b776670c1abf732cfed3d4a1ce49b64bc5b5d116fe87d5'
   })
 
   def self.install


### PR DESCRIPTION
## Description

Updating the terraform CLI to version 1.6.5

## Additional information

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`