### PR TITLE
Add phpbrew package

### DIFF
--- a/manifest/armv7l/p/phpbrew.filelist
+++ b/manifest/armv7l/p/phpbrew.filelist
@@ -1,0 +1,4 @@
+/usr/local/bin/phpbrew
+/usr/local/etc/bash.d/10-phpbrew
+/usr/local/etc/env.d/10-phpbrew
+/home/chronos/user/.phpbrew/bashrc

--- a/manifest/x86_64/p/phpbrew.filelist
+++ b/manifest/x86_64/p/phpbrew.filelist
@@ -1,0 +1,4 @@
+/usr/local/bin/phpbrew
+/usr/local/etc/bash.d/10-phpbrew
+/usr/local/etc/env.d/10-phpbrew
+/home/chronos/user/.phpbrew/bashrc

--- a/packages/phpbrew.rb
+++ b/packages/phpbrew.rb
@@ -1,0 +1,35 @@
+require 'package'
+
+class Phpbrew < Package
+  description 'Brew & manage PHP versions in pure PHP at HOME'
+  homepage 'https://phpbrew.github.io/phpbrew/'
+  version '2.2.0'
+  license 'MIT'
+  compatibility 'x86_64 aarch64 armv7l'
+  source_url 'https://github.com/phpbrew/phpbrew/releases/download/2.2.0/phpbrew.phar'
+  source_sha256 '3247b8438888827d068542b2891392e3beffebe122f4955251fa4f9efa0da03d'
+
+  depends_on 'php83' unless File.exist? "#{CREW_PREFIX}/bin/php"
+
+  no_compile_needed
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/env.d"
+    File.write "#{CREW_DEST_PREFIX}/etc/env.d/10-phpbrew", <<~EOF
+      PHPBREW_SET_PROMPT=1
+      PHPBREW_RC_ENABLE=1
+    EOF
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/bash.d"
+    File.write "#{CREW_DEST_PREFIX}/etc/bash.d/10-phpbrew", <<~EOF
+      [[ ! -s #{HOME}/.phpbrew/bashrc ]] && phpbrew init
+      [[ -e #{HOME}/.phpbrew/bashrc ]] && source #{HOME}/.phpbrew/bashrc
+    EOF
+    FileUtils.mkdir_p "#{CREW_DEST_HOME}/.phpbrew"
+    FileUtils.touch "#{CREW_DEST_HOME}/.phpbrew/bashrc"
+    FileUtils.install 'phpbrew.phar', "#{CREW_DEST_PREFIX}/bin/phpbrew", mode: 0o755
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nSee https://github.com/phpbrew/phpbrew/wiki/Quick-Start for more information.\n".lightblue
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -6906,6 +6906,11 @@ url: https://github.com/nbs-system/php-malware-finder
 activity: low
 ---
 kind: url
+name: phpbrew
+url: https://github.com/phpbrew/phpbrew/releases
+activity: low
+---
+kind: url
 name: phpsysinfo
 url: https://sourceforge.net/projects/phpsysinfo/files/phpsysinfo/
 activity: low


### PR DESCRIPTION
phpbrew builds and installs multiple version php(s) in your $HOME directory.

What phpbrew can do for you:

- Configure options are simplified into variants, no worries about the path anymore!
- Build php with different variants like PDO, mysql, sqlite, debug ...etc.
- Compile apache php module and separate them by different versions.
- Build and install php(s) in your home directory, so you don't need root permission.
- Switch versions very easily and is integrated with bash/zsh shell.
- Automatic feature detection.
- Install & enable php extensions into current environment with ease.
- Install multiple php into system-wide environment.
- Path detection optimization for HomeBrew and MacPorts.

Tested and working in arm and x86_64 containers.  See https://phpbrew.github.io/phpbrew/.