### PR TITLE
Only add musl bin to path if musl is installed

### DIFF
--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -3,11 +3,11 @@ require 'package'
 class Crew_profile_base < Package
   description 'Crew-profile-base sets up Chromebrew\'s environment capabilities.'
   homepage 'https://github.com/chromebrew/crew-profile-base'
-  version '0.0.11'
+  version '0.0.12'
   license 'GPL-3+'
   compatibility 'all'
   source_url "https://github.com/chromebrew/crew-profile-base/archive/refs/tags/#{version}.tar.gz"
-  source_sha256 '4f13afdca466ac51c0c76373cd909fa3ae76befd9d45394e8119109dbdee9e68'
+  source_sha256 '7236cfa4fba6557a6215c1d23ac3d8057490a021a45fdc3e40217d1fe30fe68e'
 
   no_compile_needed
 

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -10,6 +10,7 @@ class Crew_profile_base < Package
   source_sha256 '7236cfa4fba6557a6215c1d23ac3d8057490a021a45fdc3e40217d1fe30fe68e'
 
   no_compile_needed
+  print_source_bashrc
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/"

--- a/packages/musl_brotli.rb
+++ b/packages/musl_brotli.rb
@@ -21,6 +21,7 @@ class Musl_brotli < Package
 
   is_musl
   is_static
+  print_source_bashrc
 
   def self.build
     load "#{CREW_LIB_PATH}/lib/musl.rb"

--- a/packages/musl_bz2.rb
+++ b/packages/musl_bz2.rb
@@ -18,6 +18,7 @@ class Musl_bz2 < Package
   })
 
   depends_on 'patchelf' => :build
+  print_source_bashrc
 
   def self.patch
     load "#{CREW_LIB_PATH}/lib/musl.rb"

--- a/packages/musl_c_ares.rb
+++ b/packages/musl_c_ares.rb
@@ -27,6 +27,7 @@ class Musl_c_ares < Package
   depends_on 'patchelf' => :build
 
   is_static
+  print_source_bashrc
 
   def self.build
     load "#{CREW_LIB_PATH}/lib/musl.rb"

--- a/packages/musl_cc_toolchain.rb
+++ b/packages/musl_cc_toolchain.rb
@@ -24,6 +24,8 @@ class Musl_cc_toolchain < Package
      x86_64: 'ca388d227d187db9b60c53aa191803882a9ac21bcb6c0d1d2815ea2bb8725023'
   })
 
+  print_source_bashrc
+
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_MUSL_PREFIX}/lib"
     FileUtils.cp_r '.', "#{CREW_DEST_MUSL_PREFIX}/", verbose: true

--- a/packages/musl_curl.rb
+++ b/packages/musl_curl.rb
@@ -33,6 +33,7 @@ class Musl_curl < Package
   is_musl
   is_static
   patchelf
+  print_source_bashrc
 
   def self.patch
     # Fix arm build error

--- a/packages/musl_cyrus_sasl.rb
+++ b/packages/musl_cyrus_sasl.rb
@@ -26,6 +26,7 @@ class Musl_cyrus_sasl < Package
   depends_on 'musl_krb5' => :build
 
   is_static
+  print_source_bashrc
 
   def self.build
     load "#{CREW_LIB_PATH}/lib/musl.rb"

--- a/packages/musl_expat.rb
+++ b/packages/musl_expat.rb
@@ -20,8 +20,9 @@ class Musl_expat < Package
   depends_on 'musl_native_toolchain' => :build
 
   is_musl
-  patchelf
   is_static
+  patchelf
+  print_source_bashrc
 
   def self.patch
     system 'filefix'

--- a/packages/musl_getaddrinfo_test.rb
+++ b/packages/musl_getaddrinfo_test.rb
@@ -9,6 +9,7 @@ class Musl_getaddrinfo_test < Package
   source_url 'SKIP'
 
   depends_on 'musl_native_toolchain' => :build
+  print_source_bashrc
 
   def self.build
     load "#{CREW_LIB_PATH}/lib/musl.rb"

--- a/packages/musl_krb5.rb
+++ b/packages/musl_krb5.rb
@@ -25,6 +25,7 @@ class Musl_krb5 < Package
   depends_on 'musl_openssl' => :build
 
   is_static
+  print_source_bashrc
 
   def self.build
     load "#{CREW_LIB_PATH}/lib/musl.rb"

--- a/packages/musl_libbacktrace.rb
+++ b/packages/musl_libbacktrace.rb
@@ -21,6 +21,7 @@ class Musl_libbacktrace < Package
   })
 
   depends_on 'musl_native_toolchain' => :build
+  print_source_bashrc
 
   def self.build
     load "#{CREW_LIB_PATH}/lib/musl.rb"

--- a/packages/musl_libidn2.rb
+++ b/packages/musl_libidn2.rb
@@ -25,6 +25,7 @@ class Musl_libidn2 < Package
   is_musl
   is_static
   patchelf
+  print_source_bashrc
 
   def self.patch
     FileUtils.rm_f 'doc/idn2.1'

--- a/packages/musl_libnghttp2.rb
+++ b/packages/musl_libnghttp2.rb
@@ -25,6 +25,7 @@ class Musl_libnghttp2 < Package
   depends_on 'musl_openssl' => :build
 
   is_static
+  print_source_bashrc
 
   def self.build
     load "#{CREW_LIB_PATH}/lib/musl.rb"

--- a/packages/musl_libssh.rb
+++ b/packages/musl_libssh.rb
@@ -27,6 +27,7 @@ class Musl_libssh < Package
   depends_on 'py3_abimap' => :build
 
   is_static
+  print_source_bashrc
 
   def self.build
     load "#{CREW_LIB_PATH}/lib/musl.rb"

