### PR TITLE
Add mhash package

### DIFF
--- a/manifest/armv7l/m/mhash.filelist
+++ b/manifest/armv7l/m/mhash.filelist
@@ -1,0 +1,13 @@
+/usr/local/include/mhash.h
+/usr/local/include/mutils/mglobal.h
+/usr/local/include/mutils/mhash.h
+/usr/local/include/mutils/mhash_config.h
+/usr/local/include/mutils/mincludes.h
+/usr/local/include/mutils/mtypes.h
+/usr/local/include/mutils/mutils.h
+/usr/local/lib/libmhash.a
+/usr/local/lib/libmhash.la
+/usr/local/lib/libmhash.so
+/usr/local/lib/libmhash.so.2
+/usr/local/lib/libmhash.so.2.0.1
+/usr/local/share/man/man3/mhash.3.zst

--- a/manifest/i686/m/mhash.filelist
+++ b/manifest/i686/m/mhash.filelist
@@ -1,0 +1,13 @@
+/usr/local/include/mhash.h
+/usr/local/include/mutils/mglobal.h
+/usr/local/include/mutils/mhash.h
+/usr/local/include/mutils/mhash_config.h
+/usr/local/include/mutils/mincludes.h
+/usr/local/include/mutils/mtypes.h
+/usr/local/include/mutils/mutils.h
+/usr/local/lib/libmhash.a
+/usr/local/lib/libmhash.la
+/usr/local/lib/libmhash.so
+/usr/local/lib/libmhash.so.2
+/usr/local/lib/libmhash.so.2.0.1
+/usr/local/share/man/man3/mhash.3.zst

--- a/manifest/x86_64/m/mhash.filelist
+++ b/manifest/x86_64/m/mhash.filelist
@@ -1,0 +1,13 @@
+/usr/local/include/mhash.h
+/usr/local/include/mutils/mglobal.h
+/usr/local/include/mutils/mhash.h
+/usr/local/include/mutils/mhash_config.h
+/usr/local/include/mutils/mincludes.h
+/usr/local/include/mutils/mtypes.h
+/usr/local/include/mutils/mutils.h
+/usr/local/lib64/libmhash.a
+/usr/local/lib64/libmhash.la
+/usr/local/lib64/libmhash.so
+/usr/local/lib64/libmhash.so.2
+/usr/local/lib64/libmhash.so.2.0.1
+/usr/local/share/man/man3/mhash.3.zst

--- a/packages/mhash.rb
+++ b/packages/mhash.rb
@@ -1,0 +1,23 @@
+require 'buildsystems/autotools'
+
+class Mhash < Autotools
+  description 'Mhash is a free (under GNU Lesser GPL) library which provides a uniform interface to a large number of hash algorithms.'
+  homepage 'https://mhash.sourceforge.net/'
+  version '0.9.9.9'
+  license 'LGPLv2'
+  compatibility 'all'
+  source_url 'https://downloads.sourceforge.net/project/mhash/mhash/0.9.9.9/mhash-0.9.9.9.tar.bz2'
+  source_sha256 '56521c52a9033779154432d0ae47ad7198914785265e1f570cee21ab248dfef0'
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+    aarch64: 'ae5cde52b8d93b956ef6bc634c3e8a12821534fc5dfc83a145a0a4ffd264e720',
+     armv7l: 'ae5cde52b8d93b956ef6bc634c3e8a12821534fc5dfc83a145a0a4ffd264e720',
+       i686: '1faf6e2dc281564034e6325b8a3ea7eddb978610117fdb3ab1bb374c63a9d1ec',
+     x86_64: 'd97e86742b4b9c4b5cbbf1423bc36a2d9ef1ebaa5b630494ee1c0a6940bf2cd1'
+  })
+
+  depends_on 'glibc' # R
+
+  run_tests
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -5671,6 +5671,11 @@ url: https://github.com/troglobit/mg/releases/
 activity: medium
 ---
 kind: url
+name: mhash
+url: https://sourceforge.net/projects/mhash/files/mhash/
+activity: none
+---
+kind: url
 name: micro
 url: https://github.com/zyedidia/micro/releases
 activity: high


### PR DESCRIPTION
Libmhash is a library that provides a uniform interface to several hash algorithms. It supports the basics for message authentication by following rfc2104 (HMAC). It also includes some key generation algorithms which are based on hash algorithms.  See https://mhash.sourceforge.net/.  All tests passed.