### PR TITLE
Remove CREW_MESON_FNO_LTO_OPTIONS

### DIFF
--- a/lib/buildsystems/meson.rb
+++ b/lib/buildsystems/meson.rb
@@ -5,7 +5,7 @@ class Meson < Package
 
   def self.build
     puts "Additional meson_options being used: #{@pre_meson_options.nil? ? '<no pre_meson_options>' : @pre_meson_options} #{@meson_options.nil? ? '<no meson_options>' : @meson_options}".orange
-    @crew_meson_options = @no_lto ? CREW_MESON_FNO_LTO_OPTIONS : CREW_MESON_OPTIONS
+    @crew_meson_options = @no_lto ? CREW_MESON_OPTIONS.sub('-Db_lto=true', '-Db_lto=false') : CREW_MESON_OPTIONS
     @mold_linker_prefix_cmd = CREW_LINKER == 'mold' ? 'mold -run' : ''
     system "#{@pre_meson_options} #{@mold_linker_prefix_cmd} meson setup #{@crew_meson_options} #{@meson_options} builddir"
     system 'meson configure --no-pager builddir'

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -2,7 +2,7 @@
 # Defines common constants used in different parts of crew
 require 'etc'
 
-CREW_VERSION = '1.48.9'
+CREW_VERSION = '1.49.0'
 
 # kernel architecture
 KERN_ARCH = Etc.uname[:machine]
@@ -259,20 +259,6 @@ CREW_MESON_OPTIONS = <<~OPT.chomp
   -Dsharedstatedir=#{CREW_PREFIX}/var/local/lib \
   -Dbuildtype=release \
   -Db_lto=true \
-  -Dstrip=true \
-  -Db_pie=true \
-  -Dcpp_args='#{CREW_CORE_FLAGS}' \
-  -Dc_args='#{CREW_CORE_FLAGS}'
-OPT
-
-CREW_MESON_FNO_LTO_OPTIONS = <<~OPT.chomp
-  -Dprefix=#{CREW_PREFIX} \
-  -Dlibdir=#{CREW_LIB_PREFIX} \
-  -Dlocalstatedir=#{CREW_PREFIX}/var/local \
-  -Dmandir=#{CREW_MAN_PREFIX} \
-  -Dsharedstatedir=#{CREW_PREFIX}/var/local/lib \
-  -Dbuildtype=release \
-  -Db_lto=false \
   -Dstrip=true \
   -Db_pie=true \
   -Dcpp_args='#{CREW_CORE_FLAGS}' \

--- a/packages/colord.rb
+++ b/packages/colord.rb
@@ -1,6 +1,6 @@
-require 'package'
+require 'buildsystems/meson'
 
-class Colord < Package
+class Colord < Meson
   description 'colord is a system service that makes it easy to manage, install and generate color profiles to accurately color manage input and output devices.'
   homepage 'https://www.freedesktop.org/software/colord/'
   version '1.4.5'
@@ -27,17 +27,11 @@ class Colord < Package
   depends_on 'polkit'
   depends_on 'vala'
 
+  no_lto
+
   def self.patch
     system "sed -i 's,-fstack-protector-strong,-fno-stack-protector,' meson.build"
   end
 
-  def self.build
-    system "meson setup #{CREW_MESON_FNO_LTO_OPTIONS} -Dsystemd=false -Ddaemon_user=#{USER} builddir"
-    system 'meson configure --no-pager builddir'
-    system 'ninja -C builddir'
-  end
-
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-  end
+  meson_options "-Dsystemd=false -Ddaemon_user=#{USER}"
 end

--- a/packages/xorg_intel_driver.rb
+++ b/packages/xorg_intel_driver.rb
@@ -1,8 +1,8 @@
 # following https://github.com/archlinux/svntogit-packages/blob/packages/xf86-video-intel/trunk/PKGBUILD
 
-require 'package'
+require 'buildsystems/meson'
 
-class Xorg_intel_driver < Package
+class Xorg_intel_driver < Meson
   description 'The Xorg Intel Driver package contains the X.Org Video Driver for Intel integrated video chips including 8xx, 9xx, Gxx, Qxx, HD, Iris, and Iris Pro graphics processors.'
   homepage 'https://01.org/linuxgraphics/'
   @_ver = '31486f40f8e8f8923ca0799aea84b58799754564'
@@ -22,18 +22,9 @@ class Xorg_intel_driver < Package
   # See https://gitlab.freedesktop.org/xorg/driver/xf86-video-intel/-/issues/180#note_387356
   # depends_on 'libxvmc' => :build
 
-  def self.build
-    # LTO is broken with this build.
-    # See https://gitlab.freedesktop.org/xorg/driver/xf86-video-intel/-/issues/28
-    system "meson setup #{CREW_MESON_FNO_LTO_OPTIONS} \
-            -Ddefault-dri=3 \
-            -Dxvmc=false \
-            builddir"
-    system 'meson configure --no-pager builddir'
-    system 'ninja -C builddir'
-  end
+  # LTO is broken with this build.
+  # See https://gitlab.freedesktop.org/xorg/driver/xf86-video-intel/-/issues/28
+  no_lto
 
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} ninja -C builddir install"
-  end
+  meson_options '-Ddefault-dri=3 -Dxvmc=false'
 end


### PR DESCRIPTION
Deduplicating some things, and swapping `colord` and `xorg_intel_driver` to the meson buildsystem and stopping them from using the variable directly. 

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=whynot crew update
```
