### PR TITLE
Fix install.sh fallback libc install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -169,9 +169,14 @@ BOOTSTRAP_PACKAGES='zstd crew_mvdir ruby git ca_certificates libyaml openssl'
 [[ "${ARCH}" == "i686" ]] && BOOTSTRAP_PACKAGES+=' zlibpkg gcc_lib'
 
 if [[ -n "${CHROMEOS_RELEASE_CHROME_MILESTONE}" ]]; then
-  sudo cp "/lib$LIB_SUFFIX/libc.so*" "$CREW_PREFIX/lib$LIB_SUFFIX"
-  sudo chown chronos "$CREW_PREFIX/lib$LIB_SUFFIX/libc.so*"
-  sudo chmod 644 "$CREW_PREFIX/lib$LIB_SUFFIX/libc.so*"
+  mkdir -p "$CREW_PREFIX/lib$LIB_SUFFIX/"
+  for i in /lib$LIB_SUFFIX/libc.so*
+  do
+    sudo cp "$i" "$CREW_PREFIX/lib$LIB_SUFFIX/"
+    libcname=$(basename "$i")
+    sudo chown chronos "$CREW_PREFIX/lib$LIB_SUFFIX/${libcname}"
+    sudo chmod 644 "$CREW_PREFIX/lib$LIB_SUFFIX/${libcname}"
+  done
   if (( "${CHROMEOS_RELEASE_CHROME_MILESTONE}" > "112" )); then
     # Recent Arm systems have a cut down system.
     [[ "${ARCH}" == "armv7l" ]] && BOOTSTRAP_PACKAGES+=' bzip2 ncurses readline pcre2 gcc_lib'

--- a/install.sh
+++ b/install.sh
@@ -169,7 +169,7 @@ BOOTSTRAP_PACKAGES='zstd crew_mvdir ruby git ca_certificates libyaml openssl'
 [[ "${ARCH}" == "i686" ]] && BOOTSTRAP_PACKAGES+=' zlibpkg gcc_lib'
 
 if [[ -n "${CHROMEOS_RELEASE_CHROME_MILESTONE}" ]]; then
-  mkdir -p "$CREW_PREFIX/lib$LIB_SUFFIX/"
+  # shellcheck disable=SC2231
   for i in /lib$LIB_SUFFIX/libc.so*
   do
     sudo cp "$i" "$CREW_PREFIX/lib$LIB_SUFFIX/"


### PR DESCRIPTION
- Fixes issues with glob expansion from https://github.com/chromebrew/chromebrew/commit/d3239143ccc812de523ef3c04f2e18249ca32572
```
sudo cp "/lib$LIB_SUFFIX/libc.so*" "$CREW_PREFIX/lib$LIB_SUFFIX"
cp: cannot stat '/lib64/libc.so*': No such file or directory
```
- Maybe we need a unit test for changes to `install.sh` ?

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
