### PR TITLE
Add install_extras properties to buildsystems

### DIFF
--- a/lib/buildsystems/autotools.rb
+++ b/lib/buildsystems/autotools.rb
@@ -2,7 +2,7 @@ require 'fileutils'
 require 'package'
 
 class Autotools < Package
-  property :configure_options, :pre_configure_options
+  property :configure_options, :pre_configure_options, :install_extras
 
   def self.build
     unless File.file?('Makefile') && CREW_CACHE_BUILD
@@ -31,6 +31,7 @@ class Autotools < Package
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    eval @install_extras if @install_extras
   end
 
   def self.check

--- a/lib/buildsystems/meson.rb
+++ b/lib/buildsystems/meson.rb
@@ -1,7 +1,7 @@
 require 'package'
 
 class Meson < Package
-  property :meson_options, :pre_meson_options
+  property :meson_options, :pre_meson_options, :meson_install_extras
 
   def self.build
     puts "Additional meson_options being used: #{@pre_meson_options.nil? ? '<no pre_meson_options>' : @pre_meson_options} #{@meson_options.nil? ? '<no meson_options>' : @meson_options}".orange
@@ -14,6 +14,7 @@ class Meson < Package
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
+    eval @meson_install_extras if @meson_install_extras
   end
 
   def self.check

--- a/lib/buildsystems/perl.rb
+++ b/lib/buildsystems/perl.rb
@@ -1,7 +1,7 @@
 require 'package'
 
 class PERL < Package
-  property :pre_perl_options
+  property :pre_perl_options, :perl_install_extras
 
   def self.prebuild
     puts "Additional pre_perl_options being used: #{@pre_perl_options.nil? ? '<no pre_perl_options>' : @pre_perl_options}".orange
@@ -16,5 +16,6 @@ class PERL < Package
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    eval @perl_install_extras if @perl_install_extras
   end
 end

--- a/lib/buildsystems/python.rb
+++ b/lib/buildsystems/python.rb
@@ -1,9 +1,7 @@
 require 'package'
 
 class Python < Package
-  property :python_build_options
-  property :python_install_options
-  property :no_svem
+  property :python_build_options, :python_install_options, :python_install_extras, :no_svem
 
   def self.build
     #@required_pip_modules = %w[build installer setuptools wheel pyproject_hooks]
@@ -32,5 +30,6 @@ class Python < Package
       puts "Python install options being used: #{PY3_INSTALLER_OPTIONS}".orange
       system "MAKEFLAGS=-j#{CREW_NPROC} python3 -m installer #{PY3_INSTALLER_OPTIONS}"
     end
+    eval @python_install_extras if @python_install_extras
   end
 end

--- a/lib/buildsystems/qmake.rb
+++ b/lib/buildsystems/qmake.rb
@@ -1,6 +1,8 @@
 require 'package'
 
 class Qmake < Package
+  property :qmake_install_extras
+
   def self.build
     system 'qmake'
     system 'make'
@@ -8,5 +10,6 @@ class Qmake < Package
 
   def self.install
     system "make INSTALL_ROOT=#{CREW_DEST_DIR} install"
+    eval @qmake_install_extras if @qmake_install_extras
   end
 end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.40.4'
+CREW_VERSION = '1.40.5'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
I needed this for python so I decided to add to all other buildsystems just in case I might have a need in the future.  Makes everything more flexible.