### PR TITLE
Terraform 1.8.0 => 1.8.1

### DIFF
--- a/packages/terraform.rb
+++ b/packages/terraform.rb
@@ -3,7 +3,7 @@ require 'package'
 class Terraform < Package
   description 'Terraform is a tool for building, changing, and combining infrastructure safely and efficiently.'
   homepage 'https://www.terraform.io/'
-  version '1.8.0'
+  version '1.8.1'
   license 'Apache-2.0, BSD-2, BSD-4, ECL-2.0, imagemagick, ISC, JSON, MIT, MIT-with-advertising, MPL-2.0 and unicode'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Terraform < Package
      x86_64: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_amd64.zip"
   })
   source_sha256({
-    aarch64: '439ffbd0a24bd9564823e4f56c3bbbb78625aa07f981e5bf5bda93461dfef349',
-     armv7l: '439ffbd0a24bd9564823e4f56c3bbbb78625aa07f981e5bf5bda93461dfef349',
-       i686: '80319b98736e46cd300ed69dcd230b575d1a67d4d49be56dc9f4c7344bcbcc17',
-     x86_64: '561523d4d685bd8f6cad6ecbc48611c19f179c42419cbf1a8ec8099d7bb63d15'
+    aarch64: 'c2812f60b6cde793c12b83d0adfe94491b0b51cd85c020ae307d149b2b5e6d96',
+     armv7l: 'c2812f60b6cde793c12b83d0adfe94491b0b51cd85c020ae307d149b2b5e6d96',
+       i686: 'b93314e7883ce6b36f7f50e5736280291bf9c907a6cb3a64fa0045bfa2d89887',
+     x86_64: 'c3cb6c7cefef4cc3f8f4c4a2f574a8a00ff3996aca01a0724759375696552e24'
   })
 
   def self.install


### PR DESCRIPTION
## Description

This commit updates the Terraform CLI from 1.8.0 to 1.8.1.

## Additional information

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`