### PR TITLE
Bash Update to 5.2, patchlevel 16, update crew_profile_base to deal with bash_completion error messages

### DIFF
--- a/manifest/armv7l/b/bash.filelist
+++ b/manifest/armv7l/b/bash.filelist
@@ -110,7 +110,7 @@
 /usr/local/share/doc/bash/README
 /usr/local/share/doc/bash/bash.html
 /usr/local/share/doc/bash/bashref.html
-/usr/local/share/info/bash.info.gz
+/usr/local/share/info/bash.info.zst
 /usr/local/share/locale/af/LC_MESSAGES/bash.mo
 /usr/local/share/locale/bg/LC_MESSAGES/bash.mo
 /usr/local/share/locale/ca/LC_MESSAGES/bash.mo
@@ -150,5 +150,5 @@
 /usr/local/share/locale/vi/LC_MESSAGES/bash.mo
 /usr/local/share/locale/zh_CN/LC_MESSAGES/bash.mo
 /usr/local/share/locale/zh_TW/LC_MESSAGES/bash.mo
-/usr/local/share/man/man1/bash.1.gz
-/usr/local/share/man/man1/bashbug.1.gz
+/usr/local/share/man/man1/bash.1.zst
+/usr/local/share/man/man1/bashbug.1.zst

--- a/manifest/i686/b/bash.filelist
+++ b/manifest/i686/b/bash.filelist
@@ -110,7 +110,7 @@
 /usr/local/share/doc/bash/README
 /usr/local/share/doc/bash/bash.html
 /usr/local/share/doc/bash/bashref.html
-/usr/local/share/info/bash.info.gz
+/usr/local/share/info/bash.info.zst
 /usr/local/share/locale/af/LC_MESSAGES/bash.mo
 /usr/local/share/locale/bg/LC_MESSAGES/bash.mo
 /usr/local/share/locale/ca/LC_MESSAGES/bash.mo
@@ -150,5 +150,5 @@
 /usr/local/share/locale/vi/LC_MESSAGES/bash.mo
 /usr/local/share/locale/zh_CN/LC_MESSAGES/bash.mo
 /usr/local/share/locale/zh_TW/LC_MESSAGES/bash.mo
-/usr/local/share/man/man1/bash.1.gz
-/usr/local/share/man/man1/bashbug.1.gz
+/usr/local/share/man/man1/bash.1.zst
+/usr/local/share/man/man1/bashbug.1.zst

--- a/manifest/x86_64/b/bash.filelist
+++ b/manifest/x86_64/b/bash.filelist
@@ -110,7 +110,7 @@
 /usr/local/share/doc/bash/README
 /usr/local/share/doc/bash/bash.html
 /usr/local/share/doc/bash/bashref.html
-/usr/local/share/info/bash.info.gz
+/usr/local/share/info/bash.info.zst
 /usr/local/share/locale/af/LC_MESSAGES/bash.mo
 /usr/local/share/locale/bg/LC_MESSAGES/bash.mo
 /usr/local/share/locale/ca/LC_MESSAGES/bash.mo
@@ -150,5 +150,5 @@
 /usr/local/share/locale/vi/LC_MESSAGES/bash.mo
 /usr/local/share/locale/zh_CN/LC_MESSAGES/bash.mo
 /usr/local/share/locale/zh_TW/LC_MESSAGES/bash.mo
-/usr/local/share/man/man1/bash.1.gz
-/usr/local/share/man/man1/bashbug.1.gz
+/usr/local/share/man/man1/bash.1.zst
+/usr/local/share/man/man1/bashbug.1.zst

--- a/packages/bash.rb
+++ b/packages/bash.rb
@@ -13,10 +13,10 @@ class Bash < Autotools
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '491cec8a98cdaf51555e132501a12aefb747b1055af4d4ca79571c441978bb55',
-     armv7l: '491cec8a98cdaf51555e132501a12aefb747b1055af4d4ca79571c441978bb55',
-       i686: 'ed8867045a27edb51582bf20fee3060fc75fc3f2d49237b9a729084793400829',
-     x86_64: 'a0aec6a5f64365b174f8d6834a7dfbb50073bed90da42ded7e0bfb4cb843522d'
+    aarch64: 'a53c3392a334427b0381236789387217d8731e07f966d64b967ddf63cb60ba94',
+     armv7l: 'a53c3392a334427b0381236789387217d8731e07f966d64b967ddf63cb60ba94',
+       i686: 'ab4ccf3dbdea01b6cecbb5e28696f518e48a0bc38730060afad7b8e2d9724ce9',
+     x86_64: '6c77b4a7cee18276a1b41807bfb6763626ac92bbfd6594422a4a9c3e3d9102c7'
   })
 
   depends_on 'gcc_lib' # R
