### PR TITLE
binutils => 2.42

### DIFF
--- a/manifest/armv7l/b/binutils.filelist
+++ b/manifest/armv7l/b/binutils.filelist
@@ -85,8 +85,9 @@
 /usr/local/lib/ldscripts/armelf_linux_eabi.xu
 /usr/local/lib/ldscripts/armelf_linux_eabi.xw
 /usr/local/lib/ldscripts/armelf_linux_eabi.xwe
+/usr/local/lib/ldscripts/stamp
 /usr/local/lib/libbfd-2.39.50.so
-/usr/local/lib/libbfd-2.41.so
+/usr/local/lib/libbfd-2.42.so
 /usr/local/lib/libbfd.a
 /usr/local/lib/libbfd.la
 /usr/local/lib/libbfd.so
@@ -102,7 +103,7 @@
 /usr/local/lib/libctf.so.0.0.0
 /usr/local/lib/libiberty.a
 /usr/local/lib/libopcodes-2.39.50.so
-/usr/local/lib/libopcodes-2.41.so
+/usr/local/lib/libopcodes-2.42.so
 /usr/local/lib/libopcodes.a
 /usr/local/lib/libopcodes.la
 /usr/local/lib/libopcodes.so
@@ -179,6 +180,7 @@
 /usr/local/share/locale/ja/LC_MESSAGES/ld.mo
 /usr/local/share/locale/ka/LC_MESSAGES/bfd.mo
 /usr/local/share/locale/ka/LC_MESSAGES/gprof.mo
+/usr/local/share/locale/ka/LC_MESSAGES/ld.mo
 /usr/local/share/locale/ms/LC_MESSAGES/gprof.mo
 /usr/local/share/locale/nl/LC_MESSAGES/gprof.mo
 /usr/local/share/locale/nl/LC_MESSAGES/opcodes.mo
@@ -191,6 +193,7 @@
 /usr/local/share/locale/ro/LC_MESSAGES/binutils.mo
 /usr/local/share/locale/ro/LC_MESSAGES/gold.mo
 /usr/local/share/locale/ro/LC_MESSAGES/gprof.mo
+/usr/local/share/locale/ro/LC_MESSAGES/ld.mo
 /usr/local/share/locale/ro/LC_MESSAGES/opcodes.mo
 /usr/local/share/locale/ru/LC_MESSAGES/bfd.mo
 /usr/local/share/locale/ru/LC_MESSAGES/binutils.mo

--- a/manifest/i686/b/binutils.filelist
+++ b/manifest/i686/b/binutils.filelist
@@ -129,8 +129,9 @@
 /usr/local/lib/ldscripts/elf_x86_64.xu
 /usr/local/lib/ldscripts/elf_x86_64.xw
 /usr/local/lib/ldscripts/elf_x86_64.xwe
+/usr/local/lib/ldscripts/stamp
 /usr/local/lib/libbfd-2.39.50.so
-/usr/local/lib/libbfd-2.41.so
+/usr/local/lib/libbfd-2.42.so
 /usr/local/lib/libbfd.a
 /usr/local/lib/libbfd.la
 /usr/local/lib/libbfd.so
@@ -146,7 +147,7 @@
 /usr/local/lib/libctf.so.0.0.0
 /usr/local/lib/libiberty.a
 /usr/local/lib/libopcodes-2.39.50.so
-/usr/local/lib/libopcodes-2.41.so
+/usr/local/lib/libopcodes-2.42.so
 /usr/local/lib/libopcodes.a
 /usr/local/lib/libopcodes.la
 /usr/local/lib/libopcodes.so
@@ -223,6 +224,7 @@
 /usr/local/share/locale/ja/LC_MESSAGES/ld.mo
 /usr/local/share/locale/ka/LC_MESSAGES/bfd.mo
 /usr/local/share/locale/ka/LC_MESSAGES/gprof.mo
+/usr/local/share/locale/ka/LC_MESSAGES/ld.mo
 /usr/local/share/locale/ms/LC_MESSAGES/gprof.mo
 /usr/local/share/locale/nl/LC_MESSAGES/gprof.mo
 /usr/local/share/locale/nl/LC_MESSAGES/opcodes.mo
@@ -235,6 +237,7 @@
 /usr/local/share/locale/ro/LC_MESSAGES/binutils.mo
 /usr/local/share/locale/ro/LC_MESSAGES/gold.mo
 /usr/local/share/locale/ro/LC_MESSAGES/gprof.mo
