### PR TITLE
cleanups for crew_profile_base

### DIFF
--- a/packages/crew_profile_base.rb
+++ b/packages/crew_profile_base.rb
@@ -3,11 +3,11 @@ require 'package'
 class Crew_profile_base < Package
   description 'Crew-profile-base sets up Chromebrew\'s environment capabilities.'
   homepage 'https://github.com/chromebrew/crew-profile-base'
-  version '0.0.19'
+  version '0.0.20'
   license 'GPL-3+'
   compatibility 'all'
   source_url "https://github.com/chromebrew/crew-profile-base/archive/refs/tags/#{version}.tar.gz"
-  source_sha256 '3972298c20070b88adf1f73d75a7c7295d54cfaafae8f0ae7258351f5bb65bd9'
+  source_sha256 '37f115f98259e2925f8737db13e9483df3fb0267f35fc27843ee274c5ab822bf'
 
   no_compile_needed
   print_source_bashrc


### PR DESCRIPTION
Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=crew_profile_base_cleanup crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
