### PR TITLE
meld rebuild

### DIFF
--- a/packages/meld.rb
+++ b/packages/meld.rb
@@ -3,11 +3,11 @@ require 'buildsystems/meson'
 class Meld < Meson
   description 'Meld is a visual diff and merge tool targeted at developers.'
   homepage 'https://meldmerge.org/'
-  version '3.22.0-684e1e2-py3.12'
+  version '3.22.0-2f7dbde-py3.12'
   license 'GPL-2'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.gnome.org/GNOME/meld.git'
-  git_hashtag '684e1e27f31b4f0053da546a273a4ecf07df595f'
+  git_hashtag '2f7dbdedd2b022fce238ba25e182929e0a8cea1e'
   binary_compression 'tar.zst'
 
   binary_sha256({
@@ -19,9 +19,9 @@ class Meld < Meson
   depends_on 'desktop_file_utils' # L
   depends_on 'gtk3' # L
   depends_on 'gtksourceview_4' # L
-  depends_on 'python3' # L
-  depends_on 'py3_pycairo' # L
   depends_on 'py3_libxml2' # L
+  depends_on 'py3_pycairo' # L
+  depends_on 'python3' # L
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"

--- a/packages/meld.rb
+++ b/packages/meld.rb
@@ -11,9 +11,9 @@ class Meld < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'c9044c2ee4f70158c0f271a764f475c6a7cb095525699fe20c3ab6e55c3a622d',
-     armv7l: 'c9044c2ee4f70158c0f271a764f475c6a7cb095525699fe20c3ab6e55c3a622d',
-     x86_64: '0e8c2e68b57acfc2e826411a62c7bb5c5bea7303d4c82c84bb5e489af3182076'
+    aarch64: '8b120c9f6920d07e12fbcd333d8df4e118fa0d89f13dc2fc8b77726a8f7325d7',
+     armv7l: '8b120c9f6920d07e12fbcd333d8df4e118fa0d89f13dc2fc8b77726a8f7325d7',
+     x86_64: '1a2072e7778760cadadc01e6fd716eb14bcf2f34a1b51b967ac7f23ab1d5021e'
   })
 
   depends_on 'desktop_file_utils' # L


### PR DESCRIPTION
- fixes issue with missing binaries on gitlab.

Builds properly:
- [x] `x86_64`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=meld crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
