### PR TITLE
mtdev 1.1.5-0 -> 1.1.7

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -547,7 +547,7 @@ def download
           system 'git config advice.detachedHead false'
           system 'git config init.defaultBranch master'
           system "git remote add origin #{@pkg.source_url}", exception: true
-          system "git fetch --depth 1 origin #{@pkg.git_hashtag}", exception: true
+          system "git fetch #{'--depth 1' unless @pkg.git_clone_deep?} origin #{@pkg.git_hashtag}", exception: true
           system 'git checkout FETCH_HEAD'
         else
           # Leave a message because this step can be slow.
@@ -558,7 +558,6 @@ def download
         end
         system 'git submodule update --init --recursive' unless @pkg.no_git_submodules?
         system 'git fetch --tags', exception: true if @pkg.git_fetchtags?
-        system "git fetch origin #{@pkg.git_hashtag}", exception: true if @pkg.git_clone_deep?
         puts 'Repository downloaded.'.lightgreen
       end
       # Stow file in cache if requested and cache is writable.

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -2,7 +2,7 @@
 # Defines common constants used in different parts of crew
 require 'etc'
 
-CREW_VERSION = '1.49.5'
+CREW_VERSION = '1.49.6'
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]

--- a/manifest/armv7l/m/mtdev.filelist
+++ b/manifest/armv7l/m/mtdev.filelist
@@ -2,6 +2,7 @@
 /usr/local/include/mtdev-mapping.h
 /usr/local/include/mtdev-plumbing.h
 /usr/local/include/mtdev.h
+/usr/local/lib/libmtdev.a
 /usr/local/lib/libmtdev.la
 /usr/local/lib/libmtdev.so
 /usr/local/lib/libmtdev.so.1

--- a/manifest/i686/m/mtdev.filelist
+++ b/manifest/i686/m/mtdev.filelist
@@ -2,6 +2,7 @@
 /usr/local/include/mtdev-mapping.h
 /usr/local/include/mtdev-plumbing.h
 /usr/local/include/mtdev.h
+/usr/local/lib/libmtdev.a
 /usr/local/lib/libmtdev.la
 /usr/local/lib/libmtdev.so
 /usr/local/lib/libmtdev.so.1

--- a/manifest/x86_64/m/mtdev.filelist
+++ b/manifest/x86_64/m/mtdev.filelist
@@ -2,6 +2,7 @@
 /usr/local/include/mtdev-mapping.h
 /usr/local/include/mtdev-plumbing.h
 /usr/local/include/mtdev.h
+/usr/local/lib64/libmtdev.a
 /usr/local/lib64/libmtdev.la
 /usr/local/lib64/libmtdev.so
 /usr/local/lib64/libmtdev.so.1

--- a/packages/mtdev.rb
+++ b/packages/mtdev.rb
@@ -1,32 +1,24 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Mtdev < Package
+class Mtdev < Autotools
   description 'The mtdev is a stand-alone library which transforms all variants of kernel MT events to the slotted type B protocol.'
   homepage 'https://bitmath.org/code/mtdev/'
-  version '1.1.5-0'
+  version '1.1.7'
   license 'MIT'
   compatibility 'all'
-  source_url 'https://bitmath.org/code/mtdev/mtdev-1.1.5.tar.bz2'
-  source_sha256 '6677d5708a7948840de734d8b4675d5980d4561171c5a8e89e54adf7a13eba7f'
-  binary_compression 'tar.xz'
+  source_url 'https://bitmath.org/git/mtdev.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '6c0bbb0650a3777648f106279d11e702c75c01c2b036f113bd8cf0cab6bf463a',
-     armv7l: '6c0bbb0650a3777648f106279d11e702c75c01c2b036f113bd8cf0cab6bf463a',
-       i686: '0a18d63b9ecbd32dabc98e0b63f8514696ffd133227a42173193e828e1e7752f',
-     x86_64: 'ef6142c6cbaa71698acbb2cfcc3c40d5e9674931adfbb7352ce71b9b45c1027f'
+    aarch64: 'e3aa454e83b4dd1fe256fe4fbdd4304d94c4cac24beafa479c1069ee589c6a5e',
+     armv7l: 'e3aa454e83b4dd1fe256fe4fbdd4304d94c4cac24beafa479c1069ee589c6a5e',
+       i686: 'f5fc42cb0f32c91392a5850cd43dfddb3bbdff969173cbff6f2eca0026467c9b',
+     x86_64: '49dbf2523821a3c5a2fc582adb4b2b3e36726b9f73b5cf7bf9920e846f5ddf31'
   })
 
-  def self.build
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           '--enable-shared',
-           '--disable-static'
-    system 'make'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  # Otherwise the clone fails like so:
+  # fatal: dumb http transport does not support shallow capabilities
+  # It seems like git should just retry with a non-shallow clone in this scenario, but that doesn't seem to be the case.
+  git_clone_deep
 end


### PR DESCRIPTION
I had to backport some of my `crew download` refactoring changes, so this PR wasn't waiting on other reviews.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=hungr crew update
```