### PR TITLE
Add buildsystem_test and check

### DIFF
--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -21,6 +21,7 @@ jobs:
             yes | crew install vim && \
             yes | crew remove vim && \
             ruby ../tests/prop_test && \
+            ruby ../tests/buildsystem_test && \
             ruby ../tests/commands/* && \
             cd ~ && \
             git clone --depth=1 https://github.com/chromebrew/chromebrew.git build_test && \

--- a/bin/crew
+++ b/bin/crew
@@ -1863,6 +1863,7 @@ end
 
 def check_command(args)
   args['<name>'].each do |name|
+    check_package(name)
     search name
     if @opt_version
       Dir.chdir CREW_PACKAGES_PATH do
@@ -1871,6 +1872,7 @@ def check_command(args)
     else
       Dir.chdir CREW_PACKAGES_PATH do
         system "../tests/prop_test #{name}"
+        system "../tests/buildsystem_test #{name}"
       end
     end
   end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.45.8'
+CREW_VERSION = '1.45.9'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/tests/buildsystem_test
+++ b/tests/buildsystem_test
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+
+require_relative '../lib/color'
+
+def get_buildsystems(file, field)
+  return `grep ^class #{file} | cut -d' ' -f#{field} | xargs`.chomp
+end
+
+def check_buildsystem(name)
+  puts "Checking #{name} package ...".yellow
+  buildsystem = get_buildsystems("../packages/#{name}.rb", 4)
+  if @buildsystems.include?(buildsystem)
+    puts "Buildsystem test for #{name} passed.".lightgreen
+  else
+    puts "#{buildsystem} is an invalid buildsystem. Valid buildsystems include #{@buildsystems.sort.join(', ')}.".lightred
+    puts "Buildsystem test for #{name} failed.".lightred
+    @tofail += 1
+  end
+end
+
+@tofail = 0
+@buildsystems = "Package #{get_buildsystems('../lib/buildsystems/*.rb', 2)}".split
+
+if ARGV[0]
+  ARGV.each do |arg|
+    if File.file? "../packages/#{arg}.rb"
+      check_buildsystem(arg)
+    else
+      puts "Package #{arg} not found.".lightred
+    end
+  end
+else
+  Dir['../packages/*.rb'].each do |filename|
+    name = File.basename(filename, '.rb')
+    check_buildsystem(name)
+  end
+
+  if @tofail.positive?
+    puts "\n#{@tofail} packages failed buildsystem tests.".lightred
+    exit(1)
+  else
+    puts "\nAll packages passed buildsystem tests.".lightgreen
+  end
+end


### PR DESCRIPTION
Tested and working both as a standalone script and with the `crew check` command.  Also added check to see if there were any changes to warrant a copy to crew from the local working repo.

Example in action:
```
$ crew check perl_test
Checking perl_test package ...
Property tests for perl_test passed.
Checking perl_test package ...
Perl is an invalid buildsystem. Valid buildsystems include Autotools, CMake, Meson, PERL, Package, Pip, Python, Qmake, RUBY.
Buildsystem test for perl_test failed.
```
Notice `Perl` is not all capital letters.  This is a common mistake when building packages.