### PR TITLE
Terraform 1.9.1 => 1.9.2

### DIFF
--- a/packages/terraform.rb
+++ b/packages/terraform.rb
@@ -3,7 +3,7 @@ require 'package'
 class Terraform < Package
   description 'Terraform is a tool for building, changing, and combining infrastructure safely and efficiently.'
   homepage 'https://www.terraform.io/'
-  version '1.9.1'
+  version '1.9.2'
   license 'Apache-2.0, BSD-2, BSD-4, ECL-2.0, imagemagick, ISC, JSON, MIT, MIT-with-advertising, MPL-2.0 and unicode'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Terraform < Package
      x86_64: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_amd64.zip"
   })
   source_sha256({
-    aarch64: '9485893c50efc266d12f5384c9830f250359691b014098006897f179337bd338',
-     armv7l: '9485893c50efc266d12f5384c9830f250359691b014098006897f179337bd338',
-       i686: '9485893c50efc266d12f5384c9830f250359691b014098006897f179337bd338',
-     x86_64: 'bb7018419e8aabe1b0c3febbfc5259af0bc6871fed8e75cee1247a8a28d9a913'
+    aarch64: '58d65a85a4f9d0f7284d49e4390c1b6b4b8ad4977908021fb2e8c95e3aa23369',
+     armv7l: '58d65a85a4f9d0f7284d49e4390c1b6b4b8ad4977908021fb2e8c95e3aa23369',
+       i686: 'e4017501d1657d5c53bcf58f026be3e4372497708ab54e882900b7d16fd472eb',
+     x86_64: '8e18f9a97ac69bd9481f83bcc1aa3cb6caeb327abf22e41b25964448d2ced912'
   })
 
   def self.install


### PR DESCRIPTION
## Description

This commit updates the Terraform CLI from version 1.9.1 to 1.9.2.

## Additional information

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` 
