### PR TITLE
More crew filejoin & remove a cd usage

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -875,7 +875,9 @@ def download
         end
         puts "Git cachefile is #{cachefile}".orange if @opt_verbose
         if File.file?(cachefile) && File.file?("#{cachefile}.sha256")
-          if system "cd #{CREW_CACHE_DIR} && sha256sum -c #{cachefile}.sha256"
+          if Dir.chdir CREW_CACHE_DIR do
+               system "sha256sum -c #{cachefile}.sha256"
+             end
             FileUtils.mkdir_p @extract_dir
             system "tar -Izstd -x#{@verbose}f #{cachefile} -C #{@extract_dir}"
             return { source:, filename: }

--- a/bin/crew
+++ b/bin/crew
@@ -528,7 +528,7 @@ def help(pkgName = nil)
 end
 
 def cache_build
-  @build_cachefile = "#{CREW_CACHE_DIR}/#{@pkg.name}-#{@pkg.version}-build-#{@device[:architecture]}.tar.zst"
+  @build_cachefile = File.join(CREW_CACHE_DIR, "#{@pkg.name}-#{@pkg.version}-build-#{@device[:architecture]}.tar.zst")
   if CREW_CACHE_ENABLED && File.writable?(CREW_CACHE_DIR)
     puts 'Caching build dir...'
     @pkg_build_dirname_absolute = File.join(CREW_BREW_DIR, @extract_dir)
@@ -777,7 +777,7 @@ def download
   sha256sum = @pkg.get_sha256(@device[:architecture])
   @extract_dir = @pkg.get_extract_dir
 
-  @build_cachefile = "#{CREW_CACHE_DIR}/#{@pkg.name}-#{@pkg.version}-build-#{@device[:architecture]}.tar.zst"
+  @build_cachefile = File.join(CREW_CACHE_DIR, "#{@pkg.name}-#{@pkg.version}-build-#{@device[:architecture]}.tar.zst")
   return { source:, filename: } if CREW_CACHE_BUILD && File.file?(@build_cachefile)
 
   if !url

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.40.8'
+CREW_VERSION = '1.40.9'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
- more cleanup

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=more_crew_filejoin crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
