### PR TITLE
Remove activesupport gem package from core, adjust installer to insta…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -160,7 +160,7 @@ find "${CREW_LIB_PATH}" -mindepth 1 -delete
 # Download the chromebrew repository.
 curl -L --progress-bar https://github.com/"${OWNER}"/"${REPO}"/tarball/"${BRANCH}" | tar -xz --strip-components=1 -C "${CREW_LIB_PATH}"
 
-BOOTSTRAP_PACKAGES="zstd crew_mvdir ruby git ca_certificates openssl"
+BOOTSTRAP_PACKAGES="zstd crew_mvdir ruby git ca_certificates libyaml openssl"
 
 # Older i686 systems.
 [[ "${ARCH}" == "i686" ]] && BOOTSTRAP_PACKAGES+=" gcc_lib"
@@ -264,6 +264,11 @@ for package in $BOOTSTRAP_PACKAGES; do
   extract_install "${package}" "${tarfile}"
   update_device_json "${package}" "${version}" "${sha256}"
 done
+
+# Install activesupport gem for ruby
+gem update -N --system
+gem install -N activesupport --conservative
+gem install -N concurrent-ruby --conservative
 
 # Work around https://github.com/chromebrew/chromebrew/issues/3305.
 # shellcheck disable=SC2024

--- a/packages/core.rb
+++ b/packages/core.rb
@@ -3,7 +3,7 @@ require 'package'
 class Core < Package
   description 'Core Chromebrew Packages.'
   homepage 'https://github.com/chromebrew/chromebrew'
-  version '2.1'
+  version '2.2'
   license 'GPL-3+'
   compatibility 'all'
 
@@ -72,7 +72,6 @@ class Core < Package
   depends_on 'readline'
   depends_on 'rtmpdump'
   depends_on 'ruby'
-  depends_on 'ruby_activesupport'
   depends_on 'slang'
   depends_on 'sqlite'
   depends_on 'uchardet'


### PR DESCRIPTION
- The installer here succeeds to the point that `core` installs, so remove ruby_activesupport from core.

