### PR TITLE
Add slack_cli package

### DIFF
--- a/manifest/armv7l/s/slack_cli.filelist
+++ b/manifest/armv7l/s/slack_cli.filelist
@@ -1,0 +1,1 @@
+/usr/local/bin/slack

--- a/manifest/i686/s/slack_cli.filelist
+++ b/manifest/i686/s/slack_cli.filelist
@@ -1,0 +1,1 @@
+/usr/local/bin/slack

--- a/manifest/x86_64/s/slack_cli.filelist
+++ b/manifest/x86_64/s/slack_cli.filelist
@@ -1,0 +1,1 @@
+/usr/local/bin/slack

--- a/packages/slack_cli.rb
+++ b/packages/slack_cli.rb
@@ -1,0 +1,34 @@
+require 'package'
+
+class Slack_cli < Package
+  description 'The Slack CLI allows you to interact with your workflow apps via the command line.'
+  homepage 'https://api.slack.com/automation/cli/commands'
+  version '2.22.0'
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://downloads.slack-edge.com/slack-cli/slack_cli_2.22.0_linux_64-bit.tar.gz'
+  source_sha256 '6416ca1a03c6ac161c961ead9056dbb833f6361049c7b6b12fc577983acef4fb'
+
+  depends_on 'git' # R
+
+  no_compile_needed
+  no_shrink
+
+  def self.install
+    FileUtils.install 'bin/slack', "#{CREW_DEST_PREFIX}/bin/slack", mode: 0o755
+  end
+
+  def self.remove
+    config_dir = "#{HOME}/.slack"
+    if Dir.exist? config_dir
+      print "Would you like to remove the #{config_dir} directory? [y/N] "
+      case $stdin.gets.chomp.downcase
+      when 'y', 'yes'
+        FileUtils.rm_rf config_dir
+        puts "#{config_dir} removed.".lightgreen
+      else
+        puts "#{config_dir} saved.".lightgreen
+      end
+    end
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -8021,6 +8021,11 @@ url: https://github.com/mtoyoda/sl/releases
 activity: none
 ---
 kind: url
+name: slack_cli
+url: https://api.slack.com/automation/cli/install-mac-linux
+activity: low
+---
+kind: url
 name: slang
 url: http://www.jedsoft.org/releases/slang
 activity: medium


### PR DESCRIPTION
The Slack CLI allows you to interact with your workflow apps via the command line.  See https://api.slack.com/automation/quickstart.  Tested and working on all architectures.