### PR TITLE
Add 6.1 builds to linuxheaders

### DIFF
--- a/packages/linuxheaders.rb
+++ b/packages/linuxheaders.rb
@@ -39,6 +39,12 @@ class Linuxheaders < Package
        armv7l: 'f777a2fa6f124a808f32dc3dea4d71d939bd6b1237d6eff6bd61e53a21d60707',
        x86_64: '5b0fa3daf6ac8f2cd1028bd326a6c64f0cac052ba225845ba314e06d12a3de76'
     })
+  when '6.1'
+    binary_sha256({
+      aarch64: '424399cfc8e7f1372003e9766fde2006c4597a70253069a4a3c4a4254a94c7d8',
+       armv7l: '424399cfc8e7f1372003e9766fde2006c4597a70253069a4a3c4a4254a94c7d8',
+       x86_64: '9b3cd996703add46eaf40b8e18b0cfa8a11cf9387f106434d6bfd4e1958b85c0'
+    })
   else
     binary_sha256({
       aarch64: '23b6f70dad19663d42a1bb8707e66eb1b35c4934ef051577701397b4708e8cff',
@@ -73,7 +79,7 @@ class Linuxheaders < Package
   end
 
   def self.postinstall
-    return unless %w[3.8 4.14 5.4 5.10 5.15].include? CREW_KERNEL_VERSION
+    return unless %w[3.8 4.14 5.4 5.10 5.15 6.1].include? CREW_KERNEL_VERSION
 
     puts 'The installed kernel headers do NOT match the current kernel version.'.orange
     puts 'Please build and install the appropriate kernel headers with:'.orange

--- a/packages/linuxheaders.rb
+++ b/packages/linuxheaders.rb
@@ -47,6 +47,8 @@ class Linuxheaders < Package
     })
   end
 
+  depends_on 'rsync' => :build
+
   no_env_options
   no_fhs
 


### PR DESCRIPTION
Milestone 122 builds are running kernel 6.1, so...

Tested and working on `x86_64` and `armv7l`.

The `rsync` build dep is because the build, at least on `6.1` and `x86_64`, fails without it.

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=6sandwich crew update
```
