### PR TITLE
getrealdeps.rb: fix file array removal logic

### DIFF
--- a/tools/getrealdeps.rb
+++ b/tools/getrealdeps.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# getrealdeps version 1.4 (for Chromebrew)
+# getrealdeps version 1.5 (for Chromebrew)
 # Author: Satadru Pramanik (satmandu) satadru at gmail dot com
 require 'fileutils'
 
@@ -85,7 +85,7 @@ def main(pkg)
 
   FileUtils.rm_rf("/tmp/deps/#{pkg}")
   # Remove files we don't care about, such as man files and non-binaries.
-  pkgfiles = pkgfiles.reject { |i| !File.file?(i.chomp) || !File.read(i.chomp, 4) == "\x7FELF" || i.include?('.zst') }
+  pkgfiles = pkgfiles.reject { |i| !File.file?(i.chomp) || File.read(i.chomp, 4) != "\x7FELF" || i.include?('.zst') }
 
   # Use readelf to determine library dependencies, as
   # this doesn't almost run a program like using ldd would.


### PR DESCRIPTION
- Comparison logic wasn't working properly.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=getrealdeps4 crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
