### PR TITLE
Rework installer, change USER_SPACE_ARCH

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.42.5'
+CREW_VERSION = '1.42.6'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp
@@ -41,8 +41,8 @@ QEMU_EMULATED = !CPU_SUPPORTED_ARCH.include?(KERN_ARCH)
 # which report armv8l when linux32 is run.
 ARCH = KERN_ARCH.eql?('armv8l') ? 'armv7l' : KERN_ARCH
 
-# This helps determine if there is a difference between kernel and user space
-USER_SPACE_ARCH = ARCH.eql?('aarch64') && !Dir.exist?('/lib64') ? 'armv7l' : ARCH
+# This doesn't actually represent the userspace architecture (if the userspace architecture is aarch64), but we behave as if it does
+USER_SPACE_ARCH = ARCH.eql?('aarch64') ? 'armv7l' : ARCH
 
 # Allow for edge case of i686 install on a x86_64 host before linux32 is
 # downloaded, e.g. in a docker container.


### PR DESCRIPTION
This fixes, among other things, installs on `aarch64` userspaces.

For the rework to the installer, I just worked in using the `binary_compression` value, then noticed that we could unify some code.

Regarding the  `USER_SPACE_ARCH` removal: 
1. If `USER_SPACE_ARCH` is `aarch64`, a bunch of things break. 
2. At any rate, we treat `aarch64` userspaces like `armv7l` ones, so there's no need to make a distinction.
3. Once we properly support `aarch64` userspaces, there won't be a need for special handling.

This will require a rebase from #9223, but apart from that most of the changes there still apply.

Tested and working on all architectures, except `i686`, where the missing curl binary breaks **all** installs, not just this one. The install on `i686` does proceed flawlessly up until that point, so it'll work once the curl issue is fixed.

### Run the following to get this pull request's changes locally for testing.
```
exec bash --init-file <(curl -Ls https://raw.githubusercontent.com/Zopolis4/chromebrew/quifix/install.sh)
```