### PR TITLE
Split whatprovides command into separate file

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -11,6 +11,7 @@ require_relative '../commands/list'
 require_relative '../commands/prop'
 require_relative '../commands/remove'
 require_relative '../commands/sysinfo'
+require_relative '../commands/whatprovides'
 require_relative '../lib/color'
 require_relative '../lib/const'
 require_relative '../lib/crewlog'
@@ -277,23 +278,6 @@ def cache_build
     puts 'CREW_CACHE_ENABLED is not set.'.orange unless CREW_CACHE_ENABLED
     puts 'CREW_CACHE_DIR is not writable.'.lightred unless File.writable?(CREW_CACHE_DIR)
   end
-end
-
-def whatprovides(regex_pat)
-  matched_list = `grep -R "#{regex_pat}" #{CREW_LIB_PATH}/manifest/#{ARCH}`.lines(chomp: true).flat_map do |result|
-    filelist, matched_file = result.split(':', 2)
-    pkg_name = File.basename(filelist, '.filelist')
-    pkg_name_status = pkg_name
-    if @device[:compatible_packages].any? { |elem| elem[:name] == pkg_name }
-      pkg_name_status = pkg_name.lightgreen if File.file? "#{CREW_META_PATH}/#{pkg_name}.filelist"
-    else
-      pkg_name_status = pkg_name.lightred
-    end
-
-    "#{pkg_name_status}: #{matched_file}"
-  end.sort
-
-  puts matched_list, "\nTotal found: #{matched_list.length}".lightgreen if matched_list.any?
 end
 
 def update
@@ -1894,8 +1878,8 @@ def upload_command(args)
 end
 
 def whatprovides_command(args)
-  args['<pattern>'].each do |name|
-    whatprovides name
+  args['<pattern>'].each do |regex|
+    Command.whatprovides(regex)
   end
 end
 

--- a/commands/whatprovides.rb
+++ b/commands/whatprovides.rb
@@ -1,0 +1,22 @@
+require_relative '../lib/const'
+require_relative '../lib/package'
+require_relative '../lib/package_utils'
+
+class Command
+  def self.whatprovides(regex)
+    matched_list = `grep -R "#{regex}" #{CREW_LIB_PATH}/manifest/#{ARCH}`.lines(chomp: true).flat_map do |result|
+      filelist, matched_file = result.split(':', 2)
+      pkg_name = File.basename(filelist, '.filelist')
+      pkg_name_status = pkg_name
+      if PackageUtils.compatible?(Package.load_package(File.join(CREW_PACKAGES_PATH, "#{pkg_name}.rb")))
+        pkg_name_status = pkg_name.lightgreen if PackageUtils.installed?(pkg_name)
+      else
+        pkg_name_status = pkg_name.lightred
+      end
+
+      "#{pkg_name_status}: #{matched_file}"
+    end.sort
+
+    puts matched_list, "\nTotal found: #{matched_list.length}".lightgreen if matched_list.any?
+  end
+end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -2,7 +2,7 @@
 # Defines common constants used in different parts of crew
 require 'etc'
 
-CREW_VERSION = '1.48.1'
+CREW_VERSION = '1.48.2'
 
 # kernel architecture
 KERN_ARCH = Etc.uname[:machine]
@@ -365,7 +365,7 @@ CREW_DOCOPT = <<~DOCOPT
     crew update [options] [-v|--verbose] [<compatible>]
     crew upgrade [options] [-k|--keep] [-s|--source] [-v|--verbose] [<name> ...]
     crew upload [options] [-v|--verbose] [<name> ...]
-    crew whatprovides [options] [-v|--verbose] <pattern> ...
+    crew whatprovides <pattern> ...
 
     -b --include-build-deps  Include build dependencies in output.
     -t --tree                Print dependencies in a tree-structure format.


### PR DESCRIPTION
Not much here, probably could have refactored it a bit further but there's always time to do that later. Splitting this out into a command now so that I can use it in refactoring `getrealdeps.rb` later.

Behaviour changes:
- Fix the docopt string for `crew whatprovides`.

Refactoring changes:
- Use `PackageUtils.installed?` instead of checking for a filelist.
- Use `PackageUtils.compatible?` instead of checking `@device[:compatible_packages]`
  - This was the only use of `@device[:compatible_packages]`, which is just an old vestige anyways, so that can be removed now. I'll deal with that when I split out `crew update` unless someone gets to it first.

Tested and working on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=projectregula9 crew update
```
