### PR TITLE
Add min_glibc version and missing dependencies to smplayer

### DIFF
--- a/packages/smplayer.rb
+++ b/packages/smplayer.rb
@@ -6,6 +6,7 @@ class Smplayer < Package
   version '24.5.0'
   license 'GPL-2'
   compatibility 'x86_64'
+  min_glibc '2.30'
   source_url "https://github.com/smplayer-dev/smplayer/releases/download/v#{version}/SMPlayer-#{version}-x86_64.AppImage"
   source_sha256 '85fb5a2322f48a298b7784fc3516e672525593c017ca504310bff05e1330457b'
 
@@ -13,6 +14,8 @@ class Smplayer < Package
 
   depends_on 'gdk_base'
   depends_on 'gtk3'
+  depends_on 'jack'
+  depends_on 'libthai'
   depends_on 'sommelier'
 
   def self.build


### PR DESCRIPTION
Fixes the following:
```
bin/smplayer: /usr/local/lib64/libm.so.6: version `GLIBC_2.29' not found (required by /usr/local/share/smplayer/lib/libQt5Widgets.so.5)
bin/smplayer: /usr/local/lib64/libm.so.6: version `GLIBC_2.29' not found (required by /usr/local/share/smplayer/lib/libQt5Gui.so.5)
bin/smplayer: /usr/local/lib64/libm.so.6: version `GLIBC_2.29' not found (required by /usr/local/share/smplayer/lib/libQt5Qml.so.5)
bin/smplayer: /usr/local/lib64/libm.so.6: version `GLIBC_2.29' not found (required by /usr/local/share/smplayer/lib/libQt5Core.so.5)
bin/smplayer: /usr/local/lib64/libc.so.6: version `GLIBC_2.28' not found (required by /usr/local/share/smplayer/lib/libQt5Core.so.5)
bin/smplayer: /usr/local/lib64/libm.so.6: version `GLIBC_2.29' not found (required by /usr/local/share/smplayer/lib/libpng16.so.16)
bin/smplayer: /usr/local/lib64/libm.so.6: version `GLIBC_2.29' not found (required by /usr/local/share/smplayer/lib/libicui18n.so.66)
bin/smplayer: /usr/local/lib64/libm.so.6: version `GLIBC_2.29' not found (required by /usr/local/share/smplayer/lib/libicuuc.so.66)
bin/smplayer: /usr/local/lib64/libc.so.6: version `GLIBC_2.28' not found (required by /usr/local/share/smplayer/lib/libglib-2.0.so.0)
bin/smplayer: /usr/local/lib64/libc.so.6: version `GLIBC_2.28' not found (required by /usr/local/share/smplayer/lib/libsystemd.so.0)
bin/smplayer: /usr/local/lib64/libc.so.6: version `GLIBC_2.30' not found (required by /usr/local/share/smplayer/lib/libsystemd.so.0)
```