### PR TITLE
Update crew_profile_base => 0.0.18

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -347,10 +347,8 @@ def update
     different_version = (package[:version] != @pkg.version)
     has_sha = !(PackageUtils.get_sha256(@pkg).to_s.empty? || package[:sha256].to_s.empty?)
     different_sha = has_sha && package[:sha256] != PackageUtils.get_sha256(@pkg)
-    crewlog "#{@pkg.name}: different_version: #{different_version}, has_sha: #{has_sha}, different_sha: #{different_sha}, @pkg.no_compile_needed, #{@pkg.no_compile_needed?}"
     
     can_be_updated += 1 if different_version || different_sha
-    crewlog "#{@pkg.name}: different_version: #{different_version}, has_sha: #{has_sha}, different_sha: #{different_sha}, @pkg.no_compile_needed, #{@pkg.no_compile_needed?}" if different_version || different_sha
 
     if different_version && !different_sha && has_sha
       unless @pkg.no_compile_needed?
@@ -363,7 +361,6 @@ def update
       puts "#{@pkg.name} could be updated (rebuild)"
     end
   end
-  crewlog "can_be_updated: #{can_be_updated}"
 
   if can_be_updated.positive?
     puts "\n#{can_be_updated} packages can be updated."

--- a/bin/crew
+++ b/bin/crew
@@ -347,9 +347,9 @@ def update
     different_version = (package[:version] != @pkg.version)
     has_sha = !(PackageUtils.get_sha256(@pkg).to_s.empty? || package[:sha256].to_s.empty?)
     different_sha = has_sha && package[:sha256] != PackageUtils.get_sha256(@pkg)
-    crewlog "different_version: #{different_version}, has_sha: #{has_sha}, different_sha: #{different_sha}, @pkg.no_compile_needed, #{@pkg.no_compile_needed?}"
 
     can_be_updated += 1 if different_version || different_sha
+    crewlog "#{@pkg.name}: different_version: #{different_version}, has_sha: #{has_sha}, different_sha: #{different_sha}, @pkg.no_compile_needed, #{@pkg.no_compile_needed?}" if different_version || different_sha
 
     if different_version && !different_sha && has_sha
       unless @pkg.no_compile_needed?

--- a/bin/crew
+++ b/bin/crew
@@ -347,6 +347,7 @@ def update
     different_version = (package[:version] != @pkg.version)
     has_sha = !(PackageUtils.get_sha256(@pkg).to_s.empty? || package[:sha256].to_s.empty?)
     different_sha = has_sha && package[:sha256] != PackageUtils.get_sha256(@pkg)
+
     can_be_updated += 1 if different_version || different_sha
 
     if different_version && !different_sha && has_sha

--- a/bin/crew
+++ b/bin/crew
@@ -347,7 +347,8 @@ def update
     different_version = (package[:version] != @pkg.version)
     has_sha = !(PackageUtils.get_sha256(@pkg).to_s.empty? || package[:sha256].to_s.empty?)
     different_sha = has_sha && package[:sha256] != PackageUtils.get_sha256(@pkg)
-
+    crewlog "#{@pkg.name}: different_version: #{different_version}, has_sha: #{has_sha}, different_sha: #{different_sha}, @pkg.no_compile_needed, #{@pkg.no_compile_needed?}"
+    
     can_be_updated += 1 if different_version || different_sha
     crewlog "#{@pkg.name}: different_version: #{different_version}, has_sha: #{has_sha}, different_sha: #{different_sha}, @pkg.no_compile_needed, #{@pkg.no_compile_needed?}" if different_version || different_sha
 

--- a/bin/crew
+++ b/bin/crew
@@ -347,6 +347,7 @@ def update
     different_version = (package[:version] != @pkg.version)
     has_sha = !(PackageUtils.get_sha256(@pkg).to_s.empty? || package[:sha256].to_s.empty?)
     different_sha = has_sha && package[:sha256] != PackageUtils.get_sha256(@pkg)
+    crewlog "different_version: #{different_version}, has_sha: #{has_sha}, different_sha: #{different_sha}, @pkg.no_compile_needed, #{@pkg.no_compile_needed?}"
 
     can_be_updated += 1 if different_version || different_sha
 
@@ -361,6 +362,7 @@ def update
       puts "#{@pkg.name} could be updated (rebuild)"
     end
   end
+  crewlog "can_be_updated: #{can_be_updated}"
 
   if can_be_updated.positive?
     puts "\n#{can_be_updated} packages can be updated."

--- a/bin/crew
+++ b/bin/crew
@@ -347,7 +347,6 @@ def update
     different_version = (package[:version] != @pkg.version)
     has_sha = !(PackageUtils.get_sha256(@pkg).to_s.empty? || package[:sha256].to_s.empty?)
     different_sha = has_sha && package[:sha256] != PackageUtils.get_sha256(@pkg)
-    
     can_be_updated += 1 if different_version || different_sha
 
     if different_version && !different_sha && has_sha

--- a/bin/crew
+++ b/bin/crew
@@ -351,8 +351,10 @@ def update
     can_be_updated += 1 if different_version || different_sha
 
     if different_version && !different_sha && has_sha
