### PR TITLE
Fix invalid command error in crew

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -49,7 +49,7 @@ rescue Docopt::Exit => e
         puts "Could not understand \"crew #{ARGV.join(' ')}\".".lightred
         # Looking for similar commands
         unless CREW_COMMANDS.include?(ARGV[0])
-          similar = CREW_COMMANDS.select { |word| edit_distance(ARGV[0], word) < 4 }
+          similar = CREW_COMMANDS.split.select { |word| edit_distance(ARGV[0], word) < 4 }
           unless similar.empty?
             abort <<~EOT
               Did you mean?

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -1,7 +1,7 @@
 # lib/const.rb
 # Defines common constants used in different parts of crew
 
-CREW_VERSION = '1.47.0'
+CREW_VERSION = '1.47.1'
 
 # kernel architecture
 KERN_ARCH = `uname -m`.chomp


### PR DESCRIPTION
Before:
```
$ crew whastprovides libnsl
Could not understand "crew whastprovides libnsl".
/usr/local/bin/crew:52:in `rescue in <main>': private method `select' called for an instance of String (NoMethodError)

          similar = CREW_COMMANDS.select { |word| edit_distance(ARGV[0], word) < 4 }
                                 ^^^^^^^                                                                                                                                                                              from /usr/local/bin/crew:32:in `<main>'
/usr/local/lib/crew/lib/docopt.rb:667:in `docopt': Usage: (Docopt::Exit)
```
After:
```
$ crew whastprovides libnsl
Could not understand "crew whastprovides libnsl".
Did you mean?
  whatprovides
```