### PR TITLE
Fzf 0.46.1 => 0.49.0

### DIFF
--- a/packages/fzf.rb
+++ b/packages/fzf.rb
@@ -3,18 +3,18 @@ require 'package'
 class Fzf < Package
   description 'A command-line fuzzy finder'
   homepage 'https://github.com/junegunn/fzf'
-  version '0.46.1'
+  version '0.49.0'
   license 'MIT and BSD-with-disclosure'
   compatibility 'x86_64 aarch64 armv7l'
   source_url({
-    aarch64: 'https://github.com/junegunn/fzf/releases/download/0.46.1/fzf-0.46.1-linux_armv7.tar.gz',
-     armv7l: 'https://github.com/junegunn/fzf/releases/download/0.46.1/fzf-0.46.1-linux_armv7.tar.gz',
-     x86_64: 'https://github.com/junegunn/fzf/releases/download/0.46.1/fzf-0.46.1-linux_amd64.tar.gz'
+    aarch64: 'https://github.com/junegunn/fzf/releases/download/0.49.0/fzf-0.49.0-linux_armv7.tar.gz',
+     armv7l: 'https://github.com/junegunn/fzf/releases/download/0.49.0/fzf-0.49.0-linux_armv7.tar.gz',
+     x86_64: 'https://github.com/junegunn/fzf/releases/download/0.49.0/fzf-0.49.0-linux_amd64.tar.gz'
   })
   source_sha256({
-    aarch64: '594768969ef1ae63cb437eb29f867ed69d0c9d25f083e6b27b1e5b10cb0332a7',
-     armv7l: '594768969ef1ae63cb437eb29f867ed69d0c9d25f083e6b27b1e5b10cb0332a7',
-     x86_64: '6878dc810c0e464d392985e4e9d3525f7c4af346985f4b094ca117ce1bb0838c'
+    aarch64: '6cc088b6cf7b7a7ca988b5f4799dc624a31ca542a2d71866c6e3397425481aa3',
+     armv7l: '6cc088b6cf7b7a7ca988b5f4799dc624a31ca542a2d71866c6e3397425481aa3',
+     x86_64: '0c8df3ed2633b8d14643b0c47d4fae4bbe5987cdfc34eb1db438b2d04db3c041'
   })
 
   no_compile_needed


### PR DESCRIPTION
Tested and working in arm and x86_64 containers.  No filelist updates.