### PR TITLE
Enable rubocop-chromebrew extension

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,14 +1,6 @@
 ---
-# The behavior of RuboCop can be controlled via the .rubocop.yml
-# configuration file. It makes it possible to enable/disable
-# certain cops (checks) and to alter their behavior if they accept
-# any parameters. The file can be placed either in your home
-# directory or in some project directory.
-#
-# RuboCop will start looking for the configuration file in the directory
-# where the inspected file is and continue its way up to the root directory.
-#
-# See https://docs.rubocop.org/rubocop/configuration
+require:
+ - rubocop-chromebrew
 
 AllCops:
   NewCops: enable


### PR DESCRIPTION
Enable https://github.com/Zopolis4/rubocop-chromebrew.

Opening as draft so I can sort out the details while we transfer the repository over to the chromebrew organisation.