### PR TITLE
install.sh: Simplify syntax and improvements

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,8 +19,8 @@ CREW_BREW_DIR="${CREW_PREFIX}/tmp/crew"
 CREW_DEST_DIR="${CREW_BREW_DIR}/dest"
 : "${CREW_CACHE_DIR:=$CREW_PREFIX/tmp/packages}"
 
-BOOTSTRAP_PACKAGES="zstd crew_mvdir ruby git ca_certificates openssl"
-SPRASE_CHECKOUT="packages manifest/${USER_SPACE_ARCH} lib bin crew tests tools"
+BOOTSTRAP_PACKAGES=(zstd crew_mvdir ruby git ca_certificates openssl)
+SPRASE_CHECKOUT=(packages manifest/${USER_SPACE_ARCH} lib bin crew tests tools)
 
 # Simplify colors and print errors to stderr (2).
 echo_error()   { echo -e "\e[1;91m${*}\e[0m" >&2; }  # Use Light Red for errors.
@@ -176,18 +176,18 @@ urls=()
 sha256s=()
 
 # Older i686 systems.
-[[ "${ARCH}" == "i686" ]] && BOOTSTRAP_PACKAGES+=" gcc_lib"
+[[ "${ARCH}" == "i686" ]] && BOOTSTRAP_PACKAGES+=(gcc_lib)
 
 if [[ -n "${CHROMEOS_RELEASE_CHROME_MILESTONE}" ]] && (( "${CHROMEOS_RELEASE_CHROME_MILESTONE}" > "112" )); then
   # Append the correct packages for systems running v113 onwards.
-  BOOTSTRAP_PACKAGES+=' glibc_lib235 zlibpkg gmp'
+  BOOTSTRAP_PACKAGES+=(glibc_lib235 zlibpkg gmp)
 
   # Recent Arm systems have a cut down system.
-  [[ "${USER_SPACE_ARCH}" == "armv7l" ]] && BOOTSTRAP_PACKAGES+=' bzip2 ncurses readline pcre2 gcc_lib'
+  [[ "${USER_SPACE_ARCH}" == "armv7l" ]] && BOOTSTRAP_PACKAGES+=(bzip2 ncurses readline pcre2 gcc_lib)
 fi
 
 # Get the URLs and hashes of the bootstrap packages.
