### PR TITLE
py3_libxml2 gets pulled in on builds, so add to buildessential

### DIFF
--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -3,7 +3,7 @@ require 'package'
 class Buildessential < Package
   description 'A collection of tools essential to compile and build software.'
   homepage 'SKIP'
-  version '1.23'
+  version '1.24'
   license 'GPL-3+'
   compatibility 'all'
 

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -3,7 +3,7 @@ require 'package'
 class Buildessential < Package
   description 'A collection of tools essential to compile and build software.'
   homepage 'SKIP'
-  version '1.28'
+  version '1.23'
   license 'GPL-3+'
   compatibility 'all'
 
@@ -143,6 +143,7 @@ class Buildessential < Package
   depends_on 'py3_flit_core'
   # Pax_utils needs this.
   depends_on 'py3_pyelftools'
+  depends_on 'py3_libxml2'
 
   # Qt
   # depends_on 'qtcreator'

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -141,9 +141,9 @@ class Buildessential < Package
   # depends_on 'py3_build'
   # depends_on 'py3_installer'
   depends_on 'py3_flit_core'
+  depends_on 'py3_libxml2'
   # Pax_utils needs this.
   depends_on 'py3_pyelftools'
-  depends_on 'py3_libxml2'
 
   # Qt
   # depends_on 'qtcreator'

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -3,7 +3,7 @@ require 'package'
 class Buildessential < Package
   description 'A collection of tools essential to compile and build software.'
   homepage 'SKIP'
-  version '1.24'
+  version '1.29'
   license 'GPL-3+'
   compatibility 'all'
 


### PR DESCRIPTION

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=builddeps crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
