### PR TITLE
Terraform 1.7.2 => 1.7.3

### DIFF
--- a/packages/terraform.rb
+++ b/packages/terraform.rb
@@ -3,7 +3,7 @@ require 'package'
 class Terraform < Package
   description 'Terraform is a tool for building, changing, and combining infrastructure safely and efficiently.'
   homepage 'https://www.terraform.io/'
-  version '1.7.2'
+  version '1.7.3'
   license 'Apache-2.0, BSD-2, BSD-4, ECL-2.0, imagemagick, ISC, JSON, MIT, MIT-with-advertising, MPL-2.0 and unicode'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Terraform < Package
      x86_64: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_amd64.zip"
   })
   source_sha256({
-    aarch64: 'fc7ecbe8729db58381c98c49247a5ef8444787fea28cdeeeec335abeb7f35f42',
-     armv7l: 'fc7ecbe8729db58381c98c49247a5ef8444787fea28cdeeeec335abeb7f35f42',
-       i686: 'e3e1c6545e9d53c96bba3e1fc1b5d52c7ed290bcb8313bba6b58f5785de6b4d2',
-     x86_64: '1eb89ec600c01e400a5659dbc05fec855e7fbe8a0837405174e912338ac9a3ec'
+    aarch64: '2d076ef74bf803e394cc09371ed66e92d850c099cb857af1dca5eb44f2b08b03',
+     armv7l: '2d076ef74bf803e394cc09371ed66e92d850c099cb857af1dca5eb44f2b08b03',
+       i686: '9fb95e5974808543f40371fcabf9f1aa1d57406e686cfce635b965e13c266222',
+     x86_64: 'f6c2746567c0f7ebdbd3c6b4902484ded111490112f2f8749153bcd6f364b581'
   })
 
   def self.install


### PR DESCRIPTION
## Description

This commit updates the Terraform CLI from 1.7.2 to 1.7.3

## Additional information

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`