### PR TITLE
Remove revision numbers which do not correspond to the built versions of packages

### DIFF
--- a/packages/anagram.rb
+++ b/packages/anagram.rb
@@ -3,7 +3,7 @@ require 'package'
 class Anagram < Package
   description 'finds anagrams or permutations of words in the target phrase'
   homepage 'https://www.fourmilab.ch/anagram/'
-  version '1.5-1'
+  version '1.5'
   license 'public-domain'
   compatibility 'all'
   source_url 'https://www.fourmilab.ch/anagram/anagram-1.5.tar.gz'

--- a/packages/ascii.rb
+++ b/packages/ascii.rb
@@ -3,7 +3,7 @@ require 'package'
 class Ascii < Package
   description 'List ASCII idiomatic names and octal/decimal code-point forms.'
   homepage 'http://www.catb.org/~esr/ascii/'
-  version '3.18-1'
+  version '3.18'
   license 'BSD'
   compatibility 'all'
   source_url 'http://www.catb.org/~esr/ascii/ascii-3.18.tar.gz'

--- a/packages/biew.rb
+++ b/packages/biew.rb
@@ -3,7 +3,7 @@ require 'package'
 class Biew < Package
   description 'EYE (Binary EYE) is a free, portable, advanced file viewer with built-in editor for binary, hexadecimal and disassembler modes.'
   homepage 'https://sourceforge.net/projects/beye/'
-  version '6.1.0-0'
+  version '6.1.0'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://downloads.sourceforge.net/project/beye/biew/6.1.0/biew-610-src.tar.bz2'

--- a/packages/brackets.rb
+++ b/packages/brackets.rb
@@ -3,7 +3,7 @@ require 'package'
 class Brackets < Package
   description 'A modern, open source text editor that understands web design.'
   homepage 'http://brackets.io/'
-  version '1.14.1-1'
+  version '1.14.1'
   license 'MPL-2.0'
   compatibility 'i686,x86_64'
   source_url 'https://github.com/adobe/brackets/archive/release-1.14.1.tar.gz'

--- a/packages/gimp.rb
+++ b/packages/gimp.rb
@@ -3,7 +3,7 @@ require 'buildsystems/meson'
 class Gimp < Meson
   description 'GIMP is a cross-platform image editor available for GNU/Linux, OS X, Windows and more operating systems.'
   homepage 'https://www.gimp.org/'
-  version '2.99.16-1'
+  version '2.99.16'
   license 'GPL-3 and LGPL-3'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://download.gimp.org/gimp/v2.99/gimp-2.99.16.tar.xz'

--- a/packages/imgur.rb
+++ b/packages/imgur.rb
@@ -3,7 +3,7 @@ require 'package'
 class Imgur < Package
   description 'Upload images to Imgur via a small bash script.'
   homepage 'https://github.com/tremby/imgur.sh'
-  version '9'
+  version 'v9'
   license 'unlicense'
   compatibility 'all'
   source_url 'https://github.com/tremby/imgur.sh/archive/v9.tar.gz'

--- a/packages/pinentry.rb
+++ b/packages/pinentry.rb
@@ -3,7 +3,7 @@ require 'package'
 class Pinentry < Package
   description 'A collection of passphrase entry dialogs which is required for almost all usages of GnuPG'
   homepage 'https://gnupg.org/software/pinentry/index.html'
-  version '1.1.0-1'
+  version '1.1.0'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://gnupg.org/ftp/gcrypt/pinentry/pinentry-1.1.0.tar.bz2'

--- a/packages/qtfm.rb
+++ b/packages/qtfm.rb
@@ -3,7 +3,7 @@ require 'buildsystems/cmake'
 class Qtfm < CMake
   description 'Lightweight desktop independent Qt file manager'
   homepage 'https://qtfm.eu/'
-  version '6.3.0-c19b9c1-2'
+  version '6.3.0-c19b9c1-1'
   license 'GPL-2+'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://github.com/rodlie/qtfm.git'

--- a/packages/sed.rb
+++ b/packages/sed.rb
@@ -3,7 +3,7 @@ require 'buildsystems/autotools'
 class Sed < Autotools
   description 'sed (stream editor) is a non-interactive command-line text editor.'
   homepage 'https://www.gnu.org/software/sed/'
-  version '4.9-1'
+  version '4.9'
   license 'GPL-3'
   compatibility 'all'
   source_url 'https://ftpmirror.gnu.org/sed/sed-4.9.tar.xz'

--- a/packages/wput.rb
+++ b/packages/wput.rb
@@ -3,7 +3,7 @@ require 'package'
 class Wput < Package
   description 'wput is a command line file upload tool, the opposite of wget'
   homepage 'http://wput.sourceforge.net/'
-  version '0.6.2-1'
+  version '0.6.2'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://downloads.sourceforge.net/project/wput/wput/0.6.2/wput-0.6.2.tgz'


### PR DESCRIPTION
As per the discussion in #7082, I'm cleaning up all the packages which have misconigured `binary_url` values.

For this batch, it's simply just removing revision numbers which don't correspond to the package version we have actually built. 

Tested and working on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=binarycleanup0 crew update
```
