### PR TITLE
Terraform 1.8.2 => 1.8.3

### DIFF
--- a/packages/terraform.rb
+++ b/packages/terraform.rb
@@ -3,7 +3,7 @@ require 'package'
 class Terraform < Package
   description 'Terraform is a tool for building, changing, and combining infrastructure safely and efficiently.'
   homepage 'https://www.terraform.io/'
-  version '1.8.2'
+  version '1.8.3'
   license 'Apache-2.0, BSD-2, BSD-4, ECL-2.0, imagemagick, ISC, JSON, MIT, MIT-with-advertising, MPL-2.0 and unicode'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Terraform < Package
      x86_64: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_amd64.zip"
   })
   source_sha256({
-    aarch64: 'defee79880898de86ea2dae8612f8a39d97bc5ab0bfe3c99773d3843f902e6de',
-     armv7l: 'defee79880898de86ea2dae8612f8a39d97bc5ab0bfe3c99773d3843f902e6de',
-       i686: 'b6cdf973c21e768c210102b8f65eb2717f082aced40e322574185f32d1918236',
-     x86_64: '3b5da3f4666bb77f9a0856bec2912e002e4c9937e22199c2dde358f0c1467888'
+    aarch64: '8620ac48290f998a36c9030c8b733d401992f13f17a393fa8ed7cdc9d463c5ce',
+     armv7l: '8620ac48290f998a36c9030c8b733d401992f13f17a393fa8ed7cdc9d463c5ce',
+       i686: '0fa26db69cefbe13a174a77f8044c7e542f70d79c0b3ae83498b732dc92f1928',
+     x86_64: 'f7578b94d98001fed8bbb00506d071b7110f1bd47ad6cb9ba234566565fb7494'
   })
 
   def self.install


### PR DESCRIPTION
## Description

This commit updates the Terraform CLI from 1.8.2 to 1.8.3.

## Additional information

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` 
