### PR TITLE
Fixup getrealdeps.rb, fixup hello_world_chromebrew.rb

### DIFF
--- a/packages/hello_world_chromebrew.rb
+++ b/packages/hello_world_chromebrew.rb
@@ -3,7 +3,7 @@ require 'package'
 class Hello_world_chromebrew < Package
   description 'Chromebrew Package Build Test (for use in PR Actions)'
   homepage 'https://github.com/chromebrew/chromebrew'
-  version '1.0'
+  version '1.1'
   license 'MIT'       # Package license (eg. GPL-3, MIT, etc.)
   compatibility 'all' # Package architecture compatibility (eg. aarch64, armv7l, i686, x86_64 or all)
   source_url 'https://github.com/chromebrew/chromebrew/raw/master/tools/hello_world_chromebrew.c'
@@ -42,7 +42,7 @@ class Hello_world_chromebrew < Package
   # Function to perform check from source build.
   # This is executed only during `crew build`.
   def self.check
-    system "#{CREW_PREFIX}/bin/hello"
+    system './hello'
   end
 
   # Function to perform install from source build.
@@ -52,6 +52,6 @@ class Hello_world_chromebrew < Package
 
   # Function to perform post-install for both source build and binary distribution
   def self.postinstall
-    system "#{CREW_PREFIX}/bin/hello"
+    system "#{CREW_PREFIX}/bin/hello_chromebrew"
   end
 end

--- a/tools/getrealdeps.rb
+++ b/tools/getrealdeps.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# getrealdeps version 1.3 (for Chromebrew)
+# getrealdeps version 1.4 (for Chromebrew)
 # Author: Satadru Pramanik (satmandu) satadru at gmail dot com
 require 'fileutils'
 
@@ -14,7 +14,7 @@ end
 
 if ARGV.include?('--use-crew-dest-dir')
   ARGV.delete('--use-crew-dest-dir')
-  opt_use_crew_dest_dir = true
+  @opt_use_crew_dest_dir = true
 end
 
 # Exit quickly if an invalid package name is given.
@@ -29,9 +29,9 @@ end
 # This is a subset of what crew whatprovides gives.
 def whatprovidesfxn(pkgdepslcl, pkg)
   filelcl = if pkgdepslcl.include?(CREW_LIB_PREFIX)
-              `#{grep} --exclude #{pkg}.filelist --exclude #{pkgfilelist} --exclude={"#{CREW_PREFIX}/etc/crew/meta/*_build.filelist"} "#{pkgdepslcl}$" "#{CREW_PREFIX}"/etc/crew/meta/*.filelist`
+              `#{@grep} --exclude #{pkg}.filelist --exclude #{pkgfilelist} --exclude={"#{CREW_PREFIX}/etc/crew/meta/*_build.filelist"} "#{pkgdepslcl}$" "#{CREW_PREFIX}"/etc/crew/meta/*.filelist`
             else
-              `#{grep} --exclude #{pkg}.filelist --exclude #{pkgfilelist} --exclude={"#{CREW_PREFIX}/etc/crew/meta/*_build.filelist"} "^#{CREW_LIB_PREFIX}.*#{pkgdepslcl}$" "#{CREW_PREFIX}"/etc/crew/meta/*.filelist`
+              `#{@grep} --exclude #{pkg}.filelist --exclude #{pkgfilelist} --exclude={"#{CREW_PREFIX}/etc/crew/meta/*_build.filelist"} "^#{CREW_LIB_PREFIX}.*#{pkgdepslcl}$" "#{CREW_PREFIX}"/etc/crew/meta/*.filelist`
             end
   filelcl.gsub(/.filelist.*/, '').gsub(%r{.*/}, '').split("\n").uniq.join("\n").gsub(':', '')
 end
@@ -39,7 +39,7 @@ end
 def main(pkg)
   puts "Checking for the runtime dependencies of #{pkg}..."
 
-  if opt_use_crew_dest_dir
+  if @opt_use_crew_dest_dir
     define_singleton_method('pkgfilelist') {File.join(CREW_DEST_DIR, 'filelist')}
     abort('Pkg was not built.') unless File.exist?(pkgfilelist)
   else
@@ -57,10 +57,10 @@ def main(pkg)
 
   # Install grep if a functional local copy does not exist.
   if system('grep --version > /dev/null 2>&1')
-    grep = 'grep'
+    @grep = 'grep'
   else
     system('crew install grep')
-    grep = "#{CREW_PREFIX}/bin/grep"
+    @grep = "#{CREW_PREFIX}/bin/grep"
   end
 
   # Gawk is needed for adding dependencies.
@@ -81,7 +81,7 @@ def main(pkg)
   # Look at files in CREW_DEST_DIR instead of assuming the package is
   # normally installed, which lets us avoid installing the package if it
   # was just built.
-  pkgfiles.map! {|item| item.prepend(CREW_DEST_DIR)} if opt_use_crew_dest_dir
+  pkgfiles.map! {|item| item.prepend(CREW_DEST_DIR)} if @opt_use_crew_dest_dir
 
   FileUtils.rm_rf("/tmp/deps/#{pkg}")
   # Remove files we don't care about, such as man files and non-binaries.
@@ -92,7 +92,7 @@ def main(pkg)
   pkgdepsfiles = pkgfiles.map do |i|
     system("upx -d #{i} > /dev/null 2>&1")
     FileUtils.mkdir_p("/tmp/deps/#{pkg}/")
-    `readelf -d "#{i}" 2>/dev/null | #{grep} NEEDED | awk '{print $5}' | sed 's/\\[//g' | sed 's/\\]//g' | awk '!x[$0]++' | tee /tmp/deps/#{pkg}/#{File.basename(i)}`
+    `readelf -d "#{i}" 2>/dev/null | #{@grep} NEEDED | awk '{print $5}' | sed 's/\\[//g' | sed 's/\\]//g' | awk '!x[$0]++' | tee /tmp/deps/#{pkg}/#{File.basename(i)}`
   end
   pkgdepsfiles = pkgdepsfiles.map do |filedeps|
     filedeps.split("\n")


### PR DESCRIPTION
- getrealdeps somehow got broken in the last 24 hours.
- Needed to also fix some logic in the test build file.
- We might need to modify the line calling getrealdeps in crew to throw an error if it fails...

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=fixes crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
