### PR TITLE
Add ollama package

### DIFF
--- a/manifest/x86_64/o/ollama.filelist
+++ b/manifest/x86_64/o/ollama.filelist
@@ -1,0 +1,1 @@
+/usr/local/bin/ollama

--- a/packages/ollama.rb
+++ b/packages/ollama.rb
@@ -1,0 +1,19 @@
+require 'package'
+
+class Ollama < Package
+  description 'Get up and running with large language models.'
+  homepage 'https://ollama.com/'
+  version '0.1.47'
+  license 'MIT'
+  compatibility 'x86_64'
+  source_url "https://github.com/ollama/ollama/releases/download/v#{version}/ollama-linux-amd64"
+  source_sha256 '4e51802b7a4b3591d1cd5999936e1fb95b6789477c866ef47ba3613f53da9713'
+
+  no_compile_needed
+  no_shrink
+  # no_strip # ./usr/local/bin/gh: 1: ./usr/local/bin/gh: Syntax error: redirection unexpected (expecting ")")
+
+  def self.install
+    FileUtils.install 'ollama-linux-amd64', "#{CREW_DEST_PREFIX}/bin/ollama", mode: 0o755
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -6311,6 +6311,11 @@ url: https://github.com/CoolerVoid/0d1n/releases
 activity: low
 ---
 kind: url
+name: ollama
+url: https://github.com/ollama/ollama/releases
+activity: high
+---
+kind: url
 name: ondir
 url: https://swapoff.org/ondir.html
 activity: low


### PR DESCRIPTION
Get up and running with large language models.  Run [Llama 3](https://ollama.com/library/llama3), [Phi 3](https://ollama.com/library/phi3), [Mistral](https://ollama.com/library/mistral), [Gemma 2](https://ollama.com/library/gemma2), and other models. Customize and create your own.  See https://ollama.com/.  Tested and working in x86_64 container.