### PR TITLE
install.sh: Some improvements

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -125,7 +125,6 @@ fi
 echo_success "Welcome to Chromebrew!"
 
 # Prompt user to enter the sudo password if it is set.
-# If the PASSWD_FILE specified by chromeos-setdevpasswd exist, that means a sudo password is set.
 if [ -f /mnt/stateful_partition/etc/devmode.passwd ]; then
   echo_intra "Please enter the developer mode password."
   # Reset sudo timeout.

--- a/install.sh
+++ b/install.sh
@@ -134,6 +134,7 @@ if [ -f /mnt/stateful_partition/etc/devmode.passwd ]; then
 fi
 
 # Force all system binaries NOT to use chromebrew libraries to prevent any compatibility issues
+# shellcheck disable=SC2139
 for exe in /bin/* /usr/bin/*; do
   alias "${exe##*/}=/usr/bin/env -u LD_LIBRARY_PATH ${exe}"
 done

--- a/install.sh
+++ b/install.sh
@@ -45,7 +45,7 @@ fi
 # Check if the user owns the CREW_PREFIX directory, as sudo is unnecessary if this is the case.
 # Check if the user is on ChromeOS v117+ and not in the VT-2 console, as sudo will not work.
 : "${CREW_PREFIX:=/usr/local}"
-if [ ！ -O "${CREW_PREFIX}" ] && grep -q 'NoNewPrivs:\s*1' /proc/$$/status; then
+if ! ([ -O "${CREW_PREFIX}" ] || grep -q 'NoNewPrivs:\s*0' /proc/$$/status); then
   echo_error "Please run the installer in the VT-2 shell."
   echo_info "To start the VT-2 session, type Ctrl + Alt + ->"
   exit 1
@@ -71,7 +71,7 @@ else
 fi
 
 # Do not redundantly use sudo if the user already owns the directory.
-if [ ! -O "${CREW_PREFIX}" ]; then
+if ! [ -O "${CREW_PREFIX}" ]; then
   # This will allow things to work without sudo.
   sudo chown "${EUID}:${EUID}" "${CREW_PREFIX}"
 fi


### PR DESCRIPTION
Fixes #9934, fixes #9923

### Changes
- Bashify some commands (like changing `basename $var` to `${var##*/}`)
- Stop system binaries from accessing chromebrew libraries, preventing issues like #9923 happen again
- Change version checking regex to a `grep` command, which should fix #9934
- Hardcoded developer mode password file path as it is unlikely to change in the future
- Removed `LD_LIBRARY_PATH` env variable setting logic, as it should be handled in `crew-profile-base` instead

Tested on `aarch64`