### PR TITLE
Autosource ~/.bashrc

### DIFF
--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -28,4 +28,4 @@ jobs:
             cd ~ && \
             git clone --depth=1 https://github.com/chromebrew/chromebrew.git build_test && \
             cd build_test && \
-            yes | crew build -f packages/hello_world_chromebrew.rb"
+            yes | CREW_CACHE_ENABLED=1 crew build -f packages/hello_world_chromebrew.rb"

--- a/bin/crew
+++ b/bin/crew
@@ -733,6 +733,7 @@ def post_install
     PRINT_SOURCE_BASHRC_EOT
       #To finish the installation, please execute the following:
       #source ~/.bashrc
+    crewlog "@pkg.print_source_bashrc?:#{@pkg.print_source_bashrc?} @pkg.gnome?:#{@pkg.gnome?}"
     if CREW_SOURCE_BASHRC_ENABLED
       Process.kill('USR1', Process.ppid)
       puts '~/.bashrc was automatically sourced.'.lightblue

--- a/bin/crew
+++ b/bin/crew
@@ -729,13 +729,17 @@ end
 def post_install
   if @pkg.print_source_bashrc? || @pkg.gnome?
     ExitMessage.add <<~PRINT_SOURCE_BASHRC_EOT.lightblue, print_last: true
-    ~/.bashrc will automatically be sourced.
+      ~/.bashrc was automatically sourced.
     PRINT_SOURCE_BASHRC_EOT
       #To finish the installation, please execute the following:
       #source ~/.bashrc
-
-    at_exit do
+    if CREW_SOURCE_BASHRC_ENABLED
       Process.kill('USR1', Process.ppid)
+      puts '~/.bashrc was automatically sourced.'.lightblue
+    else
+      at_exit do
+        exec 'bash'
+      end
     end
   end
 

--- a/bin/crew
+++ b/bin/crew
@@ -77,6 +77,7 @@ String.use_color = args['--color'] || !args['--no-color']
 @fileutils_verbose = @opt_verbose
 @verbose           = @opt_verbose ? 'v' : ''
 @short_verbose     = @opt_verbose ? '-v' : ''
+$verbose = @verbose
 
 class ExitMessage
   @messages = []

--- a/bin/crew
+++ b/bin/crew
@@ -116,8 +116,7 @@ at_exit do
     crewlog "@pkg.print_source_bashrc?:#{@pkg.print_source_bashrc?} @pkg.gnome?:#{@pkg.gnome?}"
     # Check to see if the trap was set, because otherwise, USR1 will
     # kill crosh.
-    # check if /tmp/.crew-autosource is opened in the parent shell as file descriptor 20
-    if File.file?("/proc/#{Process.ppid}/fd/20") && File.readlink("/proc/#{Process.ppid}/fd/20") == '/tmp/.crew-autosource'
+    if File.read("/proc/#{Process.ppid}/comm").include?('[trap set]')
       crewlog 'USR1 trap exists. Sourcing ~/.bashrc .'
       Process.kill('USR1', Process.ppid)
     else

--- a/bin/crew
+++ b/bin/crew
@@ -728,15 +728,12 @@ end
 
 def post_install
   if @pkg.print_source_bashrc? || @pkg.gnome?
-    ExitMessage.add <<~PRINT_SOURCE_BASHRC_EOT.lightblue, print_last: true
-      ~/.bashrc was automatically sourced.
-    PRINT_SOURCE_BASHRC_EOT
-      #To finish the installation, please execute the following:
-      #source ~/.bashrc
     crewlog "@pkg.print_source_bashrc?:#{@pkg.print_source_bashrc?} @pkg.gnome?:#{@pkg.gnome?}"
+    # Check to see if the env variable was set, because without the trap
+    # set, USR1 will kill crosh.
     if CREW_SOURCE_BASHRC_ENABLED
       Process.kill('USR1', Process.ppid)
-      puts '~/.bashrc was automatically sourced.'.lightblue
+      crewlog '~/.bashrc was automatically sourced.'
     else
       at_exit do
         exec 'bash'

--- a/bin/crew
+++ b/bin/crew
@@ -68,15 +68,14 @@ String.use_color = args['--color'] || !args['--no-color']
 
 @opt_force     = args['--force']
 @opt_keep      = args['--keep']
-@opt_verbose   = args['--verbose']
 @opt_source    = args['--source']
 @opt_recursive = args['--recursive-build']
 @opt_version   = args['--version']
 
 # Verbose options
-@fileutils_verbose = @opt_verbose
-@verbose           = @opt_verbose ? 'v' : ''
-@short_verbose     = @opt_verbose ? '-v' : ''
+@fileutils_verbose = CREW_VERBOSE
+@verbose           = CREW_VERBOSE ? 'v' : ''
+@short_verbose     = CREW_VERBOSE ? '-v' : ''
 
 class ExitMessage
   @messages = []
@@ -211,7 +210,7 @@ def list_packages
 end
 
 def generate_compatible
-  puts 'Generating compatible packages...'.orange if @opt_verbose
+  puts 'Generating compatible packages...'.orange if CREW_VERBOSE
   @device[:compatible_packages] = []
   Dir["#{CREW_PACKAGES_PATH}/*.rb"].each do |filename|
     pkg_name = File.basename filename, '.rb'
@@ -220,12 +219,12 @@ def generate_compatible
     rescue StandardError => e
       puts "Error with #{pkg_name}.rb: #{e}".red unless e.to_s.include?('uninitialized constant')
     end
-    puts "Checking #{pkg_name} for compatibility.".orange if @opt_verbose
+    puts "Checking #{pkg_name} for compatibility.".orange if CREW_VERBOSE
     if PackageUtils.compatible?(@pkg)
       # add to compatible packages
-      puts "Adding #{pkg_name} #{@pkg.version} to compatible packages.".lightgreen if @opt_verbose
+      puts "Adding #{pkg_name} #{@pkg.version} to compatible packages.".lightgreen if CREW_VERBOSE
       @device[:compatible_packages].push(name: @pkg.name)
-    elsif @opt_verbose
+    elsif CREW_VERBOSE
       puts "#{pkg_name} is not a compatible package.".lightred
     end
   end
@@ -233,7 +232,7 @@ def generate_compatible
     output = JSON.parse @device.to_json
     file.write JSON.pretty_generate(output)
   end
-  puts 'Generating compatible packages done.'.orange if @opt_verbose
+  puts 'Generating compatible packages done.'.orange if CREW_VERBOSE
 end
 
 def search(pkg_name, silent = false)
@@ -254,7 +253,7 @@ def regexp_search(pkg_pat)
   re = Regexp.new(pkg_pat, true)
   results = Dir["#{CREW_PACKAGES_PATH}/*.rb"] \
             .select  { |f| File.basename(f, '.rb') =~ re } \
-            .each    { |f| print_package(f, @opt_verbose) }
+            .each    { |f| print_package(f, CREW_VERBOSE) }
   if results.empty?
     Dir["#{CREW_PACKAGES_PATH}/*.rb"].each do |package_path|
       package_name = File.basename package_path, '.rb'
@@ -264,7 +263,7 @@ def regexp_search(pkg_pat)
         puts "Error with #{pkg_name}.rb: #{e}".red unless e.to_s.include?('uninitialized constant')
       end
       if @pkg.description =~ /#{pkg_pat}/i
-        print_current_package @opt_verbose
+        print_current_package CREW_VERBOSE
         results.push(package_name)
       end
     end
@@ -342,7 +341,7 @@ def update
   @device[:installed_packages].each do |package|
     search package[:name], true
     unless @pkg
-      puts "Package file for #{package[:name]} not found. :(".lightred if @opt_verbose
+      puts "Package file for #{package[:name]} not found. :(".lightred if CREW_VERBOSE
       next
     end
     different_version = (package[:version] != @pkg.version)
@@ -446,7 +445,7 @@ def upgrade(*pkgs, build_from_source: false)
     print_current_package
     @pkg.build_from_source = (build_from_source || CREW_BUILD_FROM_SOURCE)
 
-    puts "Updating #{@pkg.name}..." if @opt_verbose
+    puts "Updating #{@pkg.name}..." if CREW_VERBOSE
 
     @pkg.in_upgrade = true
     resolve_dependencies_and_install
@@ -494,24 +493,24 @@ def download
     when /\.zip$/i, /\.(tar(\.(gz|bz2|xz|lzma|lz|zst))?|tgz|tbz|tpxz|txz)$/i, /\.deb$/i, /\.AppImage$/i
       # Recall file from cache if requested
       if CREW_CACHE_ENABLED
-        puts "Looking for #{@pkg.name} archive in cache".orange if @opt_verbose
+        puts "Looking for #{@pkg.name} archive in cache".orange if CREW_VERBOSE
         # Privilege CREW_LOCAL_BUILD_DIR over CREW_CACHE_DIR.
         local_build_cachefile = File.join(CREW_LOCAL_BUILD_DIR, filename)
         crew_cache_dir_cachefile = File.join(CREW_CACHE_DIR, filename)
         cachefile = File.file?(local_build_cachefile) ? local_build_cachefile : crew_cache_dir_cachefile
         puts "Using #{@pkg.name} archive from the build cache at #{cachefile}; The checksum will not be checked against the package file.".orange if cachefile.include?(CREW_LOCAL_BUILD_DIR)
         if File.file?(cachefile)
