### PR TITLE
Add frp package

### DIFF
--- a/manifest/armv7l/f/frp.filelist
+++ b/manifest/armv7l/f/frp.filelist
@@ -1,0 +1,7 @@
+/usr/local/bin/frpc
+/usr/local/bin/frps
+/usr/local/share/frp/frpc
+/usr/local/share/frp/frpc.toml
+/usr/local/share/frp/frps
+/usr/local/share/frp/frps.toml
+/usr/local/share/frp/LICENSE

--- a/manifest/x86_64/f/frp.filelist
+++ b/manifest/x86_64/f/frp.filelist
@@ -1,0 +1,7 @@
+/usr/local/bin/frpc
+/usr/local/bin/frps
+/usr/local/share/frp/frpc
+/usr/local/share/frp/frpc.toml
+/usr/local/share/frp/frps
+/usr/local/share/frp/frps.toml
+/usr/local/share/frp/LICENSE

--- a/packages/frp.rb
+++ b/packages/frp.rb
@@ -1,0 +1,46 @@
+require 'package'
+
+class Frp < Package
+  description 'A fast reverse proxy'
+  homepage 'https://github.com/fatedier/frp'
+  version '0.53.0'
+  license 'Apache-2.0'
+  compatibility 'x86_64 aarch64 armv7l'
+  source_url({
+    aarch64: 'https://github.com/fatedier/frp/releases/download/v0.53.0/frp_0.53.0_linux_arm.tar.gz',
+     armv7l: 'https://github.com/fatedier/frp/releases/download/v0.53.0/frp_0.53.0_linux_arm.tar.gz',
+     x86_64: 'https://github.com/fatedier/frp/releases/download/v0.53.0/frp_0.53.0_linux_amd64.tar.gz'
+  })
+  source_sha256({
+    aarch64: 'e33075389b77f94a816ac45bf1d0ce2b540fd98dafac9828602625088967762f',
+     armv7l: 'e33075389b77f94a816ac45bf1d0ce2b540fd98dafac9828602625088967762f',
+     x86_64: '662d62af7744b9b639b3473bbdd2c4c70dfa5ac5fe1d058d13ce3cc7ea059500'
+  })
+
+  no_compile_needed
+
+  def self.build
+    File.write 'frpc.sh', <<~EOF
+      #!/bin/bash
+      #{CREW_PREFIX}/share/frp/frpc -c #{CREW_PREFIX}/share/frp/frpc.toml "$@"
+    EOF
+    File.write 'frps.sh', <<~EOF
+      #!/bin/bash
+      #{CREW_PREFIX}/share/frp/frps -c #{CREW_PREFIX}/share/frp/frps.toml "$@"
+    EOF
+  end
+
+  def self.install
+    FileUtils.install 'frpc.sh', "#{CREW_DEST_PREFIX}/bin/frpc", mode: 0o755
+    FileUtils.install 'frps.sh', "#{CREW_DEST_PREFIX}/bin/frps", mode: 0o755
+    FileUtils.rm Dir['*.sh']
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/frp"
+    FileUtils.mv Dir['*'], "#{CREW_DEST_PREFIX}/share/frp"
+  end
+
+  def self.postinstall
+    puts "\nType 'frps &' to start the server and run in the background.".lightblue
+    puts "Type 'frpc &' to start the client on another machine.".lightblue
+    puts "For more information, see https://github.com/fatedier/frp.\n".lightblue
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -2120,6 +2120,11 @@ url: https://github.com/fribidi/fribidi/releases
 activity: high
 ---
 kind: url
+name: frp
+url: https://github.com/fatedier/frp/releases
+activity: medium
+---
+kind: url
 name: fskit
 url: https://github.com/jcnelson/fskit/releases
 activity: none


### PR DESCRIPTION
A fast reverse proxy to help you expose a local server behind a NAT or firewall to the internet.  See https://github.com/fatedier/frp.  Tested on arm and x86_64.