### PR TITLE
Split files command into separate file

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -5,6 +5,7 @@ require 'json'
 require 'fileutils'
 require 'tmpdir'
 require_relative '../commands/const'
+require_relative '../commands/files'
 require_relative '../commands/help'
 require_relative '../commands/list'
 require_relative '../commands/prop'
@@ -12,7 +13,6 @@ require_relative '../commands/remove'
 require_relative '../commands/sysinfo'
 require_relative '../lib/color'
 require_relative '../lib/const'
-require_relative '../lib/convert_size'
 require_relative '../lib/deb_utils'
 require_relative '../lib/docopt'
 require_relative '../lib/downloader'
@@ -262,38 +262,6 @@ def cache_build
     puts 'CREW_CACHE_ENABLED is not set.'.orange unless CREW_CACHE_ENABLED
     puts 'CREW_CACHE_DIR is not writable.'.lightred unless File.writable?(CREW_CACHE_DIR)
   end
-end
-
-def files(pkg_name)
-  local_filelist    = File.join(CREW_META_PATH, "#{pkg_name}.filelist")
-  manifest_filelist = File.join(CREW_LIB_PATH, "manifest/#{ARCH}/#{pkg_name[0]}/#{pkg_name}.filelist")
-
-  if File.exist?(local_filelist)
-    # search for local filelist first
-    filelist_path = local_filelist
-  elsif File.exist?(manifest_filelist)
-    # search for manifest directory if not installed
-    filelist_path = manifest_filelist
-  else
-    # package does not have any filelist available
-    warn "Package #{pkg_name} is not installed. :(".lightred
-    return false
-  end
-
-  filelist = File.readlines(filelist_path, chomp: true).sort
-  lines = filelist.size
-  size = 0
-
-  filelist.each do |filename|
-    # ignore symlinks to prevent duplicating calculation
-    size += File.size(filename) if File.file?(filename) && !File.symlink?(filename)
-  end
-
-  puts filelist, <<~EOT.lightgreen
-
-    Total found: #{lines}
-    Disk usage: #{human_size(size)}
-  EOT
 end
 
 def whatprovides(regex_pat)
@@ -1755,10 +1723,8 @@ end
 
 def files_command(args)
   args['<name>'].each do |name|
-    @pkg_name = name
-    search @pkg_name
-    print_current_package
-    files name
+    search name
+    Command.files(@pkg)
   end
 end
 

--- a/commands/files.rb
+++ b/commands/files.rb
@@ -1,0 +1,42 @@
+require 'json'
+require_relative '../lib/const'
+require_relative '../lib/convert_size'
+
+class Command
+  def self.files(pkg)
+    # Check if the package is even installed first, as this is the most likely reason we cannot find a filelist.
+    device_json = JSON.load_file(File.join(CREW_CONFIG_PATH, 'device.json'))
+    if device_json['installed_packages'].none? { |entry| entry['name'] == pkg.name }
+      puts "Package #{pkg.name} is not installed.".lightred
+      return
+    end
+
+    # We can't do anything if we don't have the filelist.
+    unless File.file?(filelist_path = File.join(CREW_META_PATH, "#{pkg.name}.filelist"))
+      puts "Package #{pkg.name} does not have a filelist :(".lightred
+      return
+    end
+
+    # Print the name and description of the package.
+    puts pkg.name.lightgreen + ": #{pkg.description}".lightblue
+
+    # Read the file into memory as an array of lines.
+    filelist = File.readlines(filelist_path, chomp: true)
+    size = 0
+
+    filelist.each do |filename|
+      # Skip calculating the filesize if the file doesn't exist.
+      next unless File.file?(filename)
+      # Ignore symlinks to prevent duplicating calculation.
+      next if File.symlink?(filename)
+      # Add the size of the file to the total size.
+      size += File.size(filename)
+    end
+
+    # Print the filelist, the total number of files, and the total size of those files.
+    puts filelist
+    puts "\nTotal found: #{filelist.count}".lightgreen
+    puts "Disk usage: #{human_size(size)}".lightgreen
+  end
+end
+

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.46.3'
+CREW_VERSION = '1.46.4'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp
@@ -337,7 +337,7 @@ CREW_DOCOPT = <<~DOCOPT
     crew const [-v|--verbose] [<name> ...]
     crew deps [options] [--deep] [-t|--tree] [-b|--include-build-deps] [--exclude-buildessential] [-v|--verbose] <name> ...
     crew download [options] [-s|--source] [-v|--verbose] <name> ...
-    crew files [options] [-v|--verbose] <name> ...
+    crew files <name> ...
     crew help [<command>] [-v|--verbose] [<subcommand>]
     crew install [options] [-k|--keep] [-s|--source] [-S|--recursive-build] [-v|--verbose] <name> ...
     crew list [options] [-v|--verbose] (available|installed|compatible|incompatible)


### PR DESCRIPTION
**Split out `files` command to `commands/files.rb`.**

Behavior changes:
- Do not print files for packages that aren't installed.
  - This is consistent with the documentation, and the previous behavior would falsely report a size of 0 bytes.
  - If the consensus is that this behavior should be brought back in some way, I'm happy to implement that.
- Remove `[options]` and `[-v|--verbose]` in the docopt EOF for `crew files`.
  - Same rationale for removing `[options]` as usual, and we never actually did anything with the verbose option here.
- No newline printed after `Disk usage: ...`
  
Refactoring changes:
- Check if the package is installed before checking if it has a filelist.
- Don't use `.sort` after reading the filelist.
  - We already sort the filelists upon creation, and its not a good idea to have `crew files` possibly display a different sorting order.
- Slightly clean up the various checks on file existence and symlinks.
- Instead of using the weird previous setup of a `puts` call with multiple arguments and an EOT, separate the printing of the filelist, total number of files, and disk usage into their own `puts` calls. 


Tested and working on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=projectregula7 crew update
```
