### PR TITLE
When forcing package install is selected during archive_package, upgrade package if already installed.

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1718,8 +1718,13 @@ def archive_package(crew_archive_dest)
   if @opt_force
     FileUtils.cp "#{CREW_PACKAGES_PATH}/#{@pkgName}.rb", "#{CREW_LOCAL_REPO_ROOT}/packages/"
     puts "The package file for #{@pkgName} used has been copied to #{CREW_LOCAL_REPO_ROOT}/packages/".lightblue
-    puts "#{@pkgName} will now be installed...".lightblue
-    system "crew install #{@pkg.name}"
+    if @device[:installed_packages].any? { |pkg| pkg[:name] == @pkg.name }
+      puts "#{@pkgName} will now be upgraded...".lightblue
+      system "crew reinstall #{@pkg.name}"
+    else
+      puts "#{@pkgName} will now be installed...".lightblue
+      system "crew install #{@pkg.name}"
+    end
   end
 end
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.43.7'
+CREW_VERSION = '1.43.8'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
- When forcing package install is selected during archive_package, upgrade package if already installed.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=crew_force_reinstall crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
