### PR TITLE
spirv-tools 2023.6.rc1 -> 2024.3

### DIFF
--- a/manifest/i686/s/spirv_tools.filelist
+++ b/manifest/i686/s/spirv_tools.filelist
@@ -4,6 +4,7 @@
 /usr/local/bin/spirv-lesspipe.sh
 /usr/local/bin/spirv-link
 /usr/local/bin/spirv-lint
+/usr/local/bin/spirv-objdump
 /usr/local/bin/spirv-opt
 /usr/local/bin/spirv-reduce
 /usr/local/bin/spirv-val
@@ -33,12 +34,12 @@
 /usr/local/lib/cmake/SPIRV-Tools/SPIRV-ToolsConfig.cmake
 /usr/local/lib/cmake/SPIRV-Tools/SPIRV-ToolsTarget-release.cmake
 /usr/local/lib/cmake/SPIRV-Tools/SPIRV-ToolsTarget.cmake
-/usr/local/lib/libSPIRV-Tools-diff.a
-/usr/local/lib/libSPIRV-Tools-link.a
-/usr/local/lib/libSPIRV-Tools-lint.a
-/usr/local/lib/libSPIRV-Tools-opt.a
-/usr/local/lib/libSPIRV-Tools-reduce.a
+/usr/local/lib/libSPIRV-Tools-diff.so
+/usr/local/lib/libSPIRV-Tools-link.so
+/usr/local/lib/libSPIRV-Tools-lint.so
+/usr/local/lib/libSPIRV-Tools-opt.so
+/usr/local/lib/libSPIRV-Tools-reduce.so
 /usr/local/lib/libSPIRV-Tools-shared.so
-/usr/local/lib/libSPIRV-Tools.a
+/usr/local/lib/libSPIRV-Tools.so
 /usr/local/lib/pkgconfig/SPIRV-Tools-shared.pc
 /usr/local/lib/pkgconfig/SPIRV-Tools.pc

--- a/packages/spirv_tools.rb
+++ b/packages/spirv_tools.rb
@@ -1,36 +1,33 @@
-# Adapted from Arch Linux spirv-tools PKGBUILD at:
-# https://github.com/archlinux/svntogit-packages/raw/packages/spirv-tools/trunk/PKGBUILD
 require 'buildsystems/cmake'
 
 class Spirv_tools < CMake
   homepage 'https://github.com/KhronosGroup/SPIRV-Tools'
   description 'API and commands for processing SPIR-V modules'
-  version '2023.6.rc1'
-  license 'custom'
-  compatibility 'x86_64 aarch64 armv7l'
+  version '2024.3'
+  license 'Apache-2.0'
+  compatibility 'all'
   source_url 'https://github.com/KhronosGroup/SPIRV-Tools.git'
   git_hashtag "v#{version}"
-
-  binary_sha256({
-    aarch64: 'd925a80ea99206946477c5c6223629c06bbad55981da677e2ab54bbee23d843b',
-     armv7l: 'd925a80ea99206946477c5c6223629c06bbad55981da677e2ab54bbee23d843b',
-     x86_64: '26a772a1baadd956f875e2c9db1e371b068caf8e4546e7884965294882603974'
-  })
   binary_compression 'tar.zst'
 
-  depends_on 'spirv_headers' => :build
+  binary_sha256({
+    aarch64: '3386f244e3582ba07d6d46d81f834ffa20eca9cb8b22a3dbbf3802d032398556',
+     armv7l: '3386f244e3582ba07d6d46d81f834ffa20eca9cb8b22a3dbbf3802d032398556',
+       i686: '23393d026d53fc52be7b9a02b54e37ac057662939e57c0eec9037ed38de4e28d',
+     x86_64: '0810c092de66488afe89970578b493295b00d310264a249bcf6c4641eb439f13'
+  })
+
   depends_on 'gcc_lib' # R
   depends_on 'glibc' # R
+  # depends_on 'spirv_headers' => :build
+  depends_on 'glibc_lib' # R
 
-  git_fetchtags
-  no_lto
-
+  # https://github.com/KhronosGroup/SPIRV-Tools/issues/5728
   def self.patch
     system 'utils/git-sync-deps'
   end
 
-  cmake_options '-DSPIRV_WERROR=Off \
-      -DSPIRV_TOOLS_BUILD_STATIC=OFF \
-      -DSPIRV_SKIP_TESTS=ON \
-      -DBUILD_SHARED_LIBS=ON'
+  # https://github.com/KhronosGroup/SPIRV-Tools/issues/3909
+  cmake_options '-DSPIRV_TOOLS_BUILD_STATIC=OFF -DBUILD_SHARED_LIBS=ON'
+  run_tests
 end


### PR DESCRIPTION
@satmandu, I would really appreciate if you built the `armv7l` binaries for this one-- it took over 11 hours on my computer and didn't finish because a memory leak crashed everything, and I'd rather not have to do that again if possible.

No filelist updates for `x86_64`, and none expected for `armv7l`.
Builds for:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=can crew update
```