### PR TITLE
Remove CREW_CMAKE_FNO_LTO_OPTIONS

### DIFF
--- a/lib/buildsystems/cmake.rb
+++ b/lib/buildsystems/cmake.rb
@@ -5,7 +5,7 @@ class CMake < Package
 
   def self.build
     @cmake_build_relative_dir ||= '.'
-    @crew_cmake_options = @no_lto ? CREW_CMAKE_FNO_LTO_OPTIONS : CREW_CMAKE_OPTIONS
+    @crew_cmake_options = @no_lto ? CREW_CMAKE_OPTIONS.gsub('-flto=auto', '-fno-lto').sub('-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=TRUE', '') : CREW_CMAKE_OPTIONS
     puts 'Additional cmake options being used:'.orange
     method_list = methods.grep(/cmake_/).delete_if { |i| send(i).blank? }
     method_list.each do |method|

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -268,7 +268,6 @@ CREW_NINJA ||= ENV.fetch('CREW_NINJA', 'ninja') unless defined?(CREW_NINJA)
 # Cmake sometimes wants to use LIB_SUFFIX to install libs in LIB64, so specify such for x86_64
 # This is often considered deprecated. See discussio at https://gitlab.kitware.com/cmake/cmake/-/issues/18640
 # and also https://bugzilla.redhat.com/show_bug.cgi?id=1425064
-# Let's have two CREW_CMAKE_OPTIONS since this avoids the logic in the recipe file.
 CREW_CMAKE_OPTIONS ||= <<~OPT.chomp
   -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX} \
   -DCMAKE_LIBRARY_PATH=#{CREW_LIB_PREFIX} \
@@ -279,17 +278,6 @@ CREW_CMAKE_OPTIONS ||= <<~OPT.chomp
   -DCMAKE_SHARED_LINKER_FLAGS='#{CREW_LDFLAGS}' \
   -DCMAKE_MODULE_LINKER_FLAGS='#{CREW_LDFLAGS}' \
   -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=TRUE \
-  -DCMAKE_BUILD_TYPE=Release
-OPT
-CREW_CMAKE_FNO_LTO_OPTIONS ||= <<~OPT.chomp
-  -DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX} \
-  -DCMAKE_LIBRARY_PATH=#{CREW_LIB_PREFIX} \
-  -DCMAKE_C_FLAGS='#{CREW_COMMON_FNO_LTO_FLAGS.gsub(/-fuse-ld=.{2,4}\s/, '')}' \
-  -DCMAKE_CXX_FLAGS='#{CREW_COMMON_FNO_LTO_FLAGS.gsub(/-fuse-ld=.{2,4}\s/, '')}' \
-  -DCMAKE_EXE_LINKER_FLAGS=#{CREW_FNO_LTO_LDFLAGS} \
-  -DCMAKE_LINKER_TYPE=#{CREW_LINKER.upcase} \
-  -DCMAKE_SHARED_LINKER_FLAGS=#{CREW_FNO_LTO_LDFLAGS} \
-  -DCMAKE_MODULE_LINKER_FLAGS=#{CREW_FNO_LTO_LDFLAGS} \
   -DCMAKE_BUILD_TYPE=Release
 OPT
 

--- a/packages/libclc.rb
+++ b/packages/libclc.rb
@@ -52,7 +52,7 @@ class Libclc < Package
   def self.build
     @cmake_options = case ARCH
                      when 'i686', 'x86_64'
-                       CREW_CMAKE_FNO_LTO_OPTIONS.gsub('-fno-lto', '')
+                       CREW_CMAKE_OPTIONS.gsub('-flto=auto', '').sub('-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=TRUE', '')
                      else
                        CREW_CMAKE_OPTIONS
                      end

--- a/packages/openmp.rb
+++ b/packages/openmp.rb
@@ -55,7 +55,7 @@ class Openmp < Package
   def self.build
     @cmake_options = case ARCH
                      when 'i686', 'x86_64'
