### PR TITLE
fix mandb postinstall

### DIFF
--- a/packages/mandb.rb
+++ b/packages/mandb.rb
@@ -66,7 +66,7 @@ class Mandb < Package
     puts '(Errors from this can either be ignored or reported upstream to the relevant package maintainers.)'.yellow
     # See https://gitlab.com/man-db/man-db/-/issues/4
     # Also https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1003089
-    FileUtils.mkdir_p #{CREW_PREFIX}/var/log"
+    FileUtils.mkdir_p "#{CREW_PREFIX}/var/log"
     system "MANPATH='' MAN_DISABLE_SECCOMP=1 nice -n 20 mandb -C #{CREW_PREFIX}/etc/man_db.conf -psc &> #{CREW_PREFIX}/var/log/man-db-rebuild.log &"
   end
 end


### PR DESCRIPTION
Needed to add a `"`
Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
