### PR TITLE
Fix hardcoded device.json path in commands/list.rb

### DIFF
--- a/commands/list.rb
+++ b/commands/list.rb
@@ -6,7 +6,7 @@ require_relative '../lib/package'
 
 class Command
   def self.list(available, installed, compatible, incompatible, verbose)
-    device_json = JSON.load_file('/usr/local/etc/crew/device.json', symbolize_names: true)
+    device_json = JSON.load_file(File.join(CREW_CONFIG_PATH, 'device.json'), symbolize_names: true)
     installed_packages = {}
     device_json[:installed_packages].each do |package|
       installed_packages[package[:name]] = package[:version]

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.45.7'
+CREW_VERSION = '1.45.8'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
This snuck in during testing and I evidently forgot to remove it, my bad.

Tested and working on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=ooops crew update
```

