### PR TITLE
lib/package: Get rid of `eval` strings 

### DIFF
--- a/commands/help.rb
+++ b/commands/help.rb
@@ -79,7 +79,7 @@ class Command
       puts <<~EOT
         Explain the purpose of various package boolean properties.
         Usage: crew prop <property>
-        Available properties: #{Package.print_boolean_properties}
+        Available properties: #{Package.available_boolean_properties.join(', ')}
       EOT
     when 'reinstall'
       puts <<~EOT

--- a/commands/prop.rb
+++ b/commands/prop.rb
@@ -59,7 +59,7 @@ class Command
       puts <<~EOT
         Explain the purpose of various package boolean properties.
         Usage: crew prop <property>
-        Available properties: #{Package.print_boolean_properties}
+        Available properties: #{Package.available_boolean_properties.join(', ')}
       EOT
     end
   end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -2,7 +2,7 @@
 # Defines common constants used in different parts of crew
 require 'etc'
 
-CREW_VERSION = '1.49.4'
+CREW_VERSION = '1.49.5'
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -9,8 +9,6 @@ class Package
                    :no_compile_needed, :no_compress, :no_env_options, :no_fhs, :no_git_submodules, :no_links, :no_lto, :no_patchelf,
                    :no_shrink, :no_source_build, :no_strip, :no_upstream_update, :no_zstd, :patchelf, :print_source_bashrc, :run_tests
 
-  @boolean_properties = methods(false).join(',').gsub('?', '').split(',').sort.uniq.join(', ')
-
   property :description, :homepage, :version, :license, :compatibility,
            :binary_compression, :binary_url, :binary_sha256, :source_url, :source_sha256,
            :git_branch, :git_hashtag, :min_glibc
@@ -26,10 +24,6 @@ class Package
                      :postinstall, # Function to perform post-install for both source build and binary distribution.
                      :preremove,   # Function to perform prior to package removal.
                      :remove       # Function to perform after package removal.
-
-  def self.print_boolean_properties
-    return @boolean_properties
-  end
 
   class << self
     attr_accessor :name, :cached_build, :in_build, :build_from_source, :in_upgrade

--- a/lib/package_helpers.rb
+++ b/lib/package_helpers.rb
@@ -3,7 +3,7 @@ class InstallError < RuntimeError; end
 def create_placeholder(*functions)
   # create_placeholder: create a placeholder for functions that will be used by crew later
   functions.each do |func_name|
-    define_singleton_method(func_name) { return true }
+    define_singleton_method(func_name) { true }
   end
 end
 

--- a/lib/package_helpers.rb
+++ b/lib/package_helpers.rb
@@ -3,7 +3,7 @@ class InstallError < RuntimeError; end
 def create_placeholder(*functions)
   # create_placeholder: create a placeholder for functions that will be used by crew later
   functions.each do |func_name|
-    define_singleton_method(func_name, Proc.new)
+    define_singleton_method(func_name) { return true }
   end
 end
 

--- a/lib/package_helpers.rb
+++ b/lib/package_helpers.rb
@@ -17,10 +17,12 @@ def property(*properties)
       propVarName = "@#{propName}"
 
       if block
+        # store the block if a block is provided
         instance_variable_set(propVarName, block)
       elsif propValue
         instance_variable_set(propVarName, propValue)
       else
+        # return current value if nothing is provided
         return instance_variable_get(propVarName)
       end
     end
@@ -33,17 +35,21 @@ def boolean_property(*boolean_properties)
   #   {prop_name}            # this will return #{prop_name} as true
 
   define_singleton_method(:available_boolean_properties) do
+    # available_boolean_properties: Return all available boolean properties for use in commands/{prop,help}.rb
+    # Usage:
+    #   puts Package.available_boolean_properties => [:conflicts_ok, ...]
     return boolean_properties
   end
 
   boolean_properties.each do |propName|
     propVarName = "@#{propName}"
 
