### PR TITLE
Fix crew upload to work with all gitlab tokens

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1897,8 +1897,8 @@ def upload(pkgName = nil)
       noname = new_tarfile.split("#{package}-").last
       new_version = noname.split('-chromeos').first
       new_url = "#{base_url}/#{package}/#{new_version}_#{arch}/#{new_tarfile}".gsub("#{CREW_LOCAL_REPO_ROOT}/release/#{arch}/", '')
-      puts "curl -# --header \"DEPLOY-TOKEN: #{gitlab_token}\" --upload-file \"#{new_tarfile}\" \"#{new_url}\" | cat" if @opt_verbose
-      output = `curl -# --header "DEPLOY-TOKEN: #{gitlab_token}" --upload-file "#{new_tarfile}" "#{new_url}" | cat`.chomp
+      puts "curl -# --header \"PRIVATE-TOKEN: #{gitlab_token}\" --upload-file \"#{new_tarfile}\" \"#{new_url}\" | cat" if @opt_verbose
+      output = `curl -# --header "PRIVATE-TOKEN: #{gitlab_token}" --upload-file "#{new_tarfile}" "#{new_url}" | cat`.chomp
       if output.include?('201 Created')
         puts output.lightgreen
       else

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.42.3'
+CREW_VERSION = '1.42.4'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
As per the discussion on slack, this should fix `crew upload` for all gitlab tokens created relatively recently (~2 months ago, maximum upper bound of 6) while still allowing old tokens to work.