### PR TITLE
fix building armv7l binaries inside armv8l container regression

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -2,7 +2,7 @@
 # Defines common constants used in different parts of crew
 require 'etc'
 
-CREW_VERSION = '1.49.3'
+CREW_VERSION = '1.49.4'
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]
@@ -10,10 +10,17 @@ KERN_ARCH = Etc.uname[:machine]
 # Read and parse processor information from /proc/cpuinfo
 CPUINFO = File.readlines('/proc/cpuinfo').map { |line| line.chomp.split(/\t+: /) if line.include?("\t") }.compact.to_h
 
-# We report aarch64 machines as armv7l for now, as we treat them as if they were armv7l.
+# We report aarch64 & armv8l machines as armv7l for now, as we treat
+# them as if they were armv7l.
 # When we have proper aarch64 support, remove this.
 # Also, we allow ARCH to be changed via the ARCH environment variable.
-ARCH = KERN_ARCH.eql?('aarch64') ? 'armv7l' : ENV.fetch('ARCH', KERN_ARCH)
+ARCH = ENV.fetch('ARCH') do |_name|
+  case KERN_ARCH
+  when 'aarch64', 'armv8l'
+    'armv7l'
+  else KERN_ARCH
+  end
+end
 
 # Allow for edge case of i686 install on a x86_64 host before linux32 is
 # downloaded, e.g. in a docker container.


### PR DESCRIPTION
Fixes #10081 

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=rpi_build_fix crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
