### PR TITLE
crew: Add changes for making building easier...

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -61,6 +61,7 @@ DOC = <<~DOCOPT
     -t --tree                Print dependencies in a tree-structure format.
     -c --color               Use colors even if standard out is not a tty.
     -d --no-color            Disable colors even if standard out is a tty.
+    -f --force               Force where relevant.
     -k --keep                Keep the `CREW_BREW_DIR` (#{CREW_BREW_DIR}) directory.
     -L --license             Display the crew license.
     -s --source              Build or download from source even if pre-compiled binary exists.
@@ -115,6 +116,7 @@ end
 # override default color options if specified
 String.use_color = args['--color'] || !args['--no-color']
 
+@opt_force     = args['--force']
 @opt_keep      = args['--keep']
 @opt_verbose   = args['--verbose']
 @opt_source    = args['--source']
@@ -818,10 +820,15 @@ def download
       # Recall file from cache if requested
       if CREW_CACHE_ENABLED
         puts "Looking for #{@pkg.name} archive in cache".orange if @opt_verbose
-        cachefile = File.join(CREW_CACHE_DIR, filename)
+        # Privilege CREW_LOCAL_BUILD_DIR over CREW_CACHE_DIR.
+        @local_build_cachefile = File.join(CREW_LOCAL_BUILD_DIR, filename)
+        @crew_cache_dir_cachefile = File.join(CREW_CACHE_DIR, filename)
+        cachefile = File.file?(@local_build_cachefile) ? @local_build_cachefile : @crew_cache_dir_cachefile
+        puts "Using #{@pkg.name} archive from the build cache at #{cachefile}; The checksum will not be checked against the package file.".orange if cachefile.include?(CREW_LOCAL_BUILD_DIR)
         if File.file?(cachefile)
           puts "#{@pkg.name.capitalize} archive file exists in cache".lightgreen if @opt_verbose
-          if Digest::SHA256.hexdigest(File.read(cachefile)) == sha256sum || sha256sum =~ /^SKIP$/i
+          # Don't check checksum if file is in the build cache.
+          if Digest::SHA256.hexdigest(File.read(cachefile)) == sha256sum || sha256sum =~ /^SKIP$/i || cachefile.include?(CREW_LOCAL_BUILD_DIR)
             begin
               # Hard link cached file if possible.
               FileUtils.ln cachefile, CREW_BREW_DIR, force: true, verbose: @fileutils_verbose unless File.identical?(cachefile, "#{CREW_BREW_DIR}/#{filename}")
@@ -1703,6 +1710,9 @@ def archive_package(crew_archive_dest)
     end
   end
   system "sha256sum #{crew_archive_dest}/#{pkg_name} > #{crew_archive_dest}/#{pkg_name}.sha256"
+  # Copy package file for the successfully generated package to CREW_LOCAL_REPO_ROOT .
+  FileUtils.cp "#{CREW_PACKAGES_PATH}/#{@pkgName}.rb", "#{CREW_LOCAL_REPO_ROOT}/packages/"
+  puts "The package file for #{@pkgName} used has been copied to #{CREW_LOCAL_REPO_ROOT}/packages/".lightblue
 end
 
 def remove(pkgName)
@@ -1963,10 +1973,23 @@ end
 
 def build_command(args)
   abort 'Unable to locate local repo root directory. Change to a local chromebrew git repo directory and try again.'.lightred unless Dir.exist? CREW_LOCAL_REPO_ROOT
-  abort "Unable to locate local build directory #{CREW_LOCAL_BUILD_DIR}.".lightred unless Dir.exist? CREW_LOCAL_BUILD_DIR
+  unless Dir.exist? CREW_LOCAL_BUILD_DIR
+    if @opt_force
+      puts "Attempting to creating local build directory at #{CREW_LOCAL_BUILD_DIR} .".orange
+      FileUtils.mkdir_p CREW_LOCAL_BUILD_DIR
+    else
+      abort "Unable to locate local build directory #{CREW_LOCAL_BUILD_DIR}. It will be created if you build with the '-f' flag.".lightred
+    end
+  end
   abort "#{CREW_LOCAL_BUILD_DIR} is not writable.".lightred unless File.writable?(CREW_LOCAL_BUILD_DIR)
   args['<name>'].each do |name|
-    @pkgName = name
+    # If a package file is explicitly passed, then use that package file, whereever it is.
+    if name.include?('.rb') && File.file?(name)
+      FileUtils.cp name, "#{CREW_PACKAGES_PATH}/"
+      @pkgName = File.basename(name).gsub('.rb', '')
+    else
+      @pkgName = name
+    end
     search @pkgName
     print_current_package @opt_verbose
     next unless @pkgName

--- a/bin/crew
+++ b/bin/crew
@@ -346,7 +346,8 @@ def help(pkgName = nil)
     puts <<~EOT
       Build package(s).
       Usage: crew build [-k|--keep] [-v|--verbose] <package1> [<package2> ...]
-      Build package(s) from source and place the archive and checksum in the current working directory.
+      Build package(s) from source and place the archive and checksum in the `CREW_LOCAL_BUILD_DIR/release/<arch>` directory.
+      If `-f` or `--force` is present, the `CREW_LOCAL_BUILD_DIR/release/<arch>` directories will be created.
       If `-k` or `--keep` is present, the `CREW_BREW_DIR` (#{CREW_BREW_DIR}) directory will remain.
       If `-v` or `--verbose` is present, extra information will be displayed.
     EOT
@@ -469,6 +470,7 @@ def help(pkgName = nil)
     puts <<~EOT
       Remove and install package(s).
       Usage: crew reinstall [-k|--keep] [-s|--source] [-S|--recursive-build] [-v|--verbose] <package1> [<package2> ...]
+      If `-f` or `--force` is present, an option is forced, such as in `crew build -f packagename`.
       If `-k` or `--keep` is present, the `CREW_BREW_DIR` (#{CREW_BREW_DIR}) directory will remain.
       If `-s` or `--source` is present, the package(s) will be compiled instead of installed via binary.
       If `-S` or `--recursive-build` is present, the package(s), including all dependencies, will be compiled instead of installed via binary.

--- a/bin/crew
+++ b/bin/crew
@@ -470,7 +470,7 @@ def help(pkgName = nil)
     puts <<~EOT
       Remove and install package(s).
       Usage: crew reinstall [-k|--keep] [-s|--source] [-S|--recursive-build] [-v|--verbose] <package1> [<package2> ...]
-      If `-f` or `--force` is present, an option is forced, such as in `crew build -f packagename`.
+      If `-f` or `--force` is present, an option is forced.
       If `-k` or `--keep` is present, the `CREW_BREW_DIR` (#{CREW_BREW_DIR}) directory will remain.
       If `-s` or `--source` is present, the package(s) will be compiled instead of installed via binary.
       If `-S` or `--recursive-build` is present, the package(s), including all dependencies, will be compiled instead of installed via binary.

--- a/bin/crew
+++ b/bin/crew
@@ -1977,7 +1977,7 @@ def build_command(args)
   abort 'Change to a local chromebrew git repo directory and try again.'.lightred if CREW_PACKAGES_PATH.include?(CREW_LOCAL_REPO_ROOT)
   unless Dir.exist? CREW_LOCAL_BUILD_DIR
     if @opt_force
-      puts "Attempting to creating local build directory at #{CREW_LOCAL_BUILD_DIR} .".orange
+      puts "Attempting to create local build directory at #{CREW_LOCAL_BUILD_DIR} .".orange
       FileUtils.mkdir_p CREW_LOCAL_BUILD_DIR
     else
       abort "Unable to locate local build directory #{CREW_LOCAL_BUILD_DIR}. It will be created if you build with the '-f' flag.".lightred

--- a/bin/crew
+++ b/bin/crew
@@ -1973,8 +1973,8 @@ def update_sha256(package, key, value)
 end
 
 def build_command(args)
-  abort 'Unable to locate local repo root directory. Change to a local chromebrew git repo directory and try again.'.lightred unless Dir.exist? CREW_LOCAL_REPO_ROOT && !CREW_PACKAGES_PATH.include?(CREW_LOCAL_REPO_ROOT)
-
+  abort 'Unable to locate local repo root directory. Change to a local chromebrew git repo directory and try again.'.lightred unless Dir.exist? CREW_LOCAL_REPO_ROOT
+  abort 'Change to a local chromebrew git repo directory and try again.'.lightred if CREW_PACKAGES_PATH.include?(CREW_LOCAL_REPO_ROOT)
   unless Dir.exist? CREW_LOCAL_BUILD_DIR
     if @opt_force
       puts "Attempting to creating local build directory at #{CREW_LOCAL_BUILD_DIR} .".orange

--- a/bin/crew
+++ b/bin/crew
@@ -1712,7 +1712,7 @@ def archive_package(crew_archive_dest)
   end
   system "sha256sum #{crew_archive_dest}/#{pkg_name} > #{crew_archive_dest}/#{pkg_name}.sha256"
   # Copy package file for the successfully generated package to CREW_LOCAL_REPO_ROOT .
-  FileUtils.cp "#{CREW_PACKAGES_PATH}/#{@pkgName}.rb", "#{CREW_LOCAL_REPO_ROOT}/packages/" unless CREW_PACKAGES_PATH.include?(CREW_LOCAL_REPO_ROOT)
+  FileUtils.cp "#{CREW_PACKAGES_PATH}/#{@pkgName}.rb", "#{CREW_LOCAL_REPO_ROOT}/packages/"
   puts "The package file for #{@pkgName} used has been copied to #{CREW_LOCAL_REPO_ROOT}/packages/".lightblue
 end
 

--- a/bin/crew
+++ b/bin/crew
@@ -1711,9 +1711,11 @@ def archive_package(crew_archive_dest)
     end
   end
   system "sha256sum #{crew_archive_dest}/#{pkg_name} > #{crew_archive_dest}/#{pkg_name}.sha256"
-  # Copy package file for the successfully generated package to CREW_LOCAL_REPO_ROOT .
-  FileUtils.cp "#{CREW_PACKAGES_PATH}/#{@pkgName}.rb", "#{CREW_LOCAL_REPO_ROOT}/packages/"
-  puts "The package file for #{@pkgName} used has been copied to #{CREW_LOCAL_REPO_ROOT}/packages/".lightblue
+  # Copy package file for the successfully generated package to CREW_LOCAL_REPO_ROOT only if force is set.
+  if @opt_force
+    FileUtils.cp "#{CREW_PACKAGES_PATH}/#{@pkgName}.rb", "#{CREW_LOCAL_REPO_ROOT}/packages/"
+    puts "The package file for #{@pkgName} used has been copied to #{CREW_LOCAL_REPO_ROOT}/packages/".lightblue
+  end
 end
 
 def remove(pkgName)

--- a/bin/crew
+++ b/bin/crew
@@ -1711,6 +1711,11 @@ def archive_package(crew_archive_dest)
     end
   end
   system "sha256sum #{crew_archive_dest}/#{pkg_name} > #{crew_archive_dest}/#{pkg_name}.sha256"
+  # Copy package file for the successfully generated package to CREW_LOCAL_REPO_ROOT only if force is set.
+  if @opt_force
+    FileUtils.cp "#{CREW_PACKAGES_PATH}/#{@pkgName}.rb", "#{CREW_LOCAL_REPO_ROOT}/packages/"
+    puts "The package file for #{@pkgName} used has been copied to #{CREW_LOCAL_REPO_ROOT}/packages/".lightblue
+  end
 end
 
 def remove(pkgName)

--- a/bin/crew
+++ b/bin/crew
@@ -1712,7 +1712,7 @@ def archive_package(crew_archive_dest)
   end
   system "sha256sum #{crew_archive_dest}/#{pkg_name} > #{crew_archive_dest}/#{pkg_name}.sha256"
   # Copy package file for the successfully generated package to CREW_LOCAL_REPO_ROOT .
-  FileUtils.cp "#{CREW_PACKAGES_PATH}/#{@pkgName}.rb", "#{CREW_LOCAL_REPO_ROOT}/packages/"
+  FileUtils.cp "#{CREW_PACKAGES_PATH}/#{@pkgName}.rb", "#{CREW_LOCAL_REPO_ROOT}/packages/" unless CREW_PACKAGES_PATH.include?(CREW_LOCAL_REPO_ROOT)
   puts "The package file for #{@pkgName} used has been copied to #{CREW_LOCAL_REPO_ROOT}/packages/".lightblue
 end
 
@@ -1973,7 +1973,8 @@ def update_sha256(package, key, value)
 end
 
 def build_command(args)
-  abort 'Unable to locate local repo root directory. Change to a local chromebrew git repo directory and try again.'.lightred unless Dir.exist? CREW_LOCAL_REPO_ROOT
+  abort 'Unable to locate local repo root directory. Change to a local chromebrew git repo directory and try again.'.lightred unless Dir.exist? CREW_LOCAL_REPO_ROOT && !CREW_PACKAGES_PATH.include?(CREW_LOCAL_REPO_ROOT)
+
   unless Dir.exist? CREW_LOCAL_BUILD_DIR
     if @opt_force
       puts "Attempting to creating local build directory at #{CREW_LOCAL_BUILD_DIR} .".orange

--- a/bin/crew
+++ b/bin/crew
@@ -1711,11 +1711,6 @@ def archive_package(crew_archive_dest)
     end
   end
   system "sha256sum #{crew_archive_dest}/#{pkg_name} > #{crew_archive_dest}/#{pkg_name}.sha256"
-  # Copy package file for the successfully generated package to CREW_LOCAL_REPO_ROOT only if force is set.
-  if @opt_force
-    FileUtils.cp "#{CREW_PACKAGES_PATH}/#{@pkgName}.rb", "#{CREW_LOCAL_REPO_ROOT}/packages/"
-    puts "The package file for #{@pkgName} used has been copied to #{CREW_LOCAL_REPO_ROOT}/packages/".lightblue
-  end
 end
 
 def remove(pkgName)
@@ -1891,9 +1886,9 @@ def upload(pkgName = nil)
   [packages].each do |package|
     %w[x86_64 i686 armv7l].each do |arch|
       pkgfile = "#{CREW_LOCAL_REPO_ROOT}/packages/#{package}.rb"
-      new_tarfile = Dir["#{CREW_LOCAL_REPO_ROOT}/release/#{arch}/#{package}-*-chromeos-#{arch}.{tar.xz,tar.zst}"].max_by { |f| File.mtime(f) }
+      new_tarfile = Dir["#{CREW_LOCAL_BUILD_DIR}/#{package}-*-chromeos-#{arch}.{tar.xz,tar.zst}"].max_by { |f| File.mtime(f) }
       if new_tarfile.nil?
-        puts "#{CREW_LOCAL_REPO_ROOT}/release/#{arch}/#{package}-#-chromeos-#{arch}.(tar.xz|tar.zst) not found.\n".lightred
+        puts "#{CREW_LOCAL_BUILD_DIR}/#{package}-#-chromeos-#{arch}.(tar.xz|tar.zst) not found.\n".lightred
         next
       end
       if binary_compression_set.nil?

--- a/bin/crew
+++ b/bin/crew
@@ -470,7 +470,6 @@ def help(pkgName = nil)
     puts <<~EOT
       Remove and install package(s).
       Usage: crew reinstall [-k|--keep] [-s|--source] [-S|--recursive-build] [-v|--verbose] <package1> [<package2> ...]
-      If `-f` or `--force` is present, an option is forced.
       If `-k` or `--keep` is present, the `CREW_BREW_DIR` (#{CREW_BREW_DIR}) directory will remain.
       If `-s` or `--source` is present, the package(s) will be compiled instead of installed via binary.
       If `-S` or `--recursive-build` is present, the package(s), including all dependencies, will be compiled instead of installed via binary.

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.42.5'
+CREW_VERSION = '1.42.6'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
- Add `--force` flag.
- Use build cache for installs if a binary exists there.
- Create `release` folders in `CREW_LOCAL_BUILD_DIR` if the `-f` flag is passed to `crew build`
- let `crew build` point to a package file somewhere, i.e. `crew build -f /output/new_package.rb`
- Copy package.rb file from a successful build to `CREW_LOCAL_BUILD_DIR/packages`

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=crew_build_changes crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
