### PR TITLE
crew: run git-restore-mtime on crew update

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -386,6 +386,7 @@ def update
 
     system "git fetch #{CREW_REPO} #{CREW_BRANCH}", exception: true
     system 'git reset --hard FETCH_HEAD', exception: true
+    system 'git-restore-mtime -sq 2>/dev/null', exception: true if File.file?("#{CREW_PREFIX}/bin/git-restore-mtime")
   end
 
   puts 'Package lists, crew, and library updated.'

--- a/install.sh
+++ b/install.sh
@@ -286,7 +286,6 @@ echo "export CREW_PREFIX=${CREW_PREFIX}" >> "${CREW_PREFIX}/etc/env.d/profile"
 crew update compatible
 
 echo_info "Installing core Chromebrew packages...\n"
-# We need these to install core.
 yes | crew install core
 
 echo_info "\nRunning Bootstrap package postinstall scripts...\n"

--- a/install.sh
+++ b/install.sh
@@ -287,7 +287,6 @@ crew update compatible
 
 echo_info "Installing core Chromebrew packages...\n"
 # We need these to install core.
-yes | crew install pixz
 yes | crew install core
 
 echo_info "\nRunning Bootstrap package postinstall scripts...\n"
@@ -319,6 +318,9 @@ else
   # Set sparse-checkout folders.
   git sparse-checkout set packages "manifest/${ARCH}" lib commands bin crew tests tools
   git reset --hard origin/"${BRANCH}"
+
+  # Set mtimes of files to when the file was committed.
+  git-restore-mtime -sq 2>/dev/null
 fi
 echo -e "${RESET}"
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.45.1'
+CREW_VERSION = '1.45.2'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/packages/core.rb
+++ b/packages/core.rb
@@ -3,7 +3,7 @@ require 'package'
 class Core < Package
   description 'Core Chromebrew Packages.'
   homepage 'https://github.com/chromebrew/chromebrew'
-  version '1.9'
+  version '2.0'
   license 'GPL-3+'
   compatibility 'all'
 
@@ -24,6 +24,7 @@ class Core < Package
   depends_on 'gdbm'
   depends_on 'gettext'
   depends_on 'git'
+  depends_on 'git_mestrelion_tools'
   depends_on 'glibc_lib'
   depends_on 'gmp'
   depends_on 'gnutls'


### PR DESCRIPTION
- We only run `git fetch`, and so we cannot use a git hook for running `git-restore-mtime`. ([No git hook exists](https://git-scm.com/docs/githooks) for `git fetch`.)
- The simpler way to handle this is to just run `git-restore-mtime` during crew update from crew. (Hence the addition of the tool to `core.rb`.)
- Note that STDERR is removed on purpose when running this command, because otherwise the output is littered with sparse-checkout excluded folder information. See https://github.com/MestreLion/git-tools/issues/70
- Also use `git-restore-mtime` in the installer.
- Replaces approach in https://github.com/chromebrew/chromebrew/pull/9473

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=crew_add_git-restore-mtime crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
