### PR TITLE
Adjust git sparse checkout options

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -434,9 +434,14 @@ def update
   abort "'crew update' is used to update crew itself. Use 'crew upgrade <package1> [<package2> ...]' to update specific packages.".orange if @pkg_name
 
   # update package lists
+  @other_arches = %w[i686 x86_64 armv7l]
+  @other_arches.reject! { |n| n == ARCH }
   Dir.chdir(CREW_LIB_PATH) do
     # Set sparse-checkout folders.
-    system "git sparse-checkout set packages manifest/#{ARCH} lib commands bin crew tests tools"
+    system "git sparse-checkout set --no-cone \"/*\" packages \"/manifest/#{ARCH}/*\" lib commands bin crew tests tools"
+    @other_arches.each do |other_arch|
+      system "git sparse-checkout add \"!/manifest/#{other_arch}/\""
+    end
     system 'git sparse-checkout reapply'
 
     system "git fetch #{CREW_REPO} #{CREW_BRANCH}", exception: true

--- a/bin/crew
+++ b/bin/crew
@@ -438,7 +438,7 @@ def update
   @other_arches.reject! { |n| n == ARCH }
   Dir.chdir(CREW_LIB_PATH) do
     # Set sparse-checkout folders.
-    system "git sparse-checkout set --no-cone \"/*\" packages \"/manifest/#{ARCH}/*\" lib commands bin crew tests tools"
+    system "git sparse-checkout set --no-cone \"/*\" bin commands crew lib \"/manifest/#{ARCH}/*\" packages tests tools"
     @other_arches.each do |other_arch|
       system "git sparse-checkout add \"!/manifest/#{other_arch}/\""
     end

--- a/install.sh
+++ b/install.sh
@@ -317,7 +317,7 @@ else
 
   # Set sparse-checkout folders.
   set +H
-  git sparse-checkout set --no-cone "/*" packages "/manifest/${ARCH}/*" lib commands bin crew tests tools
+  git sparse-checkout set --no-cone "/*" bin commands crew lib "/manifest/${ARCH}/*" packages tests tools
   # shellcheck disable=SC2010
   # Note that extglob doesn't work here for some reason.
   for i in $(ls manifest| grep -v "${ARCH}") ; do git sparse-checkout add "!/manifest/${i}/" ; done

--- a/install.sh
+++ b/install.sh
@@ -287,7 +287,6 @@ crew update compatible
 
 echo_info "Installing core Chromebrew packages...\n"
 # We need these to install core.
-yes | crew install pixz
 yes | crew install core
 
 echo_info "\nRunning Bootstrap package postinstall scripts...\n"
@@ -317,8 +316,16 @@ else
   git checkout -f "${BRANCH}"
 
   # Set sparse-checkout folders.
-  git sparse-checkout set packages "manifest/${ARCH}" lib commands bin crew tests tools
+  set +H
+  git sparse-checkout set --no-cone "/*" packages "/manifest/${ARCH}/*" lib commands bin crew tests tools
+  # shellcheck disable=SC2010
+  # Note that extglob doesn't work here for some reason.
+  for i in $(ls manifest| grep -v "${ARCH}") ; do git sparse-checkout add "!/manifest/${i}/" ; done
+  set -H
+
   git reset --hard origin/"${BRANCH}"
+  git sparse-checkout reapply
+  crew update
 fi
 echo -e "${RESET}"
 


### PR DESCRIPTION
- This is all in service of trying to get rid of the i686 container sparse checkout error messages on opening a container.
![image](https://github.com/chromebrew/chromebrew/assets/1096701/9f28dcd3-4267-400c-adcb-5edb3aefa9d3)

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=git_sparse crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
