### PR TITLE
update xwayland, xorg_server

### DIFF
--- a/packages/xorg_server.rb
+++ b/packages/xorg_server.rb
@@ -3,23 +3,21 @@ require 'package'
 class Xorg_server < Package
   description 'The Xorg Server is the core of the X Window system.'
   homepage 'https://www.x.org'
-  version '21.1.7'
+  version '21.1.10'
   license 'BSD-3, MIT, BSD-4, MIT-with-advertising, ISC and custom'
-  compatibility 'all'
+  compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.freedesktop.org/xorg/xserver.git'
   git_hashtag "xorg-server-#{version}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.7_armv7l/xorg_server-21.1.7-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.7_armv7l/xorg_server-21.1.7-chromeos-armv7l.tar.zst',
-       i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.7_i686/xorg_server-21.1.7-chromeos-i686.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.7_x86_64/xorg_server-21.1.7-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.10_armv7l/xorg_server-21.1.10-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.10_armv7l/xorg_server-21.1.10-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xorg_server/21.1.10_x86_64/xorg_server-21.1.10-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'd42c06ceb209fb5fb76efbafddd71d9d70fbf22b1a26eed272260c568df24d59',
-     armv7l: 'd42c06ceb209fb5fb76efbafddd71d9d70fbf22b1a26eed272260c568df24d59',
-       i686: '30050665805c5ff827611a2e5e20ca7a2d7da17c95474f3cb488dcac6686f85f',
-     x86_64: '28d7c2d8632c1dd232cc3847c3161ea494ef8b86108bedc1b69da6d4daf5d782'
+    aarch64: 'a9ef1edc061677e829132e250ed5c774c25a738dc06d5a2b4bd5e5f360614524',
+     armv7l: 'a9ef1edc061677e829132e250ed5c774c25a738dc06d5a2b4bd5e5f360614524',
+     x86_64: '08d117a7c5429a46e8d0886e9b7a6de7e751454cceb94721d7f1d852903f3961'
   })
 
   depends_on 'dbus' # R
@@ -43,8 +41,8 @@ class Xorg_server < Package
   depends_on 'libxcvt' # R
   depends_on 'libxdmcp' # R
   depends_on 'libxext' # R
-  depends_on 'libxfont' => :build
   depends_on 'libxfont2' # R
+  depends_on 'libxfont' => :build
   depends_on 'libxfont' # R
   depends_on 'libxkbcommon' => :build
   depends_on 'libxkbfile' # R
@@ -54,23 +52,14 @@ class Xorg_server < Package
   depends_on 'mesa' # R
   depends_on 'pixman' # R
   depends_on 'xcb_util_cursor' => :build
+  depends_on 'xcb_util_image' # R
+  depends_on 'xcb_util_keysyms' # R
   depends_on 'xcb_util' # R
+  depends_on 'xcb_util_renderutil' # R
+  depends_on 'xcb_util_wm' # R
   depends_on 'xcb_util_xrm' => :build
   depends_on 'xkbcomp' => :build
   depends_on 'xorg_proto' => :build
-  depends_on 'xcb_util_image' # R
-  depends_on 'xcb_util_keysyms' # R
-  depends_on 'xcb_util_renderutil' # R
-  depends_on 'xcb_util_wm' # R
-
-  case ARCH
-  when 'armv7l', 'aarch64'
-    @peer_cmd_prefix = '/lib/ld-linux-armhf.so.3'
-  when 'i686'
-    @peer_cmd_prefix = '/lib/ld-linux.so.2'
-  when 'x86_64'
-    @peer_cmd_prefix = '/lib64/ld-linux-x86-64.so.2'
-  end
 
   def self.build
     system 'meson setup build'

--- a/packages/xwayland.rb
+++ b/packages/xwayland.rb
@@ -3,21 +3,21 @@ require 'package'
 class Xwayland < Package
   description 'X server configured to work with weston or sommelier'
   homepage 'https://x.org'
-  version '23.2.0'
+  version '23.2.3'
   license 'MIT-with-advertising, ISC, BSD-3, BSD and custom'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.freedesktop.org/xorg/xserver.git'
   git_hashtag "xwayland-#{version}"
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xwayland/23.2.0_armv7l/xwayland-23.2.0-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xwayland/23.2.0_armv7l/xwayland-23.2.0-chromeos-armv7l.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xwayland/23.2.0_x86_64/xwayland-23.2.0-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xwayland/23.2.3_armv7l/xwayland-23.2.3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xwayland/23.2.3_armv7l/xwayland-23.2.3-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/xwayland/23.2.3_x86_64/xwayland-23.2.3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
-    aarch64: 'ecfae880ef9c93fe1b773de79b88c6bca42f3ccefa40d9e8e68e5fbbe2b4fcc6',
-     armv7l: 'ecfae880ef9c93fe1b773de79b88c6bca42f3ccefa40d9e8e68e5fbbe2b4fcc6',
-     x86_64: '1a528a4f10404cb1a2be9448bd8d27a5b2be8080b6d71d1d54f5c3ac07f13c6d'
+    aarch64: 'e9d428fd69fe6d5e4fe30c22c492833de98825d74cf9af664cfe177a54750190',
+     armv7l: 'e9d428fd69fe6d5e4fe30c22c492833de98825d74cf9af664cfe177a54750190',
+     x86_64: '9e8803363d834c6a08050e3bf23d9c83e882e2bdf3dd1ce449841944bb449158'
   })
 
   no_env_options
@@ -28,11 +28,12 @@ class Xwayland < Package
   depends_on 'font_util' => :build
   depends_on 'gcc_lib' # R
   depends_on 'glibc' # R
-  depends_on 'glproto'
-  depends_on 'graphite'
+  depends_on 'glproto' => :build
+  depends_on 'graphite' => :build
   depends_on 'libbsd' # R
   depends_on 'libdrm' # R
   depends_on 'libepoxy' # R
+  depends_on 'libglvnd' # R
   depends_on 'libmd' # R
   depends_on 'libtirpc' # R
   depends_on 'libunwind' # Runtime dependency for sommelier
@@ -41,7 +42,7 @@ class Xwayland < Package
   depends_on 'libxdmcp' # R
   depends_on 'libxfont2' # R
   depends_on 'libxfont' # R
-  depends_on 'libxkbcommon'
+  depends_on 'libxkbcommon' => :build
   depends_on 'libxkbfile' # R
   depends_on 'libxshmfence' # R
   depends_on 'libxtrans' => :build
@@ -50,7 +51,6 @@ class Xwayland < Package
   depends_on 'rendercheck' # R
   depends_on 'wayland' # R
   depends_on 'xkbcomp' => :build
-  depends_on 'libglvnd' # R
 
   def self.build
     system "mold -run meson setup #{CREW_MESON_OPTIONS.sub(/(-Dcpp_args='*)(.*)(')/, '')} \


### PR DESCRIPTION
- See https://www.phoronix.com/news/XOrg-Security-Two-CVEs-End-2023

Builds properly:
- [x] `x86_64`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=xupdates crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
