### PR TITLE
Terraform 1.7.5 => 1.8.0

### DIFF
--- a/packages/terraform.rb
+++ b/packages/terraform.rb
@@ -3,7 +3,7 @@ require 'package'
 class Terraform < Package
   description 'Terraform is a tool for building, changing, and combining infrastructure safely and efficiently.'
   homepage 'https://www.terraform.io/'
-  version '1.7.5'
+  version '1.8.0'
   license 'Apache-2.0, BSD-2, BSD-4, ECL-2.0, imagemagick, ISC, JSON, MIT, MIT-with-advertising, MPL-2.0 and unicode'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Terraform < Package
      x86_64: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_amd64.zip"
   })
   source_sha256({
-    aarch64: '0339d513ff4f88e65bea82abda5ca56f4545276cb97ce943251d1977a2b30001',
-     armv7l: '0339d513ff4f88e65bea82abda5ca56f4545276cb97ce943251d1977a2b30001',
-       i686: '16969e4dd1c1362bdf427af3fc2d596215107f548da8cde3e3a717c8258b7bb0',
-     x86_64: '9c9c3433038f11c3fb3c06b757de877afdcbc45d9295db438efdca08da404d0c'
+    aarch64: '439ffbd0a24bd9564823e4f56c3bbbb78625aa07f981e5bf5bda93461dfef349',
+     armv7l: '439ffbd0a24bd9564823e4f56c3bbbb78625aa07f981e5bf5bda93461dfef349',
+       i686: '80319b98736e46cd300ed69dcd230b575d1a67d4d49be56dc9f4c7344bcbcc17',
+     x86_64: '561523d4d685bd8f6cad6ecbc48611c19f179c42419cbf1a8ec8099d7bb63d15'
   })
 
   def self.install


### PR DESCRIPTION
## Description

This commit updates the Terraform CLI from version 1.7.5 to version 1.8.0.

## Additional information

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`