### PR TITLE
Add git hook that runs git-restore-mtime

### DIFF
--- a/manifest/armv7l/g/git_mestrelion_tools.filelist
+++ b/manifest/armv7l/g/git_mestrelion_tools.filelist
@@ -4,6 +4,7 @@
 /usr/local/bin/git-rebase-theirs
 /usr/local/bin/git-restore-mtime
 /usr/local/bin/git-strip-merge
+/usr/local/lib/crew/.git/hooks/post-merge
 /usr/local/share/man/man1/git-branches-rename.1.zst
 /usr/local/share/man/man1/git-clone-subset.1.zst
 /usr/local/share/man/man1/git-find-uncommitted-repos.1.zst

--- a/manifest/i686/g/git_mestrelion_tools.filelist
+++ b/manifest/i686/g/git_mestrelion_tools.filelist
@@ -4,6 +4,7 @@
 /usr/local/bin/git-rebase-theirs
 /usr/local/bin/git-restore-mtime
 /usr/local/bin/git-strip-merge
+/usr/local/lib/crew/.git/hooks/post-merge
 /usr/local/share/man/man1/git-branches-rename.1.zst
 /usr/local/share/man/man1/git-clone-subset.1.zst
 /usr/local/share/man/man1/git-find-uncommitted-repos.1.zst

--- a/manifest/x86_64/g/git_mestrelion_tools.filelist
+++ b/manifest/x86_64/g/git_mestrelion_tools.filelist
@@ -4,6 +4,7 @@
 /usr/local/bin/git-rebase-theirs
 /usr/local/bin/git-restore-mtime
 /usr/local/bin/git-strip-merge
+/usr/local/lib/crew/.git/hooks/post-merge
 /usr/local/share/man/man1/git-branches-rename.1.zst
 /usr/local/share/man/man1/git-clone-subset.1.zst
 /usr/local/share/man/man1/git-find-uncommitted-repos.1.zst

--- a/packages/git_mestrelion_tools.rb
+++ b/packages/git_mestrelion_tools.rb
@@ -15,10 +15,10 @@ class Git_mestrelion_tools < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'e008b4240a6ff1580dcb0786cc687454608d2a3dd3351da9bb7aa0a17a44cfa7',
-     armv7l: 'e008b4240a6ff1580dcb0786cc687454608d2a3dd3351da9bb7aa0a17a44cfa7',
-       i686: 'ccb3144001c111b47c4851e6b670090e8cfccee02d1a19624865dfdbdeafc47a',
-     x86_64: '9cc57f97e060f2604f8a0e1710ac118869bc27f7487017d8dd58652398fe1346'
+    aarch64: '2098e6f26114e57c9a2e84e0f423e0e017a0c1d4f6429eae43b51f66d48990ca',
+     armv7l: '2098e6f26114e57c9a2e84e0f423e0e017a0c1d4f6429eae43b51f66d48990ca',
+       i686: '8496e6d04cc4d6a49315b5e887185cc975fcea5c207bbf5c2c108feb6ca4e053',
+     x86_64: '25f152b9490a5f06d3545f40033e25433360d28befc86992099409ab14670850'
   })
 
   depends_on 'git' # L
@@ -28,7 +28,7 @@ class Git_mestrelion_tools < Package
     @post_merge_hook = <<~POST_MERGE_HOOK_EOF
       #!/bin/sh
       # This is installed in the git_mestrelion_tools package.
-      exec git-restore-mtime -s
+      exec git-restore-mtime -sq 2>/dev/null
     POST_MERGE_HOOK_EOF
     File.write('post-merge', @post_merge_hook)
   end
@@ -45,8 +45,9 @@ class Git_mestrelion_tools < Package
   end
 
   def self.postinstall
+    # restore mtime after install.
     Dir.chdir(CREW_LIB_PATH) do
-      system 'git-restore-mtime -s'
+      system 'git-restore-mtime -s 2>/dev/null'
     end
   end
 end

--- a/packages/git_mestrelion_tools.rb
+++ b/packages/git_mestrelion_tools.rb
@@ -15,10 +15,10 @@ class Git_mestrelion_tools < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '2098e6f26114e57c9a2e84e0f423e0e017a0c1d4f6429eae43b51f66d48990ca',
-     armv7l: '2098e6f26114e57c9a2e84e0f423e0e017a0c1d4f6429eae43b51f66d48990ca',
-       i686: '8496e6d04cc4d6a49315b5e887185cc975fcea5c207bbf5c2c108feb6ca4e053',
-     x86_64: '25f152b9490a5f06d3545f40033e25433360d28befc86992099409ab14670850'
+    aarch64: 'e9cd005b5739d50dcc7fe4e50d38c1b51e372ebc0bbf03ee36d3dbf042011db8',
+     armv7l: 'e9cd005b5739d50dcc7fe4e50d38c1b51e372ebc0bbf03ee36d3dbf042011db8',
+       i686: '79f534b94ff2c6b80aaf8eb829d3d9717f4a94c61fe3253f63bd64baa71a117f',
+     x86_64: '704dee30d25eda119b3f816f9b407f02dca6f7ee385d8ee173f2419abe7f2ba6'
   })
 
   depends_on 'git' # L
@@ -27,7 +27,7 @@ class Git_mestrelion_tools < Package
   def self.build
     @post_merge_hook = <<~POST_MERGE_HOOK_EOF
       #!/bin/sh
-      # This is installed in the git_mestrelion_tools package.
+      # This is from the git_mestrelion_tools package.
       exec git-restore-mtime -sq 2>/dev/null
     POST_MERGE_HOOK_EOF
     File.write('post-merge', @post_merge_hook)


### PR DESCRIPTION
Works properly:
- [ ] `x86_64`
- [ ] `i686`
- [ ] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=git-restore-mtime crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