--- a/packages/musl_libucontext.rb
+++ b/packages/musl_libucontext.rb
@@ -20,6 +20,7 @@ class Musl_libucontext < Package
   depends_on 'musl_native_toolchain' => :build
 
   is_static
+  print_source_bashrc
 
   def self.patch
     load "#{CREW_LIB_PATH}/lib/musl.rb"

--- a/packages/musl_libunbound.rb
+++ b/packages/musl_libunbound.rb
@@ -23,6 +23,7 @@ class Musl_libunbound < Package
 
   is_musl
   is_static
+  print_source_bashrc
 
   def self.patch
     system 'filefix'

--- a/packages/musl_libunistring.rb
+++ b/packages/musl_libunistring.rb
@@ -24,6 +24,7 @@ class Musl_libunistring < Package
   is_musl
   is_static
   patchelf
+  print_source_bashrc
 
   def self.build
     system "#{MUSL_ENV_OPTIONS} ./configure --prefix=#{CREW_MUSL_PREFIX} \

--- a/packages/musl_libunwind.rb
+++ b/packages/musl_libunwind.rb
@@ -20,6 +20,7 @@ class Musl_libunwind < Package
   depends_on 'musl_native_toolchain' => :build
   depends_on 'musl_libbacktrace' => :build
   depends_on 'musl_libucontext' => :build
+  print_source_bashrc
 
   def self.patch
     # As per https://www.linuxquestions.org/questions/linux-software-2/building-libunwind-on-x86-musl-libc-against-libucontext-4175692781/#post6235105

--- a/packages/musl_linuxheaders.rb
+++ b/packages/musl_linuxheaders.rb
@@ -29,6 +29,7 @@ class Musl_linuxheaders < Package
 
   no_env_options
   no_fhs
+  print_source_bashrc
 
   def self.install
     # make fails if it detects gold linker.

--- a/packages/musl_lz4.rb
+++ b/packages/musl_lz4.rb
@@ -20,6 +20,7 @@ class Musl_lz4 < Package
   depends_on 'musl_native_toolchain' => :build
 
   is_static
+  print_source_bashrc
 
   def self.build
     load "#{CREW_LIB_PATH}/lib/musl.rb"

--- a/packages/musl_native_toolchain.rb
+++ b/packages/musl_native_toolchain.rb
@@ -26,6 +26,7 @@ class Musl_native_toolchain < Package
 
   is_musl
   conflicts_ok
+  print_source_bashrc
 
   @archflags = ''
   @linux_ver = '4.14.275'

--- a/packages/musl_ncurses.rb
+++ b/packages/musl_ncurses.rb
@@ -25,6 +25,7 @@ class Musl_ncurses < Package
   is_musl
   is_static
   patchelf
+  print_source_bashrc
 
   def self.build
     system "#{MUSL_ENV_OPTIONS} ./configure --prefix=#{CREW_MUSL_PREFIX} \

--- a/packages/musl_obstack.rb
+++ b/packages/musl_obstack.rb
@@ -20,6 +20,7 @@ class Musl_obstack < Package
   depends_on 'musl_native_toolchain' => :build
 
   is_static
+  print_source_bashrc
 
   def self.build
     load "#{CREW_LIB_PATH}/lib/musl.rb"

--- a/packages/musl_openssl.rb
+++ b/packages/musl_openssl.rb
@@ -25,6 +25,7 @@ class Musl_openssl < Package
 
   is_musl
   is_static
+  print_source_bashrc
 
   def self.build
     # rand-seed is needed to keep git from breaking with an error about

--- a/packages/musl_perl.rb
+++ b/packages/musl_perl.rb
@@ -22,6 +22,7 @@ class Musl_perl < Package
   depends_on 'musl_native_toolchain'
   depends_on 'musl_zlib' => :build
   depends_on 'musl_bz2' => :build
+  print_source_bashrc
 
   def self.build
     load "#{CREW_LIB_PATH}/lib/musl.rb"

--- a/packages/musl_wolfssl.rb
+++ b/packages/musl_wolfssl.rb
@@ -23,6 +23,7 @@ class Musl_wolfssl < Package
   depends_on 'musl_native_toolchain'
 
   is_static
+  print_source_bashrc
 
   def self.build
     load "#{CREW_LIB_PATH}/lib/musl.rb"

--- a/packages/musl_xz.rb
+++ b/packages/musl_xz.rb
@@ -21,6 +21,7 @@ class Musl_xz < Package
   depends_on 'musl_native_toolchain' => :build
 
   is_static
+  print_source_bashrc
 
   def self.build
     load "#{CREW_LIB_PATH}/lib/musl.rb"

--- a/packages/musl_zlib.rb
+++ b/packages/musl_zlib.rb
@@ -20,8 +20,9 @@ class Musl_zlib < Package
 
   depends_on 'musl_native_toolchain' => :build
   is_musl
-  patchelf
   is_static
+  patchelf
+  print_source_bashrc
 
   def self.build
     system "#{MUSL_ENV_OPTIONS} ./configure --prefix=#{CREW_MUSL_PREFIX} \

--- a/packages/musl_zstd.rb
+++ b/packages/musl_zstd.rb
@@ -19,10 +19,11 @@ class Musl_zstd < Package
 
   depends_on 'musl_native_toolchain' => :build
 
+  conflicts_ok # copies in libc.so from musl
   is_musl
   no_zstd
   patchelf
-  conflicts_ok # copies in libc.so from musl
+  print_source_bashrc
 
   def self.build
     FileUtils.mkdir('build/cmake/builddir')


### PR DESCRIPTION
- This also updates all musl packages to ask user to source ~/.bashrc as that will fix up the path for them after they do a musl install.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=musl crew update ; crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
