### PR TITLE
installer fix for docker images

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.47.0'
+CREW_VERSION = '1.47.1'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -165,7 +165,7 @@ def external_downloader(uri, filename = File.basename(url), verbose = false)
   # i686 curl throws a "SSL certificate problem: self signed certificate in certificate chain" error.
   # Only bypass this when we are using the system curl early in install.
   @default_curl = `which curl`.chomp
-  curl_cmdline = ARCH == 'i686' && @default_curl = '/usr/bin/curl' ? 'curl %<verbose>s -kL -# --retry %<retry>s %<url>s -o %<output>s' : 'curl %<verbose>s -L -# --retry %<retry>s %<url>s -o %<output>s'
+  curl_cmdline = ARCH == 'i686' && @default_curl == '/usr/bin/curl' ? 'curl %<verbose>s -kL -# --retry %<retry>s %<url>s -o %<output>s' : 'curl %<verbose>s -L -# --retry %<retry>s %<url>s -o %<output>s'
 
   # use CREW_DOWNLOADER if specified, use curl by default
   downloader_cmdline = CREW_DOWNLOADER || curl_cmdline

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -163,7 +163,9 @@ def external_downloader(uri, filename = File.basename(url), verbose = false)
   #       %<url>s: Will be substitute to #{url}
   #    %<output>s: Will be substitute to #{filename}
   # i686 curl throws a "SSL certificate problem: self signed certificate in certificate chain" error.
-  curl_cmdline = ARCH == 'i686' ? 'curl %<verbose>s -kL -# --retry %<retry>s %<url>s -o %<output>s' : 'curl %<verbose>s -L -# --retry %<retry>s %<url>s -o %<output>s'
+  # Only bypass this when we are using the system curl early in install.
+  @default_curl = `which curl`.chomp
+  curl_cmdline = ARCH == 'i686' && @default_curl = '/usr/bin/curl' ? 'curl %<verbose>s -kL -# --retry %<retry>s %<url>s -o %<output>s' : 'curl %<verbose>s -L -# --retry %<retry>s %<url>s -o %<output>s'
 
   # use CREW_DOWNLOADER if specified, use curl by default
   downloader_cmdline = CREW_DOWNLOADER || curl_cmdline

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -162,7 +162,8 @@ def external_downloader(uri, filename = File.basename(url), verbose = false)
   #      %<retry>: Will be substitute to #{CREW_DOWNLOADER_RETRY}
   #       %<url>s: Will be substitute to #{url}
   #    %<output>s: Will be substitute to #{filename}
-  curl_cmdline = 'curl %<verbose>s -L -# --retry %<retry>s %<url>s -o %<output>s'
+  # i686 curl throws a "SSL certificate problem: self signed certificate in certificate chain" error.
+  curl_cmdline = ARCH == 'i686' ? 'curl %<verbose>s -kL -# --retry %<retry>s %<url>s -o %<output>s' : 'curl %<verbose>s -L -# --retry %<retry>s %<url>s -o %<output>s'
 
   # use CREW_DOWNLOADER if specified, use curl by default
   downloader_cmdline = CREW_DOWNLOADER || curl_cmdline

--- a/lib/progress_bar.rb
+++ b/lib/progress_bar.rb
@@ -28,7 +28,7 @@ class ProgressBar
     trap('WINCH') do
       # reset width settings after terminal resized
       # get terminal size, calculate the width of progress bar based on it
-      @terminal_h, @terminal_w = IO.console&.winsize == [0, 0] ? [25, 80] : IO.console&.winsize
+      @terminal_h, @terminal_w = !IO.console&.console_mode || IO.console&.winsize == [0, 0] ? [25, 80] : IO.console&.winsize
       @bar_width = @terminal_w -
                    @info_before_bar.merge(@info_after_bar).values.sum - # space that all info blocks takes
                    (@info_before_bar.merge(@info_after_bar).length * 2) # space for separator (whitespaces) between each info


### PR DESCRIPTION
- This adjusts `progress_bar.rb` to do a further check for tty being present, so that terminal size default is used when install is in a docker container. (Currently `@terminal_w` is `nil` in the docker image builds.)
```
#12 53.08 /usr/local/lib/crew/lib/progress_bar.rb:32:in `block in initialize': undefined method `-' for nil (NoMethodError)
#12 53.08 
#12 53.08       @bar_width = @terminal_w -
#12 53.08                                ^
#12 53.08 	from /usr/local/lib/crew/lib/progress_bar.rb:37:in `kill'
#12 53.08 	from /usr/local/lib/crew/lib/progress_bar.rb:37:in `initialize'
#12 53.08 	from /usr/local/lib/crew/lib/downloader.rb:119:in `new'
#12 53.08 	from /usr/local/lib/crew/lib/downloader.rb:119:in `block (2 levels) in http_downloader'
```
- This also adjusts curl usage in `downloader.rb` for i686 to hopefully allow it to succeed during install on i686.
```
#12 53.08 curl: (60) SSL certificate problem: self signed certificate in certificate chain
#12 53.08 More details here: https://curl.haxx.se/docs/sslcerts.html
#12 53.08 
#12 53.08 curl performs SSL certificate verification by default, using a "bundle"
#12 53.08  of Certificate Authority (CA) public keys (CA certs). If the default
#12 53.08  bundle file isn't adequate, you can specify an alternate file
#12 53.08  using the --cacert option.
#12 53.08 If this HTTPS server uses a certificate signed by a CA represented in
#12 53.08  the bundle, the certificate verification probably failed due to a
#12 53.08  problem with the certificate (it might be expired, or the name might
#12 53.08  not match the domain name in the URL).
#12 53.08 If you'd like to turn off curl's verification of the certificate, use
#12 53.08  the -k (or --insecure) option.
#12 53.08 /usr/local/lib/crew/lib/downloader.rb:170:in `system': Command failed with exit 60: curl  -L -# --retry 3 https://gitlab.com/api/v4/projects/26210301/packages/generic/bzip2/1.0.8-2_i686/bzip2-1.0.8-2-chromeos-i686.tar.zst -o bzip2-1.0.8-2-chromeos-i686.tar.zst (RuntimeError)
#12 53.08 	from /usr/local/lib/crew/lib/downloader.rb:170:in `external_downloader'
#12 53.08 	from /usr/local/lib/crew/lib/downloader.rb:78:in `rescue in downloader'
#12 53.08 	from /usr/local/lib/crew/lib/downloader.rb:22:in `downloader'
```

Works properly:
(hopefully... it is hard to test unless merged... but we will know immediately if the container rebuilds succeed.)

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=install_fix crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