-          puts "#{@pkg.name.capitalize} archive file exists in cache".lightgreen if @opt_verbose
+          puts "#{@pkg.name.capitalize} archive file exists in cache".lightgreen if CREW_VERBOSE
           # Don't check checksum if file is in the build cache.
           if Digest::SHA256.hexdigest(File.read(cachefile)) == sha256sum || sha256sum =~ /^SKIP$/i || cachefile.include?(CREW_LOCAL_BUILD_DIR)
             begin
               # Hard link cached file if possible.
               FileUtils.ln cachefile, CREW_BREW_DIR, force: true, verbose: @fileutils_verbose unless File.identical?(cachefile, "#{CREW_BREW_DIR}/#{filename}")
-              puts 'Archive hard linked from cache'.green if @opt_verbose
+              puts 'Archive hard linked from cache'.green if CREW_VERBOSE
             rescue StandardError
               # Copy cached file if hard link fails.
               FileUtils.cp cachefile, CREW_BREW_DIR, verbose: @fileutils_verbose unless File.identical?(cachefile, "#{CREW_BREW_DIR}/#{filename}")
-              puts 'Archive copied from cache'.green if @opt_verbose
+              puts 'Archive copied from cache'.green if CREW_VERBOSE
             end
             puts 'Archive found in cache'.lightgreen
             return { source:, filename: }
@@ -525,7 +524,7 @@ def download
         end
       end
       # Download file if not cached.
-      downloader url, sha256sum, filename, @opt_verbose
+      downloader url, sha256sum, filename, CREW_VERBOSE
 
       puts "#{@pkg.name.capitalize} archive downloaded.".lightgreen
       # Stow file in cache if requested, if file is not from cache,
@@ -534,11 +533,11 @@ def download
         begin
           # Hard link to cache if possible.
           FileUtils.ln filename, CREW_CACHE_DIR, verbose: @fileutils_verbose
-          puts 'Archive hard linked to cache'.green if @opt_verbose
+          puts 'Archive hard linked to cache'.green if CREW_VERBOSE
         rescue StandardError
           # Copy to cache if hard link fails.
           FileUtils.cp filename, CREW_CACHE_DIR, verbose: @fileutils_verbose
-          puts 'Archive copied to cache'.green if @opt_verbose
+          puts 'Archive copied to cache'.green if CREW_VERBOSE
         end
       end
       return { source:, filename: }
@@ -549,7 +548,7 @@ def download
       git = true
     else
       Dir.mkdir @extract_dir
-      downloader url, sha256sum, filename, @opt_verbose
+      downloader url, sha256sum, filename, CREW_VERBOSE
 
       puts "#{filename}: File downloaded.".lightgreen
 
@@ -572,7 +571,7 @@ def download
           # Use to the day granularity for a branch timestamp with no specific commit specified.
           cachefile = File.join(CREW_CACHE_DIR, "#{filename}#{@pkg.git_branch.gsub(/[^0-9A-Za-z.-]/, '_')}#{Time.now.strftime('%m%d%Y')}.tar.zst")
         end
-        puts "Git cachefile is #{cachefile}".orange if @opt_verbose
+        puts "Git cachefile is #{cachefile}".orange if CREW_VERBOSE
         if File.file?(cachefile) && File.file?("#{cachefile}.sha256")
           if Dir.chdir CREW_CACHE_DIR do
                system "sha256sum -c #{cachefile}.sha256"
@@ -646,7 +645,7 @@ def unpack(meta)
       case File.basename meta[:filename]
       when /\.zip$/i
         puts "Unpacking archive using 'unzip', this may take a while..."
-        system 'unzip', (@opt_verbose ? '-v' : '-qq'), '-d', @extract_dir, meta[:filename], exception: true
+        system 'unzip', (CREW_VERBOSE ? '-v' : '-qq'), '-d', @extract_dir, meta[:filename], exception: true
       when /\.(tar(\.(gz|bz2|xz|lzma|lz))?|tgz|tbz|txz|tpxz)$/i
         puts "Unpacking archive using 'tar', this may take a while..."
         system 'tar', "-x#{@verbose}f", meta[:filename], '-C', @extract_dir, exception: true
@@ -667,7 +666,7 @@ def unpack(meta)
       # Check the number of directories in the archive
       entries = Dir["#{@extract_dir}/*"]
 
-      if entries.empty? && @opt_verbose
+      if entries.empty? && CREW_VERBOSE
         # This will happen with SKIP packages.
         puts "Empty archive: #{meta[:filename]}".orange
       end
@@ -906,9 +905,9 @@ def patchelf_set_need_paths(dir)
     return if execfiles.empty?
 
     patchelf_lib_prefix = @pkg.is_musl? ? "#{CREW_MUSL_PREFIX}/lib" : CREW_LIB_PREFIX
-    puts "patchelf_lib_prefix is #{patchelf_lib_prefix}" if @opt_verbose
+    puts "patchelf_lib_prefix is #{patchelf_lib_prefix}" if CREW_VERBOSE
     patchelf_interpreter = @pkg.is_musl? ? "#{CREW_MUSL_PREFIX}/lib/libc.so" : 'CREW_LIB_PREFIX/libc.so.6'
-    puts "patchelf_interpreter is #{patchelf_interpreter}" if @opt_verbose
+    puts "patchelf_interpreter is #{patchelf_interpreter}" if CREW_VERBOSE
 
     puts 'Running patchelf to patch binaries for library paths'.lightblue
     execfiles.each_line(chomp: true) do |execfiletopatch|
@@ -935,7 +934,7 @@ def patchelf_set_need_paths(dir)
         # hierarchy for neededlib_basename if the intent is to allow
         # using a different CREW_PREFIX during package installs.
         if File.file?(neededlibspatchednamepath) || File.file?(Dir.pwd + neededlibspatchednamepath)
-          puts "patchelf --replace-needed #{neededlibspatch} #{neededlibspatchednamepath} #{execfiletopatch}" if @opt_verbose
+          puts "patchelf --replace-needed #{neededlibspatch} #{neededlibspatchednamepath} #{execfiletopatch}" if CREW_VERBOSE
           system "patchelf --replace-needed #{neededlibspatch} #{neededlibspatchednamepath} #{execfiletopatch}"
         else
           puts "#{execfiletopatch} needed library #{neededlib_basename} not found in #{patchelf_lib_prefix} or #{Dir.pwd + neededlibspatchednamepath}.".lightred
@@ -958,7 +957,7 @@ def strip_find_files(find_cmd, strip_option = '')
 
   # Run find_cmd and strip only files with ar or elf magic headers.
   system "#{find_cmd} | xargs -r chmod u+w"
-  strip_verbose = @opt_verbose ? 'echo "Stripping ${0:1}" &&' : ''
+  strip_verbose = CREW_VERBOSE ? 'echo "Stripping ${0:1}" &&' : ''
   # The craziness here is from having to escape the special characters
   # in the magic headers for these files.
   system "#{find_cmd} | xargs -P#{CREW_NPROC} -n1 -r bash -c 'header=$(head -c4 ${0}); elfheader='$(printf '\\\177ELF')' ; arheader=\\!\\<ar ; case $header in $elfheader|$arheader) #{strip_verbose} llvm-strip #{strip_option} ${0} ;; esac'"
@@ -1038,11 +1037,11 @@ def shrink_dir(dir)
               puts "Attempting to compress #{execfile} ...".orange
               # Make tmp file for compression
               unless system "upx --lzma #{execfile}-crewupxtmp"
-                puts "Compression of #{execfile} failed...".orange if @opt_verbose
+                puts "Compression of #{execfile} failed...".orange if CREW_VERBOSE
                 FileUtils.rm_f "#{execfile}-crewupxtmp"
               end
               if File.file?("#{execfile}-crewupxtmp")
-                puts "Testing compressed #{execfile}...".lightblue if @opt_verbose
+                puts "Testing compressed #{execfile}...".lightblue if CREW_VERBOSE
                 if system 'upx', '-t', "#{execfile}-crewupxtmp"
                   puts "#{execfile} successfully compressed...".lightgreen
                   FileUtils.cp "#{execfile}-crewupxtmp", execfile
@@ -1098,16 +1097,16 @@ def install_package(pkgdir)
     unless CREW_NOT_LINKS || @pkg.no_links?
       brokensymlinks = `find . -type l -exec test ! -e {} \\; -print`.chomp
       unless brokensymlinks.to_s.empty?
-        puts 'There are broken symlinks. Will try to fix.'.orange if @opt_verbose
+        puts 'There are broken symlinks. Will try to fix.'.orange if CREW_VERBOSE
         brokensymlinks.each_line(chomp: true) do |fixlink|
           brokentarget = `readlink -n #{fixlink}`.chomp
-          puts "Attempting fix of: #{fixlink.delete_prefix('.')} -> #{brokentarget}".orange if @opt_verbose
+          puts "Attempting fix of: #{fixlink.delete_prefix('.')} -> #{brokentarget}".orange if CREW_VERBOSE
           fixedtarget = brokentarget.delete_prefix(CREW_DEST_DIR)
           fixedlink_loc = File.join(pkgdir, fixlink.delete_prefix('.'))
           # If no changes were made, don't replace symlink
           unless fixedtarget == brokentarget
             FileUtils.ln_sf fixedtarget, fixedlink_loc
-            puts "Fixed: #{fixedtarget} -> #{fixlink.delete_prefix('.')}".orange if @opt_verbose
+            puts "Fixed: #{fixedtarget} -> #{fixlink.delete_prefix('.')}".orange if CREW_VERBOSE
           end
         end
       end
@@ -1290,11 +1289,11 @@ def install
   # remove it just before the file copy
   if @pkg.in_upgrade
     puts 'Removing since upgrade or reinstall...'
-    Command.remove(@pkg, @opt_verbose)
+    Command.remove(@pkg, CREW_VERBOSE)
   end
 
   if @pkg.is_fake?
