### PR TITLE
terraform 1.6.5 => 1.6.6

### DIFF
--- a/packages/terraform.rb
+++ b/packages/terraform.rb
@@ -3,7 +3,7 @@ require 'package'
 class Terraform < Package
   description 'Terraform is a tool for building, changing, and combining infrastructure safely and efficiently.'
   homepage 'https://www.terraform.io/'
-  version '1.6.5'
+  version '1.6.6'
   license 'Apache-2.0, BSD-2, BSD-4, ECL-2.0, imagemagick, ISC, JSON, MIT, MIT-with-advertising, MPL-2.0 and unicode'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Terraform < Package
      x86_64: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_amd64.zip"
   })
   source_sha256({
-    aarch64: 'abc220cef21d0937878e42de5c3085bdd8b7ca2e135163bfeeac1881da148a4b',
-     armv7l: 'abc220cef21d0937878e42de5c3085bdd8b7ca2e135163bfeeac1881da148a4b',
-       i686: 'f82fc45597a574234cbaf2825ac26a02158191d5e581c425bdadde7294a2a120',
-     x86_64: 'f6404dc264aff75fc1b776670c1abf732cfed3d4a1ce49b64bc5b5d116fe87d5'
+    aarch64: '4a5342a4577d462d880bc392e808f453b101a48aaf383baf99383999a2254fc7',
+     armv7l: '4a5342a4577d462d880bc392e808f453b101a48aaf383baf99383999a2254fc7',
+       i686: 'fbe1ea5d043f0f4785fd02948a4cecda111e24741bf6d8fe5a67415416ddf246',
+     x86_64: 'd117883fd98b960c5d0f012b0d4b21801e1aea985e26949c2d1ebb39af074f00'
   })
 
   def self.install


### PR DESCRIPTION
## Description

This commit updates the Terraform CLI from version 1.6.5 to 1.6.6

## Additional information

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`