### PR TITLE
Revert "libpsl 0.21.2 -> 0.21.5"

### DIFF
--- a/manifest/armv7l/l/libpsl.filelist
+++ b/manifest/armv7l/l/libpsl.filelist
@@ -3,7 +3,7 @@
 /usr/local/include/libpsl.h
 /usr/local/lib/libpsl.so
 /usr/local/lib/libpsl.so.5
-/usr/local/lib/libpsl.so.5.3.5
+/usr/local/lib/libpsl.so.5.3.4
 /usr/local/lib/pkgconfig/libpsl.pc
 /usr/local/share/man/man1/psl-make-dafsa.1.zst
 /usr/local/share/man/man1/psl.1.zst

--- a/manifest/i686/l/libpsl.filelist
+++ b/manifest/i686/l/libpsl.filelist
@@ -3,7 +3,7 @@
 /usr/local/include/libpsl.h
 /usr/local/lib/libpsl.so
 /usr/local/lib/libpsl.so.5
-/usr/local/lib/libpsl.so.5.3.5
+/usr/local/lib/libpsl.so.5.3.4
 /usr/local/lib/pkgconfig/libpsl.pc
 /usr/local/share/man/man1/psl-make-dafsa.1.zst
 /usr/local/share/man/man1/psl.1.zst

--- a/manifest/x86_64/l/libpsl.filelist
+++ b/manifest/x86_64/l/libpsl.filelist
@@ -3,7 +3,7 @@
 /usr/local/include/libpsl.h
 /usr/local/lib64/libpsl.so
 /usr/local/lib64/libpsl.so.5
-/usr/local/lib64/libpsl.so.5.3.5
+/usr/local/lib64/libpsl.so.5.3.4
 /usr/local/lib64/pkgconfig/libpsl.pc
 /usr/local/share/man/man1/psl-make-dafsa.1.zst
 /usr/local/share/man/man1/psl.1.zst

--- a/packages/libpsl.rb
+++ b/packages/libpsl.rb
@@ -3,25 +3,22 @@ require 'buildsystems/meson'
 class Libpsl < Meson
   description 'C library for the Public Suffix List'
   homepage 'https://github.com/rockdaboot/libpsl'
-  version '0.21.5'
+  @_ver = '0.21.2'
+  version @_ver.to_s
   license 'MIT'
   compatibility 'all'
-  source_url 'https://github.com/rockdaboot/libpsl.git'
-  git_hashtag version
+  source_url "https://github.com/rockdaboot/libpsl/releases/download/#{@_ver}/libpsl-#{@_ver}.tar.lz"
+  source_sha256 'aa3d706c452786d1345e094dae201cd36d81f03cf81d636d5cfc10d365907f17'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '33bd40a1ed45022c73edba450ea4c6880852a191a2efa14d94956cbb8b84dc92',
-     armv7l: '33bd40a1ed45022c73edba450ea4c6880852a191a2efa14d94956cbb8b84dc92',
-       i686: '2a9b55b193a0525fd07f1a5c5a67cfa1f913a4731e05a500a78112e2459d425a',
-     x86_64: 'efdc1d563225e066bb9ec3415715d721fcff2caf24d7304670bea57999c1f649'
+    aarch64: '81c52e6dc9a2d935016d0f1d65dde2e2fa122f55e79c3a4a9465698041c5fe63',
+     armv7l: '81c52e6dc9a2d935016d0f1d65dde2e2fa122f55e79c3a4a9465698041c5fe63',
+       i686: '3c9c931dc72bf5dac871eef9dda2a866087b42457d6bd7535f2c760f33f27128',
+     x86_64: '2ee50e70cf121a7f46577e0494cbfe121eb13c23ae8bc308027e5315ec8b4ccb'
   })
 
   depends_on 'glibc' # R
   depends_on 'libidn2' # R
   depends_on 'libunistring' # R
-  depends_on 'python3' => :build
-
-  # https://github.com/rockdaboot/libpsl/issues/218
-  # run_tests
 end


### PR DESCRIPTION
Reverts chromebrew/chromebrew#10125

Needs to be built on an older container:

```
Initialized empty Git repository in /usr/local/tmp/crew/mesonbuild.20240711173915.dir/.git/
/usr/local/libexec/git-core/git-remote-https: /usr/local/lib64/libc.so.6: version `GLIBC_2.33' not found (required by /usr/local/lib64/libpsl.so.5)
/usr/local/bin/crew:550:in `system': Command failed with exit 128: git (RuntimeError)  
```