### PR TITLE
Update git_prompt, have install use new faster git reftable support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -333,7 +333,7 @@ else
   git config --global init.defaultBranch main
 
   # Setup the folder with git information.
-  git init
+  git init --ref-format=reftable
   git remote add origin "https://github.com/${OWNER}/${REPO}"
 
   # Checkout, overwriting local files.

--- a/manifest/armv7l/g/git_prompt.filelist
+++ b/manifest/armv7l/g/git_prompt.filelist
@@ -1,0 +1,1 @@
+/usr/local/etc/bash.d/git-prompt.sh

--- a/manifest/i686/g/git_prompt.filelist
+++ b/manifest/i686/g/git_prompt.filelist
@@ -1,0 +1,1 @@
+/usr/local/etc/bash.d/git-prompt.sh

--- a/packages/git.rb
+++ b/packages/git.rb
@@ -1,3 +1,5 @@
+# When upgrading git, be sure to update git_prompt binaries in tandem.
+
 require 'package'
 
 class Git < Package

--- a/packages/git.rb
+++ b/packages/git.rb
@@ -1,5 +1,3 @@
-# When upgrading git, be sure to update git_prompt binaries in tandem.
-
 require 'package'
 
 class Git < Package

--- a/packages/git_prompt.rb
+++ b/packages/git_prompt.rb
@@ -4,18 +4,17 @@ require_relative 'git'
 class Git_prompt < Package
   description 'Display the git branch and status in the command prompt'
   homepage 'https://github.com/git/git'
-  version '2.44.0'
+  version Git.version
   # When upgrading git_prompt, be sure to upgrade git in tandem.
-  puts "#{self} version differs from Git version #{Git.version}".orange if version != Git.version
+  # puts "#{self} version differs from Git version #{Git.version}".orange if version != Git.version
   license 'GPL-2'
   compatibility 'all'
-  source_url 'SKIP'
+  source_url Git.source_url
+  source_sha256 Git.source_sha256
 
   print_source_bashrc
 
   def self.build
-    downloader "https://raw.githubusercontent.com/git/git/v#{version}/contrib/completion/git-prompt.sh",
-               'f1eafdac2be85158de4cd62bca5b4404e3fc3b4f3604ab6e00e1dc44efe315cd'
     git_env = <<~EOF
 
       GIT_PS1_SHOWDIRTYSTATE=yes
@@ -27,11 +26,11 @@ class Git_prompt < Package
 
       PS1='\\[\\033[1;34m\\]\\u@\\H \\[\\033[1;33m\\]\\w \\[\\033[1;31m\\]$(__git_ps1 "(%s)")\\[\\033[0m\\]\\$ '
     EOF
-    File.write('git-prompt.sh', git_env, mode: 'a')
+    File.write('contrib/completion/git-prompt.sh', git_env, mode: 'a')
   end
 
   def self.install
-    FileUtils.install 'git-prompt.sh', "#{CREW_DEST_PREFIX}/etc/bash.d/git-prompt.sh", mode: 0o644
+    FileUtils.install 'contrib/completion/git-prompt.sh', "#{CREW_DEST_PREFIX}/etc/bash.d/git-prompt.sh", mode: 0o644
   end
 
   def self.postinstall

--- a/packages/git_prompt.rb
+++ b/packages/git_prompt.rb
@@ -11,15 +11,9 @@ class Git_prompt < Package
   source_sha256 Git.source_sha256
   binary_compression 'tar.zst'
 
-  binary_sha256({
-    aarch64: '1541e237594840c458b5a234278cb2150dc1f01d5e7d0c7932a8397e598a6837',
-     armv7l: '1541e237594840c458b5a234278cb2150dc1f01d5e7d0c7932a8397e598a6837',
-       i686: 'caa10c0cfa40b0c20454151433599482eee9a431a06856eeea1d4c0d455caa33',
-     x86_64: 'dab1b1d174feb393035fb6e3ba38cb53282ec827916580e46f43b2eaaff83554'
-  })
-
   depends_on 'git' # L
 
+  no_compile_needed
   print_source_bashrc
 
   def self.build

--- a/packages/git_prompt.rb
+++ b/packages/git_prompt.rb
@@ -5,12 +5,20 @@ class Git_prompt < Package
   description 'Display the git branch and status in the command prompt'
   homepage 'https://github.com/git/git'
   version Git.version
-  # When upgrading git_prompt, be sure to upgrade git in tandem.
-  # puts "#{self} version differs from Git version #{Git.version}".orange if version != Git.version
   license 'GPL-2'
   compatibility 'all'
   source_url Git.source_url
   source_sha256 Git.source_sha256
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+    aarch64: '1541e237594840c458b5a234278cb2150dc1f01d5e7d0c7932a8397e598a6837',
+     armv7l: '1541e237594840c458b5a234278cb2150dc1f01d5e7d0c7932a8397e598a6837',
+       i686: 'caa10c0cfa40b0c20454151433599482eee9a431a06856eeea1d4c0d455caa33',
+     x86_64: 'dab1b1d174feb393035fb6e3ba38cb53282ec827916580e46f43b2eaaff83554'
+  })
+
+  depends_on 'git' # L
 
   print_source_bashrc
 


### PR DESCRIPTION
- Adds the faster git reftable support only during installs as per https://github.blog/2024-04-29-highlights-from-git-2-45/
- install change tested on `i686`.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=git-install crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
