### PR TITLE
Fixup gcc_lib and crew update for very old milestone installs

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -4,7 +4,14 @@ require 'digest/sha2'
 require 'json'
 require 'fileutils'
 require 'tmpdir'
-require_relative '../commands/const'
+begin
+  require_relative '../commands/const'
+rescue LoadError
+  # Older crew installs won't have the commands dir in the sparse checkout,
+  # so disable sparse checkout if those files are missing.
+  system 'git sparse-checkout disable'
+  require_relative '../commands/const'
+end
 require_relative '../commands/files'
 require_relative '../commands/help'
 require_relative '../commands/list'

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -2,7 +2,7 @@
 # Defines common constants used in different parts of crew
 require 'etc'
 
-CREW_VERSION = '1.48.4'
+CREW_VERSION = '1.48.5'
 
 # kernel architecture
 KERN_ARCH = Etc.uname[:machine]
@@ -50,7 +50,7 @@ CREW_LIB_SUFFIX = ARCH.eql?('x86_64') && Dir.exist?('/lib64') ? '64' : ''
 ARCH_LIB        = "lib#{CREW_LIB_SUFFIX}"
 
 # Glibc version can be found from the output of libc.so.6
-LIBC_VERSION = Etc.confstr(Etc::CS_GNU_LIBC_VERSION).split.last
+LIBC_VERSION = ENV.fetch('LIBC_VERSION', Etc.confstr(Etc::CS_GNU_LIBC_VERSION).split.last )
 
 CREW_PREFIX = ENV.fetch('CREW_PREFIX', '/usr/local')
 

--- a/packages/gcc_build.rb
+++ b/packages/gcc_build.rb
@@ -15,7 +15,7 @@ class Gcc_build < Package
     binary_sha256({
          i686: '0850517263680419c1ae4152ba8237a5ee1d40651b31832f211ed450df94999c'
     })
-  when '2.27', '2.35'
+  when '2.27', '2.32', '2.33', '2.35'
     binary_sha256({
       aarch64: 'c53f34ca91bf3eee1ac207b4054c41928da311bf4fa55f8595cc21f1285d398d',
        armv7l: 'c53f34ca91bf3eee1ac207b4054c41928da311bf4fa55f8595cc21f1285d398d',

--- a/packages/gcc_lib.rb
+++ b/packages/gcc_lib.rb
@@ -17,7 +17,7 @@ class Gcc_lib < Package
     binary_sha256({
          i686: '192f52beaa24ebbf3e1ae1787c9f12c75ad59e7f7885729d90b7c40b1177d796'
     })
-  when '2.27', '2.35'
+  when '2.27', '2.32', '2.33', '2.35'
     binary_sha256({
       aarch64: '82d95874bc0326967b821420afec5d809c2b883be10bca5798314a4490b11622',
        armv7l: '82d95874bc0326967b821420afec5d809c2b883be10bca5798314a4490b11622',


### PR DESCRIPTION
Probably Fixes #9901 

- These issues come up when I open the M106 container...

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=old_install_fix crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