+/usr/local/share/locale/ro/LC_MESSAGES/ld.mo
 /usr/local/share/locale/ro/LC_MESSAGES/opcodes.mo
 /usr/local/share/locale/ru/LC_MESSAGES/bfd.mo
 /usr/local/share/locale/ru/LC_MESSAGES/binutils.mo

--- a/manifest/x86_64/b/binutils.filelist
+++ b/manifest/x86_64/b/binutils.filelist
@@ -129,8 +129,9 @@
 /usr/local/lib64/ldscripts/elf_x86_64.xu
 /usr/local/lib64/ldscripts/elf_x86_64.xw
 /usr/local/lib64/ldscripts/elf_x86_64.xwe
+/usr/local/lib64/ldscripts/stamp
 /usr/local/lib64/libbfd-2.39.50.so
-/usr/local/lib64/libbfd-2.41.so
+/usr/local/lib64/libbfd-2.42.so
 /usr/local/lib64/libbfd.a
 /usr/local/lib64/libbfd.la
 /usr/local/lib64/libbfd.so
@@ -146,7 +147,7 @@
 /usr/local/lib64/libctf.so.0.0.0
 /usr/local/lib64/libiberty.a
 /usr/local/lib64/libopcodes-2.39.50.so
-/usr/local/lib64/libopcodes-2.41.so
+/usr/local/lib64/libopcodes-2.42.so
 /usr/local/lib64/libopcodes.a
 /usr/local/lib64/libopcodes.la
 /usr/local/lib64/libopcodes.so
@@ -223,6 +224,7 @@
 /usr/local/share/locale/ja/LC_MESSAGES/ld.mo
 /usr/local/share/locale/ka/LC_MESSAGES/bfd.mo
 /usr/local/share/locale/ka/LC_MESSAGES/gprof.mo
+/usr/local/share/locale/ka/LC_MESSAGES/ld.mo
 /usr/local/share/locale/ms/LC_MESSAGES/gprof.mo
 /usr/local/share/locale/nl/LC_MESSAGES/gprof.mo
 /usr/local/share/locale/nl/LC_MESSAGES/opcodes.mo
@@ -235,6 +237,7 @@
 /usr/local/share/locale/ro/LC_MESSAGES/binutils.mo
 /usr/local/share/locale/ro/LC_MESSAGES/gold.mo
 /usr/local/share/locale/ro/LC_MESSAGES/gprof.mo
+/usr/local/share/locale/ro/LC_MESSAGES/ld.mo
 /usr/local/share/locale/ro/LC_MESSAGES/opcodes.mo
 /usr/local/share/locale/ru/LC_MESSAGES/bfd.mo
 /usr/local/share/locale/ru/LC_MESSAGES/binutils.mo

--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -5,18 +5,18 @@ require 'package'
 class Binutils < Package
   description 'The GNU Binutils are a collection of binary tools.'
   homepage 'https://www.gnu.org/software/binutils/'
-  @_ver = '2.41'
+  @_ver = '2.42'
   version @_ver
   license 'GPL-3+'
   compatibility 'all'
   source_url "https://ftpmirror.gnu.org/binutils/binutils-#{@_ver}.tar.bz2"
-  source_sha256 'a4c4bec052f7b8370024e60389e194377f3f48b56618418ea51067f67aaab30b'
+  source_sha256 'aa54850ebda5064c72cd4ec2d9b056c294252991486350d9a97ab2a6dfdfaf12'
 
   binary_sha256({
-    aarch64: '8c22ec06120ffc67645c99dcfab36b1e1070b7ab10445dc8f738ee739abe4416',
-     armv7l: '8c22ec06120ffc67645c99dcfab36b1e1070b7ab10445dc8f738ee739abe4416',
-       i686: '606a990b5664dcb77037e2461f260621d8b9e79cdc7de4061d640bc280058f1e',
-     x86_64: '4518d1cd954c98f6f30f98518fde9bf0e32fc0f31972a24fd5f0781973ef5adb'
+    aarch64: '18cab64dbb525b4ae98a6c05ddea5d32029f86f90de51ea16b53f68ed38b73d8',
+     armv7l: '18cab64dbb525b4ae98a6c05ddea5d32029f86f90de51ea16b53f68ed38b73d8',
+       i686: '9fa43b03e93d1bfcb311bf7e263f71a9e30dd022090e325cf783ce594eca6716',
+     x86_64: '029c70874c1a17c3ff6f341e4cd76a92f1ffe2b764716936932a3e951bfd2020'
   })
   binary_compression 'tar.zst'
 


### PR DESCRIPTION


Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=binutils crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
