### PR TITLE
Fix 'gcc_libmakedep' dependency in oneko

### DIFF
--- a/packages/oneko.rb
+++ b/packages/oneko.rb
@@ -22,7 +22,7 @@ class Oneko < Package
   depends_on 'sommelier'
   depends_on 'imake' => :build
   depends_on 'xorg_cf_files' => :build
-  depends_on 'gcc_libmakedep' => :build
+  depends_on 'gccmakedep' => :build
 
   def self.patch
     # Download extra sources


### PR DESCRIPTION
Probably from an overmatching find and replace in #8335.