### PR TITLE
Correct dependencies of prop_test

### DIFF
--- a/tests/prop_test
+++ b/tests/prop_test
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
 
-# Add >LOCAL< lib to LOAD_PATH
+# Add >LOCAL< lib to LOAD_PATH so that packages can be loaded
 $LOAD_PATH.unshift '../lib'
 
-require 'find'
+require 'fileutils'
 require_relative '../lib/const'
 require_relative '../lib/color'
 require_relative '../lib/package'


### PR DESCRIPTION
Noticed this at a glance, it gets the `fileutils` dep through recursive requires, but its still good to have the right dependencies set up.l

Tested and working on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=ontheawy crew update
```