### PR TITLE
Add no_source_build property

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1904,7 +1904,7 @@ def build_command(args)
     # Process preflight block to see if package should be built
     pre_flight
 
-    if !@pkg.is_fake? && @pkg.compatible? && @pkg.source?(ARCH) && @pkg.source_url.to_s.upcase != 'SKIP' && !@pkg.no_compile_needed?
+    if !@pkg.is_fake? && @pkg.compatible? && @pkg.source?(ARCH) && ( @pkg.no_source_build? || @pkg.source_url.to_s.upcase != 'SKIP' ) && !@pkg.no_compile_needed?
       resolve_dependencies_and_build
     else
       puts 'Unable to build a fake package. Skipping build.'.lightred if @pkg.is_fake?

--- a/commands/help.rb
+++ b/commands/help.rb
@@ -187,6 +187,8 @@ def help_prop(property)
       puts "Use the 'no_patchelf' property to bypass patchelf execution."
     when 'no_shrink'
       puts "Use the 'no_shrink' property to bypass upx binary compression."
+    when 'no_source_build'
+      puts "Use the 'no_source_build' property to build even if source is unspecified or unavailable."
     when 'no_strip'
       puts "Use the 'no_strip' property to bypass strip execution."
     when 'no_lto'

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.44.6'
+CREW_VERSION = '1.44.7'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -11,7 +11,7 @@ class Package
 
   boolean_property :arch_flags_override, :conflicts_ok, :git_clone_deep, :git_fetchtags, :gnome, :is_fake, :is_musl, :is_static,
                    :no_compile_needed, :no_compress, :no_env_options, :no_fhs, :no_git_submodules,
-                   :no_links, :no_lto, :no_patchelf, :no_shrink, :no_strip, :no_zstd, :patchelf,
+                   :no_links, :no_lto, :no_patchelf, :no_shrink, :no_source_build, :no_strip, :no_zstd, :patchelf,
                    :print_source_bashrc, :run_tests
 
   create_placeholder :preflight,   # Function for checks to see if install should occur.


### PR DESCRIPTION
- As used in https://github.com/chromebrew/chromebrew/pull/9329 for `llvm*_dev` and `llvm*_lib`.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=no_source_build crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
