### PR TITLE
crew: Use rubocop to sanitize package file after upload

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1968,6 +1968,8 @@ def upload(pkgName = nil)
         end
       end
       puts
+      # Use rubocop to sanitize package file, and let errors get flagged.
+      system "rubocop -c #{File.join(CREW_LOCAL_REPO_ROOT, '.rubocop.yml')} -A #{pkg_file}", exception: true
     end
   end
 end

--- a/bin/crew
+++ b/bin/crew
@@ -1967,7 +1967,7 @@ def upload(pkgName = nil)
           system "sed -i 's/#{old_sha256}/#{new_sha256}/g' #{pkg_file}"
         end
       end
-      puts
+      puts "Using rubocop to sanitize #{pkg_file} .".lightblue
       # Use rubocop to sanitize package file, and let errors get flagged.
       system "rubocop -c #{File.join(CREW_LOCAL_REPO_ROOT, '.rubocop.yml')} -A #{pkg_file}", exception: true
     end

--- a/bin/crew
+++ b/bin/crew
@@ -1969,6 +1969,9 @@ def upload(pkgName = nil)
       end
       puts "Using rubocop to sanitize #{pkg_file} .".orange
       # Use rubocop to sanitize package file, and let errors get flagged.
+      unless @device[:installed_packages].any? { |elem| elem[:name] == 'ruby_rubocop' }
+        system 'yes | crew install ruby_rubocop'
+      end
       system "rubocop -c #{File.join(CREW_LOCAL_REPO_ROOT, '.rubocop.yml')} -A #{pkg_file}", exception: true
     end
   end

--- a/bin/crew
+++ b/bin/crew
@@ -1967,7 +1967,7 @@ def upload(pkgName = nil)
           system "sed -i 's/#{old_sha256}/#{new_sha256}/g' #{pkg_file}"
         end
       end
-      puts "Using rubocop to sanitize #{pkg_file} .".lightblue
+      puts "Using rubocop to sanitize #{pkg_file} .".orange
       # Use rubocop to sanitize package file, and let errors get flagged.
       system "rubocop -c #{File.join(CREW_LOCAL_REPO_ROOT, '.rubocop.yml')} -A #{pkg_file}", exception: true
     end

--- a/bin/crew
+++ b/bin/crew
@@ -1968,9 +1968,7 @@ def upload(pkgName = nil)
         end
       end
       # Use rubocop to sanitize package file, and let errors get flagged.
-      unless @device[:installed_packages].any? { |elem| elem[:name] == 'ruby_rubocop' }
-        system 'yes | crew install ruby_rubocop'
-      end
+      system 'yes | crew install ruby_rubocop' unless @device[:installed_packages].any? { |elem| elem[:name] == 'ruby_rubocop' }
       puts "Using rubocop to sanitize #{pkg_file} .".orange
       system "rubocop -c #{File.join(CREW_LOCAL_REPO_ROOT, '.rubocop.yml')} -A #{pkg_file}", exception: true
     end

--- a/bin/crew
+++ b/bin/crew
@@ -1967,11 +1967,11 @@ def upload(pkgName = nil)
           system "sed -i 's/#{old_sha256}/#{new_sha256}/g' #{pkg_file}"
         end
       end
-      puts "Using rubocop to sanitize #{pkg_file} .".orange
       # Use rubocop to sanitize package file, and let errors get flagged.
       unless @device[:installed_packages].any? { |elem| elem[:name] == 'ruby_rubocop' }
         system 'yes | crew install ruby_rubocop'
       end
+      puts "Using rubocop to sanitize #{pkg_file} .".orange
       system "rubocop -c #{File.join(CREW_LOCAL_REPO_ROOT, '.rubocop.yml')} -A #{pkg_file}", exception: true
     end
   end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.43.3'
+CREW_VERSION = '1.43.4'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=rubocop_crew2 crew update
```

![image](https://github.com/chromebrew/chromebrew/assets/1096701/7a4740e4-abcd-40cf-adde-0f3cc19d9356)
