### PR TITLE
Terraform 1.8.5 => 1.9.0

### DIFF
--- a/packages/terraform.rb
+++ b/packages/terraform.rb
@@ -3,7 +3,7 @@ require 'package'
 class Terraform < Package
   description 'Terraform is a tool for building, changing, and combining infrastructure safely and efficiently.'
   homepage 'https://www.terraform.io/'
-  version '1.8.5'
+  version '1.9.0'
   license 'Apache-2.0, BSD-2, BSD-4, ECL-2.0, imagemagick, ISC, JSON, MIT, MIT-with-advertising, MPL-2.0 and unicode'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Terraform < Package
      x86_64: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_amd64.zip"
   })
   source_sha256({
-    aarch64: '180701072b7f9f8bdb6854348fb0e728a78c778595cdf33b5462a7c9fa93689f',
-     armv7l: '180701072b7f9f8bdb6854348fb0e728a78c778595cdf33b5462a7c9fa93689f',
-       i686: '6dbfc8c6b0c250d17faac79d55823f2e6079d21ace62939193c693d012a3f88e',
-     x86_64: '026da7f222d6c7506e882173cb48611d50638dcbe98e87639e047797bee69817'
+    aarch64: '972b034014005ec2c9d707aff7310b059353b92dea785bd8b493b42c28d8c9b0',
+     armv7l: '972b034014005ec2c9d707aff7310b059353b92dea785bd8b493b42c28d8c9b0',
+       i686: '37a415a1ea08733281da9d5d2db350242f01d6133296ee5b8f08105ecae0c5f8',
+     x86_64: '45917b05302aa843b46037a38eee31feeb350ee443680f04cc203f547c390783'
   })
 
   def self.install


### PR DESCRIPTION
## Description

This commit updates the Terraform CLI from version 1.8.5 to 1.9.0.

## Additional information

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` 