### PR TITLE
zoneinfo => 2024a

### DIFF
--- a/manifest/armv7l/z/zoneinfo.filelist
+++ b/manifest/armv7l/z/zoneinfo.filelist
@@ -1209,5 +1209,6 @@
 /usr/local/share/zoneinfo/WET
 /usr/local/share/zoneinfo/W-SU
 /usr/local/share/zoneinfo/zone1970.tab
+/usr/local/share/zoneinfo/zonenow.tab
 /usr/local/share/zoneinfo/zone.tab
 /usr/local/share/zoneinfo/Zulu

--- a/manifest/i686/z/zoneinfo.filelist
+++ b/manifest/i686/z/zoneinfo.filelist
@@ -1209,5 +1209,6 @@
 /usr/local/share/zoneinfo/WET
 /usr/local/share/zoneinfo/W-SU
 /usr/local/share/zoneinfo/zone1970.tab
+/usr/local/share/zoneinfo/zonenow.tab
 /usr/local/share/zoneinfo/zone.tab
 /usr/local/share/zoneinfo/Zulu

--- a/manifest/x86_64/z/zoneinfo.filelist
+++ b/manifest/x86_64/z/zoneinfo.filelist
@@ -1209,5 +1209,6 @@
 /usr/local/share/zoneinfo/WET
 /usr/local/share/zoneinfo/W-SU
 /usr/local/share/zoneinfo/zone1970.tab
+/usr/local/share/zoneinfo/zonenow.tab
 /usr/local/share/zoneinfo/zone.tab
 /usr/local/share/zoneinfo/Zulu

--- a/packages/zoneinfo.rb
+++ b/packages/zoneinfo.rb
@@ -3,18 +3,18 @@ require 'package'
 class Zoneinfo < Package
   description 'Code and data that represent the history of local time for many representative locations around the globe.'
   homepage 'https://www.iana.org/time-zones'
-  version '2023c'
+  version '2024a'
   license 'public-domain'
   compatibility 'all'
-  source_url 'https://data.iana.org/time-zones/releases/tzdb-2023c.tar.lz'
-  source_sha256 '08fd090f1a16d522ae4e9247445056f4155002239e5be760b31ba0376d2e632c'
+  source_url 'https://data.iana.org/time-zones/releases/tzdb-2024a.tar.lz'
+  source_sha256 '511af6b467f40b1ec9ac3684d1701793af470f3e29ddfb97b82be438e8601a7a'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '6ecd6e1b0cf305c29e35e048b68cc93053a63e2cf3fe7e319d852e862f4a73c7',
-     armv7l: '6ecd6e1b0cf305c29e35e048b68cc93053a63e2cf3fe7e319d852e862f4a73c7',
-       i686: '3a0dca29f8249deb77d84caf69bb2049b50098eacbfb9acaf6fbddb4894db71e',
-     x86_64: '0ebd46313c486a377673e4552bb301a640d36401f711d535801be770ac9e315e'
+    aarch64: 'e0daf569178baf4d59c6f6641c3819dba2999cf71e3917d9fc0bf8e1f4149b50',
+     armv7l: 'e0daf569178baf4d59c6f6641c3819dba2999cf71e3917d9fc0bf8e1f4149b50',
+       i686: '66c5afe3e8961c11bf253d9a8826e1c0c79bd12bad7c1f9645f36ccec363625b',
+     x86_64: 'd6a147311371d94f7ec2a4bbf412bd35a83324062adc64a374a1c844db686c86'
   })
 
   depends_on 'glibc' # R


### PR DESCRIPTION
Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=zoneinfo crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
