### PR TITLE
libsm rebuild

### DIFF
--- a/packages/libsm.rb
+++ b/packages/libsm.rb
@@ -1,19 +1,19 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Libsm < Package
+class Libsm < Autotools
   description 'X.org X Session Management Library'
   homepage 'http://www.x.org'
-  version '1.2.4'
+  version '1.2.4-5edd20b'
   license 'MIT'
   compatibility 'x86_64 aarch64 armv7l'
-  source_url 'https://www.x.org/archive/individual/lib/libSM-1.2.4.tar.gz'
-  source_sha256 '51464ce1abce323d5b6707ceecf8468617106e1a8a98522f8342db06fd024c15'
+  source_url 'https://gitlab.freedesktop.org/xorg/lib/libsm.git'
+  git_hashtag '5edd20b307ce70ccb14c360f1b94914c49544a24'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'c8ac7992e45ada38ff88bbd3f72f824e028ba8ab2ee5b410b03ca6588a97e847',
-     armv7l: 'c8ac7992e45ada38ff88bbd3f72f824e028ba8ab2ee5b410b03ca6588a97e847',
-     x86_64: 'd58420a4d0a1cd459db032a5cee77848648483b9e00da0f6161edece6e3d2533'
+    aarch64: '0bddd0de07a4a833a9b6ae2238eb549f5f012f6dfc0a79062551f39ca02c5ec8',
+     armv7l: '0bddd0de07a4a833a9b6ae2238eb549f5f012f6dfc0a79062551f39ca02c5ec8',
+     x86_64: '3177c18fbb37de01bb93cab3ee821a50987034e5fa146a48e6eb581ebb8cf773'
   })
 
   depends_on 'glibc' # R
@@ -21,14 +21,6 @@ class Libsm < Package
   depends_on 'libice' # R
   depends_on 'libmd' # R
   depends_on 'libx11' => :build
+  depends_on 'libxtrans' => :build
   depends_on 'util_linux' # R
-
-  def self.build
-    system "./configure #{CREW_OPTIONS}"
-    system 'make'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
 end


### PR DESCRIPTION
Fixes this xterm error:
```
xterm: /usr/local/lib64/libuuid.so.1: no version information available (required by /usr/local/lib64/libSM.so.6)
```

Builds properly:
- [x] `x86_64`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=libsm crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
