### PR TITLE
We no longer use symlinks in crew, so remove from buildessential

### DIFF
--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -3,7 +3,7 @@ require 'package'
 class Buildessential < Package
   description 'A collection of tools essential to compile and build software.'
   homepage 'SKIP'
-  version '1.29'
+  version '1.30'
   license 'GPL-3+'
   compatibility 'all'
 
@@ -163,7 +163,6 @@ class Buildessential < Package
 
   # Packages needed for shrinking package archives
   depends_on 'rdfind'
-  depends_on 'symlinks'
   depends_on 'upx'
 
   # Packages needed for compressing archives

--- a/tools/core_packages.txt
+++ b/tools/core_packages.txt
@@ -147,7 +147,6 @@ shared_mime_info
 shellcheck
 slang
 sqlite
-symlinks
 texinfo
 trousers
 uchardet


### PR DESCRIPTION
- also remove from `tools/core_packages.txt`

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=symlinks_buildessential crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
