### PR TITLE
Make prop_test and cycle_test cwd-agnostic

### DIFF
--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -20,9 +20,8 @@ jobs:
             yes | crew upgrade && \
             yes | crew install vim && \
             yes | crew remove vim && \
-            cd ../tests && \
-            ./prop_test && \
-            ruby commands/* && \
+            ruby ../tests/prop_test && \
+            ruby ../tests/commands/* && \
             cd ~ && \
             git clone --depth=1 https://github.com/chromebrew/chromebrew.git build_test && \
             cd build_test && \

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,4 +1,3 @@
 # Tests
 
 These are a collection of programs used to ensure crew is working correctly.
-They **must** be run in this directory, otherwise they will result in false positives.

--- a/tests/cycle_test
+++ b/tests/cycle_test
@@ -2,13 +2,13 @@
 
 # This test checks whether the packages create a dependency cycle.
 
-# Add >LOCAL< lib to LOAD_PATH
-$LOAD_PATH.unshift '../lib'
-
 require 'find'
 require_relative '../lib/const'
 require_relative '../lib/color'
 require_relative '../lib/package'
+
+# Add >LOCAL< lib to LOAD_PATH so that packages can be loaded
+$LOAD_PATH.unshift File.join(CREW_LIB_PATH, 'lib')
 
 @all_pkgs = {}
 

--- a/tests/prop_test
+++ b/tests/prop_test
@@ -1,12 +1,11 @@
 #!/usr/bin/env ruby
 
-# Add >LOCAL< lib to LOAD_PATH so that packages can be loaded
-$LOAD_PATH.unshift '../lib'
-
-require 'fileutils'
 require_relative '../lib/const'
 require_relative '../lib/color'
 require_relative '../lib/package'
+
+# Add >LOCAL< lib to LOAD_PATH so that packages can be loaded
+$LOAD_PATH.unshift File.join(CREW_LIB_PATH, 'lib')
 
 tofail = 0
 


### PR DESCRIPTION
Noticed this in other testing.

Tested and working on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=histull crew update
```
