### PR TITLE
Simplify crew prop command

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -360,17 +360,11 @@ def files(pkg_name)
 end
 
 def prop(silent = false)
-  props = []
-  pkg = Package.new
-  excluded_methods = %w[compatible binary source json_creatable autoload include const_defined class_variable_defined singleton_class method_defined public_method_defined private_method_defined protected_method_defined instance_variable_defined instance_of kind_of is_a frozen nil eql respond_to equal]
-  all_methods = pkg.class.methods.grep(/\?$/).to_s.gsub(/([?:,\[\]])/, '').split
-  all_methods.each do |method|
-    props.push(method) unless excluded_methods.include?(method)
-  end
+  props = Package.print_boolean_properties
   if silent
     return props
   else
-    puts props.sort
+    puts props
     puts "For more information, type 'crew help prop <property>' where <property> is one of the above properties.".lightblue
   end
 end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.45.6'
+CREW_VERSION = '1.45.7'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -5,13 +5,15 @@ require_relative 'package_helpers'
 require_relative 'selector'
 
 class Package
-  property :description, :homepage, :version, :license, :compatibility,
-           :binary_compression, :binary_url, :binary_sha256, :source_url, :source_sha256,
-           :git_branch, :git_hashtag, :min_glibc
-
   boolean_property :arch_flags_override, :conflicts_ok, :git_clone_deep, :git_fetchtags, :gnome, :is_fake, :is_musl, :is_static,
                    :no_compile_needed, :no_compress, :no_env_options, :no_fhs, :no_git_submodules, :no_links, :no_lto, :no_patchelf,
                    :no_shrink, :no_source_build, :no_strip, :no_upstream_update, :no_zstd, :patchelf, :print_source_bashrc, :run_tests
+
+  @boolean_properties = methods(false).join(',').gsub('?', '').split(',').sort.uniq.join(', ')
+
+  property :description, :homepage, :version, :license, :compatibility,
+           :binary_compression, :binary_url, :binary_sha256, :source_url, :source_sha256,
+           :git_branch, :git_hashtag, :min_glibc
 
   create_placeholder :preflight,   # Function for checks to see if install should occur.
                      :patch,       # Function to perform patch operations prior to build from source.
@@ -24,6 +26,10 @@ class Package
                      :postinstall, # Function to perform post-install for both source build and binary distribution.
                      :preremove,   # Function to perform prior to package removal.
                      :remove       # Function to perform after package removal.
+
+  def self.print_boolean_properties
+    return @boolean_properties
+  end
 
   class << self
     attr_accessor :name, :cached_build, :in_build, :build_from_source, :in_upgrade


### PR DESCRIPTION
Helps improve #9514 by providing a solution to avoid repeating the properties output in 4 different places.  Caveat is `require 'package'` is a prerequisite for each file requiring the method reference.