-                       CREW_CMAKE_FNO_LTO_OPTIONS.gsub('-fno-lto', '')
+                       CREW_CMAKE_OPTIONS.gsub('-flto=auto', '').sub('-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=TRUE', '')
                      else
                        CREW_CMAKE_OPTIONS
                      end

--- a/packages/webkit2gtk_4.rb
+++ b/packages/webkit2gtk_4.rb
@@ -144,7 +144,7 @@ class Webkit2gtk_4 < Package
       @arch_linker_flags = ARCH == 'x86_64' ? '' : '-Wl,--no-keep-memory'
       system "CREW_LINKER_FLAGS='#{@arch_linker_flags}' CC='#{@workdir}/bin/gcc' CXX='#{@workdir}/bin/g++' \
             cmake -B builddir -G Ninja \
-            #{CREW_CMAKE_FNO_LTO_OPTIONS.gsub('mold', 'gold').sub('-pipe', '-pipe -Wno-error').gsub('-fno-lto', '')} \
+            #{CREW_CMAKE_OPTIONS.sub('-pipe', '-pipe -Wno-error').gsub('-flto=auto', '').sub('-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=TRUE', '')} \
             -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
             -DENABLE_BUBBLEWRAP_SANDBOX=OFF \
             -DENABLE_DOCUMENTATION=OFF \

--- a/packages/webkit2gtk_4_1.rb
+++ b/packages/webkit2gtk_4_1.rb
@@ -96,7 +96,7 @@ class Webkit2gtk_4_1 < Package
       @arch_linker_flags = ARCH == 'x86_64' ? '' : '-Wl,--no-keep-memory'
       system "CREW_LINKER_FLAGS='#{@arch_linker_flags}' \
           cmake -B builddir -G Ninja \
-          #{CREW_CMAKE_FNO_LTO_OPTIONS.sub('-pipe', '-pipe -Wno-error').gsub('-fno-lto', '')} \
+          #{CREW_CMAKE_OPTIONS.sub('-pipe', '-pipe -Wno-error').gsub('-flto=auto', '').sub('-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=TRUE', '')} \
           -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
           -DENABLE_BUBBLEWRAP_SANDBOX=OFF \
           -DENABLE_DOCUMENTATION=OFF \

--- a/packages/webkitgtk_6.rb
+++ b/packages/webkitgtk_6.rb
@@ -148,7 +148,7 @@ class Webkitgtk_6 < Package
       @arch_linker_flags = ARCH == 'x86_64' ? '' : '-Wl,--no-keep-memory'
       system "CREW_LINKER_FLAGS='#{@arch_linker_flags}' CC='#{@workdir}/bin/gcc' CXX='#{@workdir}/bin/g++' \
           cmake -B builddir -G Ninja \
-          #{CREW_CMAKE_FNO_LTO_OPTIONS.gsub('-DCMAKE_LINKER_TYPE=MOLD', '').sub('-pipe', '-pipe -Wno-error').gsub('-fno-lto', '')} \
+          #{CREW_CMAKE_OPTIONS.sub('-pipe', '-pipe -Wno-error').gsub('-flto=auto', '').sub('-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=TRUE', '')} \
           -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
           -DENABLE_BUBBLEWRAP_SANDBOX=OFF \
           -DENABLE_DOCUMENTATION=OFF \


### PR DESCRIPTION
Removing `CREW_LINKER_FLAGS` was pretty simple, nothing of note there.

However, I have marked this PR as draft to get additional feedback on the `CREW_CMAKE_FNO_LTO_OPTIONS` changes-- there's more manual modification than I'd like, and thats because the affected packages aren't on buildsystems yet.

I could probably switch most of them over to buildsystems, but I'd like @satmandu's thoughts first, because he's the one who builds them.

Also, why do these packages select `CREW_CMAKE_FNO_LTO_OPTIONS` but then delete `-fno-lto`? If I knew why they were doing that and if that needed to be done, things could probably be simpler.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=bowling crew update
```
