### PR TITLE
Fix unnecessary warning about packages with changed versions but not updated binaries

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -673,7 +673,6 @@ def update
 
     if differentVersion && !differentSha && hasSha
       canBeUpdated -= 1
-      puts "#{@pkg.name} has a version change but does not have updated binaries".yellow
     elsif differentVersion
       puts "#{@pkg.name} could be updated from #{package[:version]} to #{@pkg.version}"
     elsif !differentVersion && differentSha

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.42.1'
+CREW_VERSION = '1.42.2'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
While it would prevent issues like what happened in #9134, overall the legitimate occurences of changing a version without new binaries, namely removing unnecessary revision tags, outweight the bugs it catches.

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=beautifulbasilisk crew update
```
