### PR TITLE
Add force flag bypass for dependency installation

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1343,16 +1343,20 @@ def resolve_dependencies
 
   puts @dependencies.join(' ')
 
-  print 'Do you agree? [Y/n] '
-  response = $stdin.gets.chomp.downcase
-  case response
-  when 'n', 'no'
-    abort 'No changes made.'
-  when '', 'y', 'yes'
-    puts 'Proceeding...'
+  if @opt_force
+    puts 'Proceeding with dependency package installation...'.orange
   else
-    puts "I don't understand `#{response}`. :(".lightred
-    abort 'No changes made.'
+    print 'Do you agree? [Y/n] '
+    response = $stdin.gets.chomp.downcase
+    case response
+    when 'n', 'no'
+      abort 'No changes made.'
+    when '', 'y', 'yes'
+      puts 'Proceeding...'
+    else
+      puts "I don't understand `#{response}`. :(".lightred
+      abort 'No changes made.'
+    end
   end
 
   @dependencies.each do |dep|

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.44.1'
+CREW_VERSION = '1.44.2'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=crew_force crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
