### PR TITLE
Mandb: background cache rebuild from postinstall

### DIFF
--- a/packages/mandb.rb
+++ b/packages/mandb.rb
@@ -62,10 +62,11 @@ class Mandb < Package
   end
 
   def self.postinstall
-    puts 'Starting backgrounded mandb cache rebuild. This will be logged to /tmp/man-db-rebuild.log.'.yellow
+    puts "Starting backgrounded mandb cache rebuild. This will be logged to #{CREW_PREFIX}/var/log/man-db-rebuild.log.'.yellow
     puts '(Errors from this can either be ignored or reported upstream to the relevant package maintainers.)'.yellow
     # See https://gitlab.com/man-db/man-db/-/issues/4
     # Also https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1003089
-    system "MANPATH='' MAN_DISABLE_SECCOMP=1 nice -n 20 mandb -C #{CREW_PREFIX}/etc/man_db.conf -psc &>/tmp/man-db-rebuild.log &"
+    FileUtils.mkdir_p #{CREW_PREFIX}/var/log"
+    system "MANPATH='' MAN_DISABLE_SECCOMP=1 nice -n 20 mandb -C #{CREW_PREFIX}/etc/man_db.conf -psc &> #{CREW_PREFIX}/var/log/man-db-rebuild.log &"
   end
 end

--- a/packages/mandb.rb
+++ b/packages/mandb.rb
@@ -62,10 +62,10 @@ class Mandb < Package
   end
 
   def self.postinstall
-    puts 'Started mandb cache rebuild. (Errors from this can either be ignored or reported upstream to the relevant package maintainers.)'.yellow
+    puts 'Starting backgrounded mandb cache rebuild. This will be logged to /tmp/man-db-rebuild.log.'.yellow
+    puts '(Errors from this can either be ignored or reported upstream to the relevant package maintainers.)'.yellow
     # See https://gitlab.com/man-db/man-db/-/issues/4
     # Also https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1003089
-    system "MANPATH='' MAN_DISABLE_SECCOMP=1 mandb -C #{CREW_PREFIX}/etc/man_db.conf -psc"
-    puts 'Finished mandb cache rebuild.'.lightgreen
+    system "MANPATH='' MAN_DISABLE_SECCOMP=1 nice -n 20 mandb -C #{CREW_PREFIX}/etc/man_db.conf -psc &>/tmp/man-db-rebuild.log &"
   end
 end

--- a/packages/mandb.rb
+++ b/packages/mandb.rb
@@ -62,7 +62,7 @@ class Mandb < Package
   end
 
   def self.postinstall
-    puts "Starting backgrounded mandb cache rebuild. This will be logged to #{CREW_PREFIX}/var/log/man-db-rebuild.log.'.yellow
+    puts "Starting backgrounded mandb cache rebuild. This will be logged to #{CREW_PREFIX}/var/log/man-db-rebuild.log.".yellow
     puts '(Errors from this can either be ignored or reported upstream to the relevant package maintainers.)'.yellow
     # See https://gitlab.com/man-db/man-db/-/issues/4
     # Also https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1003089


### PR DESCRIPTION
- the i686 installs hang for a very long time on the mandb cache generation process, so background the process to try to let installs continue.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=mandb crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
