### PR TITLE
Fix install part 2: Add no_compile_needed to all ruby_packages

### DIFF
--- a/packages/ruby_asciidoctor.rb
+++ b/packages/ruby_asciidoctor.rb
@@ -7,4 +7,6 @@ class Ruby_asciidoctor < RUBY
   license 'MIT'
   compatibility 'all'
   source_url 'SKIP'
+
+  no_compile_needed
 end

--- a/packages/ruby_concurrent_ruby.rb
+++ b/packages/ruby_concurrent_ruby.rb
@@ -9,4 +9,5 @@ class Ruby_concurrent_ruby < RUBY
   source_url 'SKIP'
 
   conflicts_ok
+  no_compile_needed
 end

--- a/packages/ruby_docopt.rb
+++ b/packages/ruby_docopt.rb
@@ -7,4 +7,6 @@ class Ruby_docopt < RUBY
   license 'MIT'
   compatibility 'all'
   source_url 'SKIP'
+
+  no_compile_needed
 end

--- a/packages/ruby_mdl.rb
+++ b/packages/ruby_mdl.rb
@@ -9,4 +9,5 @@ class Ruby_mdl < RUBY
   source_url 'SKIP'
 
   conflicts_ok
+  no_compile_needed
 end

--- a/packages/ruby_rubocop.rb
+++ b/packages/ruby_rubocop.rb
@@ -16,6 +16,7 @@ class Ruby_rubocop < RUBY
   depends_on 'xdg_base'
 
   conflicts_ok
+  no_compile_needed
   no_fhs
 
   ruby_install_extras <<~EOF

--- a/packages/ruby_webrick.rb
+++ b/packages/ruby_webrick.rb
@@ -7,4 +7,6 @@ class Ruby_webrick < RUBY
   license 'BSD-2'
   compatibility 'all'
   source_url 'SKIP'
+
+  no_compile_needed
 end

--- a/packages/ruby_yaml_lint.rb
+++ b/packages/ruby_yaml_lint.rb
@@ -7,4 +7,6 @@ class Ruby_yaml_lint < RUBY
   license 'MIT'
   compatibility 'all'
   source_url 'SKIP'
+
+  no_compile_needed
 end


### PR DESCRIPTION
- This address a race condition during installs. `crew` wants to run `getrealdeps.rb` on `ruby_mdl`, which isn't marked as `no_compile_needed`, so it wants to install `upx`, which `getrealdeps.rb` needs... but that install wipes out `CREW_DEST_DIR`, so everything breaks.
- Adding `no_compile_needed` to the `ruby_` packages should fix this.
- The root cause is that each install should use a separate `CREW_DEST_DIR` , but that's an issue for another day.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=getrealdeps3 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
