### PR TITLE
Fix repology workflow

### DIFF
--- a/.github/workflows/Repology.yml
+++ b/.github/workflows/Repology.yml
@@ -11,6 +11,7 @@ jobs:
       - name: Generate JSON
         run: |
           git config --global safe.directory /usr/local/lib/crew
+          git pull
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global credential.helper store


### PR DESCRIPTION
Hopefully this works-- we can't use `crew update` because satmandu's containers are root by default, but my containers have a broken sudo right now, so we can't use those either, and we have to use a container until #9218 is merged (and maybe even after that), so this is my best option.