-for package in $BOOTSTRAP_PACKAGES; do
+for package in "${BOOTSTRAP_PACKAGES[@]}"; do
   cd "${CREW_LIB_PATH}/packages"
   [[ "$(sed -n '/binary_sha256/,/}/p' "${package}.rb")" =~ .*${ARCH}:[[:blank:]]*[\'\"]([^\'\"]*) ]]
     sha256s+=("${BASH_REMATCH[1]}")
@@ -333,10 +333,7 @@ echo_info "Installing core Chromebrew packages...\n"
 yes | crew install core
 
 echo_info "\nRunning Bootstrap package postinstall scripts...\n"
-# Due to a bug in crew where it accepts spaces in package files names rather than
-# splitting strings at spaces, we cannot quote ${BOOTSTRAP_PACKAGES}.
-# shellcheck disable=SC2086
-crew postinstall ${BOOTSTRAP_PACKAGES}
+crew postinstall "${BOOTSTRAP_PACKAGES[@]}"
 
 if ! "${CREW_PREFIX}"/bin/git version &> /dev/null; then
   echo_error "\nGit is broken on your system, and crew update will not work properly."

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,7 @@ CREW_BREW_DIR="${CREW_PREFIX}/tmp/crew"
 CREW_DEST_DIR="${CREW_BREW_DIR}/dest"
 : "${CREW_CACHE_DIR:=$CREW_PREFIX/tmp/packages}"
 
+BOOTSTRAP_PACKAGES="zstd crew_mvdir ruby git ca_certificates openssl"
 SPRASE_CHECKOUT="packages manifest/${USER_SPACE_ARCH} lib bin crew tests tools"
 
 # Simplify colors and print errors to stderr (2).
@@ -40,21 +41,21 @@ fi
 # Check if the script is being run as root.
 if [ "${EUID}" == "0" ]; then
   echo_error "Chromebrew should not be installed or run as root."
-  echo_info "Please login as 'chronos' and restart the install."
+  echo_info  "Please login as 'chronos' and restart the install."
   exit 1
 fi
 
 # Reject crostini.
 if [[ -d /opt/google/cros-containers && "${CREW_FORCE_INSTALL}" != '1' ]]; then
   echo_error "Crostini containers are not supported by Chromebrew :/"
-  echo_info "Run 'CREW_FORCE_INSTALL=1 exec bash --init-file <(curl -Ls git.io/vddgY)' to perform install anyway"
+  echo_info  "Run 'CREW_FORCE_INSTALL=1 exec bash --init-file <(curl -Ls git.io/vddgY)' to perform install anyway"
   exit 1
 fi
 
 # Reject non-stable Chrome OS channels.
 if ! [[ "${CHROMEOS_RELEASE_TRACK}" == 'stable-channel' || "${CREW_FORCE_INSTALL}" == '1' ]]; then
   echo_error "The beta, dev, and canary channel are unsupported by Chromebrew."
-  echo_info "Run 'CREW_FORCE_INSTALL=1 exec bash --init-file <(curl -Ls git.io/vddgY)' to perform install anyway."
+  echo_info  "Run 'CREW_FORCE_INSTALL=1 exec bash --init-file <(curl -Ls git.io/vddgY)' to perform install anyway."
   exit 1
 fi
 
@@ -173,8 +174,6 @@ curl -L --progress-bar "${REPO_URL}/tarball/${BRANCH}" | tar -xz --strip-compone
 # Prepare urls and sha256s variables.
 urls=()
 sha256s=()
-
-BOOTSTRAP_PACKAGES="zstd crew_mvdir ruby git ca_certificates openssl"
 
 # Older i686 systems.
 [[ "${ARCH}" == "i686" ]] && BOOTSTRAP_PACKAGES+=" gcc_lib"

--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ CREW_DEST_DIR="${CREW_BREW_DIR}/dest"
 : "${CREW_CACHE_DIR:=$CREW_PREFIX/tmp/packages}"
 
 BOOTSTRAP_PACKAGES=(zstd crew_mvdir ruby git ca_certificates openssl)
-SPRASE_CHECKOUT=(packages manifest/${USER_SPACE_ARCH} lib bin crew tests tools)
+SPARSE_CHECKOUT=(packages manifest/${USER_SPACE_ARCH} lib bin crew tests tools)
 
 # Simplify colors and print errors to stderr (2).
 echo_error()   { echo -e "\e[1;91m${*}\e[0m" >&2; }  # Use Light Red for errors.
@@ -169,7 +169,7 @@ crew_folders="bin cache doc docbook include lib/crew/packages lib$LIB_SUFFIX lib
 find "${CREW_LIB_PATH}" -mindepth 1 -delete
 
 # Download the chromebrew repository.
-curl -L --progress-bar "${REPO_URL}/tarball/${BRANCH}" | tar -xz --strip-components=1 ${SPRASE_CHECKOUT} -C "${CREW_LIB_PATH}"
+curl -L --progress-bar "${REPO_URL}/tarball/${BRANCH}" | tar -xz --strip-components=1 "${SPARSE_CHECKOUT[@]}" -C "${CREW_LIB_PATH}"
 
 # Prepare urls and sha256s variables.
 urls=()
@@ -356,7 +356,7 @@ else
   git checkout -f "${BRANCH}"
 
   # Set sparse-checkout folders.
-  git sparse-checkout set ${SPRASE_CHECKOUT}
+  git sparse-checkout set "${SPARSE_CHECKOUT[@]}"
   git reset --hard origin/"${BRANCH}"
 fi
 echo -e "${RESET}"


### PR DESCRIPTION
### Changes
- Check for `sudo` availability in a more elegant way
- Group constants in a place
- Import `/etc/lsb-release` directly instead of using `grep`
- Replace all `$(id -u)` calls with `${EUID}`
- Align comments
- Put repository URLs into variables
- Remove `pixz` since `.pixz` should be backward compatible with `xz`
- Only extract files specified in `git sparse-checkout` from the repo tarball
- Simplify syntax
- Use array on `BOOTSTRAP_PACKAGES` instead of string

### Not tested yet