### PR TITLE
Fix json.rb to work with frozen strings

### DIFF
--- a/tools/json.rb
+++ b/tools/json.rb
@@ -16,7 +16,7 @@ Dir.glob('../packages/*.rb').each do |filename|
   # Skip fake packages.
   next if pkg.is_fake?
   # Present a useful version to Repology.
-  version = pkg.version
+  version = +pkg.version
   # That starts by trimming off our language version tagging.
   version.delete_suffix!('-py3.12')
   version.delete_suffix!('-perl5.40')


### PR DESCRIPTION
Why the actions have somehow enabled frozen strings despite them not being enabled by default till ruby 3.4, I couldn't tell you. 

Anyways, this should almost certainly fix the issue (fixed it in local testing when I set `RUBYOPT="--enable=frozen_string_literal"`), but github actions are fickle.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=g crew update
```