### PR TITLE
fixup: don't add path because crew_profile_base should provide it.

### DIFF
--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -4,22 +4,6 @@
 # remove deprecated directory
 FileUtils.rm_rf "#{HOME}/.cache/crewcache/manifest"
 
-# Fix missing $PATH not added in install.sh
-@need_path = false
-if !File.file?("#{CREW_PREFIX}/etc/env.d/path")
-  @need_path = true
-elsif !system("grep -q '$PATH' #{CREW_PREFIX}/etc/env.d/path") || Gem::Version.new(CREW_VERSION.to_s) < Gem::Version.new('1.36.4')
-  @need_path = true
-end
-if @need_path
-  FileUtils.mkdir_p "#{CREW_PREFIX}/etc/env.d"
-  File.write "#{CREW_PREFIX}/etc/env.d/path", <<~ENVD_PATH_EOF
-    ## Inserted by Chromebrew version #{CREW_VERSION}
-    PATH=#{CREW_PREFIX}/bin:#{CREW_PREFIX}/sbin:#{CREW_PREFIX}/share/musl/bin:$PATH
-  ENVD_PATH_EOF
-  ExitMessage.add "Fixed path env.d file...\nPlease run 'source ~/.bashrc'".orange
-end
-
 # Remove install.sh provided path file since we supersede it.
 if File.exist?("#{CREW_PREFIX}/etc/env.d/00-path")
   puts "Removing #{CREW_PREFIX}/etc/env.d/path installed by the Chromebrew installer.\n".orange

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -5,7 +5,7 @@
 FileUtils.rm_rf "#{HOME}/.cache/crewcache/manifest"
 
 # Remove install.sh provided path file since we supersede it.
-if File.exist?("#{CREW_PREFIX}/etc/env.d/00-path")
+if File.exist?("#{CREW_PREFIX}/etc/env.d/00-path") && File.exist?("#{CREW_PREFIX}/etc/env.d/path")
   puts "Removing #{CREW_PREFIX}/etc/env.d/path installed by the Chromebrew installer.\n".orange
   FileUtils.rm "#{CREW_PREFIX}/etc/env.d/path"
 end


### PR DESCRIPTION
- Can't believe I didn't notice this before...

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=fixup_fix crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
