### PR TITLE
Handle case where ruby needs an upgrade, but openssl also needs to be upgraded, and other M106 fixes.

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1,7 +1,13 @@
 #!/usr/bin/env ruby
 require 'uri'
 require 'digest/sha2'
-require 'json'
+begin
+  require 'json'
+rescue LoadError
+  puts ' -> install gem json'
+  Gem.install('json')
+  require 'json'
+end
 require 'fileutils'
 require 'tmpdir'
 begin

--- a/bin/crew
+++ b/bin/crew
@@ -360,7 +360,10 @@ def upgrade(*pkgs, build_from_source: false)
   # Upgrade OpenSSL first if OpenSSL is in the upgrade list, as other
   # package upgrades, especially their postinstalls, may break until the
   # new version of OpenSSL is installed.
-  to_be_upgraded.insert(0, to_be_upgraded.delete('openssl')) if to_be_upgraded.include?('openssl')
+  if to_be_upgraded.include?('openssl')
+    to_be_upgraded.insert(0, to_be_upgraded.delete('openssl'))
+    rerun_upgrade = true
+  end
 
   # Only upgrade ruby if ruby is in the upgrade list, as other
   # package upgrades may break until crew is rerun with the new

--- a/bin/crew
+++ b/bin/crew
@@ -366,7 +366,11 @@ def upgrade(*pkgs, build_from_source: false)
   # package upgrades may break until crew is rerun with the new
   # version of ruby.
   if to_be_upgraded.include?('ruby')
-    to_be_upgraded = ['ruby']
+    if to_be_upgraded.include?('openssl')
+      to_be_upgraded.delete('ruby')
+    else
+      to_be_upgraded = ['ruby']
+    end
     rerun_upgrade = true
   end
 

--- a/bin/crew
+++ b/bin/crew
@@ -4,6 +4,7 @@ require 'digest/sha2'
 begin
   require 'json'
 rescue LoadError
+  # The json gem can break when upgrading from a mufh older version of ruby.
   puts ' -> install gem json'
   Gem.install('json')
   require 'json'

--- a/bin/crew
+++ b/bin/crew
@@ -4,7 +4,7 @@ require 'digest/sha2'
 begin
   require 'json'
 rescue LoadError
-  # The json gem can break when upgrading from a mufh older version of ruby.
+  # The json gem can break when upgrading from a much older version of ruby.
   puts ' -> install gem json'
   Gem.install('json')
   require 'json'

--- a/lib/buildsystems/pip.rb
+++ b/lib/buildsystems/pip.rb
@@ -39,7 +39,7 @@ class Pip < Package
       @pip_path = File.expand_path("#{@pip_files_base}#{pip_file}")
       @destpath = File.join(CREW_DEST_DIR, @pip_path)
       # Handle older FileUtils from older ruby versions.
-      FileUtils.mkdir_p File.join(CREW_DEST_DIR, @pip_files_base) if Gem::Version.new(RUBY_VERSION.to_s) < Gem::Version.new('3.3')
+      FileUtils.mkdir_p File.dirname(@destpath) if Gem::Version.new(RUBY_VERSION.to_s) < Gem::Version.new('3.3')
       FileUtils.install @pip_path, @destpath
     end
     eval @pip_install_extras if @pip_install_extras

--- a/lib/buildsystems/pip.rb
+++ b/lib/buildsystems/pip.rb
@@ -37,7 +37,9 @@ class Pip < Package
     @pip_files_lines = @pip_files[/(?<=Files:\n)[\W|\w]*/, 0].split
     @pip_files_lines.each do |pip_file|
       @pip_path = File.expand_path("#{@pip_files_base}#{pip_file}")
-      @destpath = "#{CREW_DEST_DIR.chomp('/')}#{@pip_path}"
+      @destpath = File.join(CREW_DEST_DIR, @pip_path)
+      # Handle older FileUtils from older ruby versions.
+      FileUtils.mkdir_p File.join(CREW_DEST_DIR, @pip_files_base) if Gem::Version.new(RUBY_VERSION.to_s) < Gem::Version.new('3.3')
       FileUtils.install @pip_path, @destpath
     end
     eval @pip_install_extras if @pip_install_extras

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -2,7 +2,7 @@
 # Defines common constants used in different parts of crew
 require 'etc'
 
-CREW_VERSION = '1.48.6'
+CREW_VERSION = '1.48.7'
 
 # kernel architecture
 KERN_ARCH = Etc.uname[:machine]

--- a/packages/gcc_dev.rb
+++ b/packages/gcc_dev.rb
@@ -17,7 +17,7 @@ class Gcc_dev < Package
     binary_sha256({
          i686: '68823c2d372559b5ba9e304529bd01f24ccf7c0a71a14824d048b2d323643257'
     })
-  when '2.27', '2.35'
+  when '2.27', '2.32', '2.33', '2.35'
     binary_sha256({
       aarch64: 'f649c41a0d2fbfb5077068319d6dd8cca84b4047d409213b8f32623dff4e2bbd',
        armv7l: 'f649c41a0d2fbfb5077068319d6dd8cca84b4047d409213b8f32623dff4e2bbd',

--- a/packages/libssp.rb
+++ b/packages/libssp.rb
@@ -18,7 +18,7 @@ class Libssp < Package
     binary_sha256({
          i686: 'f1e548a41f577f4865675e8b280fb949c7a10459980b652d24b80d7f86e673a5'
     })
-  when '2.27', '2.35'
+  when '2.27', '2.32', '2.33', '2.35'
     binary_sha256({
       aarch64: '2b8d8b39ae8ad8e4ec938279b4a23468e7dc7f56c8c3f692f700a0d49f557855',
        armv7l: '2b8d8b39ae8ad8e4ec938279b4a23468e7dc7f56c8c3f692f700a0d49f557855',

--- a/packages/py3_packaging.rb
+++ b/packages/py3_packaging.rb
@@ -3,7 +3,7 @@ require 'buildsystems/pip'
 class Py3_packaging < Pip
   description 'Packaging provides core utilities for Python packages'
   homepage 'https://packaging.pypa.io/'
-  @_ver = '23.2'
+  @_ver = '24.0'
   version "#{@_ver}-py3.12"
   license 'BSD-2 or Apache-2.0'
   compatibility 'all'

--- a/packages/py3_pip.rb
+++ b/packages/py3_pip.rb
@@ -3,7 +3,7 @@ require 'buildsystems/python'
 class Py3_pip < Python
   description 'Pip is the python package manager from the Python Packaging Authority.'
   homepage 'https://pip.pypa.io/'
-  @_ver = '23.3.1'
+  @_ver = '24.0'
   version "#{@_ver}-py3.12"
   license 'MIT'
   compatibility 'all'

--- a/packages/ruby_rubocop.rb
+++ b/packages/ruby_rubocop.rb
@@ -20,6 +20,7 @@ class Ruby_rubocop < RUBY
   no_fhs
 
   ruby_install_extras <<~EOF
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/.config/rubocop/" if Gem::Version.new(RUBY_VERSION.to_s) < Gem::Version.new('3.3')
     FileUtils.install '.rubocop.yml', "#{CREW_DEST_PREFIX}/.config/rubocop/config.yml", mode: 0o644
   EOF
 


### PR DESCRIPTION
- Trying to fixup the M106 container.
- This fixes 99% of issues opening the M106 container and updating/upgrading to current.
- Left for another day is fixing the upgrade of older versions of installed is_fake packages like `gcc`, `llvm`, etc...

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=ruby_openssl_upgrade crew update ; yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
