### PR TITLE
Update glibc_lib237 to use system libraries

### DIFF
--- a/manifest/armv7l/g/glibc_lib237.filelist
+++ b/manifest/armv7l/g/glibc_lib237.filelist
@@ -287,6 +287,7 @@
 /usr/local/lib/libm.so
 /usr/local/lib/libm.so.6
 /usr/local/lib/libmemusage.so
+/usr/local/lib/libmvec.so.1
 /usr/local/lib/libnsl.so.2
 /usr/local/lib/libnss_compat.so
 /usr/local/lib/libnss_compat.so.2

--- a/packages/glibc_lib237.rb
+++ b/packages/glibc_lib237.rb
@@ -4,19 +4,20 @@ require_relative 'glibc_build237'
 class Glibc_lib237 < Package
   description 'glibc libraries'
   homepage Glibc_build237.homepage
-  version '2.37' # Do not use @_ver here, it will break the installer.
+  version '2.37-1' # Do not use @_ver here, it will break the installer.
   license Glibc_build237.license
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'SKIP'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '8e8ea16654e689209ebf82c01cc86808e991ac9b45819c3c6eea993a69967ac1',
-     armv7l: '8e8ea16654e689209ebf82c01cc86808e991ac9b45819c3c6eea993a69967ac1',
-     x86_64: '56b8c62ab11bc5e1a95bec2ad7e1e64ce7ee07aff7560a720c9a2d937ef42c5e'
+    aarch64: 'efb6e1f5593f97b6fe8232e7e265911bba0f632e178f86c3f0412c1265cf2962',
+     armv7l: 'efb6e1f5593f97b6fe8232e7e265911bba0f632e178f86c3f0412c1265cf2962',
+     x86_64: '2645a7f26f0d0f007c57f296ef18c853253b98da4756f7ada840a40147c8c8ed'
   })
 
   depends_on 'glibc_build237' => :build
+  depends_on 'glibc' # R
 
   conflicts_ok
   no_shrink
@@ -39,6 +40,12 @@ class Glibc_lib237 < Package
       @destpath = File.join(CREW_DEST_DIR, filename)
       @filename_target = File.realpath(filename)
       FileUtils.install @filename_target, @destpath
+    end
+    # Symlinks to system libraries.
+    %w[libanl.so.1 libc_malloc_debug.so.0 libc.so.6 libdl.so.2 libm.so.6
+       libmvec.so.1 libnss_dns.so.2 libnss_files.so.2 libpthread.so.0
+       libresolv.so.2 librt.so.1 libthread_db.so.1 libutil.so.1].each do |lib|
+      FileUtils.ln_sf "/#{ARCH_LIB}/#{lib}", "#{CREW_DEST_LIB_PREFIX}/#{lib}"
     end
   end
 end


### PR DESCRIPTION
The current package libraries are broken and prevent m125 stable channel installs.  Fixes #9923.  Fixes #9934.