### PR TITLE
fix installs on i686

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -136,8 +136,13 @@ function curl () {
   # the 'curl: (7) Couldn't connect to server' error, a for loop is used
   # here.
   for (( i = 0; i < 4; i++ )); do
-    # Force TLS as we know GitLab supports it.
-    env -u LD_LIBRARY_PATH curl --ssl-reqd --tlsv1.2 -C - "${@}" && return 0
+    if [[ "$ARCH" == "i686" ]]; then
+      # i686 curl throws a "SSL certificate problem: self signed certificate in certificate chain" error.
+      env -u LD_LIBRARY_PATH curl -kC - "${@}" && return 0
+    else
+      # Force TLS as we know GitLab supports it.
+      env -u LD_LIBRARY_PATH curl --ssl-reqd --tlsv1.2 -C - "${@}" && return 0
+    fi
     echo_info "Retrying, $((3-i)) retries left."
   done
   # The download failed if we're still here.


### PR DESCRIPTION
- The built-in `curl` on i686 now has cert issues with SSL, so disable SSL verification until our curl gets installed.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