-      can_be_updated -= 1
-      puts "#{@pkg.name} has a version change but does not have updated binaries".yellow
+      unless @pkg.no_compile_needed?
+        can_be_updated -= 1
+        puts "#{@pkg.name} has a version change but does not have updated binaries".yellow
+      end
     elsif different_version
       puts "#{@pkg.name} could be updated from #{package[:version]} to #{@pkg.version}"
     elsif !different_version && different_sha

--- a/lib/buildsystems/ruby.rb
+++ b/lib/buildsystems/ruby.rb
@@ -15,7 +15,7 @@ class RUBY < Package
     @gem_ver = version.split('-', 2).first
     @ruby_ver = version.split('-', 3).last
     system "yes | gem uninstall -a #{@gem_name}", exception: false
-    system "gem install -i #{CREW_DEST_LIB_PREFIX}/ruby/gems/#{@ruby_ver}.0 -n #{CREW_DEST_PREFIX}/bin -N -v #{@gem_ver} #{@gem_name}", exception: false
+    system "gem install -i #{CREW_DEST_LIB_PREFIX}/ruby/gems/#{@ruby_ver}.0 -n #{CREW_DEST_PREFIX}/bin -N #{@gem_name}", exception: false
     eval @ruby_install_extras if @ruby_install_extras
   end
 end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -2,7 +2,7 @@
 # Defines common constants used in different parts of crew
 require 'etc'
 
-CREW_VERSION = '1.47.2'
+CREW_VERSION = '1.47.3'
 
 # kernel architecture
 KERN_ARCH = Etc.uname[:machine]

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -7,7 +7,7 @@ class Crew_profile_base < Package
   license 'GPL-3+'
   compatibility 'all'
   source_url "https://github.com/chromebrew/crew-profile-base/archive/refs/tags/#{version}.tar.gz"
-  source_sha256 '752266207e79fca8b995012310ddd9afe5e253e07e6e91d7b682f4b8e3e64ccd'
+  source_sha256 '3cac55ef8b187d3cb085d95309d131c6885d4cfef6d8ef535adfc2146f16e6b8'
 
   no_compile_needed
   print_source_bashrc

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -7,7 +7,7 @@ class Crew_profile_base < Package
   license 'GPL-3+'
   compatibility 'all'
   source_url "https://github.com/chromebrew/crew-profile-base/archive/refs/tags/#{version}.tar.gz"
-  source_sha256 '3cac55ef8b187d3cb085d95309d131c6885d4cfef6d8ef535adfc2146f16e6b8'
+  source_sha256 'e9be29e4070c91285f125e66a9426b5cfb2b334cffb770394aa33a7cff667a2c'
 
   no_compile_needed
   print_source_bashrc
@@ -16,9 +16,6 @@ class Crew_profile_base < Package
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/env.d"
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/profile.d"
-
-    # dbus file moved to dbus package, so remove it.
-    FileUtils.rm_f './src/env.d/04-dbus'
 
     # Don't overwrite custom changes
     %w[01-locale 02-editor 03-pager 99-custom].each do |custom_files|

--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -3,7 +3,7 @@ require 'package'
 class Crew_profile_base < Package
   description 'Crew-profile-base sets up Chromebrew\'s environment capabilities.'
   homepage 'https://github.com/chromebrew/crew-profile-base'
-  version '0.0.17'
+  version '0.0.18'
   license 'GPL-3+'
   compatibility 'all'
   source_url "https://github.com/chromebrew/crew-profile-base/archive/refs/tags/#{version}.tar.gz"

--- a/packages/ruby_asciidoctor.rb
+++ b/packages/ruby_asciidoctor.rb
@@ -3,7 +3,7 @@ require 'buildsystems/ruby'
 class Ruby_asciidoctor < RUBY
   description 'A fast text processor & publishing toolchain for converting AsciiDoc to HTML5, DocBook & more.'
   homepage 'https://asciidoctor.org/'
-  version '2.0.20-ruby-3.3'
+  version '2.0.22-ruby-3.3'
   license 'MIT'
   compatibility 'all'
   source_url 'SKIP'

--- a/packages/ruby_concurrent_ruby.rb
+++ b/packages/ruby_concurrent_ruby.rb
@@ -3,7 +3,7 @@ require 'buildsystems/ruby'
 class Ruby_concurrent_ruby < RUBY
   description 'Modern concurrency tools for Ruby. Inspired by Erlang, Clojure, Scala, Haskell, F#, C#, Java, and classic concurrency patterns.'
   homepage 'https://github.com/ruby-concurrency/concurrent-ruby'
-  version '1.2.2-ruby-3.3'
+  version '1.2.3-ruby-3.3'
   license 'MIT'
   compatibility 'all'
   source_url 'SKIP'


### PR DESCRIPTION
- Updates some ruby gems.
- Sets ruby gems to update to latest version
- fixes crew bash loading in /usr/local/etc/profile
- Adds workaround that _may work_ in some cases when glibc gets updated from under crew.
- removes extra dbus env.d file from `crew_profile_base` that has been moved to the dbus package
- Fixes crew upgrade of `no_compile_needed` packages.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=crewprofilebase crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
