### PR TITLE
Only access filelist and directorylist in remove function if they exist.

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -2,7 +2,7 @@
 # Defines common constants used in different parts of crew
 require 'etc'
 
-CREW_VERSION = '1.48.5'
+CREW_VERSION = '1.48.6'
 
 # kernel architecture
 KERN_ARCH = Etc.uname[:machine]


### PR DESCRIPTION
Noticed this issue when opening the M106 container:
```
Ruby_debug found in package fixup list
Ruby_debug is deprecated and should be removed.
Ruby_debug: Integrated into ruby package.

Would you like to remove deprecated package Ruby_debug? [y/N] y
/usr/local/lib/crew/commands/remove.rb:29:in `foreach': No such file or directory @ rb_sysopen - /usr/local/etc/crew/meta/ruby_debug.filelist (Errno::ENOENT)                                                         from /usr/local/lib/crew/commands/remove.rb:29:in `block in remove'
        from /usr/local/lib/crew/commands/remove.rb:27:in `chdir'
        from /usr/local/lib/crew/commands/remove.rb:27:in `remove'
        from /usr/local/lib/crew/lib/fixup.rb:154:in `block in <top (required)>'
        from /usr/local/lib/crew/lib/fixup.rb:77:in `each'                                                                                                                                                            from /usr/local/lib/crew/lib/fixup.rb:77:in `<top (required)>'
        from /usr/local/bin/crew:270:in `load'
        from /usr/local/bin/crew:270:in `update'
        from /usr/local/bin/crew:1836:in `update_command'
        from /usr/local/bin/crew:1870:in `<main>'
```
- The absence of those files shouldn't cause crew to error out.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=old_container_fix crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