-    puts "Install will be skipped since #{@pkg.name} is a fake package.".orange if @opt_verbose
+    puts "Install will be skipped since #{@pkg.name} is a fake package.".orange if CREW_VERBOSE
   else
     # perform pre-install process
     pre_install dest_dir
@@ -1391,7 +1390,7 @@ def archive_package(crew_archive_dest)
       # See https://lists.archlinux.org/pipermail/arch-dev-public/2019-March/029542.html
       # Use nice so that user can (possibly) do other things during compression.
       if crew_prefix_zstd_available
-        puts 'Using standard zstd'.lightblue if @opt_verbose
+        puts 'Using standard zstd'.lightblue if CREW_VERBOSE
         system "tar c#{@verbose} * | nice -n 20 #{CREW_PREFIX}/bin/zstd -c -T0 --ultra -20 - > #{crew_archive_dest}/#{pkg_name}"
       end
     end
@@ -1522,13 +1521,13 @@ def upload(pkg_name = nil)
         puts "Setting binary compression in #{pkg_file}..."
         # Add binary compression setting, and add the line if it doesn't exist.
         if File.read(pkg_file).include?('binary_compression')
-          puts "sed -i \"s/binary_compression.*/binary_compression 'tar#{ext}'/\" #{pkg_file}" if @opt_verbose
+          puts "sed -i \"s/binary_compression.*/binary_compression 'tar#{ext}'/\" #{pkg_file}" if CREW_VERBOSE
           system "sed -i \"s/binary_compression.*/binary_compression 'tar#{ext}'/\" #{pkg_file}"
         elsif File.read(pkg_file).include?('source_sha256')
-          puts "sed -i \"/source_sha256/a \\\ \\\ binary_compression 'tar#{ext}'\" #{pkg_file}" if @opt_verbose
+          puts "sed -i \"/source_sha256/a \\\ \\\ binary_compression 'tar#{ext}'\" #{pkg_file}" if CREW_VERBOSE
           system "sed -i \"/source_sha256/a \\\ \\\ binary_compression 'tar#{ext}'\" #{pkg_file}"
         elsif File.read(pkg_file).include?('git_hashtag')
-          puts "sed -i \"/git_hashtag/a \\\ \\\ binary_compression 'tar#{ext}'\" #{pkg_file}" if @opt_verbose
+          puts "sed -i \"/git_hashtag/a \\\ \\\ binary_compression 'tar#{ext}'\" #{pkg_file}" if CREW_VERBOSE
           system "sed -i \"/git_hashtag/a \\\ \\\ binary_compression 'tar#{ext}'\" #{pkg_file}"
         else
           puts "Unable to tell where to add \"binary_compression 'tar#{ext}'\" to #{pkg_file}. Please add it and manually.".lightblue
@@ -1543,15 +1542,15 @@ def upload(pkg_name = nil)
       new_version = noname.split('-chromeos').first
       new_url = "#{base_url}/#{package}/#{new_version}_#{arch}/#{new_tarfile}".gsub("#{release_dir}/", '')
       token_label = gitlab_token.split('-').first == 'glpat' ? 'PRIVATE-TOKEN' : 'DEPLOY-TOKEN'
-      puts "curl -# --header \"#{token_label}: #{gitlab_token}\" --upload-file \"#{new_tarfile}\" \"#{new_url}\" | cat" if @opt_verbose
+      puts "curl -# --header \"#{token_label}: #{gitlab_token}\" --upload-file \"#{new_tarfile}\" \"#{new_url}\" | cat" if CREW_VERBOSE
       output = `curl -# --header "#{token_label}: #{gitlab_token}" --upload-file "#{new_tarfile}" "#{new_url}" | cat`.chomp
       if output.include?('201 Created')
-        puts "curl -Ls #{new_url} | sha256sum" if @opt_verbose
+        puts "curl -Ls #{new_url} | sha256sum" if CREW_VERBOSE
         upstream_sha256 = `curl -Ls #{new_url} | sha256sum`.chomp.split.first
         if upstream_sha256 == new_sha256
           puts output.lightgreen
         else
-          if @opt_verbose
+          if CREW_VERBOSE
             puts "expected sha256 hash=#{new_sha256}"
             puts "upstream sha256 hash=#{upstream_sha256}"
           end
@@ -1566,7 +1565,7 @@ def upload(pkg_name = nil)
       old_sha256 = `grep -m 1 #{arch}: #{pkg_file} 2> /dev/null`.chomp
       if old_sha256.empty?
         unless File.readlines(pkg_file).grep(/binary_sha256/).any?
