### PR TITLE
Do not search for package in archive_package install

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1523,14 +1523,12 @@ def archive_package(crew_archive_dest)
     puts "The package file for #{@pkg_name} used has been copied to #{CREW_LOCAL_REPO_ROOT}/packages/".lightblue
     if @device[:installed_packages].any? { |pkg| pkg[:name] == @pkg.name }
       puts "#{@pkg_name} will now be upgraded...".lightgreen
-      search @pkg_name
       @pkg.in_upgrade = true
       @pkg.build_from_source = false
       resolve_dependencies_and_install
       @pkg.in_upgrade = false
     else
       puts "#{@pkg_name} will now be installed...".lightgreen
-      search @pkg_name
       @pkg.build_from_source = false
       resolve_dependencies_and_install
     end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.44.5'
+CREW_VERSION = '1.44.6'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=install_no_search crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
