### PR TITLE
Split list command into separate file

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -6,6 +6,7 @@ require 'fileutils'
 require 'tmpdir'
 require_relative '../commands/const'
 require_relative '../commands/help'
+require_relative '../commands/list'
 require_relative '../lib/docopt'
 require_relative '../lib/color'
 require_relative '../lib/const'
@@ -219,62 +220,6 @@ end
 def list_packages
   Dir["#{CREW_PACKAGES_PATH}/*.rb"].each do |filename|
     print_package filename
-  end
-end
-
-def list_available
-  Dir["#{CREW_PACKAGES_PATH}/*.rb"].each do |filename|
-    pkg_name     = File.basename(filename, '.rb')
-    filelist     = File.join(CREW_META_PATH, "#{pkg_name}.filelist")
-    not_installed = !File.file?(filelist)
-
-    next unless not_installed
-
-    begin
-      set_package pkg_name, filename
-    rescue StandardError => e
-      puts "Error with #{pkg_name}.rb: #{e}".red unless e.to_s.include?('uninitialized constant')
-    end
-    puts pkg_name if @pkg.compatible?
-  end
-end
-
-def list_installed
-  if @opt_verbose
-    installed_packages = []
-    @device[:installed_packages].each do |package|
-      search package[:name], true
-      installed_packages.append("#{package[:name]} #{package[:version]}")
-    end
-    sorted_installed_packages = installed_packages.sort
-    sorted_installed_packages.unshift('======= =======')
-    sorted_installed_packages.unshift('Package Version')
-    first_col_width = sorted_installed_packages.map(&:split).map(&:first).max_by(&:size).size + 2
-    sorted_installed_packages.map(&:strip).each do |line|
-      puts "%-#{first_col_width}s%s".lightgreen % line.split
-    end
-    print "\n"
-  else
-    Dir["#{CREW_META_PATH}/*.directorylist"].map do |f|
-      File.basename(f, '.directorylist').lightgreen
-    end
-  end
-end
-
-def list_compatible(compat = true)
-  Dir["#{CREW_PACKAGES_PATH}/*.rb"].each do |filename|
-    pkg_name = File.basename filename, '.rb'
-    if @device[:compatible_packages].any? { |elem| elem[:name] == pkg_name }
-      if compat
-        if File.file? "#{CREW_META_PATH}/#{pkg_name}.filelist"
-          puts pkg_name.lightgreen
-        else
-          puts pkg_name
-        end
-      end
-    elsif !compat
-      puts pkg_name.lightred
-    end
   end
 end
 
@@ -1964,15 +1909,7 @@ def install_command(args)
 end
 
 def list_command(args)
-  if args['available']
-    list_available
-  elsif args['installed']
-    puts list_installed
-  elsif args['compatible']
-    list_compatible true
-  elsif args['incompatible']
-    list_compatible false
-  end
+  Command.list(args['available'], args['installed'], args['compatible'], args['incompatible'], @opt_verbose)
 end
 
 def postinstall_command(args)

--- a/commands/list.rb
+++ b/commands/list.rb
@@ -1,0 +1,50 @@
+require 'fileutils'
+require 'json'
+require_relative '../lib/color'
+require_relative '../lib/const'
+require_relative '../lib/package'
+
+class Command
+  def self.list(available, installed, compatible, incompatible, verbose)
+    device_json = JSON.load_file('/usr/local/etc/crew/device.json', symbolize_names: true)
+    installed_packages = {}
+    device_json[:installed_packages].each do |package|
+      installed_packages[package[:name]] = package[:version]
+    end
+
+    if available
+      Dir["#{CREW_PACKAGES_PATH}/*.rb"].each do |filename|
+        pkg_name = File.basename(filename, '.rb')
+        next if installed_packages.key?(pkg_name)
+        pkg = Package.load_package(filename)
+        puts pkg_name if pkg.compatible?
+      end
+    elsif installed
+      if verbose
+        installed_packages['======='] = '======='
+        installed_packages['Package'] = 'Version'
+        first_col_width = installed_packages.keys.max {|a, b| a.size <=> b.size }.size
+        installed_packages.sort.to_h.each do |package, version|
+          puts "#{package.ljust(first_col_width)}  #{version}".lightgreen
+        end
+      else
+        installed_packages.each_key do |package|
+          puts package.lightgreen
+        end
+      end
+    elsif compatible
+      Dir["#{CREW_PACKAGES_PATH}/*.rb"].each do |filename|
+        pkg_name = File.basename(filename, '.rb')
+        pkg = Package.load_package(filename)
+        puts pkg_name.lightgreen if pkg.compatible? && installed_packages.key?(pkg_name)
+        puts pkg_name if pkg.compatible?
+      end
+    elsif incompatible
+      Dir["#{CREW_PACKAGES_PATH}/*.rb"].each do |filename|
+        pkg_name = File.basename(filename, '.rb')
+        pkg = Package.load_package(filename)
+        puts pkg_name.lightred unless pkg.compatible?
+      end
+    end
+  end
+end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.44.9'
+CREW_VERSION = '1.45.0'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
**Split out `const` command to `commands/const.rb`.**

No behaviour changes.

Refactoring changes:
- Merge commands back into one function, to allow for re-use of the installed_packages hash
- Use `pkg.compatible?` instead of `@device[:compatible_packages]`
  - Load packages to test compatibility
- Check if packages are installed by accessing `installed_packages`, rather than checking for a filelist in `CREW_META_PATH`
- Do not rescue errors on loading packages (these will be caught by `prop_test` in CI before they get merged)
- Find the width of the first column of installed packages through a `.size` based `.max` comparison
- Align the installed packages via `.ljust` and two manual spaces in `puts` 

The code could probably be simplified a bit further if it shared the `Dir["#{CREW_PACKAGES_PATH}/*.rb"].each do |filename|` loop, but this seems like it would dramatically impact performance (not sure).

No testing added, simply because the current testing method is not well set up for testing cases like these where the expected output is hundreds of lines long. I may go back in future and work out a testing method.

Tested and working on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=projectregula2 crew update
```