### PR TITLE
Deprecate ruby_debug package

### DIFF
--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -53,6 +53,7 @@ pkg_update_arr = [
   { pkg_name: 'qtwebglplugin', pkg_rename: 'qt5_webglplugin', pkg_deprecated: nil, comments: nil },
   { pkg_name: 'qtwebsockets', pkg_rename: 'qt5_websockets', pkg_deprecated: nil, comments: nil },
   { pkg_name: 'qtx11extras', pkg_rename: 'qt5_x11extras', pkg_deprecated: nil, comments: nil },
+  { pkg_name: 'ruby_debug', pkg_deprecated: nil, comments: nil },
   { pkg_name: 'wget', pkg_rename: 'wget2', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' }
 ]
 


### PR DESCRIPTION
Fixes the following:
```
$ crew upgrade
Package file for installed package ruby_debug is missing.
/usr/local/lib/crew/lib/package.rb:39:in `read': No such file or directory @ rb_sysopen - /usr/local/lib/crew/packages/ruby_debug.rb (Errno::ENOENT)
	from /usr/local/lib/crew/lib/package.rb:39:in `load_package'
	from /usr/local/lib/crew/lib/package.rb:81:in `get_deps_list'
	from /usr/local/lib/crew/lib/package.rb:109:in `block in get_deps_list'
	from /usr/local/lib/crew/lib/package.rb:95:in `map'
	from /usr/local/lib/crew/lib/package.rb:95:in `get_deps_list'
	from /usr/local/lib/crew/lib/package.rb:109:in `block in get_deps_list'
	from /usr/local/lib/crew/lib/package.rb:95:in `map'
	from /usr/local/lib/crew/lib/package.rb:95:in `get_deps_list'
	from /usr/local/bin/crew:1479:in `resolve_dependencies'
	from /usr/local/bin/crew:750:in `block in upgrade'
	from /usr/local/bin/crew:748:in `each'
	from /usr/local/bin/crew:748:in `upgrade'
	from /usr/local/bin/crew:2024:in `upgrade_command'
	from /usr/local/bin/crew:2046:in `<main>'
```