-          if @opt_verbose
+          if CREW_VERBOSE
             puts "sed -e '/binary_compression/ a\\
 \\
 \\ \\ binary_sha256({' -i #{pkg_file}"
@@ -1589,7 +1588,7 @@ def upload(pkg_name = nil)
           puts "Updating binary_sha256 in #{pkg_file}..."
           puts "from: #{arch}: '#{old_sha256}'"
           puts "  to: #{arch}: '#{new_sha256}'"
-          puts "sed -i 's/#{old_sha256}/#{new_sha256}/g' #{pkg_file}" if @opt_verbose
+          puts "sed -i 's/#{old_sha256}/#{new_sha256}/g' #{pkg_file}" if CREW_VERBOSE
           system "sed -i 's/#{old_sha256}/#{new_sha256}/g' #{pkg_file}"
         end
       end
@@ -1615,10 +1614,10 @@ def update_sha256(package, key, value)
   end
   comma = key == 'x86_64' ? '\\n\\ \\ })' : ','
   if File.readlines(package).grep(/#{key}:/).any?
-    puts "sed -e \"/#{key}:.*['\"][0-9a-f]*['\"]/c#{leading_space}#{key}: '#{value}'#{comma}\" -i #{package}" if @opt_verbose
+    puts "sed -e \"/#{key}:.*['\"][0-9a-f]*['\"]/c#{leading_space}#{key}: '#{value}'#{comma}\" -i #{package}" if CREW_VERBOSE
     system "sed -e \"/#{key}:.*['\"][0-9a-f]*['\"]/c#{leading_space}#{key}: '#{value}'#{comma}\" -i #{package}"
   else
-    puts "sed -e \"/binary_sha256.*({/a#{leading_space}#{key}: '#{value}'#{comma}\" -i #{package}" if @opt_verbose
+    puts "sed -e \"/binary_sha256.*({/a#{leading_space}#{key}: '#{value}'#{comma}\" -i #{package}" if CREW_VERBOSE
     system "sed -e \"/binary_sha256.*({/a#{leading_space}#{key}: '#{value}'#{comma}\" -i #{package}"
   end
 end
@@ -1691,7 +1690,7 @@ def build_command(args)
     next if check_package(@pkg_name)
 
     search @pkg_name
-    print_current_package @opt_verbose
+    print_current_package CREW_VERBOSE
     next unless @pkg_name
 
     # Process preflight block to see if package should be built
@@ -1754,7 +1753,7 @@ def download_command(args)
     @pkg_name = name
     search @pkg_name
     @pkg.build_from_source = true if @opt_source
-    print_current_package @opt_verbose
+    print_current_package CREW_VERBOSE
     download
   end
 end
@@ -1794,7 +1793,7 @@ def install_command(args)
 end
 
 def list_command(args)
-  Command.list(args['available'], args['installed'], args['compatible'], args['incompatible'], @opt_verbose)
+  Command.list(args['available'], args['installed'], args['compatible'], args['incompatible'], CREW_VERBOSE)
 end
 
 def postinstall_command(args)
@@ -1835,7 +1834,7 @@ end
 def remove_command(args)
   args['<name>'].each do |name|
     search name
-    Command.remove(@pkg, @opt_verbose)
+    Command.remove(@pkg, CREW_VERBOSE)
   end
 end
 
@@ -1846,7 +1845,7 @@ def search_command(args)
 end
 
 def sysinfo_command(_args)
-  Command.sysinfo(@opt_verbose)
+  Command.sysinfo(CREW_VERBOSE)
 end
 
 def test_command(args)

--- a/bin/crew
+++ b/bin/crew
@@ -111,23 +111,26 @@ at_exit do
   end
   require 'active_support/core_ext/object/blank'
   GnomePostinstall.run unless GnomePostinstall.gnome_packages.blank?
-  # Print exit messages.
-  ExitMessage.print
 
   if @pkg.print_source_bashrc? || @pkg.gnome?
     crewlog "@pkg.print_source_bashrc?:#{@pkg.print_source_bashrc?} @pkg.gnome?:#{@pkg.gnome?}"
     # Check to see if the trap was set, because otherwise, USR1 will
     # kill crosh.
-    if CREW_SOURCE_BASHRC_ACTIVATED
+    # check if /tmp/.crew-autosource is opened in the parent shell as file descriptor 20
+    if File.readlink("/proc/#{Process.ppid}/fd/20") == '/tmp/.crew-autosource'
       crewlog 'USR1 trap exists. Sourcing ~/.bashrc .'
       Process.kill('USR1', Process.ppid)
     else
-      at_exit do
-        crewlog 'USR1 trap does not exist. Spawning shell to source ~/.bashrc .'
-        exec 'bash'
-      end
+      ExitMessage.add <<~PRINT_SOURCE_BASHRC_EOT.lightblue, print_last: true
+
+        To finish the installation, please execute the following:
+        source ~/.bashrc
+      PRINT_SOURCE_BASHRC_EOT
     end
   end
+
+  # Print exit messages.
+  ExitMessage.print
 end
 
 def crewlog(str)

--- a/bin/crew
+++ b/bin/crew
@@ -731,7 +731,7 @@ def post_install
     crewlog "@pkg.print_source_bashrc?:#{@pkg.print_source_bashrc?} @pkg.gnome?:#{@pkg.gnome?}"
     # Check to see if the env variable was set, because without the trap
     # set, USR1 will kill crosh.
-    if CREW_SOURCE_BASHRC_ENABLED
+    if CREW_SOURCE_BASHRC_ACTIVATED
       Process.kill('USR1', Process.ppid)
       crewlog '~/.bashrc was automatically sourced.'
     else

--- a/bin/crew
+++ b/bin/crew
@@ -731,15 +731,14 @@ def post_install
     crewlog "@pkg.print_source_bashrc?:#{@pkg.print_source_bashrc?} @pkg.gnome?:#{@pkg.gnome?}"
     # Check to see if the trap was set, because otherwise, USR1 will
     # kill crosh.
-    if `bash --noprofile --norc -c 'trap -p USR1|grep -v "source ~/.bashrc"'`.chomp
-      # trap not set. Just spawn a new shell at exit.
+    if CREW_SOURCE_BASHRC_ACTIVATED
+      crewlog 'USR1 trap exists. Sourcing ~/.bashrc .'
+      Process.kill('USR1', Process.ppid)
+    else
       at_exit do
         crewlog 'USR1 trap does not exist. Spawning shell to source ~/.bashrc .'
         exec 'bash'
       end
-    else
-      crewlog 'USR1 trap exists. Sourcing ~/.bashrc .'
-      Process.kill('USR1', Process.ppid)
     end
   end
 

--- a/bin/crew
+++ b/bin/crew
@@ -112,7 +112,7 @@ at_exit do
   require 'active_support/core_ext/object/blank'
   GnomePostinstall.run unless GnomePostinstall.gnome_packages.blank?
 
-  if @pkg.print_source_bashrc? || @pkg.gnome?
+  if @pkg&.print_source_bashrc? || @pkg&.gnome?
     crewlog "@pkg.print_source_bashrc?:#{@pkg.print_source_bashrc?} @pkg.gnome?:#{@pkg.gnome?}"
     # Check to see if the trap was set, because otherwise, USR1 will
     # kill crosh.

--- a/bin/crew
+++ b/bin/crew
@@ -13,6 +13,7 @@ require_relative '../commands/remove'
 require_relative '../commands/sysinfo'
 require_relative '../lib/color'
 require_relative '../lib/const'
+require_relative '../lib/crewlog'
 require_relative '../lib/deb_utils'
 require_relative '../lib/docopt'
 require_relative '../lib/downloader'
@@ -130,10 +131,6 @@ at_exit do
 
   # Print exit messages.
   ExitMessage.print
-end
-
-def crewlog(str)
-  caller_locations(1, 1).first.tap {|loc| puts "#{loc.path}:#{loc.lineno}:#{caller_locations(3).first.label}:#{str}".lightpurple if @opt_verbose}
 end
 
 def load_json

--- a/bin/crew
+++ b/bin/crew
@@ -77,7 +77,6 @@ String.use_color = args['--color'] || !args['--no-color']
 @fileutils_verbose = @opt_verbose
 @verbose           = @opt_verbose ? 'v' : ''
 @short_verbose     = @opt_verbose ? '-v' : ''
-$verbose = @verbose
 
 class ExitMessage
   @messages = []

--- a/bin/crew
+++ b/bin/crew
@@ -728,11 +728,14 @@ end
 
 def post_install
   if @pkg.print_source_bashrc? || @pkg.gnome?
-    ExitMessage.add <<~PRINT_SOURCE_BASHRC_EOT.lightblue, print_last: true
+    #ExitMessage.add <<~PRINT_SOURCE_BASHRC_EOT.lightblue, print_last: true
 
-      To finish the installation, please execute the following:
-      source ~/.bashrc
-    PRINT_SOURCE_BASHRC_EOT
+      #To finish the installation, please execute the following:
+      #source ~/.bashrc
+    #PRINT_SOURCE_BASHRC_EOT
+    at_exit do
+      Process.kill('USR1', Process.ppid)
+    end
   end
 
   GnomePostinstall.add @pkg.name if @pkg.gnome?

--- a/bin/crew
+++ b/bin/crew
@@ -114,8 +114,8 @@ at_exit do
 
   if @pkg&.print_source_bashrc? || @pkg&.gnome?
     crewlog "@pkg.print_source_bashrc?:#{@pkg.print_source_bashrc?} @pkg.gnome?:#{@pkg.gnome?}"
-    # Check to see if the trap was set, because otherwise, USR1 will
-    # kill crosh.
+    # Check to see if the trap was set in #{CREW_PREFIX}/etc/profile
+    # from crew_profile_base, because otherwise, USR1 will kill crosh.
     if File.read("/proc/#{Process.ppid}/comm").include?('[trap set]')
       crewlog 'USR1 trap exists. Sourcing ~/.bashrc .'
       Process.kill('USR1', Process.ppid)

--- a/bin/crew
+++ b/bin/crew
@@ -146,7 +146,7 @@ def load_json
 end
 
 def save_json(json_object)
-  crewlog 'Saving device.json...'
+  # crewlog 'Saving device.json...'
   begin
     File.write File.join(CREW_CONFIG_PATH, 'device.json.tmp'), JSON.pretty_generate(JSON.parse(json_object.to_json))
   rescue StandardError
@@ -1316,7 +1316,7 @@ def install
     crewlog "Removing package #{@pkg.name} from device.json since a version is already marked as installed."
     @device[:installed_packages].delete_if { |entry| entry[:name] == @pkg.name }
   end
-  crewlog "Adding package #{@pkg.name} to device.json."
+  # crewlog "Adding package #{@pkg.name} to device.json."
   @device[:installed_packages].push(name: @pkg.name, version: @pkg.version, sha256: PackageUtils.get_sha256(@pkg, build_from_source: @opt_source))
   save_json(@device)
 end

--- a/bin/crew
+++ b/bin/crew
@@ -113,7 +113,7 @@ at_exit do
   GnomePostinstall.run unless GnomePostinstall.gnome_packages.blank?
 
   if @pkg&.print_source_bashrc? || @pkg&.gnome?
-    # crewlog "@pkg.print_source_bashrc?:#{@pkg.print_source_bashrc?} @pkg.gnome?:#{@pkg.gnome?}"
+    crewlog "@pkg.print_source_bashrc?:#{@pkg.print_source_bashrc?} @pkg.gnome?:#{@pkg.gnome?}"
     # Check to see if the trap was set in #{CREW_PREFIX}/etc/profile
     # from crew_profile_base, because otherwise, USR1 will kill crosh.
     if File.read("/proc/#{Process.ppid}/comm").include?('[trap set]')
@@ -142,7 +142,7 @@ def load_json
 end
 
 def save_json(json_object)
-  # crewlog 'Saving device.json...'
+  crewlog 'Saving device.json...'
   begin
     File.write File.join(CREW_CONFIG_PATH, 'device.json.tmp'), JSON.pretty_generate(JSON.parse(json_object.to_json))
   rescue StandardError
@@ -1309,10 +1309,10 @@ def install
 
   # Add to installed packages list in devices.json, but remove first if it is already there.
   if PackageUtils.installed?(@pkg.name)
-    # crewlog "Removing package #{@pkg.name} from device.json since a version is already marked as installed."
+    crewlog "Removing package #{@pkg.name} from device.json since a version is already marked as installed."
     @device[:installed_packages].delete_if { |entry| entry[:name] == @pkg.name }
   end
-  # crewlog "Adding package #{@pkg.name} to device.json."
+  crewlog "Adding package #{@pkg.name} to device.json."
   @device[:installed_packages].push(name: @pkg.name, version: @pkg.version, sha256: PackageUtils.get_sha256(@pkg, build_from_source: @opt_source))
   save_json(@device)
 end

--- a/bin/crew
+++ b/bin/crew
@@ -731,15 +731,15 @@ def post_install
     crewlog "@pkg.print_source_bashrc?:#{@pkg.print_source_bashrc?} @pkg.gnome?:#{@pkg.gnome?}"
     # Check to see if the trap was set, because otherwise, USR1 will
     # kill crosh.
-    if `trap -p USR1|grep -q 'source ~/.bashrc'`.chomp
-      crewlog 'USR1 trap exists. Sourcing ~/.bashrc .'
-      Process.kill('USR1', Process.ppid)
-    else
+    if `bash --noprofile --norc -c 'trap -p USR1|grep -v "source ~/.bashrc"'`.chomp
       # trap not set. Just spawn a new shell at exit.
       at_exit do
         crewlog 'USR1 trap does not exist. Spawning shell to source ~/.bashrc .'
         exec 'bash'
       end
+    else
+      crewlog 'USR1 trap exists. Sourcing ~/.bashrc .'
+      Process.kill('USR1', Process.ppid)
     end
   end
 

--- a/bin/crew
+++ b/bin/crew
@@ -117,7 +117,7 @@ at_exit do
     # Check to see if the trap was set, because otherwise, USR1 will
     # kill crosh.
     # check if /tmp/.crew-autosource is opened in the parent shell as file descriptor 20
-    if File.readlink("/proc/#{Process.ppid}/fd/20") == '/tmp/.crew-autosource'
+    if File.file?("/proc/#{Process.ppid}/fd/20") && File.readlink("/proc/#{Process.ppid}/fd/20") == '/tmp/.crew-autosource'
       crewlog 'USR1 trap exists. Sourcing ~/.bashrc .'
       Process.kill('USR1', Process.ppid)
     else

--- a/bin/crew
+++ b/bin/crew
@@ -728,11 +728,12 @@ end
 
 def post_install
   if @pkg.print_source_bashrc? || @pkg.gnome?
-    #ExitMessage.add <<~PRINT_SOURCE_BASHRC_EOT.lightblue, print_last: true
-
+    ExitMessage.add <<~PRINT_SOURCE_BASHRC_EOT.lightblue, print_last: true
+    ~/.bashrc will automatically be sourced.
+    PRINT_SOURCE_BASHRC_EOT
       #To finish the installation, please execute the following:
       #source ~/.bashrc
-    #PRINT_SOURCE_BASHRC_EOT
+
     at_exit do
       Process.kill('USR1', Process.ppid)
     end

--- a/bin/crew
+++ b/bin/crew
@@ -113,7 +113,7 @@ at_exit do
   GnomePostinstall.run unless GnomePostinstall.gnome_packages.blank?
 
   if @pkg&.print_source_bashrc? || @pkg&.gnome?
-    crewlog "@pkg.print_source_bashrc?:#{@pkg.print_source_bashrc?} @pkg.gnome?:#{@pkg.gnome?}"
+    # crewlog "@pkg.print_source_bashrc?:#{@pkg.print_source_bashrc?} @pkg.gnome?:#{@pkg.gnome?}"
     # Check to see if the trap was set in #{CREW_PREFIX}/etc/profile
     # from crew_profile_base, because otherwise, USR1 will kill crosh.
     if File.read("/proc/#{Process.ppid}/comm").include?('[trap set]')
@@ -1309,7 +1309,7 @@ def install
 
   # Add to installed packages list in devices.json, but remove first if it is already there.
   if PackageUtils.installed?(@pkg.name)
-    crewlog "Removing package #{@pkg.name} from device.json since a version is already marked as installed."
+    # crewlog "Removing package #{@pkg.name} from device.json since a version is already marked as installed."
     @device[:installed_packages].delete_if { |entry| entry[:name] == @pkg.name }
   end
   # crewlog "Adding package #{@pkg.name} to device.json."

--- a/bin/crew
+++ b/bin/crew
@@ -729,13 +729,15 @@ end
 def post_install
   if @pkg.print_source_bashrc? || @pkg.gnome?
     crewlog "@pkg.print_source_bashrc?:#{@pkg.print_source_bashrc?} @pkg.gnome?:#{@pkg.gnome?}"
-    # Check to see if the env variable was set, because without the trap
-    # set, USR1 will kill crosh.
-    if CREW_SOURCE_BASHRC_ACTIVATED
+    # Check to see if the trap was set, because otherwise, USR1 will
+    # kill crosh.
+    if `trap -p USR1|grep -q 'source ~/.bashrc'`.chomp
+      crewlog 'USR1 trap exists. Sourcing ~/.bashrc .'
       Process.kill('USR1', Process.ppid)
-      crewlog '~/.bashrc was automatically sourced.'
     else
+      # trap not set. Just spawn a new shell at exit.
       at_exit do
+        crewlog 'USR1 trap does not exist. Spawning shell to source ~/.bashrc .'
         exec 'bash'
       end
     end

--- a/bin/crew
+++ b/bin/crew
@@ -113,6 +113,21 @@ at_exit do
   GnomePostinstall.run unless GnomePostinstall.gnome_packages.blank?
   # Print exit messages.
   ExitMessage.print
+
+  if @pkg.print_source_bashrc? || @pkg.gnome?
+    crewlog "@pkg.print_source_bashrc?:#{@pkg.print_source_bashrc?} @pkg.gnome?:#{@pkg.gnome?}"
+    # Check to see if the trap was set, because otherwise, USR1 will
+    # kill crosh.
+    if CREW_SOURCE_BASHRC_ACTIVATED
+      crewlog 'USR1 trap exists. Sourcing ~/.bashrc .'
+      Process.kill('USR1', Process.ppid)
+    else
+      at_exit do
+        crewlog 'USR1 trap does not exist. Spawning shell to source ~/.bashrc .'
+        exec 'bash'
+      end
+    end
+  end
 end
 
 def crewlog(str)
@@ -727,21 +742,6 @@ def pre_install(dest_dir)
 end
 
 def post_install
-  if @pkg.print_source_bashrc? || @pkg.gnome?
-    crewlog "@pkg.print_source_bashrc?:#{@pkg.print_source_bashrc?} @pkg.gnome?:#{@pkg.gnome?}"
-    # Check to see if the trap was set, because otherwise, USR1 will
-    # kill crosh.
-    if CREW_SOURCE_BASHRC_ACTIVATED
-      crewlog 'USR1 trap exists. Sourcing ~/.bashrc .'
-      Process.kill('USR1', Process.ppid)
-    else
-      at_exit do
-        crewlog 'USR1 trap does not exist. Spawning shell to source ~/.bashrc .'
-        exec 'bash'
-      end
-    end
-  end
-
   GnomePostinstall.add @pkg.name if @pkg.gnome?
 
   # return unless the postinstall function was defined by the package recipe

--- a/install.sh
+++ b/install.sh
@@ -370,5 +370,3 @@ You may wish to edit the ${CREW_PREFIX}/etc/env.d/02-editor file for an editor d
 Chromebrew provides nano, vim and emacs as default TUI editor options."
 
 echo_success "Chromebrew installed successfully and package lists updated."
-# Exit into a new shell so that the source_bashrc trap in ${CREW_PREFIX}/etc/profile is loaded.
-exec "${CREW_PREFIX}/bin/bash"

--- a/install.sh
+++ b/install.sh
@@ -370,3 +370,5 @@ You may wish to edit the ${CREW_PREFIX}/etc/env.d/02-editor file for an editor d
 Chromebrew provides nano, vim and emacs as default TUI editor options."
 
 echo_success "Chromebrew installed successfully and package lists updated."
+# Exit into a new shell so that the source_bashrc trap in ${CREW_PREFIX}/etc/profile is loaded.
+exec "${CREW_PREFIX}/bin/bash"

--- a/lib/buildsystems/pip.rb
+++ b/lib/buildsystems/pip.rb
@@ -2,15 +2,16 @@ Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
 require 'json'
 require 'package'
+require_relative '../const'
 
 class Pip < Package
   property :pip_install_extras, :pre_configure_options
 
   def self.install
-    puts 'Checking for pip updates'.orange if @opt_verbose
+    puts 'Checking for pip updates'.orange if CREW_VERBOSE
     system "python3 -s -m pip install -U pip | grep -v 'Requirement already satisfied'", exception: false
     @py_pkg = name.gsub('py3_', '')
-    puts "Checking for #{@py_pkg} python dependencies...".orange if @opt_verbose
+    puts "Checking for #{@py_pkg} python dependencies...".orange if CREW_VERBOSE
     @py_pkg_pypi = `curl -Ls https://pypi.org/pypi/#{@py_pkg}/json`.chomp
     @py_pkg_pypi_hash = JSON.parse(@py_pkg_pypi)
     @py_pkg_version = @py_pkg_pypi_hash['info']['version']

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -117,7 +117,7 @@ CREW_CACHE_DIR          = ENV.fetch('CREW_CACHE_DIR', "#{HOME}/.cache/crewcache"
 CREW_CACHE_BUILD        = ENV.fetch('CREW_CACHE_BUILD', '0').eql?('1')
 CREW_CACHE_FAILED_BUILD = ENV.fetch('CREW_CACHE_FAILED_BUILD', '0').eql?('1')
 
-CREW_VERBOSE = %w[-v --verbose].include?(ARGV)
+CREW_VERBOSE = ARGV.intersect?(%w[-v --verbose])
 
 # Set CREW_NPROC from environment variable, `distcc -j`, or `nproc`.
 CREW_NPROC = if File.file?("#{CREW_PREFIX}/bin/distcc")

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -117,6 +117,8 @@ CREW_CACHE_DIR          = ENV.fetch('CREW_CACHE_DIR', "#{HOME}/.cache/crewcache"
 CREW_CACHE_BUILD        = ENV.fetch('CREW_CACHE_BUILD', '0').eql?('1')
 CREW_CACHE_FAILED_BUILD = ENV.fetch('CREW_CACHE_FAILED_BUILD', '0').eql?('1')
 
+CREW_VERBOSE = %w[-v --verbose].include?(ARGV)
+
 # Set CREW_NPROC from environment variable, `distcc -j`, or `nproc`.
 CREW_NPROC = if File.file?("#{CREW_PREFIX}/bin/distcc")
                ENV.fetch('CREW_NPROC', `distcc -j`.chomp)

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -116,6 +116,7 @@ CREW_DEST_HOME          = File.join(CREW_DEST_DIR, HOME)
 CREW_CACHE_DIR          = ENV.fetch('CREW_CACHE_DIR', "#{HOME}/.cache/crewcache")
 CREW_CACHE_BUILD        = ENV.fetch('CREW_CACHE_BUILD', '0').eql?('1')
 CREW_CACHE_FAILED_BUILD = ENV.fetch('CREW_CACHE_FAILED_BUILD', '0').eql?('1')
+CREW_SOURCE_BASHRC_ACTIVATED = ENV.fetch('CREW_SOURCE_BASHRC_ACTIVATED', '0').eql?('1')
 
 # Set CREW_NPROC from environment variable, `distcc -j`, or `nproc`.
 CREW_NPROC = if File.file?("#{CREW_PREFIX}/bin/distcc")

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -116,6 +116,7 @@ CREW_DEST_HOME          = File.join(CREW_DEST_DIR, HOME)
 CREW_CACHE_DIR          = ENV.fetch('CREW_CACHE_DIR', "#{HOME}/.cache/crewcache")
 CREW_CACHE_BUILD        = ENV.fetch('CREW_CACHE_BUILD', '0').eql?('1')
 CREW_CACHE_FAILED_BUILD = ENV.fetch('CREW_CACHE_FAILED_BUILD', '0').eql?('1')
+CREW_SOURCE_BASHRC_ENABLED = ENV.fetch('CREW_SOURCE_BASHRC_ENABLED', '0').eql?('1')
 
 # Set CREW_NPROC from environment variable, `distcc -j`, or `nproc`.
 CREW_NPROC = if File.file?("#{CREW_PREFIX}/bin/distcc")
@@ -133,7 +134,6 @@ CREW_NOT_COMPRESS                    = ENV.fetch('CREW_NOT_COMPRESS', '0').eql?(
 CREW_NOT_LINKS                       = ENV.fetch('CREW_NOT_LINKS', '0').eql?('1')                       # or use no_links
 CREW_NOT_STRIP                       = ENV.fetch('CREW_NOT_STRIP', '0').eql?('1')                       # or use no_strip
 CREW_NOT_SHRINK_ARCHIVE              = ENV.fetch('CREW_NOT_SHRINK_ARCHIVE', '0').eql?('1')              # or use no_shrink
-CREW_SOURCE_BASHRC_ENABLED           = ENV.fetch('CREW_SOURCE_BASHRC_ENABLED', '0').eql?('1')
 
 # Allow git constants to be set from environment variables (for testing)
 CREW_REPO   = ENV.fetch('CREW_REPO', 'https://github.com/chromebrew/chromebrew.git')

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.46.9'
+CREW_VERSION = '1.47.0'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -116,7 +116,6 @@ CREW_DEST_HOME          = File.join(CREW_DEST_DIR, HOME)
 CREW_CACHE_DIR          = ENV.fetch('CREW_CACHE_DIR', "#{HOME}/.cache/crewcache")
 CREW_CACHE_BUILD        = ENV.fetch('CREW_CACHE_BUILD', '0').eql?('1')
 CREW_CACHE_FAILED_BUILD = ENV.fetch('CREW_CACHE_FAILED_BUILD', '0').eql?('1')
-CREW_SOURCE_BASHRC_ACTIVATED = ENV.fetch('CREW_SOURCE_BASHRC_ACTIVATED', '0').eql?('1')
 
 # Set CREW_NPROC from environment variable, `distcc -j`, or `nproc`.
 CREW_NPROC = if File.file?("#{CREW_PREFIX}/bin/distcc")

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -133,6 +133,7 @@ CREW_NOT_COMPRESS                    = ENV.fetch('CREW_NOT_COMPRESS', '0').eql?(
 CREW_NOT_LINKS                       = ENV.fetch('CREW_NOT_LINKS', '0').eql?('1')                       # or use no_links
 CREW_NOT_STRIP                       = ENV.fetch('CREW_NOT_STRIP', '0').eql?('1')                       # or use no_strip
 CREW_NOT_SHRINK_ARCHIVE              = ENV.fetch('CREW_NOT_SHRINK_ARCHIVE', '0').eql?('1')              # or use no_shrink
+CREW_SOURCE_BASHRC_ENABLED           = ENV.fetch('CREW_SOURCE_BASHRC_ENABLED', '0').eql?('1')
 
 # Allow git constants to be set from environment variables (for testing)
 CREW_REPO   = ENV.fetch('CREW_REPO', 'https://github.com/chromebrew/chromebrew.git')

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -116,7 +116,7 @@ CREW_DEST_HOME          = File.join(CREW_DEST_DIR, HOME)
 CREW_CACHE_DIR          = ENV.fetch('CREW_CACHE_DIR', "#{HOME}/.cache/crewcache")
 CREW_CACHE_BUILD        = ENV.fetch('CREW_CACHE_BUILD', '0').eql?('1')
 CREW_CACHE_FAILED_BUILD = ENV.fetch('CREW_CACHE_FAILED_BUILD', '0').eql?('1')
-CREW_SOURCE_BASHRC_ENABLED = ENV.fetch('CREW_SOURCE_BASHRC_ENABLED', '0').eql?('1')
+CREW_SOURCE_BASHRC_ACTIVATED = ENV.fetch('CREW_SOURCE_BASHRC_ACTIVATED', '0').eql?('1')
 
 # Set CREW_NPROC from environment variable, `distcc -j`, or `nproc`.
 CREW_NPROC = if File.file?("#{CREW_PREFIX}/bin/distcc")

--- a/lib/crewlog.rb
+++ b/lib/crewlog.rb
@@ -1,5 +1,6 @@
 require_relative 'color'
+require_relative 'const'
 
 def crewlog(str)
-  caller_locations(1, 1).first.tap {|loc| puts "#{loc.path}:#{loc.lineno}:#{caller_locations(3).first.label}:#{str}".lightpurple if $verbose}
+  caller_locations(1, 1).first.tap {|loc| puts "#{loc.path}:#{loc.lineno}:#{caller_locations(3).first.label}:#{str}".lightpurple if CREW_VERBOSE}
 end

--- a/lib/crewlog.rb
+++ b/lib/crewlog.rb
@@ -1,0 +1,5 @@
+require_relative 'color'
+
+def crewlog(str)
+  caller_locations(1, 1).first.tap {|loc| puts "#{loc.path}:#{loc.lineno}:#{caller_locations(3).first.label}:#{str}".lightpurple if @opt_verbose}
+end

--- a/lib/crewlog.rb
+++ b/lib/crewlog.rb
@@ -1,5 +1,5 @@
 require_relative 'color'
 
 def crewlog(str)
-  caller_locations(1, 1).first.tap {|loc| puts "#{loc.path}:#{loc.lineno}:#{caller_locations(3).first.label}:#{str}".lightpurple if @opt_verbose}
+  caller_locations(1, 1).first.tap {|loc| puts "#{loc.path}:#{loc.lineno}:#{caller_locations(3).first.label}:#{str}".lightpurple if $verbose}
 end

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -1,7 +1,7 @@
 # lib/fixup.rb
 # Add fixups to be run during crew update here.
 
-require_relative 'const'
+CREW_VERBOSE = ARGV.intersect?(%w[-v --verbose]) unless defined?(CREW_VERBOSE)
 
 # remove deprecated directory
 FileUtils.rm_rf "#{HOME}/.cache/crewcache/manifest"

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -1,6 +1,8 @@
 # lib/fixup.rb
 # Add fixups to be run during crew update here.
 
+require_relative 'const'
+
 # remove deprecated directory
 FileUtils.rm_rf "#{HOME}/.cache/crewcache/manifest"
 
@@ -138,7 +140,7 @@ pkg_update_arr.each do |pkg|
       def self.preremove; end
       def self.remove; end
     end
-    Command.remove(pkg_object, @opt_verbose)
+    Command.remove(pkg_object, CREW_VERBOSE)
   else
     puts "#{pkg[:pkg_name].capitalize} not removed.".lightblue
   end
@@ -157,7 +159,7 @@ end
 
 unless @new_const_git_commit == CREW_CONST_GIT_COMMIT
   puts 'Restarting crew update since there is an updated crew version.'.lightcyan
-  puts "CREW_REPO=#{CREW_REPO} CREW_BRANCH=#{CREW_BRANCH} crew update".orange if @opt_verbose
+  puts "CREW_REPO=#{CREW_REPO} CREW_BRANCH=#{CREW_BRANCH} crew update".orange if CREW_VERBOSE
   exec "CREW_REPO=#{CREW_REPO} CREW_BRANCH=#{CREW_BRANCH} crew update"
 end
 

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -88,6 +88,7 @@ class ProgressBar
         completed_length = (@bar_width * (@percentage / 100)).to_i
         puts "completed_length: #{completed_length}"
         uncompleted_length = @bar_width - completed_length
+        puts "uncompleted_length: #{uncompleted_length}"
 
         # print info and progress bar
         @info_before_bar.each_pair do |var_name, width|

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -32,6 +32,11 @@ class ProgressBar
       @bar_width = @terminal_w -
                    @info_before_bar.merge(@info_after_bar).values.sum - # space that all info blocks takes
                    (@info_before_bar.merge(@info_after_bar).length * 2) # space for separator (whitespaces) between each info
+      if @bar_width.negative?
+        puts "@bar_width is #{@bar_width}"
+        puts "@info_before_bar.merge(@info_after_bar).values.sum is #{@info_before_bar.merge(@info_after_bar).values.sum}"
+        puts "(@info_before_bar.merge(@info_after_bar).length * 2) is #{@info_before_bar.merge(@info_after_bar).length * 2}"
+      end
     end
 
     Process.kill('WINCH', 0) # trigger the trap above

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -32,15 +32,6 @@ class ProgressBar
       @bar_width = @terminal_w -
                    @info_before_bar.merge(@info_after_bar).values.sum - # space that all info blocks takes
                    (@info_before_bar.merge(@info_after_bar).length * 2) # space for separator (whitespaces) between each info
-      if @bar_width.negative?
-        puts "IO.console&.console_mode is #{IO.console&.console_mode}"
-        puts "IO.console&.winsize reports #{IO.console&.winsize}"
-        puts "@terminal_h is #{@terminal_h}"
-        puts "@terminal_w is #{@terminal_w}"
-        puts "@bar_width is #{@bar_width}"
-        puts "@info_before_bar.merge(@info_after_bar).values.sum is #{@info_before_bar.merge(@info_after_bar).values.sum}"
-        puts "(@info_before_bar.merge(@info_after_bar).length * 2) is #{@info_before_bar.merge(@info_after_bar).length * 2}"
-      end
     end
 
     Process.kill('WINCH', 0) # trigger the trap above
@@ -96,12 +87,6 @@ class ProgressBar
 
         completed_length = (@bar_width * (@percentage / 100)).to_i
         uncompleted_length = @bar_width - completed_length
-        if completed_length.negative? || uncompleted_length.negative?
-          puts "@bar_width is #{@bar_width}"
-          puts "@percentage is #{@percentage}"
-          puts "completed_length: #{completed_length}"
-          puts "uncompleted_length: #{uncompleted_length}"
-        end
 
         # print info and progress bar
         @info_before_bar.each_pair do |var_name, width|

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -33,6 +33,7 @@ class ProgressBar
                    @info_before_bar.merge(@info_after_bar).values.sum - # space that all info blocks takes
                    (@info_before_bar.merge(@info_after_bar).length * 2) # space for separator (whitespaces) between each info
       if @bar_width.negative?
+        puts "@terminal_w is #{@terminal_w}"
         puts "@bar_width is #{@bar_width}"
         puts "@info_before_bar.merge(@info_after_bar).values.sum is #{@info_before_bar.merge(@info_after_bar).values.sum}"
         puts "(@info_before_bar.merge(@info_after_bar).length * 2) is #{@info_before_bar.merge(@info_after_bar).length * 2}"

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -33,6 +33,8 @@ class ProgressBar
                    @info_before_bar.merge(@info_after_bar).values.sum - # space that all info blocks takes
                    (@info_before_bar.merge(@info_after_bar).length * 2) # space for separator (whitespaces) between each info
       if @bar_width.negative?
+        puts "IO.console&.winsize reports #{IO.console&.winsize}"
+        puts "@terminal_h is #{@terminal_h}"
         puts "@terminal_w is #{@terminal_w}"
         puts "@bar_width is #{@bar_width}"
         puts "@info_before_bar.merge(@info_after_bar).values.sum is #{@info_before_bar.merge(@info_after_bar).values.sum}"

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -29,7 +29,7 @@ class ProgressBar
       # reset width settings after terminal resized
       # get terminal size, calculate the width of progress bar based on it
       @zero_terminal = [0, 0]
-      @terminal_h, @terminal_w = IO.console&.winsize&.include?(@zero_terminal) ? [25, 80] : IO.console&.winsize
+      @terminal_h, @terminal_w = IO.console&.winsize == @zero_terminal ? [25, 80] : IO.console&.winsize
       @bar_width = @terminal_w -
                    @info_before_bar.merge(@info_after_bar).values.sum - # space that all info blocks takes
                    (@info_before_bar.merge(@info_after_bar).length * 2) # space for separator (whitespaces) between each info

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -28,7 +28,7 @@ class ProgressBar
     trap('WINCH') do
       # reset width settings after terminal resized
       # get terminal size, calculate the width of progress bar based on it
-      @terminal_h, @terminal_w = IO.console&.winsize || [25, 80]
+      @terminal_h, @terminal_w = IO.console&.console_mode ? IO.console&.winsize : [25, 80]
       @bar_width = @terminal_w -
                    @info_before_bar.merge(@info_after_bar).values.sum - # space that all info blocks takes
                    (@info_before_bar.merge(@info_after_bar).length * 2) # space for separator (whitespaces) between each info

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -28,18 +28,20 @@ class ProgressBar
     trap('WINCH') do
       # reset width settings after terminal resized
       # get terminal size, calculate the width of progress bar based on it
-      @terminal_h, @terminal_w = IO.console&.console_mode ? IO.console&.winsize : [25, 80]
+      @zero_terminal = [0, 0]
+      @terminal_h, @terminal_w = IO.console&.winsize&.include?(@zero_terminal) ? [25, 80] : IO.console&.winsize
       @bar_width = @terminal_w -
                    @info_before_bar.merge(@info_after_bar).values.sum - # space that all info blocks takes
                    (@info_before_bar.merge(@info_after_bar).length * 2) # space for separator (whitespaces) between each info
-      if @bar_width.negative?
-        puts "IO.console&.winsize reports #{IO.console&.winsize}"
-        puts "@terminal_h is #{@terminal_h}"
-        puts "@terminal_w is #{@terminal_w}"
-        puts "@bar_width is #{@bar_width}"
-        puts "@info_before_bar.merge(@info_after_bar).values.sum is #{@info_before_bar.merge(@info_after_bar).values.sum}"
-        puts "(@info_before_bar.merge(@info_after_bar).length * 2) is #{@info_before_bar.merge(@info_after_bar).length * 2}"
-      end
+      # if @bar_width.negative?
+      puts "IO.console&.console_mode is #{IO.console&.console_mode}"
+      puts "IO.console&.winsize reports #{IO.console&.winsize}"
+      puts "@terminal_h is #{@terminal_h}"
+      puts "@terminal_w is #{@terminal_w}"
+      puts "@bar_width is #{@bar_width}"
+      puts "@info_before_bar.merge(@info_after_bar).values.sum is #{@info_before_bar.merge(@info_after_bar).values.sum}"
+      puts "(@info_before_bar.merge(@info_after_bar).length * 2) is #{@info_before_bar.merge(@info_after_bar).length * 2}"
+      # end
     end
 
     Process.kill('WINCH', 0) # trigger the trap above

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -86,9 +86,13 @@ class ProgressBar
         sleep 0.15 # update progress bar after each 0.15 seconds
 
         completed_length = (@bar_width * (@percentage / 100)).to_i
-        puts "completed_length: #{completed_length}"
         uncompleted_length = @bar_width - completed_length
-        puts "uncompleted_length: #{uncompleted_length}"
+        if completed_length.negative? || uncompleted_length.negative?
+          puts "@bar_width is #{@bar_width}"
+          puts "@percentage is #{@percentage}"
+          puts "completed_length: #{completed_length}"
+          puts "uncompleted_length: #{uncompleted_length}"
+        end
 
         # print info and progress bar
         @info_before_bar.each_pair do |var_name, width|

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -86,6 +86,7 @@ class ProgressBar
         sleep 0.15 # update progress bar after each 0.15 seconds
 
         completed_length = (@bar_width * (@percentage / 100)).to_i
+        puts "completed_length: #{completed_length}"
         uncompleted_length = @bar_width - completed_length
 
         # print info and progress bar

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -28,7 +28,7 @@ class ProgressBar
     trap('WINCH') do
       # reset width settings after terminal resized
       # get terminal size, calculate the width of progress bar based on it
-      @terminal_h, @terminal_w = IO.console&.winsize = [0, 0] ? [25, 80] : IO.console&.winsize
+      @terminal_h, @terminal_w = IO.console&.winsize == [0, 0] ? [25, 80] : IO.console&.winsize
       @bar_width = @terminal_w -
                    @info_before_bar.merge(@info_after_bar).values.sum - # space that all info blocks takes
                    (@info_before_bar.merge(@info_after_bar).length * 2) # space for separator (whitespaces) between each info

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -28,20 +28,19 @@ class ProgressBar
     trap('WINCH') do
       # reset width settings after terminal resized
       # get terminal size, calculate the width of progress bar based on it
-      @zero_terminal = [0, 0]
-      @terminal_h, @terminal_w = IO.console&.winsize == @zero_terminal ? [25, 80] : IO.console&.winsize
+      @terminal_h, @terminal_w = IO.console&.winsize = [0, 0] ? [25, 80] : IO.console&.winsize
       @bar_width = @terminal_w -
                    @info_before_bar.merge(@info_after_bar).values.sum - # space that all info blocks takes
                    (@info_before_bar.merge(@info_after_bar).length * 2) # space for separator (whitespaces) between each info
-      # if @bar_width.negative?
-      puts "IO.console&.console_mode is #{IO.console&.console_mode}"
-      puts "IO.console&.winsize reports #{IO.console&.winsize}"
-      puts "@terminal_h is #{@terminal_h}"
-      puts "@terminal_w is #{@terminal_w}"
-      puts "@bar_width is #{@bar_width}"
-      puts "@info_before_bar.merge(@info_after_bar).values.sum is #{@info_before_bar.merge(@info_after_bar).values.sum}"
-      puts "(@info_before_bar.merge(@info_after_bar).length * 2) is #{@info_before_bar.merge(@info_after_bar).length * 2}"
-      # end
+      if @bar_width.negative?
+        puts "IO.console&.console_mode is #{IO.console&.console_mode}"
+        puts "IO.console&.winsize reports #{IO.console&.winsize}"
+        puts "@terminal_h is #{@terminal_h}"
+        puts "@terminal_w is #{@terminal_w}"
+        puts "@bar_width is #{@bar_width}"
+        puts "@info_before_bar.merge(@info_after_bar).values.sum is #{@info_before_bar.merge(@info_after_bar).values.sum}"
+        puts "(@info_before_bar.merge(@info_after_bar).length * 2) is #{@info_before_bar.merge(@info_after_bar).length * 2}"
+      end
     end
 
     Process.kill('WINCH', 0) # trigger the trap above

--- a/lib/selector.rb
+++ b/lib/selector.rb
@@ -1,6 +1,7 @@
 # selector.rb: Prompt user to choose an option in a list of options
 # See packages/hunspell.rb for example usage
 require_relative 'color'
+require 'io/console'
 
 class Selector
   @@default_prompt = {
@@ -10,7 +11,9 @@ class Selector
 
   def initialize(options, prompt = @@default_prompt, timeout = 10)
     @options = options
-    @timeout = timeout
+    # Set timeout to zero if a non-interactive console.
+    # Check noninteractive usage with `setsid command`.
+    @timeout = IO.console&.console_mode ? timeout : 0
 
     # substitute expressions in the message ("%{variable}")
     @prompt = prompt.transform_values {|p| format(p, { total_opts: @options.size, default: @options[0][:value] }) }

--- a/lib/selector.rb
+++ b/lib/selector.rb
@@ -15,8 +15,6 @@ class Selector
     # Set timeout to zero if a non-interactive console.
     # Check noninteractive usage with `setsid command`.
     @timeout = if !IO.console&.console_mode || IO.console&.winsize == [0, 0]
-      # crewlog "IO.console&.console_mode is #{IO.console&.console_mode}"
-      # crewlog "IO.console&.winsize is #{IO.console&.winsize}"
                  1
                else
                  timeout

--- a/lib/selector.rb
+++ b/lib/selector.rb
@@ -14,13 +14,13 @@ class Selector
     @options = options
     # Set timeout to zero if a non-interactive console.
     # Check noninteractive usage with `setsid command`.
-    if !IO.console&.console_mode || IO.console&.winsize == [0, 0]
+    @timeout = if !IO.console&.console_mode || IO.console&.winsize == [0, 0]
       # crewlog "IO.console&.console_mode is #{IO.console&.console_mode}"
       # crewlog "IO.console&.winsize is #{IO.console&.winsize}"
-      @timeout = 1
-    else
-      @timeout = timeout
-    end
+                 1
+               else
+                 timeout
+               end
 
     # substitute expressions in the message ("%{variable}")
     @prompt = prompt.transform_values {|p| format(p, { total_opts: @options.size, default: @options[0][:value] }) }

--- a/lib/selector.rb
+++ b/lib/selector.rb
@@ -13,7 +13,11 @@ class Selector
     @options = options
     # Set timeout to zero if a non-interactive console.
     # Check noninteractive usage with `setsid command`.
-    @timeout = IO.console&.console_mode ? timeout : 0
+    @timeout = if !IO.console&.console_mode || IO.console&.winsize == [0, 0]
+                 0
+               else
+                 timeout
+               end
 
     # substitute expressions in the message ("%{variable}")
     @prompt = prompt.transform_values {|p| format(p, { total_opts: @options.size, default: @options[0][:value] }) }

--- a/lib/selector.rb
+++ b/lib/selector.rb
@@ -17,7 +17,7 @@ class Selector
     if !IO.console&.console_mode || IO.console&.winsize == [0, 0]
       crewlog "IO.console&.console_mode is #{IO.console&.console_mode}"
       crewlog "IO.console&.winsize is #{IO.console&.winsize}"
-      @timeout = 0
+      @timeout = 1
     else
       @timeout = timeout
     end

--- a/lib/selector.rb
+++ b/lib/selector.rb
@@ -15,8 +15,8 @@ class Selector
     # Set timeout to zero if a non-interactive console.
     # Check noninteractive usage with `setsid command`.
     if !IO.console&.console_mode || IO.console&.winsize == [0, 0]
-      crewlog "IO.console&.console_mode is #{IO.console&.console_mode}"
-      crewlog "IO.console&.winsize is #{IO.console&.winsize}"
+      # crewlog "IO.console&.console_mode is #{IO.console&.console_mode}"
+      # crewlog "IO.console&.winsize is #{IO.console&.winsize}"
       @timeout = 1
     else
       @timeout = timeout

--- a/lib/selector.rb
+++ b/lib/selector.rb
@@ -1,6 +1,7 @@
 # selector.rb: Prompt user to choose an option in a list of options
 # See packages/hunspell.rb for example usage
 require_relative 'color'
+require_relative 'crewlog'
 require 'io/console'
 
 class Selector

--- a/lib/selector.rb
+++ b/lib/selector.rb
@@ -13,11 +13,13 @@ class Selector
     @options = options
     # Set timeout to zero if a non-interactive console.
     # Check noninteractive usage with `setsid command`.
-    @timeout = if !IO.console&.console_mode || IO.console&.winsize == [0, 0]
-                 0
-               else
-                 timeout
-               end
+    if !IO.console&.console_mode || IO.console&.winsize == [0, 0]
+      crewlog "IO.console&.console_mode is #{IO.console&.console_mode}"
+      crewlog "IO.console&.winsize is #{IO.console&.winsize}"
+      @timeout = 0
+    else
+      @timeout = timeout
+    end
 
     # substitute expressions in the message ("%{variable}")
     @prompt = prompt.transform_values {|p| format(p, { total_opts: @options.size, default: @options[0][:value] }) }

--- a/packages/ccache.rb
+++ b/packages/ccache.rb
@@ -24,6 +24,8 @@ class Ccache < CMake
   depends_on 'xdg_base'
   depends_on 'zstd' # R
 
+  print_source_bashrc
+
   cmake_options "-DCMAKE_INSTALL_SYSCONFDIR=#{CREW_PREFIX}/etc \
       -DENABLE_IPO=ON \
       -DENABLE_TESTING=OFF \

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -7,7 +7,7 @@ class Crew_profile_base < Package
   license 'GPL-3+'
   compatibility 'all'
   source_url "https://github.com/chromebrew/crew-profile-base/archive/refs/tags/#{version}.tar.gz"
-  source_sha256 '516eb2a5a0797e78f6aaa385e9ea3988cf51c60112f76e2e4cdd898f7d3f6340'
+  source_sha256 '47c8ad25a139d64f6ec768f24ce70aaef2a99e38b6a1370b4223aa6b02de6b90'
 
   no_compile_needed
   print_source_bashrc

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -7,7 +7,7 @@ class Crew_profile_base < Package
   license 'GPL-3+'
   compatibility 'all'
   source_url "https://github.com/chromebrew/crew-profile-base/archive/refs/tags/#{version}.tar.gz"
-  source_sha256 '47c8ad25a139d64f6ec768f24ce70aaef2a99e38b6a1370b4223aa6b02de6b90'
+  source_sha256 '6c39b1c03a650fb25e74638844c7b086fb12a761325562059071ab3fdcccd7da'
 
   no_compile_needed
   print_source_bashrc

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -7,7 +7,7 @@ class Crew_profile_base < Package
   license 'GPL-3+'
   compatibility 'all'
   source_url "https://github.com/chromebrew/crew-profile-base/archive/refs/tags/#{version}.tar.gz"
-  source_sha256 '29ff1c26cdf0167577a3fb9cc6caeb1c744319adf547b3097d41561e2408faa3'
+  source_sha256 '68dbe544547f0de843926ff3476e5ee7b654eaec956cebca27c9719b44a23b39'
 
   no_compile_needed
   print_source_bashrc

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -7,7 +7,7 @@ class Crew_profile_base < Package
   license 'GPL-3+'
   compatibility 'all'
   source_url "https://github.com/chromebrew/crew-profile-base/archive/refs/tags/#{version}.tar.gz"
-  source_sha256 '68dbe544547f0de843926ff3476e5ee7b654eaec956cebca27c9719b44a23b39'
+  source_sha256 '516eb2a5a0797e78f6aaa385e9ea3988cf51c60112f76e2e4cdd898f7d3f6340'
 
   no_compile_needed
   print_source_bashrc

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -3,11 +3,11 @@ require 'package'
 class Crew_profile_base < Package
   description 'Crew-profile-base sets up Chromebrew\'s environment capabilities.'
   homepage 'https://github.com/chromebrew/crew-profile-base'
-  version '0.0.15'
+  version '0.0.17'
   license 'GPL-3+'
   compatibility 'all'
   source_url "https://github.com/chromebrew/crew-profile-base/archive/refs/tags/#{version}.tar.gz"
-  source_sha256 'a50ac3a6daa494bbfcae041d79e44c186078ff27c27a62bc0ac0aa7ae4fd64a8'
+  source_sha256 '7cfa3a7165fdbacc439a3a7dd0e4909761e5dee3a76ce45ac292a3a08faf1265'
 
   no_compile_needed
   print_source_bashrc

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -7,7 +7,7 @@ class Crew_profile_base < Package
   license 'GPL-3+'
   compatibility 'all'
   source_url "https://github.com/chromebrew/crew-profile-base/archive/refs/tags/#{version}.tar.gz"
-  source_sha256 '6c39b1c03a650fb25e74638844c7b086fb12a761325562059071ab3fdcccd7da'
+  source_sha256 '752266207e79fca8b995012310ddd9afe5e253e07e6e91d7b682f4b8e3e64ccd'
 
   no_compile_needed
   print_source_bashrc

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -7,7 +7,7 @@ class Crew_profile_base < Package
   license 'GPL-3+'
   compatibility 'all'
   source_url "https://github.com/chromebrew/crew-profile-base/archive/refs/tags/#{version}.tar.gz"
-  source_sha256 '7cfa3a7165fdbacc439a3a7dd0e4909761e5dee3a76ce45ac292a3a08faf1265'
+  source_sha256 '29ff1c26cdf0167577a3fb9cc6caeb1c744319adf547b3097d41561e2408faa3'
 
   no_compile_needed
   print_source_bashrc


### PR DESCRIPTION
Inspired by @Zopolis4 's https://github.com/chromebrew/chromebrew/pull/9516, but without all the changes to `print_source_bashrc` in package files, so hopefully that PR can be merged after this since it has all the relevant changes in those files.

As suggested by @supechicken in https://github.com/chromebrew/chromebrew/pull/9516#issuecomment-2045854314

This is also dependent upon the enabling changes in https://github.com/chromebrew/crew-profile-base/pull/22

- With this, `~/.bashrc` no longer has to be manually sourced, except the first time this updated `crew_profile_base` is installed.
- Sets `selector.rb` timeout to `1` when run non-interactively.
- Fixed the `progress_bar` errors that were causing issues in the non-interactive unit tests.
- Moved `crewlog` to `lib/crewlog.rb` so I could call it from other files.
- Added `CREW_VERBOSE` constant so I wouldn't have to pass verbose to `crewlog`...

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=autosource crew update ; crew upgrade -v  ; setsid bash -c "crew reinstall crew_profile_base -v"
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
