### PR TITLE
crew: Skip SHA256 check for official prebuilt binary

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -790,12 +790,12 @@ def upgrade(*pkgs, build_from_source: false)
 end
 
 def download
-  url = @pkg.get_url(@device[:architecture])
+  url, is_trusted = @pkg.get_url(@device[:architecture])
   source = @pkg.is_source?(@device[:architecture])
 
   uri = URI.parse url
   filename = File.basename(uri.path)
-  sha256sum = @pkg.get_sha256(@device[:architecture])
+  sha256sum = is_trusted ? 'SKIP' : @pkg.get_sha256(@device[:architecture])
   @extract_dir = @pkg.get_extract_dir
 
   @build_cachefile = File.join(CREW_CACHE_DIR, "#{@pkg.name}-#{@pkg.version}-build-#{@device[:architecture]}.tar.zst")

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -198,13 +198,18 @@ class Package
   end
 
   def self.get_url(architecture)
+    is_trusted = false
+
     if !@build_from_source && @binary_sha256 && @binary_sha256.key?(architecture)
-      return get_binary_url(architecture)
+      is_trusted   = true
+      download_url = get_binary_url(architecture)
     elsif @source_url.respond_to?(:has_key?)
-      return @source_url.key?(architecture) ? @source_url[architecture] : nil
+      download_url = @source_url.key?(architecture) ? @source_url[architecture] : nil
     else
-      return @source_url
+      download_url = @source_url
     end
+
+    return [download_url, is_trusted]
   end
 
   def self.get_binary_url(architecture)

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -201,8 +201,8 @@ class Package
     is_trusted = false
 
     if !@build_from_source && @binary_sha256 && @binary_sha256.key?(architecture)
-      is_trusted   = true
       download_url = get_binary_url(architecture)
+      is_trusted   = true if File.extname(download_url) == '.zst'
     elsif @source_url.respond_to?(:has_key?)
       download_url = @source_url.key?(architecture) ? @source_url[architecture] : nil
     else


### PR DESCRIPTION
### Why?
When a prebuilt binary is downloaded, the `binary_sha256` section is used to verify the integrity, however:

- `https` can ensure the binary comes from verified sources
- `zstd` archives already include an XXH64 checksum for detecting corruption
- In our case, each binary file will remain unchanged once uploaded

... which does the job well and makes `binary_sha256` redundant.

We can also apply this to `install.sh` for getting rid of those `sed` hacks :)

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/supechicken/chromebrew.git CREW_BRANCH=disable_sha256 crew update
```