### PR TITLE
Terraform 1.7.3 => 1.7.4

### DIFF
--- a/packages/terraform.rb
+++ b/packages/terraform.rb
@@ -3,7 +3,7 @@ require 'package'
 class Terraform < Package
   description 'Terraform is a tool for building, changing, and combining infrastructure safely and efficiently.'
   homepage 'https://www.terraform.io/'
-  version '1.7.3'
+  version '1.7.4'
   license 'Apache-2.0, BSD-2, BSD-4, ECL-2.0, imagemagick, ISC, JSON, MIT, MIT-with-advertising, MPL-2.0 and unicode'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Terraform < Package
      x86_64: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_amd64.zip"
   })
   source_sha256({
-    aarch64: '2d076ef74bf803e394cc09371ed66e92d850c099cb857af1dca5eb44f2b08b03',
-     armv7l: '2d076ef74bf803e394cc09371ed66e92d850c099cb857af1dca5eb44f2b08b03',
-       i686: '9fb95e5974808543f40371fcabf9f1aa1d57406e686cfce635b965e13c266222',
-     x86_64: 'f6c2746567c0f7ebdbd3c6b4902484ded111490112f2f8749153bcd6f364b581'
+    aarch64: 'fa96919947f988505a0e39a1394187aa0ea2136d52829965cfec4ad41a36ff74',
+     armv7l: 'fa96919947f988505a0e39a1394187aa0ea2136d52829965cfec4ad41a36ff74',
+       i686: '421cb39ed7471c69abb895aecf98abfb0806d1d734366393068cfdeb9878cb3b',
+     x86_64: '140568896c466be68335a898756bb65c81422b488dcae2a93916d5784bcdc88f'
   })
 
   def self.install


### PR DESCRIPTION
## Description

This commit updates the Terraform CLI from version 1.7.3 to 1.7.4.

## Additional information

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`