### PR TITLE
buildsystem: Use native ruby block in `install_extras`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,9 +17,6 @@ AllCops:
     - 'lib/docopt.rb'
 
 # These cops have been temporarily disabled and should be reenabled asap
-Security/Eval:
-  Enabled: false
-
 Lint/ShadowingOuterLocalVariable:
   Enabled: false
 

--- a/lib/buildsystems/autotools.rb
+++ b/lib/buildsystems/autotools.rb
@@ -31,7 +31,7 @@ class Autotools < Package
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    eval @install_extras if @install_extras
+    @install_extras.call if @install_extras
   end
 
   def self.check

--- a/lib/buildsystems/autotools.rb
+++ b/lib/buildsystems/autotools.rb
@@ -31,7 +31,7 @@ class Autotools < Package
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    @install_extras.call if @install_extras
+    @install_extras&.call
   end
 
   def self.check

--- a/lib/buildsystems/meson.rb
+++ b/lib/buildsystems/meson.rb
@@ -14,7 +14,7 @@ class Meson < Package
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
-    @meson_install_extras.call if @meson_install_extras
+    @meson_install_extras&.call
   end
 
   def self.check

--- a/lib/buildsystems/meson.rb
+++ b/lib/buildsystems/meson.rb
@@ -14,7 +14,7 @@ class Meson < Package
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
-    eval @meson_install_extras if @meson_install_extras
+    @meson_install_extras.call if @meson_install_extras
   end
 
   def self.check

--- a/lib/buildsystems/perl.rb
+++ b/lib/buildsystems/perl.rb
@@ -16,6 +16,6 @@ class PERL < Package
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    eval @perl_install_extras if @perl_install_extras
+    @perl_install_extras.call if @perl_install_extras
   end
 end

--- a/lib/buildsystems/perl.rb
+++ b/lib/buildsystems/perl.rb
@@ -16,6 +16,6 @@ class PERL < Package
 
   def self.install
     system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    @perl_install_extras.call if @perl_install_extras
+    @perl_install_extras&.call
   end
 end

--- a/lib/buildsystems/pip.rb
+++ b/lib/buildsystems/pip.rb
@@ -42,6 +42,6 @@ class Pip < Package
       FileUtils.mkdir_p File.dirname(@destpath) if Gem::Version.new(RUBY_VERSION.to_s) < Gem::Version.new('3.3')
       FileUtils.install @pip_path, @destpath
     end
-    @pip_install_extras.call if @pip_install_extras
+    @pip_install_extras&.call
   end
 end

--- a/lib/buildsystems/pip.rb
+++ b/lib/buildsystems/pip.rb
@@ -42,6 +42,6 @@ class Pip < Package
       FileUtils.mkdir_p File.dirname(@destpath) if Gem::Version.new(RUBY_VERSION.to_s) < Gem::Version.new('3.3')
       FileUtils.install @pip_path, @destpath
     end
-    eval @pip_install_extras if @pip_install_extras
+    @pip_install_extras.call if @pip_install_extras
   end
 end

--- a/lib/buildsystems/python.rb
+++ b/lib/buildsystems/python.rb
@@ -30,6 +30,6 @@ class Python < Package
       puts "Python install options being used: #{PY3_INSTALLER_OPTIONS}".orange
       system "MAKEFLAGS=-j#{CREW_NPROC} python3 -m installer #{PY3_INSTALLER_OPTIONS}"
     end
-    eval @python_install_extras if @python_install_extras
+    @python_install_extras.call if @python_install_extras
   end
 end

--- a/lib/buildsystems/python.rb
+++ b/lib/buildsystems/python.rb
@@ -30,6 +30,6 @@ class Python < Package
       puts "Python install options being used: #{PY3_INSTALLER_OPTIONS}".orange
       system "MAKEFLAGS=-j#{CREW_NPROC} python3 -m installer #{PY3_INSTALLER_OPTIONS}"
     end
-    @python_install_extras.call if @python_install_extras
+    @python_install_extras&.call
   end
 end

--- a/lib/buildsystems/qmake.rb
+++ b/lib/buildsystems/qmake.rb
@@ -10,6 +10,6 @@ class Qmake < Package
 
   def self.install
     system "make INSTALL_ROOT=#{CREW_DEST_DIR} install"
-    eval @qmake_install_extras if @qmake_install_extras
+    @qmake_install_extras.call if @qmake_install_extras
   end
 end

