### PR TITLE
Minor cleanups for version setting and url conformance

### DIFF
--- a/packages/asmc.rb
+++ b/packages/asmc.rb
@@ -5,7 +5,7 @@ class Asmc < Package
   homepage 'https://github.com/nidud/asmc'
   license 'GPL-2.0'
   @_commit = '3663995a73c333742c6c3bd022ba7ba33e4f5155'
-  version "2.33.27-#{@_commit[0..7]}"
+  version "2.33.27-#{@_commit[0..6]}"
   compatibility 'all'
   source_url "https://github.com/nidud/asmc/raw/#{@_commit}/bin/asmc"
   source_sha256 '90d227fa76ceba80da6aa63e90b945577daf7c13d93c3a08b76b9d488875d4a0'

--- a/packages/linux_sources.rb
+++ b/packages/linux_sources.rb
@@ -3,8 +3,7 @@ require 'package'
 class Linux_sources < Package
   description 'Sources for the Linux kernel'
   homepage 'https://kernel.org/'
-  @version = CREW_KERNEL_VERSION == '4.14' ? "#{CREW_KERNEL_VERSION}-1" : CREW_KERNEL_VERSION
-  version @version
+  version ARCH == 'i686' ? '3.8' : '4.14-1'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://chromium.googlesource.com/chromiumos/third_party/kernel.git'

--- a/packages/netavark.rb
+++ b/packages/netavark.rb
@@ -6,7 +6,7 @@ require 'package'
 class Netavark < Package
   description 'Container network stack'
   homepage 'https://github.com/containers/netavark'
-  version '1.4.0'
+  version '1.0.1'
   license 'Apache'
   compatibility 'all'
   source_url 'https://github.com/containers/netavark.git'

--- a/packages/nss.rb
+++ b/packages/nss.rb
@@ -5,7 +5,7 @@ class Nss < Package
   homepage 'https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS'
   @nss_ver = '3.69.1'
   @nspr_ver = '4.32'
-  version "nss.#{@nss_ver}.nspr.#{@nss_ver}"
+  version "nss.#{@nss_ver}.nspr.#{@nspr_ver}"
   license 'MPL-2.0, GPL-2 or LGPL-2.1'
   compatibility 'all'
   source_url 'https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_69_1_RTM/src/nss-3.69.1-with-nspr-4.32.tar.gz'

--- a/packages/rust.rb
+++ b/packages/rust.rb
@@ -3,7 +3,7 @@ require 'package'
 class Rust < Package
   description 'Rust is a systems programming language that runs blazingly fast, prevents segfaults, and guarantees thread safety.'
   homepage 'https://www.rust-lang.org/'
-  version '1.75.0'
+  version '1.74.1'
   license 'Apache-2.0 and MIT'
   compatibility 'all'
   source_url 'https://github.com/rust-lang/rustup.git'

--- a/packages/xorg_intel_driver.rb
+++ b/packages/xorg_intel_driver.rb
@@ -6,7 +6,7 @@ class Xorg_intel_driver < Package
   description 'The Xorg Intel Driver package contains the X.Org Video Driver for Intel integrated video chips including 8xx, 9xx, Gxx, Qxx, HD, Iris, and Iris Pro graphics processors.'
   homepage 'https://01.org/linuxgraphics/'
   @_ver = '31486f40f8e8f8923ca0799aea84b58799754564'
-  version "2.99.917+916+g#{@_ver[0..7]}"
+  version "2.99.917+916+g#{@_ver[0..6]}"
   license 'MIT and ISC'
   compatibility 'x86_64'
   source_url "https://gitlab.freedesktop.org/xorg/driver/xf86-video-intel/-/archive/#{@_ver}/xf86-video-intel-#{@_ver}.tar.gz"


### PR DESCRIPTION
Some packages simply didn't have the correct version in regards to the builds available, some packages had typos, some packages had minor inconsistencies, etc.

Some of these packages could benefit from a proper refactoring (i.e. `asmc`) but without #7082 merged my build workflow doesn't work, so in order to get around the chicken and egg problem I'm putting in a quick fix now and I'll properly work on them later.

Tested and working on all architectures.

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=binarycleanup2 crew update
```
