### PR TITLE
Add vcpkg package

### DIFF
--- a/manifest/armv7l/v/vcpkg.filelist
+++ b/manifest/armv7l/v/vcpkg.filelist
@@ -1,0 +1,2 @@
+/usr/local/bin/vcpkg
+/usr/local/etc/env.d/vcpkg_completion.bash

--- a/manifest/i686/v/vcpkg.filelist
+++ b/manifest/i686/v/vcpkg.filelist
@@ -1,0 +1,2 @@
+/usr/local/bin/vcpkg
+/usr/local/etc/env.d/vcpkg_completion.bash

--- a/manifest/x86_64/v/vcpkg.filelist
+++ b/manifest/x86_64/v/vcpkg.filelist
@@ -1,0 +1,2 @@
+/usr/local/bin/vcpkg
+/usr/local/etc/env.d/vcpkg_completion.bash

--- a/packages/vcpkg.rb
+++ b/packages/vcpkg.rb
@@ -1,0 +1,29 @@
+require 'package'
+
+class Vcpkg < Package
+  description 'C++ Library Manager for Windows, Linux, and MacOS'
+  homepage 'https://github.com/microsoft/vcpkg'
+  version '2024.05.24'
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://github.com/microsoft/vcpkg.git'
+  git_hashtag version
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+    aarch64: 'd83257325d352eddb3d880f10cf03ec3982ba826198f45fc8967930ef10aa8c1',
+     armv7l: 'd83257325d352eddb3d880f10cf03ec3982ba826198f45fc8967930ef10aa8c1',
+       i686: 'e35d5be2cc00cc50042f79a60168debbf0c981290a34f68da92ab386ef9bfac7',
+     x86_64: 'e62740df23b57ae09fa940304c7e52fbb040e24bde36acf40ddeb12f90d6bad8'
+  })
+
+  def self.build
+    ENV['VCPKG_FORCE_SYSTEM_BINARIES'] = 'ON'
+    system './bootstrap-vcpkg.sh'
+  end
+
+  def self.install
+    FileUtils.install 'vcpkg', "#{CREW_DEST_PREFIX}/bin/vcpkg", mode: 0o755
+    FileUtils.install 'scripts/vcpkg_completion.bash', "#{CREW_DEST_PREFIX}/etc/env.d/vcpkg_completion.bash", mode: 0o644
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -8926,6 +8926,11 @@ url: https://github.com/intel/vc-intrinsics/releases
 activity: low
 ---
 kind: url
+name: vcpkg
+url: https://github.com/microsoft/vcpkg/releases
+activity: low
+---
+kind: url
 name: vamp_sdk
 url: https://code.soundsoftware.ac.uk/projects/vamp-plugin-sdk/files
 activity: medium


### PR DESCRIPTION
C++ Library Manager for Windows, Linux, and MacOS.  See https://github.com/microsoft/vcpkg.  Tested on all architectures.