### PR TITLE
fix aarch64 installs, Remove USER_SPACE_ARCH

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -586,7 +586,7 @@ end
 
 def files(pkgName)
   local_filelist    = File.join(CREW_META_PATH, "#{pkgName}.filelist")
-  manifest_filelist = File.join(CREW_LIB_PATH, "manifest/#{USER_SPACE_ARCH}/#{pkgName[0]}/#{pkgName}.filelist")
+  manifest_filelist = File.join(CREW_LIB_PATH, "manifest/#{ARCH}/#{pkgName[0]}/#{pkgName}.filelist")
 
   if File.exist?(local_filelist)
     # search for local filelist first
@@ -633,7 +633,7 @@ def prop(silent = false)
 end
 
 def whatprovides(regexPat)
-  matchedList = `grep -R "#{regexPat}" #{CREW_LIB_PATH}/manifest/#{USER_SPACE_ARCH}`.lines(chomp: true).flat_map do |result|
+  matchedList = `grep -R "#{regexPat}" #{CREW_LIB_PATH}/manifest/#{ARCH}`.lines(chomp: true).flat_map do |result|
     filelist, matchedFile = result.split(':', 2)
     pkgName = File.basename(filelist, '.filelist')
     pkgNameStatus = pkgName
@@ -655,7 +655,7 @@ def update
   # update package lists
   Dir.chdir(CREW_LIB_PATH) do
     # Set sparse-checkout folders.
-    system "git sparse-checkout set packages manifest/#{USER_SPACE_ARCH} lib bin crew tests tools"
+    system "git sparse-checkout set packages manifest/#{ARCH} lib bin crew tests tools"
     system 'git sparse-checkout reapply'
 
     system "git fetch #{CREW_REPO} #{CREW_BRANCH}", exception: true
@@ -1165,8 +1165,8 @@ def prepare_package(destdir)
     system "find .#{HOME} -type f,l | cut -c2- | sort", out: %w[filelist a] if Dir.exist?(CREW_DEST_HOME)
 
     if Dir.exist?("#{CREW_LOCAL_REPO_ROOT}/manifest") && File.writable?("#{CREW_LOCAL_REPO_ROOT}/manifest")
-      FileUtils.mkdir_p "#{CREW_LOCAL_REPO_ROOT}/manifest/#{USER_SPACE_ARCH}/#{@pkg.name.chr.downcase}"
-      FileUtils.cp 'filelist', "#{CREW_LOCAL_REPO_ROOT}/manifest/#{USER_SPACE_ARCH}/#{@pkg.name.chr.downcase}/#{@pkg.name}.filelist"
+      FileUtils.mkdir_p "#{CREW_LOCAL_REPO_ROOT}/manifest/#{ARCH}/#{@pkg.name.chr.downcase}"
+      FileUtils.cp 'filelist', "#{CREW_LOCAL_REPO_ROOT}/manifest/#{ARCH}/#{@pkg.name.chr.downcase}/#{@pkg.name}.filelist"
     end
 
     # check for FHS3 compliance
@@ -2016,8 +2016,8 @@ def build_command(args)
     puts 'Compile not needed. Skipping build.'.lightred if @pkg.no_compile_needed?
     puts "Package #{@pkg.name} is not compatible with your device architecture (#{ARCH}). Skipping build.".lightred unless @pkg.compatible?
     puts 'Unable to build a fake package. Skipping build.'.lightred if @pkg.is_fake?
-    puts 'Unable to build without source. Skipping build.'.lightred unless @pkg.is_source?(USER_SPACE_ARCH) && @pkg.source_url.to_s.upcase != 'SKIP'
-    resolve_dependencies_and_build if !@pkg.is_fake? && @pkg.is_source?(USER_SPACE_ARCH) && @pkg.source_url.to_s.upcase != 'SKIP' && !@pkg.no_compile_needed?
+    puts 'Unable to build without source. Skipping build.'.lightred unless @pkg.is_source?(ARCH) && @pkg.source_url.to_s.upcase != 'SKIP'
+    resolve_dependencies_and_build if !@pkg.is_fake? && @pkg.is_source?(ARCH) && @pkg.source_url.to_s.upcase != 'SKIP' && !@pkg.no_compile_needed?
   end
   puts "Builds are located in #{CREW_LOCAL_BUILD_DIR}.".yellow
 end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.42.8'
+CREW_VERSION = '1.42.9'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp
@@ -37,12 +37,10 @@ CPU_SUPPORTED_ARCH = if CPUINFO.key?('flags')
 # does not compatible with the kernel architecture natively
 QEMU_EMULATED = !CPU_SUPPORTED_ARCH.include?(KERN_ARCH)
 
-# This helps with virtualized builds on aarch64 machines
-# which report armv8l when linux32 is run.
-ARCH = KERN_ARCH.eql?('armv8l') ? 'armv7l' : KERN_ARCH
-
-# This doesn't actually represent the userspace architecture (if the userspace architecture is aarch64), but we behave as if it does
-USER_SPACE_ARCH = ARCH.eql?('aarch64') ? 'armv7l' : ARCH
+# This helps with virtualized builds on aarch64 machines which report armv8l when linux32 is run.
+# We also report aarch64 machines as armv7l for now, as we treat them as if they were armv7l.
+# When we have proper aarch64 support, remove this.
+ARCH = %w[aarch64 armv8l].include?(KERN_ARCH) ? 'armv7l' : KERN_ARCH
 
 # Allow for edge case of i686 install on a x86_64 host before linux32 is
 # downloaded, e.g. in a docker container.
@@ -103,7 +101,7 @@ CREW_DEST_MAN_PREFIX  = File.join(CREW_DEST_DIR, CREW_MAN_PREFIX)
 
 # Local constants for contributors.
 CREW_LOCAL_REPO_ROOT = `git rev-parse --show-toplevel 2> /dev/null`.chomp
-CREW_LOCAL_BUILD_DIR = "#{CREW_LOCAL_REPO_ROOT}/release/#{USER_SPACE_ARCH}"
+CREW_LOCAL_BUILD_DIR = "#{CREW_LOCAL_REPO_ROOT}/release/#{ARCH}"
 
 # The following is used in fixup.rb to determine if crew update needs to
 # be run again.


### PR DESCRIPTION
This fixes, among other things, installs on aarch64 userspaces.

I am removing `USER_SPACE_ARCH` because there is no need to make a distinction between kernel and userspace. 

We treat `aarch64` userspaces as if they were `armv7l`, and if we do not do this, things (like installs!) will break.

This PR fixes the issue by ensuring we always treat `aarch64` userspaces as `armv7l` userspaces.

Yes, this does mean that the value of `ARCH` does not always correspond to the actual architecture. Instead, it corresponds to the architecture we treat it as. Currently, the value of USER_SPACE_ARCH` does not always correspond to the actual userspace architecture. There is no way to make `armv7l-on-aarch64` installs work without at some point, lying about the architecure. 

Yes, an alternative method to fixing this issue would be to find out where specifically telling the truth about the current architecture breaks things, and add another special-case exception for that. I don't see any value in doing that, rather than just having one value for architecrure and have it represent the architecture we are treating it as. 

