### PR TITLE
Add arpscan package

### DIFF
--- a/manifest/armv7l/a/arpscan.filelist
+++ b/manifest/armv7l/a/arpscan.filelist
@@ -1,0 +1,10 @@
+/usr/local/bin/arp-fingerprint
+/usr/local/bin/arp-scan
+/usr/local/bin/get-iab
+/usr/local/bin/get-oui
+/usr/local/etc/arp-scan/mac-vendor.txt
+/usr/local/share/arp-scan/ieee-oui.txt
+/usr/local/share/man/man1/arp-fingerprint.1.zst
+/usr/local/share/man/man1/arp-scan.1.zst
+/usr/local/share/man/man1/get-oui.1.zst
+/usr/local/share/man/man5/mac-vendor.5.zst

--- a/manifest/i686/a/arpscan.filelist
+++ b/manifest/i686/a/arpscan.filelist
@@ -1,0 +1,10 @@
+/usr/local/bin/arp-fingerprint
+/usr/local/bin/arp-scan
+/usr/local/bin/get-iab
+/usr/local/bin/get-oui
+/usr/local/etc/arp-scan/mac-vendor.txt
+/usr/local/share/arp-scan/ieee-oui.txt
+/usr/local/share/man/man1/arp-fingerprint.1.zst
+/usr/local/share/man/man1/arp-scan.1.zst
+/usr/local/share/man/man1/get-oui.1.zst
+/usr/local/share/man/man5/mac-vendor.5.zst

--- a/manifest/x86_64/a/arpscan.filelist
+++ b/manifest/x86_64/a/arpscan.filelist
@@ -1,0 +1,10 @@
+/usr/local/bin/arp-fingerprint
+/usr/local/bin/arp-scan
+/usr/local/bin/get-iab
+/usr/local/bin/get-oui
+/usr/local/etc/arp-scan/mac-vendor.txt
+/usr/local/share/arp-scan/ieee-oui.txt
+/usr/local/share/man/man1/arp-fingerprint.1.zst
+/usr/local/share/man/man1/arp-scan.1.zst
+/usr/local/share/man/man1/get-oui.1.zst
+/usr/local/share/man/man5/mac-vendor.5.zst

--- a/packages/arpscan.rb
+++ b/packages/arpscan.rb
@@ -1,0 +1,32 @@
+require 'buildsystems/autotools'
+
+class Arpscan < Autotools
+  description 'Arp-scan is an ARP (Address Resolution Protocol) scanning and fingerprinting tool.'
+  homepage 'https://github.com/royhills/arp-scan'
+  version '1.10.0'
+  license 'GPL-3'
+  compatibility 'all'
+  source_url 'https://github.com/royhills/arp-scan.git'
+  git_hashtag version
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+    aarch64: 'e41d1d62e226fbecde17b9dfcff48a34073dfa0f5a104880a635b6f069838491',
+     armv7l: 'e41d1d62e226fbecde17b9dfcff48a34073dfa0f5a104880a635b6f069838491',
+       i686: 'a3f45ce0b3793b9d72f943d7cfea0f89c3b4e5a39c2bb1eb63b91a3204e668d2',
+     x86_64: 'ebad569737c9d16d0e3d6b2ca912b2f524303e4b71eb0fc19996e17b974033c5'
+  })
+
+  depends_on 'libpcap'
+  depends_on 'libnet' => :build
+  # Perl dependencies needed for get-oui
+  depends_on 'perl_lwp_useragent'
+  depends_on 'perl_http_request'
+  depends_on 'perl_clone'
+  depends_on 'perl_uri'
+  depends_on 'perl_http_date'
+  depends_on 'perl_try_tiny'
+  depends_on 'perl_text_csv'
+
+  run_tests
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -275,6 +275,11 @@ url: https://github.com/ThomasHabets/arping/releases
 activity: low
 ---
 kind: url
+name: arpscan
+url: https://github.com/royhills/arp-scan/releases
+activity: none
+---
+kind: url
 name: ascii
 url: http://www.catb.org/~esr/ascii
 activity: low


### PR DESCRIPTION
arp-scan is a network scanning tool that uses the ARP protocol to discover and fingerprint IPv4 hosts on the local network.  See https://github.com/royhills/arp-scan.  All tests passed.