@@ -28,11 +28,13 @@ class Bash < Autotools
     (1..@_patchlevel).each do |patch|
       patchfile = "bash52-#{patch.to_s.rjust(3, '0')}"
       downloader "https://mirrors.kernel.org/gnu/bash/bash-5.2-patches/#{patchfile}", 'SKIP'
+      puts "Applying bash #{@_ver} patch #{patch}...".orange
       system "patch -Np0 -i #{patchfile}"
     end
   end
 
   configure_options '--with-curses \
+    --enable-extended-glob-default \
     --enable-readline \
     --without-bash-malloc \
     --with-installed-readline'

--- a/packages/bash_completion.rb
+++ b/packages/bash_completion.rb
@@ -16,4 +16,6 @@ class Bash_completion < Autotools
        i686: 'b687949c680d08cddd59c7e01d882db0f8006800dd01dcf38948d78fb9e30f25',
      x86_64: 'c8794d54d7e2d25c987cc1b5a50957eedac78a65965d0270e6d8aabadd61a710'
   })
+
+  depends_on 'bash' # L
 end

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -3,7 +3,7 @@ require 'package'
 class Buildessential < Package
   description 'A collection of tools essential to compile and build software.'
   homepage 'SKIP'
-  version '1.31'
+  version '1.32'
   license 'GPL-3+'
   compatibility 'all'
 
@@ -174,4 +174,7 @@ class Buildessential < Package
   depends_on 'ruby_rubocop'
   # Add ruby_concurrent_ruby
   depends_on 'ruby_concurrent_ruby'
+
+  # Add bash to stop bash_completion from complaining
+  depends_on 'bash'
 end

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -3,7 +3,7 @@ require 'package'
 class Crew_profile_base < Package
   description 'Crew-profile-base sets up Chromebrew\'s environment capabilities.'
   homepage 'https://github.com/chromebrew/crew-profile-base'
-  version '0.0.14'
+  version '0.0.15'
   license 'GPL-3+'
   compatibility 'all'
   source_url "https://github.com/chromebrew/crew-profile-base/archive/refs/tags/#{version}.tar.gz"

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -7,7 +7,7 @@ class Crew_profile_base < Package
   license 'GPL-3+'
   compatibility 'all'
   source_url "https://github.com/chromebrew/crew-profile-base/archive/refs/tags/#{version}.tar.gz"
-  source_sha256 '7521602b6939df5ff8b787a7c4d67c4bd7b93f0cd0198cd230c7da19935b0b77'
+  source_sha256 'a50ac3a6daa494bbfcae041d79e44c186078ff27c27a62bc0ac0aa7ae4fd64a8'
 
   no_compile_needed
   print_source_bashrc

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -3,11 +3,11 @@ require 'package'
 class Crew_profile_base < Package
   description 'Crew-profile-base sets up Chromebrew\'s environment capabilities.'
   homepage 'https://github.com/chromebrew/crew-profile-base'
-  version '0.0.13'
+  version '0.0.14'
   license 'GPL-3+'
   compatibility 'all'
   source_url "https://github.com/chromebrew/crew-profile-base/archive/refs/tags/#{version}.tar.gz"
-  source_sha256 'fb87692443eab131688ee900a803db326105857f5caff89d1a3fc35d361f8f67'
+  source_sha256 '1ae6998665d5dc2f6b9161651ba1f96ab16ebb915ead8bb691d9e84fb25bfb5b'
 
   no_compile_needed
   print_source_bashrc

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -7,7 +7,7 @@ class Crew_profile_base < Package
   license 'GPL-3+'
   compatibility 'all'
   source_url "https://github.com/chromebrew/crew-profile-base/archive/refs/tags/#{version}.tar.gz"
-  source_sha256 '1ae6998665d5dc2f6b9161651ba1f96ab16ebb915ead8bb691d9e84fb25bfb5b'
+  source_sha256 '7521602b6939df5ff8b787a7c4d67c4bd7b93f0cd0198cd230c7da19935b0b77'
 
   no_compile_needed
   print_source_bashrc


### PR DESCRIPTION
Fixes #9610 

- also updates `crew_profile_base`

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=bash crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
