### PR TITLE
Add build check to Github Actions, and make getrealdeps.rb failure trigger crew error

### DIFF
--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -21,4 +21,8 @@ jobs:
             yes | crew install vim && \
             yes | crew remove vim && \
             cd ../tests && \
-            ./prop_test"
+            ./prop_test && \
+            cd ~ && \
+            git clone --depth=1 https://github.com/chromebrew/chromebrew.git build_test && \
+            cd build_test && \
+            yes | crew build -f packages/hello_world_chromebrew.rb"

--- a/bin/crew
+++ b/bin/crew
@@ -1203,7 +1203,7 @@ def prepare_package(destdir)
     abort 'Exiting due to above errors.'.lightred if errors
 
     # Make sure the package file has runtime dependencies added properly.
-    system "#{CREW_LIB_PATH}/tools/getrealdeps.rb --use-crew-dest-dir #{@pkg.name}" unless @pkg.no_compile_needed?
+    system "#{CREW_LIB_PATH}/tools/getrealdeps.rb --use-crew-dest-dir #{@pkg.name}", exception: true unless @pkg.no_compile_needed?
     # create directory list
     # Remove CREW_PREFIX and HOME from the generated directorylist.
     crew_prefix_escaped = CREW_PREFIX.gsub('/', '\/')

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.43.2'
+CREW_VERSION = '1.43.3'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
- Currently neither build failures nor getrealdeps.rb errors are detected.
- This PR modifies the github actions to check for simple build failures to make sure PRs do not break building.
- Also, `crew` has been modified to throw an error when getrealdeps.rb fails, which should help us detect when an edit to getrealdeps.rb in a PR breaks it.



Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=test_build crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
