### PR TITLE
Github_cli 2.51.0 => 2.52.0

### DIFF
--- a/packages/github_cli.rb
+++ b/packages/github_cli.rb
@@ -3,7 +3,7 @@ require 'package'
 class Github_cli < Package
   description 'Official Github CLI tool'
   homepage 'https://cli.github.com/'
-  version '2.51.0'
+  version '2.52.0'
   license 'MIT'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Github_cli < Package
      x86_64: "https://github.com/cli/cli/releases/download/v#{version}/gh_#{version}_linux_amd64.tar.gz"
   })
   source_sha256({
-    aarch64: 'a9943b3ea1907fc7b4d5bca4a2c2fa81722b02bbdaf11725516b2b0cfc78c449',
-     armv7l: 'a9943b3ea1907fc7b4d5bca4a2c2fa81722b02bbdaf11725516b2b0cfc78c449',
-       i686: 'dda319dc8c0c62bfbb238c61dafd3da0db2ea08a94c6ada3111099bc808ecaf5',
-     x86_64: 'd7725fb2a643ca024edf5b4e2f2cca0431a404bbc2e251086ffca2b25e37be11'
+    aarch64: 'e5721ce20fab3676814b06119367a270d4e5b23e7a2f995aaed2ea9ccdc3e9f4',
+     armv7l: 'e5721ce20fab3676814b06119367a270d4e5b23e7a2f995aaed2ea9ccdc3e9f4',
+       i686: '1e4896c404bb626a694f853b335b8778bdf07996bd10faf3aa4876cd2102ed91',
+     x86_64: '3ea6ed8b2585f406a064cecd7e1501e58f56c8e7ca764ae1f3483d1b8ed68826'
   })
 
   no_compile_needed


### PR DESCRIPTION
Tested and working on all architectures.  No filelist updates.