### PR TITLE
Fix broken gnu_time and linuxheaders packages on i686

### DIFF
--- a/packages/gnu_time.rb
+++ b/packages/gnu_time.rb
@@ -11,12 +11,17 @@ class Gnu_time < Package
   compatibility 'all'
   source_url 'https://git.savannah.gnu.org/git/time.git'
   git_hashtag "v#{version}"
-  binary_compression 'tpxz'
+  case ARCH
+  when 'i686'
+    binary_compression 'tar.xz'
+  else
+    binary_compression 'tpxz'
+  end
 
   binary_sha256({
-    i686: 'be10181fa1e78fbbadd2fcdd7b8d6ecd71cdd8d38b1e521f400a93b3376f98a3',
     aarch64: '91fada2df988370b67ff384fbd18e002f9123f69debdb9184dacdd231afd1924',
      armv7l: '91fada2df988370b67ff384fbd18e002f9123f69debdb9184dacdd231afd1924',
+       i686: 'be10181fa1e78fbbadd2fcdd7b8d6ecd71cdd8d38b1e521f400a93b3376f98a3',
      x86_64: 'f042a1fe4d36029d2cc90a79bdc4014c0b6324008bbc971d35fb0001216a2562'
   })
 

--- a/packages/linuxheaders.rb
+++ b/packages/linuxheaders.rb
@@ -9,33 +9,41 @@ class Linuxheaders < Package
   compatibility 'all'
   source_url 'https://chromium.googlesource.com/chromiumos/third_party/kernel.git'
   git_hashtag "chromeos-#{CREW_KERNEL_VERSION}"
-  binary_compression 'tar.zst'
+  case ARCH
+  when 'i686'
+    binary_compression 'tpxz'
+  else
+    binary_compression 'tar.zst'
+  end
 
-  if CREW_KERNEL_VERSION == '3.8'
+  case CREW_KERNEL_VERSION
+  when '3.8'
     binary_sha256({
       i686: 'c16afcd95ebcffac67a026b724da19f498003ea80c13c87aeb613f09d412bb91'
     })
-  elsif CREW_KERNEL_VERSION == '4.14'
+  when '4.14'
     binary_sha256({
       aarch64: '75f253ac2cf0dd785ea8d9cdf9430d23d601ccc372e9f7afa95523a28273a340',
        armv7l: '75f253ac2cf0dd785ea8d9cdf9430d23d601ccc372e9f7afa95523a28273a340',
        x86_64: '5d58b327ca9bab5630f0df387a3036125e1f367e6c43cd551f4734ee3e634073'
     })
-  elsif CREW_KERNEL_VERSION == '4.19'
+  when '4.19'
     binary_sha256({
       aarch64: 'cc9227b5b3af3abdaba4c1eb6b5df066af6c5f20629cee3a4e351b3e40521760',
        armv7l: 'cc9227b5b3af3abdaba4c1eb6b5df066af6c5f20629cee3a4e351b3e40521760',
        x86_64: 'ea112d55cb33823a473791d146d124ae5d2cce7fb72ebe0b047d5937957ee994'
     })
-  elsif CREW_KERNEL_VERSION == '5.4'
+  when '5.4'
     binary_sha256({
       aarch64: 'b790edcfe5bcad8fc7e7b873a6ba8f9ad147b00849db2afead5f51e19f699df7',
        armv7l: 'b790edcfe5bcad8fc7e7b873a6ba8f9ad147b00849db2afead5f51e19f699df7',
        x86_64: 'e6ea539149f4333518787eb1e0fa436d0914990fd2899011c277ab418a9b78ba'
     })
-  elsif CREW_KERNEL_VERSION == '5.15' && ARCH == 'x86_64'
+  when '5.15'
     binary_sha256({
-      x86_64: '5b0fa3daf6ac8f2cd1028bd326a6c64f0cac052ba225845ba314e06d12a3de76'
+      aarch64: '23b6f70dad19663d42a1bb8707e66eb1b35c4934ef051577701397b4708e8cff',
+       armv7l: '23b6f70dad19663d42a1bb8707e66eb1b35c4934ef051577701397b4708e8cff',
+       x86_64: '5b0fa3daf6ac8f2cd1028bd326a6c64f0cac052ba225845ba314e06d12a3de76'
     })
   else
     binary_sha256({


### PR DESCRIPTION
The binaries had the incorrect compression extension.