### PR TITLE
Split const command out into separate file

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -4,6 +4,7 @@ require 'digest/sha2'
 require 'json'
 require 'fileutils'
 require 'tmpdir'
+require_relative '../commands/const'
 require_relative '../commands/help'
 require_relative '../lib/docopt'
 require_relative '../lib/color'
@@ -360,24 +361,6 @@ def cache_build
   else
     puts 'CREW_CACHE_ENABLED is not set.'.orange unless CREW_CACHE_ENABLED
     puts 'CREW_CACHE_DIR is not writable.'.lightred unless File.writable?(CREW_CACHE_DIR)
-  end
-end
-
-def const(var = nil)
-  if var
-    value = Object.const_get(var.to_sym)
-    puts "#{var}=#{value}"
-  else
-    # Get all constants defined by const.rb
-    constants = Object.constants.select do |const|
-      Object.const_source_location(const)[0] == File.join(CREW_LIB_PATH, 'lib/const.rb')
-    end.sort
-
-    # Print a sorted list of the remaining constants used by crew.
-    constants.each do |var|
-      value = Object.const_get(var.to_sym)
-      puts "#{var}=#{value}"
-    end
   end
 end
 
@@ -1917,13 +1900,9 @@ def build_command(args)
 end
 
 def const_command(args)
-  if args['<name>'].empty?
-    const
-  else
-    args['<name>'].each do |name|
-      const name
-    end
-  end
+  args['<name>'].each do |name|
+    Command.const(name)
+  end.empty? && Command.const(nil)
 end
 
 def deps_command(args)

--- a/commands/const.rb
+++ b/commands/const.rb
@@ -1,0 +1,23 @@
+require_relative '../lib/const'
+
+class Command
+  def self.const(constant)
+    if constant
+      begin
+        puts "#{constant}=#{Object.const_get(constant.to_sym)}"
+      rescue NameError
+        puts "Constant #{constant} not found"
+      end
+    else
+      # Get all constants defined by const.rb
+      constants = Object.constants.select do |const|
+        Object.const_source_location(const).first == File.join(CREW_LIB_PATH, 'lib/const.rb')
+      end.sort
+
+      # Print a sorted list of the remaining constants used by crew.
+      constants.each do |constant|
+        puts "#{constant}=#{Object.const_get(constant.to_sym)}"
+      end
+    end
+  end
+end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.44.6'
+CREW_VERSION = '1.44.7'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/tests/commands/const.rb
+++ b/tests/commands/const.rb
@@ -1,0 +1,25 @@
+require 'minitest/autorun'
+require_relative '../../commands/const'
+
+class ConstCommandTest < Minitest::Test
+  def test_no_arguments
+    expected_output = 'CREW_FNO_LTO_LDFLAGS=-fno-lto'
+    assert_output(/#{Regexp.escape(expected_output)}/, nil) do
+      Command.const(nil)
+    end
+  end
+
+  def test_valid_constant
+    expected_output = "CREW_FNO_LTO_LDFLAGS=-fno-lto\n"
+    assert_output expected_output, nil do
+      Command.const('CREW_FNO_LTO_LDFLAGS')
+    end
+  end
+
+  def test_invalid_constant
+    expected_output = "Constant INVALID not found\n"
+    assert_output expected_output, nil do
+      Command.const('INVALID')
+    end
+  end
+end


### PR DESCRIPTION
**Split out `const` command to `commands/const.rb`.**

Behaviour changes:
- Added error catching in the case of an invalid constant.

Refactoring changes:
- Change handling of no argument being passed to use `end.empty?` the same way `def search_command` does. This will be the way I handle similar cases.
 
Other changes:
- Add testing in `tests/commands/const.rb`

Tested and working on `x86_64`, and tests pass.

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=projectregula1 crew update
```