+    # Adds the self.{symbol} method
     define_singleton_method(propName) do
       instance_variable_set(propVarName, true)
     end
 
-    # Adds the symbol? method
+    # Adds the self.{symbol}? method
     define_singleton_method("#{propName}?") do
       return !!instance_variable_get(propVarName)
     end

--- a/lib/package_helpers.rb
+++ b/lib/package_helpers.rb
@@ -2,8 +2,8 @@ class InstallError < RuntimeError; end
 
 def create_placeholder(*functions)
   # create_placeholder: create a placeholder for functions that will be used by crew later
-  functions.each do |funcName|
-    define_singleton_method(funcName) {}
+  functions.each do |func_name|
+    define_singleton_method(func_name, Proc.new)
   end
 end
 
@@ -12,18 +12,18 @@ def property(*properties)
   # Examples:
   #   {prop_name}('example') # set {prop_name} to 'example'
   #   {prop_name}            # return the value of {prop_name}
-  properties.each do |propName|
-    define_singleton_method(propName) do |propValue = nil, &block|
-      propVarName = "@#{propName}"
+  properties.each do |prop_name|
+    define_singleton_method(prop_name) do |prop_value = nil, &block|
+      prop_var_name = "@#{prop_name}"
 
       if block
         # store the block if a block is provided
-        instance_variable_set(propVarName, block)
-      elsif propValue
-        instance_variable_set(propVarName, propValue)
+        instance_variable_set(prop_var_name, block)
+      elsif prop_value
+        instance_variable_set(prop_var_name, prop_value)
       else
         # return current value if nothing is provided
-        return instance_variable_get(propVarName)
+        return instance_variable_get(prop_var_name)
       end
     end
   end
@@ -41,17 +41,17 @@ def boolean_property(*boolean_properties)
     return boolean_properties
   end
 
-  boolean_properties.each do |propName|
-    propVarName = "@#{propName}"
+  boolean_properties.each do |prop_name|
+    prop_var_name = "@#{prop_name}"
 
     # Adds the self.{symbol} method
-    define_singleton_method(propName) do
-      instance_variable_set(propVarName, true)
+    define_singleton_method(prop_name) do
+      instance_variable_set(prop_var_name, true)
     end
 
     # Adds the self.{symbol}? method
-    define_singleton_method("#{propName}?") do
-      return !!instance_variable_get(propVarName)
+    define_singleton_method("#{prop_name}?") do
+      return !!instance_variable_get(prop_var_name)
     end
   end
 end

--- a/lib/package_helpers.rb
+++ b/lib/package_helpers.rb
@@ -32,9 +32,8 @@ def boolean_property(*boolean_properties)
   # Examples:
   #   {prop_name}            # this will return #{prop_name} as true
 
-  instance_eval do
-    @available_boolean_properties = boolean_properties
-    attr_reader :available_boolean_properties
+  define_singleton_method(:available_boolean_properties) do
+    return boolean_properties
   end
 
   boolean_properties.each do |propName|

--- a/lib/package_helpers.rb
+++ b/lib/package_helpers.rb
@@ -45,7 +45,7 @@ def boolean_property(*boolean_properties)
 
     # Adds the symbol? method
     define_singleton_method("#{propName}?") do
-      return !!instance_variable_get("@#{prop}")
+      return !!instance_variable_get(propVarName)
     end
   end
 end

--- a/lib/package_helpers.rb
+++ b/lib/package_helpers.rb
@@ -2,8 +2,8 @@ class InstallError < RuntimeError; end
 
 def create_placeholder(*functions)
   # create_placeholder: create a placeholder for functions that will be used by crew later
-  functions.each do |func|
-    class_eval("def self.#{func}; end", __FILE__, __LINE__)
+  functions.each do |funcName|
+    define_singleton_method(funcName) {}
   end
 end
 
@@ -12,18 +12,18 @@ def property(*properties)
   # Examples:
   #   {prop_name}('example') # set {prop_name} to 'example'
   #   {prop_name}            # return the value of {prop_name}
