### PR TITLE
Allow package removal to not error out on missing files, in case of files from a package having been manually removed

### DIFF
--- a/commands/remove.rb
+++ b/commands/remove.rb
@@ -44,7 +44,7 @@ class Command
       File.foreach(File.join(CREW_META_PATH, "#{pkg.name}.directorylist"), chomp: true) do |line|
         next unless Dir.exist?(line) && Dir.empty?(line) && line.include?(CREW_PREFIX)
         puts "Removing directory #{line}".yellow if verbose
-        Dir.rmdir line, exception: false
+        FileUtils.remove_dir line, exception: false
       end
 
       # Remove the file and directory lists.

--- a/commands/remove.rb
+++ b/commands/remove.rb
@@ -36,7 +36,7 @@ class Command
           puts "#{line} is in another package. It will not be removed during the removal of #{pkg.name}.".orange
         else
           puts "Removing file #{line}".yellow if verbose
-          FileUtils.remove_file line
+          FileUtils.remove_file line, exception: false
         end
       end
 
@@ -44,7 +44,7 @@ class Command
       File.foreach(File.join(CREW_META_PATH, "#{pkg.name}.directorylist"), chomp: true) do |line|
         next unless Dir.exist?(line) && Dir.empty?(line) && line.include?(CREW_PREFIX)
         puts "Removing directory #{line}".yellow if verbose
-        Dir.rmdir line
+        Dir.rmdir line, exception: false
       end
 
       # Remove the file and directory lists.

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.46.5'
+CREW_VERSION = '1.46.6'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=remove crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
