### PR TITLE
Minor source_url cleanups

### DIFF
--- a/packages/funny_manpages.rb
+++ b/packages/funny_manpages.rb
@@ -7,7 +7,7 @@ class Funny_manpages < Package
   version "#{@_ver}-1"
   license 'custom'
   compatibility 'all'
-  source_url 'https:///github.com/ltworf/funny-manpages.git'
+  source_url 'https://github.com/ltworf/funny-manpages.git'
   git_hashtag @_ver
 
   depends_on 'mandb'

--- a/packages/libatasmart.rb
+++ b/packages/libatasmart.rb
@@ -2,11 +2,11 @@ require 'package'
 
 class Libatasmart < Package
   description 'LIBATASMART ATA S.M.A.R.T. Reading and Parsing Library'
-  homepage 'http://git.0pointer.net/libatasmart.git/'
+  homepage 'https://git.0pointer.net/libatasmart.git'
   version '0.19'
   license 'LGPL-2.1+'
   compatibility 'all'
-  source_url 'http://git.0pointer.net/libatasmart.git'
+  source_url 'https://git.0pointer.net/clone/libatasmart.git'
   git_hashtag "v#{version}"
   git_branch 'master'
   binary_compression 'tar.zst'

--- a/packages/libdbusmenu_gtk3.rb
+++ b/packages/libdbusmenu_gtk3.rb
@@ -9,7 +9,7 @@ class Libdbusmenu_gtk3 < Package
   version '16.04.0'
   license 'GPL3 LGPL2.1 LGPL3'
   compatibility 'x86_64 aarch64 armv7l'
-  source_url 'git://git.launchpad.net/ubuntu/+source/libdbusmenu'
+  source_url 'https://git.launchpad.net/ubuntu/+source/libdbusmenu'
   git_hashtag 'a3658f1208c31b1fb03b71af6e49c01119ba52fd'
   binary_compression 'tpxz'
 

--- a/packages/musl_xz.rb
+++ b/packages/musl_xz.rb
@@ -6,7 +6,7 @@ class Musl_xz < Package
   version '5.2.5-e7da-1'
   license 'public-domain, LGPL-2.1+ and GPL-2+'
   compatibility 'all'
-  source_url 'https://github.com/xz-mirror/xz.git'
+  source_url 'https://github.com/tukaani-project/xz.git'
   git_hashtag 'e7da44d5151e21f153925781ad29334ae0786101'
   binary_compression 'tpxz'
 

--- a/packages/tepl_5.rb
+++ b/packages/tepl_5.rb
@@ -2,7 +2,7 @@ require 'buildsystems/meson'
 
 class Tepl_5 < Meson
   description 'Library that eases the development of GtkSourceView-based text editors and IDEs'
-  homepage 'https://wiki.gnome.org/Projects/Tepl'
+  homepage 'https://gitlab.gnome.org/Archive/tepl'
   version '5.1.1'
   license 'LGPL-2.1+'
   compatibility 'x86_64 aarch64 armv7l'

--- a/packages/tepl_6.rb
+++ b/packages/tepl_6.rb
@@ -2,11 +2,11 @@ require 'buildsystems/meson'
 
 class Tepl_6 < Meson
   description 'Library that eases the development of GtkSourceView-based text editors and IDEs'
-  homepage 'https://gitlab.gnome.org/swilmet/tepl'
+  homepage 'https://github.com/gedit-technology/libgedit-tepl'
   version '6.8.0'
   license 'LGPL-2.1+'
   compatibility 'x86_64 aarch64 armv7l'
-  source_url 'https://gitlab.gnome.org/swilmet/tepl.git'
+  source_url 'https://github.com/gedit-technology/libgedit-tepl.git'
   git_hashtag version
   binary_compression 'tar.zst'
 


### PR DESCRIPTION
Just going through some url's and fixing anything I see that pops up.

Apart from `libdbusmenu`, every other git `source_url` ends in `.git`, which is correct most of the time and harmless other times, but `libdbusmenu` cannot end in `.git`, as this triggers a login request.

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=tenor crew update
```
