### PR TITLE
Add missing packages to core_packages.txt

### DIFF
--- a/tools/core_packages.txt
+++ b/tools/core_packages.txt
@@ -5,7 +5,7 @@ automake
 binutils
 bison
 brotli
-bz2
+bzip2
 ca_certificates
 c_ares
 cmake
@@ -162,4 +162,5 @@ xxhash
 xzutils
 zip
 zlibpkg
+zoneinfo
 zstd


### PR DESCRIPTION
- I noticed these were reported as missing during container installs.
- My container install script uses the following:
```
echo "Packages installed but not in core_packages.txt:"
comm -13 <(cat ../tools/core_packages.txt| sort) <(crew -d list installed| sort)
```
Which results in this:
```
#12 122.4 Packages installed but not in core_packages.txt:
#12 122.9 bzip2
#12 122.9 glibc_build227
#12 122.9 zoneinfo
```
(We can ignore the glibc_build entries, and just add the other two...)

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=core_update crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