-  properties.each do |prop|
-    class_eval <<~EOT, __FILE__, __LINE__ + 1
-      def self.#{prop} (prop = nil, &block)
-        if block
-          @#{prop} = block
-        elsif prop
-          @#{prop} = prop
-        else
-          return @#{prop}
-        end
+  properties.each do |propName|
+    define_singleton_method(propName) do |propValue = nil, &block|
+      propVarName = "@#{propName}"
+
+      if block
+        instance_variable_set(propVarName, block)
+      elsif propValue
+        instance_variable_set(propVarName, propValue)
+      else
+        return instance_variable_get(propVarName)
       end
-    EOT
+    end
   end
 end
 
@@ -31,22 +31,22 @@ def boolean_property(*boolean_properties)
   # boolean_property: if this exists in a package, it will return true
   # Examples:
   #   {prop_name}            # this will return #{prop_name} as true
-  boolean_properties.each do |prop|
-    class_eval <<~EOT, __FILE__, __LINE__ + 1
-      def self.#{prop} (#{prop} = nil)
-        @#{prop} = true if #{prop}
-        !!@#{prop}
-      end
-    EOT
-    instance_eval <<~EOY, __FILE__, __LINE__ + 1
-      def self.#{prop}
-        @#{prop} = true
-      end
-    EOY
+
+  instance_eval do
+    @available_boolean_properties = boolean_properties
+    attr_reader :available_boolean_properties
+  end
+
+  boolean_properties.each do |propName|
+    propVarName = "@#{propName}"
+
+    define_singleton_method(propName) do
+      instance_variable_set(propVarName, true)
+    end
+
     # Adds the symbol? method
-    define_singleton_method("#{prop}?") do
-      @prop = instance_variable_get("@#{prop}")
-      !!@prop
+    define_singleton_method("#{propName}?") do
+      return !!instance_variable_get("@#{prop}")
     end
   end
 end

--- a/tests/commands/help.rb
+++ b/tests/commands/help.rb
@@ -17,7 +17,7 @@ class HelpCommandTest < Minitest::Test
     expected_output = <<~EOT
       Explain the purpose of various package boolean properties.
       Usage: crew prop <property>
-      Available properties: #{Package.print_boolean_properties}
+      Available properties: #{Package.available_boolean_properties.join(', ')}
     EOT
     assert_output expected_output, nil do
       Command.help('prop')

--- a/tests/commands/prop.rb
+++ b/tests/commands/prop.rb
@@ -7,7 +7,7 @@ class PropCommandTest < Minitest::Test
     expected_output = <<~EOT
       Explain the purpose of various package boolean properties.
       Usage: crew prop <property>
-      Available properties: #{Package.print_boolean_properties}
+      Available properties: #{Package.available_boolean_properties.join(', ')}
     EOT
     assert_output expected_output, nil do
       Command.prop(nil)

--- a/tests/help_test
+++ b/tests/help_test
@@ -10,7 +10,7 @@ help_lines = `wc -l ../commands/help.rb`.to_i
 tail_lines = help_lines - property_line
 help_commands = `head -#{property_line} ../commands/help.rb | grep "  when '" | cut -d"'" -f2`.split("\n")
 help_properties = `tail -#{tail_lines} ../commands/help.rb | grep "  when '" | cut -d"'" -f2`.split("\n")
-package_properties = Package.print_boolean_properties.split(', ')
+package_properties = Package.available_boolean_properties
 if (CREW_COMMANDS.length - help_commands.length).positive?
   puts 'Help is missing for the crew commands in commands/help.rb below:'.yellow
   missing_commands = CREW_COMMANDS - help_commands


### PR DESCRIPTION
## Changes
- Change all `class_eval <<~EOF` calls into `define_singleton_method()` with native ruby blocks
- The `print_boolean_properties()` logic is now handled in `def boolean_property`

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/supechicken/chromebrew.git CREW_BRANCH=package_rb_cleanup crew update
```
