### PR TITLE
Add missing quote to flutter.rb

### DIFF
--- a/packages/flutter.rb
+++ b/packages/flutter.rb
@@ -41,7 +41,7 @@ class Flutter < Package
       case response
       when 'y', 'yes'
         FileUtils.rm_rf config_dir
-        FileUtils.rm_f "#{HOME}/.flutter_tool_state
+        FileUtils.rm_f "#{HOME}/.flutter_tool_state"
         puts "#{config_dir} removed.".lightred
       else
         puts "#{config_dir} saved.".lightgreen


### PR DESCRIPTION
Not sure how this snuck past rubocop in #9036, but it's fixed now.