### PR TITLE
Add tuptime package

### DIFF
--- a/manifest/armv7l/t/tuptime.filelist
+++ b/manifest/armv7l/t/tuptime.filelist
@@ -1,0 +1,1 @@
+/usr/local/bin/tuptime

--- a/manifest/i686/t/tuptime.filelist
+++ b/manifest/i686/t/tuptime.filelist
@@ -1,0 +1,1 @@
+/usr/local/bin/tuptime

--- a/manifest/x86_64/t/tuptime.filelist
+++ b/manifest/x86_64/t/tuptime.filelist
@@ -1,0 +1,1 @@
+/usr/local/bin/tuptime

--- a/packages/tuptime.rb
+++ b/packages/tuptime.rb
@@ -1,0 +1,36 @@
+require 'package'
+
+class Tuptime < Package
+  description 'Report historical and statistical real time of the system, keeping it between restarts.'
+  homepage 'https://github.com/rfmoz/tuptime'
+  version '5.2.3'
+  license 'GPL-2.0'
+  compatibility 'all'
+  source_url 'https://github.com/rfmoz/tuptime.git'
+  git_hashtag version
+
+  no_compile_needed
+
+  def self.patch
+    system "sed -i 's,/var/lib,#{CREW_PREFIX}/var/lib,' src/tuptime"
+  end
+
+  def self.install
+    FileUtils.install 'src/tuptime', "#{CREW_DEST_PREFIX}/bin/tuptime", mode: 0o755
+  end
+
+  def self.remove
+    config_dir = "#{CREW_PREFIX}/var/lib/tuptime"
+    if Dir.exist? config_dir
+      puts "WARNING: This will remove #{CREW_PREFIX}/var/lib/tuptime/tuptime.db and all your history.".orange
+      print "Would you like to remove the #{config_dir} directory? [y/N] "
+      case $stdin.gets.chomp.downcase
+      when 'y', 'yes'
+        FileUtils.rm_rf config_dir
+        puts "#{config_dir} removed.".lightgreen
+      else
+        puts "#{config_dir} saved.".lightgreen
+      end
+    end
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -8526,6 +8526,11 @@ url: https://osdn.net/projects/hanazono-font/releases/
 activity: none
 ---
 kind: url
+name: tuptime
+url: https://github.com/rfmoz/tuptime/releases
+activity: low
+---
+kind: url
 name: twm
 url: https://www.x.org/archive//individual/app/
 activity: none


### PR DESCRIPTION
Report historical and statistical real time of the system, keeping it between restarts. Like uptime command but with more interesting output.  See https://www.tecmint.com/find-linux-uptime-shutdown-and-reboot-time-with-tuptime/.  Tested on all architectures.