### PR TITLE
Fix binary_urls of glibc_* packages

### DIFF
--- a/packages/glibc_build223.rb
+++ b/packages/glibc_build223.rb
@@ -21,7 +21,7 @@ class Glibc_build223 < Package
   source_sha256 '94efeb00e4603c8546209cefb3e1a50a5315c86fa9b078b6fad758e187ce13e9'
 
   binary_url({
-    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.23-6_i686/glibc-2.23-6-chromeos-i686.tar.zst'
+    i686: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc_build223/2.23-6_i686/glibc_build223-2.23-6-chromeos-i686.tar.zst'
   })
   binary_sha256({
     i686: 'f40aa662009999330bd1be1feb6c64efbe663a7a308973dc7c5a2b41c1faaf6b'

--- a/packages/glibc_build227.rb
+++ b/packages/glibc_build227.rb
@@ -21,9 +21,9 @@ class Glibc_build227 < Package
   source_sha256 '5172de54318ec0b7f2735e5a91d908afe1c9ca291fec16b5374d9faadfc1fc72'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.27_armv7l/glibc-2.27-chromeos-armv7l.tar.xz',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.27_armv7l/glibc-2.27-chromeos-armv7l.tar.xz',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.27_x86_64/glibc-2.27-chromeos-x86_64.tar.xz'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc_build227/2.27-1_armv7l/glibc_build227-2.27-1-chromeos-armv7l.tar.xz',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc_build227/2.27-1_armv7l/glibc_build227-2.27-1-chromeos-armv7l.tar.xz',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc_build227/2.27-1_x86_64/glibc_build227-2.27-1-chromeos-x86_64.tar.xz'
   })
   binary_sha256({
     aarch64: '64b4b73e2096998fd1a0a0e7d18472ef977aebb2f1cad83d99c77e164cb6a1d6',

--- a/packages/glibc_build232.rb
+++ b/packages/glibc_build232.rb
@@ -319,7 +319,7 @@ class Glibc_build232 < Package
     # This is the array of locales to save:
     @locales = %w[C cs_CZ de_DE en es_MX fa_IR fr_FR it_IT ja_JP ru_RU tr_TR zh]
     @localedirs = %W[#{CREW_PREFIX}/share/locale #{CREW_PREFIX}/share/i18n/locales]
-    @filelist = File.readlines("#{CREW_META_PATH}/glibc_build.filelist")
+    @filelist = File.readlines("#{CREW_META_PATH}/glibc_build232.filelist")
     @localedirs.each do |localedir|
       Dir.chdir localedir do
         Dir['*'].each do |f|
@@ -332,7 +332,7 @@ class Glibc_build232 < Package
       end
     end
     puts 'Updating glibc package filelist...'.lightblue
-    File.open("#{CREW_META_PATH}/glibc_build.filelist", 'w+') do |f|
+    File.open("#{CREW_META_PATH}/glibc_build232.filelist", 'w+') do |f|
       f.puts(@filelist)
     end
   end

--- a/packages/glibc_build233.rb
+++ b/packages/glibc_build233.rb
@@ -21,9 +21,9 @@ class Glibc_build233 < Package
   source_sha256 '2e2556000e105dbd57f0b6b2a32ff2cf173bde4f0d85dffccfd8b7e51a0677ff'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.33-3_armv7l/glibc-2.33-3-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.33-3_armv7l/glibc-2.33-3-chromeos-armv7l.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.33-3_x86_64/glibc-2.33-3-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc_build233/2.33-3_armv7l/glibc_build233-2.33-3-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc_build233/2.33-3_armv7l/glibc_build233-2.33-3-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc_build233/2.33-3_x86_64/glibc_build233-2.33-3-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
     aarch64: '11a3e7ba5eec18c325afa80bc869b4f8cc1fcbfef78ddf25e1b1e278679203a4',

--- a/packages/glibc_build233.rb
+++ b/packages/glibc_build233.rb
@@ -319,7 +319,7 @@ class Glibc_build233 < Package
     # This is the array of locales to save:
     @locales = %w[C cs_CZ de_DE en es_MX fa_IR fr_FR it_IT ja_JP ru_RU tr_TR zh]
     @localedirs = %W[#{CREW_PREFIX}/share/locale #{CREW_PREFIX}/share/i18n/locales]
-    @filelist = File.readlines("#{CREW_META_PATH}/glibc_build.filelist")
+    @filelist = File.readlines("#{CREW_META_PATH}/glibc_build233.filelist")
     @localedirs.each do |localedir|
       Dir.chdir localedir do
         Dir['*'].each do |f|
@@ -332,7 +332,7 @@ class Glibc_build233 < Package
       end
     end
     puts 'Updating glibc package filelist...'.lightblue
-    File.open("#{CREW_META_PATH}/glibc_build.filelist", 'w+') do |f|
+    File.open("#{CREW_META_PATH}/glibc_build233.filelist", 'w+') do |f|
       f.puts(@filelist)
     end
   end

--- a/packages/glibc_build235.rb
+++ b/packages/glibc_build235.rb
@@ -25,9 +25,9 @@ class Glibc_build235 < Package
   # source_sha256 '5123732f6b67ccd319305efd399971d58592122bcc2a6518a1bd2510dd0cf52e'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.35-1_armv7l/glibc-2.35-1-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.35-1_armv7l/glibc-2.35-1-chromeos-armv7l.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc/2.35-1_x86_64/glibc-2.35-1-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc_build235/2.35-1_armv7l/glibc_build235-2.35-1-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc_build235/2.35-1_armv7l/glibc_build235-2.35-1-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc_build235/2.35-1_x86_64/glibc_build235-2.35-1-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
     aarch64: '928b60200126cb0d69401bc5124a9a4e7b2294b54a1046c6f88caa45d7be32b9',

--- a/packages/glibc_build235.rb
+++ b/packages/glibc_build235.rb
@@ -313,7 +313,7 @@ class Glibc_build235 < Package
     # This is the array of locales to save:
     @locales = %w[C cs_CZ de_DE en es_MX fa_IR fr_FR it_IT ja_JP ru_RU tr_TR zh]
     @localedirs = %W[#{CREW_PREFIX}/share/locale #{CREW_PREFIX}/share/i18n/locales]
-    @filelist = File.readlines("#{CREW_META_PATH}/glibc_build.filelist")
+    @filelist = File.readlines("#{CREW_META_PATH}/glibc_build235.filelist")
     @localedirs.each do |localedir|
       Dir.chdir localedir do
         Dir['*'].each do |f|
@@ -326,7 +326,7 @@ class Glibc_build235 < Package
       end
     end
     puts 'Updating glibc package filelist...'.lightblue
-    File.open("#{CREW_META_PATH}/glibc_build.filelist", 'w+') do |f|
+    File.open("#{CREW_META_PATH}/glibc_build235.filelist", 'w+') do |f|
       f.puts(@filelist)
     end
   end

--- a/packages/glibc_dev235.rb
+++ b/packages/glibc_dev235.rb
@@ -10,9 +10,9 @@ class Glibc_dev235 < Package
   source_url 'SKIP'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc_dev/2.35_armv7l/glibc_dev-2.35-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc_dev/2.35_armv7l/glibc_dev-2.35-chromeos-armv7l.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc_dev/2.35_x86_64/glibc_dev-2.35-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc_dev235/2.35_armv7l/glibc_dev235-2.35-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc_dev235/2.35_armv7l/glibc_dev235-2.35-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc_dev235/2.35_x86_64/glibc_dev235-2.35-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
     aarch64: '18779266ab02bc47f080a3d12d710f6fca9539ce9d7d96d824bbb8d51294d530',

--- a/packages/glibc_dev235.rb
+++ b/packages/glibc_dev235.rb
@@ -29,7 +29,7 @@ class Glibc_dev235 < Package
 
   def self.install
     puts 'Installing Glibc_build to pull files for build...'.lightblue
-    @filelist_path = File.join(CREW_META_PATH, 'glibc_build.filelist')
+    @filelist_path = File.join(CREW_META_PATH, 'glibc_build235.filelist')
     abort 'File list for Glibc_build does not exist!'.lightred unless File.file?(@filelist_path)
     @filelist = File.readlines(@filelist_path, chomp: true).sort
 

--- a/packages/glibc_lib235.rb
+++ b/packages/glibc_lib235.rb
@@ -10,9 +10,9 @@ class Glibc_lib235 < Package
   source_url 'SKIP'
 
   binary_url({
-    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc_lib/2.35_armv7l/glibc_lib-2.35-chromeos-armv7l.tar.zst',
-     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc_lib/2.35_armv7l/glibc_lib-2.35-chromeos-armv7l.tar.zst',
-     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc_lib/2.35_x86_64/glibc_lib-2.35-chromeos-x86_64.tar.zst'
+    aarch64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc_lib235/2.35_armv7l/glibc_lib235-2.35-chromeos-armv7l.tar.zst',
+     armv7l: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc_lib235/2.35_armv7l/glibc_lib235-2.35-chromeos-armv7l.tar.zst',
+     x86_64: 'https://gitlab.com/api/v4/projects/26210301/packages/generic/glibc_lib235/2.35_x86_64/glibc_lib235-2.35-chromeos-x86_64.tar.zst'
   })
   binary_sha256({
     aarch64: '877f6ce14ccdbf7ca103a0e131d40a1f91654183599812b4917eae7cfce37550',


### PR DESCRIPTION
ughhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh this took forever and it sucked

Manually fixed and reuploaded all the noncompliant `glibc_*` packages.

Tested and working on all architectures.

Once this PR and the previous one are merged, 7082 is good to go after a rebase.

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=binarycleanup3 crew update
```
