### PR TITLE
Split sysinfo command into separate file

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -7,6 +7,7 @@ require 'tmpdir'
 require_relative '../commands/const'
 require_relative '../commands/help'
 require_relative '../commands/list'
+require_relative '../commands/sysinfo'
 require_relative '../lib/color'
 require_relative '../lib/const'
 require_relative '../lib/convert_size'
@@ -56,7 +57,7 @@ DOC = <<~DOCOPT
     crew reinstall [options] [-k|--keep] [-s|--source] [-S|--recursive-build] [-v|--verbose] <name> ...
     crew remove [options] [-v|--verbose] <name> ...
     crew search [options] [-v|--verbose] [<name> ...]
-    crew sysinfo [-v|--verbose] [options]
+    crew sysinfo [-v|--verbose]
     crew test [-v|--verbose] [<name> ...]
     crew update [options] [-v|--verbose] [<compatible>]
     crew upgrade [options] [-k|--keep] [-s|--source] [-v|--verbose] [<name> ...]
@@ -2000,46 +2001,7 @@ def search_command(args)
 end
 
 def sysinfo_command(_args)
-  # newer version of Chrome OS exports info to env by default
-  lsb_release = if File.file?('/etc/lsb-release')
-                  File.read('/etc/lsb-release').scan(/^(.+?)=(.+)$/).to_h
-                else
-                  # newer version of Chrome OS exports info to env by default
-                  ENV
-                end
-
-  git_commit_message_format = '%h `%s (%cr)`'
-
-  sysinfo_markdown_header = <<~MDHEADER
-    <details><summary>Expand</summary>
-
-  MDHEADER
-  sysinfo_markdown_body = <<~MDBODY
-    - Architecture: `#{KERN_ARCH}` (`#{ARCH}`)
-    - Processor vendor: `#{CPUINFO['vendor_id'] || 'ARM'}`
-    - User space: `#{Dir.exist?('/lib64') ? '64' : '32'}-bit`
-    - Chromebrew Kernel version: `#{CREW_KERNEL_VERSION}`
-    - Chromebrew Running in Container: `#{CREW_IN_CONTAINER}`
-
-    - Chromebrew version: `#{CREW_VERSION}`
-    - Chromebrew prefix: `#{CREW_PREFIX}`
-    - Chromebrew libdir: `#{CREW_LIB_PREFIX}`
-
-    - Last update in local repository: #{`git -C '#{CREW_LIB_PATH}' show -s --format='#{git_commit_message_format}'`.chomp}
-
-    - OS variant: `#{lsb_release['CHROMEOS_RELEASE_NAME']}`
-    - OS version: `#{lsb_release['CHROMEOS_RELEASE_BUILDER_PATH']}`
-    - OS channel: `#{lsb_release['CHROMEOS_RELEASE_TRACK']}`
-  MDBODY
-  sysinfo_markdown_footer = <<~MDFOOTER
-
-    </details>
-  MDFOOTER
-  if @opt_verbose
-    puts sysinfo_markdown_header, sysinfo_markdown_body, sysinfo_markdown_footer
-  else
-    puts sysinfo_markdown_body.tr('`', '')
-  end
+  Command.sysinfo(@opt_verbose)
 end
 
 def test_command(args)

--- a/commands/help.rb
+++ b/commands/help.rb
@@ -110,7 +110,7 @@ class Command
     when 'sysinfo'
       puts <<~EOT
         Show system information.
-        Usage: crew sysinfo
+        Usage: crew sysinfo [-v|--verbose]
         If `-v` or `--verbose` is present, show system information with raw markdown.
       EOT
     when 'test'

--- a/commands/sysinfo.rb
+++ b/commands/sysinfo.rb
@@ -1,0 +1,46 @@
+require_relative '../lib/const'
+
+class Command
+  def self.sysinfo(verbose)
+    # newer version of Chrome OS exports info to env by default
+    lsb_release = if File.file?('/etc/lsb-release')
+                    File.read('/etc/lsb-release').scan(/^(.+?)=(.+)$/).to_h
+                  else
+                    # newer version of Chrome OS exports info to env by default
+                    ENV
+                  end
+
+    git_commit_message_format = '%h `%s (%cr)`'
+
+    sysinfo_markdown_header = <<~MDHEADER
+      <details><summary>Expand</summary>
+
+    MDHEADER
+    sysinfo_markdown_body = <<~MDBODY
+      - Architecture: `#{KERN_ARCH}` (`#{ARCH}`)
+      - Processor vendor: `#{CPUINFO['vendor_id'] || 'ARM'}`
+      - User space: `#{Dir.exist?('/lib64') ? '64' : '32'}-bit`
+      - Chromebrew Kernel version: `#{CREW_KERNEL_VERSION}`
+      - Chromebrew Running in Container: `#{CREW_IN_CONTAINER}`
+
+      - Chromebrew version: `#{CREW_VERSION}`
+      - Chromebrew prefix: `#{CREW_PREFIX}`
+      - Chromebrew libdir: `#{CREW_LIB_PREFIX}`
+
+      - Last update in local repository: #{`git -C '#{CREW_LIB_PATH}' show -s --format='#{git_commit_message_format}'`.chomp}
+
+      - OS variant: `#{lsb_release['CHROMEOS_RELEASE_NAME']}`
+      - OS version: `#{lsb_release['CHROMEOS_RELEASE_BUILDER_PATH']}`
+      - OS channel: `#{lsb_release['CHROMEOS_RELEASE_TRACK']}`
+    MDBODY
+    sysinfo_markdown_footer = <<~MDFOOTER
+
+      </details>
+    MDFOOTER
+    if verbose
+      puts sysinfo_markdown_header, sysinfo_markdown_body, sysinfo_markdown_footer
+    else
+      puts sysinfo_markdown_body.tr('`', '')
+    end
+  end
+end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.45.5'
+CREW_VERSION = '1.45.6'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
**Split out `sysinfo` command to `commands/sysinfo.rb`.**

Behaviour changes:
- Unify and correct the help for the `sysinfo` command-- it supports `-v/--verbose`, but does not take any other options.

Tested and working on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=projectregula3 crew update
```
