### PR TITLE
crew: allow override of ARCH const in crew with env variable

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.44.8'
+CREW_VERSION = '1.44.9'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp
@@ -40,7 +40,7 @@ QEMU_EMULATED = !CPU_SUPPORTED_ARCH.include?(KERN_ARCH)
 # This helps with virtualized builds on aarch64 machines which report armv8l when linux32 is run.
 # We also report aarch64 machines as armv7l for now, as we treat them as if they were armv7l.
 # When we have proper aarch64 support, remove this.
-ARCH = %w[aarch64 armv8l].include?(KERN_ARCH) ? 'armv7l' : KERN_ARCH
+ARCH = ENV.fetch('ARCH', %w[aarch64 armv8l].include?(KERN_ARCH) ? 'armv7l' : KERN_ARCH)
 
 # Allow for edge case of i686 install on a x86_64 host before linux32 is
 # downloaded, e.g. in a docker container.

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -40,7 +40,7 @@ QEMU_EMULATED = !CPU_SUPPORTED_ARCH.include?(KERN_ARCH)
 # This helps with virtualized builds on aarch64 machines which report armv8l when linux32 is run.
 # We also report aarch64 machines as armv7l for now, as we treat them as if they were armv7l.
 # When we have proper aarch64 support, remove this.
-ARCH = ENV.fetch('ARCH', %w[aarch64 armv8l].include?(KERN_ARCH) ? 'armv7l' : KERN_ARCH)
+ARCH = %w[aarch64 armv8l].include?(KERN_ARCH) ? 'armv7l' : ENV.fetch('ARCH', KERN_ARCH)
 
 # Allow for edge case of i686 install on a x86_64 host before linux32 is
 # downloaded, e.g. in a docker container.


### PR DESCRIPTION
- The Chromebrew installer creates the wrong manifest directories during installs on `i686` because it runs without `setarch` on a `x86_64` host. Rather than go through setting up `setarch` to download first during the container installs, allow overrides of the internal `ARCH` constant if the `ARCH` env variable is set.
![image](https://github.com/chromebrew/chromebrew/assets/1096701/f2a55f85-36a7-42d2-9f43-d58ed01c449c)


Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=arch crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
