### PR TITLE
Do not pass CREW_TARGET to regular (non-compiler) builds

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -2,7 +2,7 @@
 # Defines common constants used in different parts of crew
 require 'etc'
 
-CREW_VERSION = '1.49.7'
+CREW_VERSION = '1.49.8'
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]
@@ -217,9 +217,6 @@ CREW_OPTIONS = <<~OPT.chomp
   --libdir=#{CREW_LIB_PREFIX} \
   --mandir=#{CREW_MAN_PREFIX} \
   --disable-dependency-tracking \
-  --build=#{CREW_TARGET} \
-  --host=#{CREW_TARGET} \
-  --target=#{CREW_TARGET} \
   --program-prefix='' \
   --program-suffix=''
 OPT

--- a/packages/apng2gif.rb
+++ b/packages/apng2gif.rb
@@ -21,7 +21,6 @@ class Apng2gif < Package
   depends_on 'help2man' => :build
 
   def self.patch
-    system "sed -i 's:CC         = gcc:CC         = #{CREW_TARGET}-gcc:' Makefile"
     system "sed -i 's:CFLAGS     = -Wall -pedantic:CFLAGS     = -Wall -pedantic #{CREW_COMMON_FLAGS}:' Makefile"
     system "sed -i 's:CFLAGS_OPT = -O2:CFLAGS_OPT =:' Makefile"
     # zlib is unused, remove the header and library link

--- a/packages/gif2apng.rb
+++ b/packages/gif2apng.rb
@@ -21,7 +21,6 @@ class Gif2apng < Package
   depends_on 'help2man' => :build
 
   def self.patch
-    system "sed -i 's:CC         = gcc:CC         = #{CREW_TARGET}-gcc:' Makefile"
     system "sed -i 's:CFLAGS     = -Wall -pedantic:CFLAGS     = -Wall -pedantic #{CREW_COMMON_FLAGS}:' Makefile"
     system "sed -i 's:CFLAGS_OPT = -O2:CFLAGS_OPT =:' Makefile"
     # use system zopfli

--- a/packages/librhash.rb
+++ b/packages/librhash.rb
@@ -25,8 +25,6 @@ class Librhash < Package
     system "mold -run ./configure \
             --prefix=#{CREW_PREFIX} \
             --libdir=#{CREW_LIB_PREFIX}\
-            --cc=#{CREW_TARGET}-gcc \
-            --ar=#{CREW_TARGET}-gcc-ar \
             --enable-gettext \
             --enable-openssl \
             --extra-cflags='#{CREW_COMMON_FLAGS}'"

--- a/packages/samurai.rb
+++ b/packages/samurai.rb
@@ -24,9 +24,7 @@ class Samurai < Package
   end
 
   def self.build
-    system "make CFLAGS='#{CREW_COMMON_FLAGS}' \
-                LDFLAGS='#{CREW_LDFLAGS}' \
-                CC='#{CREW_TARGET}-gcc'"
+    system "make CFLAGS='#{CREW_COMMON_FLAGS}' LDFLAGS='#{CREW_LDFLAGS}'"
   end
 
   def self.install

--- a/packages/scdoc.rb
+++ b/packages/scdoc.rb
@@ -22,9 +22,6 @@ class Scdoc < Package
   depends_on 'glibc' # R
 
   def self.patch
-    # Use correct gcc compiler
-    system "sed -i '2 s:^:CC = #{CREW_TARGET}-gcc\\n:' Makefile"
-
     # Build a dynamically linked binary
     system "sed -i 's:LDFLAGS+=-static:LDFLAGS+=:' Makefile" # Compile dynamically
   end


### PR DESCRIPTION
This improves consistency between our autotools and non-autotools builds, as well as fixing builds in some specific scenarios.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=tenpin crew update
```