### PR TITLE
Terraform 1.7.4 => 1.7.5

### DIFF
--- a/packages/terraform.rb
+++ b/packages/terraform.rb
@@ -3,7 +3,7 @@ require 'package'
 class Terraform < Package
   description 'Terraform is a tool for building, changing, and combining infrastructure safely and efficiently.'
   homepage 'https://www.terraform.io/'
-  version '1.7.4'
+  version '1.7.5'
   license 'Apache-2.0, BSD-2, BSD-4, ECL-2.0, imagemagick, ISC, JSON, MIT, MIT-with-advertising, MPL-2.0 and unicode'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Terraform < Package
      x86_64: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_amd64.zip"
   })
   source_sha256({
-    aarch64: 'fa96919947f988505a0e39a1394187aa0ea2136d52829965cfec4ad41a36ff74',
-     armv7l: 'fa96919947f988505a0e39a1394187aa0ea2136d52829965cfec4ad41a36ff74',
-       i686: '421cb39ed7471c69abb895aecf98abfb0806d1d734366393068cfdeb9878cb3b',
-     x86_64: '140568896c466be68335a898756bb65c81422b488dcae2a93916d5784bcdc88f'
+    aarch64: '0339d513ff4f88e65bea82abda5ca56f4545276cb97ce943251d1977a2b30001',
+     armv7l: '0339d513ff4f88e65bea82abda5ca56f4545276cb97ce943251d1977a2b30001',
+       i686: '16969e4dd1c1362bdf427af3fc2d596215107f548da8cde3e3a717c8258b7bb0',
+     x86_64: '9c9c3433038f11c3fb3c06b757de877afdcbc45d9295db438efdca08da404d0c'
   })
 
   def self.install


### PR DESCRIPTION
## Description

This commit updates the Terraform CLI from version 1.7.4 to version 1.7.5.

## Additional information

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` 