### PR TITLE
Fix install: Do not run getrealdeps.rb from crew if no_compile_needed is true

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1203,7 +1203,7 @@ def prepare_package(destdir)
     abort 'Exiting due to above errors.'.lightred if @_errors
 
     # Make sure the package file has runtime dependencies added properly.
-    system "#{CREW_LIB_PATH}/tools/getrealdeps.rb --use-crew-dest-dir #{@pkg.name}"
+    system "#{CREW_LIB_PATH}/tools/getrealdeps.rb --use-crew-dest-dir #{@pkg.name}" unless @pkg.no_compile_needed?
     # create directory list
     # Remove CREW_PREFIX and HOME from the generated directorylist.
     @crew_prefix_escaped = CREW_PREFIX.gsub('/', '\/')

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.43.0'
+CREW_VERSION = '1.43.1'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
- Because `no_compile_needed` packages may not have a filelist generated in `CREW_DEST_DIR`, which breaks the `getrealdeps.rb` `--use_crew_dest_dir` functionality.
- This fixes installing `crew_profile_base` and thus also the installer.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=crew_no_compile_needed crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
