### PR TITLE
Have crew_profile_base remove the path env.d file from install.sh

### DIFF
--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -30,7 +30,7 @@ class Crew_profile_base < Package
   def self.postinstall
     # Remove install.sh provided path file since we supersede it.
     if File.exist?("#{CREW_PREFIX}/etc/env.d/00-path")
-      puts "Removing #{CREW_PREFIX}/etc/env.d/path installed by the Chromebrew installer.".orange
+      puts "Removing #{CREW_PREFIX}/etc/env.d/path installed by the Chromebrew installer.\n".orange
       FileUtils.rm "#{CREW_PREFIX}/etc/env.d/path"
     end
 

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -29,7 +29,10 @@ class Crew_profile_base < Package
 
   def self.postinstall
     # Remove install.sh provided path file since we supersede it.
-    FileUtils.rm "#{CREW_PREFIX}/etc/env.d/path" if File.exist?("#{CREW_PREFIX}/etc/env.d/00-path")
+    if File.exist?("#{CREW_PREFIX}/etc/env.d/00-path")
+      puts "Removing #{CREW_PREFIX}/etc/env.d/path installed by the Chromebrew installer.".yellow
+      FileUtils.rm "#{CREW_PREFIX}/etc/env.d/path"
+    end
 
     # Write our rc files
     crew_rc_source_line = "source #{CREW_PREFIX}/etc/profile"

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -30,7 +30,7 @@ class Crew_profile_base < Package
   def self.postinstall
     # Remove install.sh provided path file since we supersede it.
     if File.exist?("#{CREW_PREFIX}/etc/env.d/00-path")
-      puts "Removing #{CREW_PREFIX}/etc/env.d/path installed by the Chromebrew installer.".yellow
+      puts "Removing #{CREW_PREFIX}/etc/env.d/path installed by the Chromebrew installer.".orange
       FileUtils.rm "#{CREW_PREFIX}/etc/env.d/path"
     end
 

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -28,6 +28,9 @@ class Crew_profile_base < Package
   end
 
   def self.postinstall
+    # Remove install.sh provided path file since we supersede it.
+    FileUtils.rm "#{CREW_PREFIX}/etc/env.d/path" if File.exist?("#{CREW_PREFIX}/etc/env.d/00-path")
+
     # Write our rc files
     crew_rc_source_line = "source #{CREW_PREFIX}/etc/profile"
     crew_rcfile = <<~CREW_PROFILE_EOF


### PR DESCRIPTION
- The chromebrew installer generates a `/usr/local/etc/env.d/path` file, but the `/usr/local/etc/env.d/00-path` file supersedes it, so remove the first file.
- Don't update the version number since this only needs to be fixed for new installs.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=path crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