--- a/lib/buildsystems/qmake.rb
+++ b/lib/buildsystems/qmake.rb
@@ -10,6 +10,6 @@ class Qmake < Package
 
   def self.install
     system "make INSTALL_ROOT=#{CREW_DEST_DIR} install"
-    @qmake_install_extras.call if @qmake_install_extras
+    @qmake_install_extras&.call
   end
 end

--- a/lib/buildsystems/ruby.rb
+++ b/lib/buildsystems/ruby.rb
@@ -16,6 +16,6 @@ class RUBY < Package
     @ruby_ver = version.split('-', 3).last
     system "yes | gem uninstall -a #{@gem_name}", exception: false
     system "gem install -i #{CREW_DEST_LIB_PREFIX}/ruby/gems/#{@ruby_ver}.0 -n #{CREW_DEST_PREFIX}/bin -N #{@gem_name}", exception: false
-    eval @ruby_install_extras if @ruby_install_extras
+    @ruby_install_extras.call if @ruby_install_extras
   end
 end

--- a/lib/buildsystems/ruby.rb
+++ b/lib/buildsystems/ruby.rb
@@ -16,6 +16,6 @@ class RUBY < Package
     @ruby_ver = version.split('-', 3).last
     system "yes | gem uninstall -a #{@gem_name}", exception: false
     system "gem install -i #{CREW_DEST_LIB_PREFIX}/ruby/gems/#{@ruby_ver}.0 -n #{CREW_DEST_PREFIX}/bin -N #{@gem_name}", exception: false
-    @ruby_install_extras.call if @ruby_install_extras
+    @ruby_install_extras&.call
   end
 end

--- a/lib/package_helpers.rb
+++ b/lib/package_helpers.rb
@@ -14,9 +14,14 @@ def property(*properties)
   #   {prop_name}            # return the value of {prop_name}
   properties.each do |prop|
     class_eval <<~EOT, __FILE__, __LINE__ + 1
-      def self.#{prop} (#{prop} = nil)
-        @#{prop} = #{prop} if #{prop}
-        @#{prop}
+      def self.#{prop} (prop = nil, &block)
+        if block
+          @#{prop} = block
+        elsif prop
+          @#{prop} = prop
+        else
+          return @#{prop}
+        end
       end
     EOT
   end

--- a/packages/ciano.rb
+++ b/packages/ciano.rb
@@ -30,10 +30,10 @@ class Ciano < Meson
   depends_on 'pango' # R
   depends_on 'vala'
 
-  meson_install_extras <<~EOF
+  meson_install_extras do
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
     FileUtils.ln_s "#{CREW_PREFIX}/bin/com.github.robertsanseries.ciano", "#{CREW_DEST_PREFIX}/bin/ciano"
-  EOF
+  end
 
   def self.postinstall
     ExitMessage.add "\nType 'ciano' to get started.\n".lightblue

--- a/packages/py3_azure_cli.rb
+++ b/packages/py3_azure_cli.rb
@@ -16,12 +16,12 @@ class Py3_azure_cli < Pip
   no_compile_needed
   print_source_bashrc
 
-  pip_install_extras <<~EXTRAS_EOF
+  pip_install_extras do
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/bash.d/"
     @azureenv = <<~AZUREEOF
       # Microsoft Azure CLI bash completion
       source #{CREW_PREFIX}/bin/az.completion.sh
     AZUREEOF
     File.write("#{CREW_DEST_PREFIX}/etc/bash.d/az", @azureenv)
-  EXTRAS_EOF
+  end
 end

--- a/packages/py3_devedeng.rb
+++ b/packages/py3_devedeng.rb
@@ -17,11 +17,11 @@ class Py3_devedeng < Python
 
   no_compile_needed
 
-  python_install_extras <<~EOF
+  python_install_extras do
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
     FileUtils.ln_s "#{CREW_PREFIX}/bin/devede_ng.py", "#{CREW_DEST_PREFIX}/bin/devede"
     FileUtils.ln_s "#{CREW_PREFIX}/bin/copy_files_verbose.py", "#{CREW_DEST_PREFIX}/bin/copy_files_verbose"
-  EOF
+  end
 
   def self.postinstall
     ExitMessage.add "Type 'devede' to get started.".lightblue


### PR DESCRIPTION
This makes it more elegant and syntax highlighting is now possible for code inside those `*_install_extras` sections:

```ruby
# Before
meson_install_extras <<~EOF
  FileUtils.install "#{variable}", ...
EOF

# After
meson_install_extras do
  FileUtils.install variable, ...
end
```

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/supechicken/chromebrew.git CREW_BRANCH=buildsystem_proc crew update
```
