### PR TITLE
Gtkmm4 4.0.1 => 4.0.2

### DIFF
--- a/packages/gtkmm4.rb
+++ b/packages/gtkmm4.rb
@@ -1,40 +1,29 @@
-require 'package'
+require 'buildsystems/meson'
 
-class Gtkmm4 < Package
+class Gtkmm4 < Meson
   description 'The Gtkmm4 package provides a C++ interface to GTK+ 4.'
   homepage 'https://www.gtkmm.org/'
-  version '4.0.1'
+  version '4.0.2'
   license 'LGPL-2.1+'
-  compatibility 'all'
-  source_url 'https://download.gnome.org/sources/gtkmm/4.0/gtkmm-4.0.1.tar.xz'
-  source_sha256 '8973d9bc7848e02cb2051e05f3ee3a4baffe2feb4af4a5487f0e3132eec03884'
+  compatibility 'x86_64 aarch64 armv7l'
+  source_url 'https://download.gnome.org/sources/gtkmm/4.0/gtkmm-4.0.2.tar.xz'
+  source_sha256 '0c836e8daffd836ef469499b7a733afda3a5260ea0e4d81c552f688ae384bd97'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtkmm4/4.0.1_armv7l/gtkmm4-4.0.1-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtkmm4/4.0.1_armv7l/gtkmm4-4.0.1-chromeos-armv7l.tar.xz',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtkmm4/4.0.1_i686/gtkmm4-4.0.1-chromeos-i686.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtkmm4/4.0.1_x86_64/gtkmm4-4.0.1-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtkmm4/4.0.2_armv7l/gtkmm4-4.0.2-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtkmm4/4.0.2_armv7l/gtkmm4-4.0.2-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/gtkmm4/4.0.2_x86_64/gtkmm4-4.0.2-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: '1d2640f81201631586b082735b8ad82a229ff9502233acc4ed628ba88dd46278',
-     armv7l: '1d2640f81201631586b082735b8ad82a229ff9502233acc4ed628ba88dd46278',
-       i686: '1be63d921a1b6013e1a36ef9be69d904ed7b6234c75dc24880598d290681914c',
-     x86_64: 'd6b5659e5e00d16442c9368db8c7baf610fb62f43111ed6f6cd93dfb0417fbf1'
+    aarch64: '9769d2f5e99b80ee126723b0614a2a5cad5298a6c14176644c9d7c7408fceb43',
+     armv7l: '9769d2f5e99b80ee126723b0614a2a5cad5298a6c14176644c9d7c7408fceb43',
+     x86_64: 'cb5053d74804b963f9fab9e9f97b336776cad30d6b38df277386e800b755c6b3'
   })
 
   depends_on 'atkmm'
   depends_on 'gtk4'
   depends_on 'pangomm'
   depends_on 'cairomm'
-
-  def self.build
-    system "meson setup #{CREW_MESON_OPTIONS} \
-    builddir"
-    system 'meson configure --no-pager builddir'
-    system 'ninja -C builddir'
-  end
-
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-  end
+  depends_on 'vulkan_headers'
+  depends_on 'gobject_introspection'
 end


### PR DESCRIPTION
Removed i686 compatibility since harfbuzz is no longer compatible.