### PR TITLE
Make sure CREW_PREFIX is set prior to referencing it.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,7 @@ fi
 
 # Check if the user owns the CREW_PREFIX directory, as sudo is unnecessary if this is the case.
 # Check if the user is on ChromeOS v117+ and not in the VT-2 console, as sudo will not work.
+: "${CREW_PREFIX:=/usr/local}"
 if [[ "$(stat -c '%u' "${CREW_PREFIX}")" == "$(id -u)" ]] && sudo 2>&1 | grep -q 'no new privileges'; then
   echo_error "Please run the installer in the VT-2 shell."
   echo_info "To start the VT-2 session, type Ctrl + Alt + ->"
@@ -76,7 +77,6 @@ fi
 : "${BRANCH:=master}"
 
 # Chromebrew directories.
-: "${CREW_PREFIX:=/usr/local}"
 CREW_LIB_PATH="${CREW_PREFIX}/lib/crew"
 CREW_CONFIG_PATH="${CREW_PREFIX}/etc/crew"
 CREW_BREW_DIR="${CREW_PREFIX}/tmp/crew"


### PR DESCRIPTION
Fixes stat: cannot stat '': No such file or directory.