### PR TITLE
Split search command into separate file

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -10,6 +10,7 @@ require_relative '../commands/help'
 require_relative '../commands/list'
 require_relative '../commands/prop'
 require_relative '../commands/remove'
+require_relative '../commands/search'
 require_relative '../commands/sysinfo'
 require_relative '../commands/whatprovides'
 require_relative '../lib/color'
@@ -140,16 +141,6 @@ def save_json(json_object)
   load_json
 end
 
-def print_package(pkg_path, extra = false)
-  pkg_name = File.basename pkg_path, '.rb'
-  begin
-    set_package pkg_path
-  rescue StandardError => e
-    warn "Error with #{pkg_name}.rb: #{e}".red unless e.to_s.include?('uninitialized constant')
-  end
-  print_current_package extra
-end
-
 def print_current_package(extra = false)
   status = if PackageUtils.installed?(@pkg.name)
              :installed
@@ -186,12 +177,6 @@ def set_package(pkg_path)
   end
 
   @pkg.build_from_source = true if @opt_recursive
-end
-
-def list_packages
-  Dir["#{CREW_PACKAGES_PATH}/*.rb"].each do |filename|
-    print_package filename
-  end
 end
 
 def generate_compatible
@@ -231,28 +216,6 @@ def search(pkg_name, pkg_path: File.join(CREW_PACKAGES_PATH, "#{pkg_name}.rb"), 
     abort "Package #{pkg_name} not found. 😞".lightred unless silent
     return
   end
-end
-
-def regexp_search(pkg_pat)
-  re = Regexp.new(pkg_pat, true)
-  results = Dir["#{CREW_PACKAGES_PATH}/*.rb"] \
-            .select  { |f| File.basename(f, '.rb') =~ re } \
-            .each    { |f| print_package(f, CREW_VERBOSE) }
-  if results.empty?
-    Dir["#{CREW_PACKAGES_PATH}/*.rb"].each do |package_path|
-      package_name = File.basename package_path, '.rb'
-      begin
-        set_package package_path
-      rescue StandardError => e
-        puts "Error with #{pkg_name}.rb: #{e}".red unless e.to_s.include?('uninitialized constant')
-      end
-      if @pkg.description =~ /#{pkg_pat}/i
-        print_current_package CREW_VERBOSE
-        results.push(package_name)
-      end
-    end
-  end
-  abort "Package #{pkg_pat} not found. :(".lightred if results.empty?
 end
 
 def cache_build
@@ -1827,8 +1790,8 @@ end
 
 def search_command(args)
   args['<name>'].each do |name|
-    regexp_search name
-  end.empty? && list_packages
+    Command.search(name, CREW_VERBOSE)
+  end
 end
 
 def sysinfo_command(_args)

--- a/commands/help.rb
+++ b/commands/help.rb
@@ -101,16 +101,16 @@ class Command
       puts <<~EOT
         Look for package(s).
         Usage: crew search [-v|--verbose] [<pattern> ...]
-        If <pattern> is omitted, all packages will be returned.
+        Both the name and description of packages will be searched.
         If the package color is " + "green".lightgreen + ", it means the package is installed.
         If the package color is " + "red".lightred + ", it means the architecture is not supported.
+        If the package color is " + "blue".lightblue + ", it means the architecture is supported but the package is not installed.
         The <pattern> string can also contain regular expressions.
-        If `-v` or `--verbose` is present, homepage, version and license will be displayed.
+        If `-v` or `--verbose` is present, the homepage, version and license of found packages will be displayed.
         Examples:
-          crew search ^lib".lightblue + " will display all packages that start with `lib`.
-          crew search audio".lightblue + " will display all packages with `audio` in the name.
-          crew search | grep -i audio".lightblue + " will display all packages with `audio` in the name or description.
-          crew search git -v".lightblue + " will display packages with `git` in the name along with homepage, version and license.
+          crew search ^lib".lightblue + " will display all packages with a name or description that starts with `lib`.
+          crew search audio".lightblue + " will display all packages with `audio` in the name or description.
+          crew search -v git".lightblue + " will display all packages with `git` in the name or description along with homepage, version and license.
       EOT
     when 'sysinfo'
       puts <<~EOT

--- a/commands/search.rb
+++ b/commands/search.rb
@@ -1,0 +1,28 @@
+require_relative '../lib/const'
+require_relative '../lib/package'
+require_relative '../lib/package_utils'
+
+class Command
+  def self.search(regex_string, verbose)
+    Dir["#{CREW_PACKAGES_PATH}/*.rb"].each do |package_path|
+      pkg = Package.load_package(package_path)
+      # Create a case-insensitive regex from the passed string.
+      regex = Regexp.new(regex_string, true)
+      next unless regex.match?(File.basename(package_path, '.rb')) || regex.match?(pkg.description)
+      # Installed packages have green names, incompatible packages have red, and compatible but not installed have blue.
+      if PackageUtils.installed?(pkg.name)
+        print pkg.name.lightgreen
+      elsif !PackageUtils.compatible?(pkg)
+        print pkg.name.lightred
+      else
+        print pkg.name.lightblue
+      end
+      puts ": #{pkg.description}".lightblue
+
+      next unless verbose
+      puts pkg.homepage
+      puts "Version: #{pkg.version}"
+      puts "License: #{pkg.license}"
+    end
+  end
+end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -2,7 +2,7 @@
 # Defines common constants used in different parts of crew
 require 'etc'
 
-CREW_VERSION = '1.48.2'
+CREW_VERSION = '1.48.3'
 
 # kernel architecture
 KERN_ARCH = Etc.uname[:machine]
@@ -359,7 +359,7 @@ CREW_DOCOPT = <<~DOCOPT
     crew prop [<property>]
     crew reinstall [options] [-k|--keep] [-s|--source] [-S|--recursive-build] [-v|--verbose] <name> ...
     crew remove [-v|--verbose] <name> ...
-    crew search [options] [-v|--verbose] [<name> ...]
+    crew search [-v|--verbose] <name> ...
     crew sysinfo [-v|--verbose]
     crew test [-v|--verbose] [<name> ...]
     crew update [options] [-v|--verbose] [<compatible>]


### PR DESCRIPTION
Behaviour changes:
- Search both the name and the description of packages, rather than first searching the name and then only searching the description if no results are found.
- Don't list every package if nothing is passed.
- Don't abort if the search returns nothing.
- Fix the docopt string for `crew search`.
- Fix the help string for `crew search`.
  - The colors in help strings are still broken, which we should probably fix at some point.

Refactoring changes:
- Drop the now-unused `print_packages` and `list_packages` functions.
- Simplify the code for handling verbosity.
- Only loop over every package once.
- Only create the regex once.
- Drop the unnecessary error handling when loading packages.
  - Any issues of this sort will be caught by `prop_test` before they get merged.


Tested and working on `x86_64` and `i686`.

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=projectregula12 crew update
```
