### PR TITLE
Add git_mestrelion_tools to core_packages.txt, fix crew_profile_base dropping tmp files in the wrong place.

### DIFF
--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -154,3 +154,5 @@ unless @new_const_git_commit == CREW_CONST_GIT_COMMIT
   exec "CREW_REPO=#{CREW_REPO} CREW_BRANCH=#{CREW_BRANCH} crew update"
 end
 
+# Remove pagerenv tmp file in CREW_PACKAGES_PATH if it exists
+FileUtils.rm "#{CREW_PACKAGES_PATH}/pagerenv" if File.file?("#{CREW_PACKAGES_PATH}/pagerenv")

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -78,19 +78,21 @@ class Crew_profile_base < Package
     ]
 
     @pager_default = Selector.new(@pager_options).show_prompt
-    File.write 'pagerenv', <<~PAGER_ENV_EOF
-      # The user's preferred pager is set here by the crew_profile_base
-      # postinstall.
+    Dir.chdir CREW_DEST_DIR do
+      File.write 'pagerenv', <<~PAGER_ENV_EOF
+        # The user's preferred pager is set here by the crew_profile_base
+        # postinstall.
 
-      # PAGER from container PAGER variable is passed through into the
-      # CONTAINER_PAGER variable.
-      if [ -z "$CONTAINER_PAGER" ]; then
-        PAGER="#{@pager_default}"
-      else
-        PAGER="$CONTAINER_PAGER"
-      fi
-    PAGER_ENV_EOF
-    FileUtils.install 'pagerenv', "#{CREW_PREFIX}/etc/env.d/03-pager", mode: 0o644
+        # PAGER from container PAGER variable is passed through into the
+        # CONTAINER_PAGER variable.
+        if [ -z "$CONTAINER_PAGER" ]; then
+          PAGER="#{@pager_default}"
+        else
+          PAGER="$CONTAINER_PAGER"
+        fi
+      PAGER_ENV_EOF
+      FileUtils.install 'pagerenv', "#{CREW_PREFIX}/etc/env.d/03-pager", mode: 0o644
+    end
     puts "The default PAGER has been set to #{@pager_default}.".lightblue
   end
 end

--- a/tools/core_packages.txt
+++ b/tools/core_packages.txt
@@ -34,6 +34,7 @@ gcc_lib
 gdbm
 gettext
 git
+git_mestrelion_tools
 glib
 glibc
 gmp


### PR DESCRIPTION
- Add `git_mestrelion_tools` to core_packages.txt
- Fix crew_profile_base dropping tmp `pagerenv` files into `#{CREW_PACKAGES_PATH}/pagerenv`:
![image](https://github.com/chromebrew/chromebrew/assets/1096701/091ecf94-b24c-4ec4-a978-fc31f83098b3)
- Also add removal of `#{CREW_PACKAGES_PATH}/pagerenv` to `fixup.rb`
