### PR TITLE
Download the correct file when there are multiple versions of a package binary.

### DIFF
--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -39,9 +39,9 @@ jobs:
               ruby ../tests/buildsystem_test $file ; \
             done ) || true ) && \
             cd ~ && \
-            git clone --depth=1 https://github.com/chromebrew/chromebrew.git build_test && \
+            git clone --depth=1 --branch=${{ github.head_ref }} ${{ github.event.pull_request.head.repo.clone_url }} build_test && \
             cd build_test && \
-            yes | CREW_CACHE_ENABLED=1 crew build -f packages/hello_world_chromebrew.rb"
+            crew build -f packages/hello_world_chromebrew.rb"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         # This is not the best way to do things, a matrix would certainly be better.
@@ -62,6 +62,6 @@ jobs:
               ruby ../tests/buildsystem_test $file ; \
             done ) || true ) && \
             cd ~ && \
-            git clone --depth=1 https://github.com/chromebrew/chromebrew.git build_test && \
+            git clone --depth=1 --branch=${{ github.head_ref }} ${{ github.event.pull_request.head.repo.clone_url }} build_test && \
             cd build_test && \
-            yes | CREW_CACHE_ENABLED=1 crew build -f packages/hello_world_chromebrew.rb"
+            crew build -f packages/hello_world_chromebrew.rb"

--- a/bin/crew
+++ b/bin/crew
@@ -420,6 +420,8 @@ def download
 
   uri = URI.parse url
   filename = File.basename(uri.path)
+  # # If we're downloading a binary, reset the filename to what it would have been if we didn't download from the API.
+  filename = "#{@pkg.name}-#{@pkg.version}-chromeos-#{ARCH}.#{@pkg.binary_compression}" if filename.eql?('download')
   sha256sum = PackageUtils.get_sha256(@pkg, build_from_source: @opt_source || @pkg.build_from_source)
   @extract_dir = "#{@pkg.name}.#{Time.now.utc.strftime('%Y%m%d%H%M%S')}.dir"
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -2,7 +2,7 @@
 # Defines common constants used in different parts of crew
 require 'etc'
 
-CREW_VERSION = '1.49.9'
+CREW_VERSION = '1.45.0'
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]

--- a/lib/package_utils.rb
+++ b/lib/package_utils.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'net/http'
 require_relative 'const'
 
 class PackageUtils
@@ -13,7 +14,7 @@ class PackageUtils
 
   def self.get_url(pkg, build_from_source: false)
     if !build_from_source && pkg.binary_sha256&.key?(ARCH.to_sym)
-      return "https://gitlab.com/api/v4/projects/26210301/packages/generic/#{pkg.name}/#{pkg.version}_#{ARCH}/#{pkg.name}-#{pkg.version}-chromeos-#{ARCH}.#{pkg.binary_compression}"
+      return get_binary_url(pkg)
     elsif pkg.source_url.is_a?(Hash) && pkg.source_url&.key?(ARCH.to_sym)
       return pkg.source_url[ARCH.to_sym]
     else
@@ -28,6 +29,25 @@ class PackageUtils
       return pkg.source_sha256[ARCH.to_sym]
     else
       return pkg.source_sha256
+    end
+  end
+
+  def self.get_binary_url(pkg)
+    # List all the packages with the name and version of the package file.
+    # The name search is fuzzy, so we need to refine it further (otherwise packages like vim, gvim and vim_runtime would break).
+    packages = JSON.parse(Net::HTTP.get(URI("https://gitlab.com/api/v4/projects/26210301/packages?package_name=#{pkg.name}&package_version=#{pkg.version}_#{ARCH}")))
+    # Loop over each result until we get an exact name match, then return the package ID for that match.
+    package_id = 0
+    (0..packages.count - 1).each do |i|
+      next unless packages[i]['name'] == pkg.name
+      package_id = packages[i]['id']
+    end
+    # List all the package files for that package ID.
+    package_files = JSON.parse(Net::HTTP.get(URI("https://gitlab.com/api/v4/projects/26210301/packages/#{package_id}/package_files")))
+    # Loop over each result until we find a matching file_sha256 to our binary_sha256.
+    (0..package_files.count - 1).each do |i|
+      next unless package_files[i]['file_sha256'] == pkg.binary_sha256[ARCH.to_sym]
+      return "https://gitlab.com/chromebrew/binaries/-/package_files/#{package_files[i]['id']}/download"
     end
   end
 

--- a/packages/hello_world_chromebrew.rb
+++ b/packages/hello_world_chromebrew.rb
@@ -12,10 +12,10 @@ class Hello_world_chromebrew < Package
 
   # These are needed to successfully build and check for dependencies.
   binary_sha256({
-    aarch64: '000',
-     armv7l: '000',
-       i686: '111',
-     x86_64: '222'
+    aarch64: '827f9794864aa76f4c99fd31f989077f1fa65771386f73db30a7681842f8736d',
+     armv7l: '827f9794864aa76f4c99fd31f989077f1fa65771386f73db30a7681842f8736d',
+       i686: 'ff0942c505b04982fed187bcda123adead37b3ac2dcfd7e2f0543ca179e81df6',
+     x86_64: '3081f1f25950c91f75db41095b644a2783987a3a7ef2832fc2b85bf138bb006f'
   })
 
   # Register dependencies (use the following line as a basis)

--- a/tests/lib/package_utils.rb
+++ b/tests/lib/package_utils.rb
@@ -50,15 +50,38 @@ class PackageUtilsTest < Minitest::Test
     refute(PackageUtils.compatible?(pkg))
   end
 
-  def test_get_binary_url
+  def test_get_binary_url_old_hash
     pkg = Class.new(Package)
-    pkg.name = 'test_package'
+    pkg.name = 'hello_world_chromebrew'
     pkg.instance_eval do
-      version '1.0'
+      version '1.1'
       binary_compression 'tar.zst'
-      binary_sha256({ ARCH.to_sym => '0000000000000000000000000000000000000000000000000000000000000000' })
+      binary_sha256({
+        aarch64: '29185a6c4a8ecc3532606649f5831e37cd977c24bfd4fb1c12328ca5ba966ff1',
+         armv7l: '29185a6c4a8ecc3532606649f5831e37cd977c24bfd4fb1c12328ca5ba966ff1',
+           i686: '6e46c31245e9e17eeecf03d61454bb7312b6e769bfaf352ced527ee93cc62518',
+         x86_64: '83f674b3e8fe29c7e761ce6adc27fd7df927d985140ff6d1ae64a0046339322b'
+      })
     end
-    assert_equal("https://gitlab.com/api/v4/projects/26210301/packages/generic/test_package/1.0_#{ARCH}/test_package-1.0-chromeos-#{ARCH}.tar.zst", PackageUtils.get_url(pkg))
+    package_file_id = { aarch64: '137956464', armv7l: '137956464', i686: '137956442', x86_64: '137956370' }
+    assert_equal("https://gitlab.com/chromebrew/binaries/-/package_files/#{package_file_id[ARCH.to_sym]}/download", PackageUtils.get_url(pkg))
+  end
+
+  def test_get_binary_url_new_hash
+    pkg = Class.new(Package)
+    pkg.name = 'hello_world_chromebrew'
+    pkg.instance_eval do
+      version '1.1'
+      binary_compression 'tar.zst'
+      binary_sha256({
+        aarch64: '827f9794864aa76f4c99fd31f989077f1fa65771386f73db30a7681842f8736d',
+         armv7l: '827f9794864aa76f4c99fd31f989077f1fa65771386f73db30a7681842f8736d',
+           i686: 'ff0942c505b04982fed187bcda123adead37b3ac2dcfd7e2f0543ca179e81df6',
+         x86_64: '3081f1f25950c91f75db41095b644a2783987a3a7ef2832fc2b85bf138bb006f'
+      })
+    end
+    package_file_id = { aarch64: '137956527', armv7l: '137956527', i686: '137956521', x86_64: '137956520' }
+    assert_equal("https://gitlab.com/chromebrew/binaries/-/package_files/#{package_file_id[ARCH.to_sym]}/download", PackageUtils.get_url(pkg))
   end
 
   def test_get_source_url_hash


### PR DESCRIPTION
Tested and working locally, and extended the unit tests to cover this.

Combined with the changes I made to `crew update` a few years ago, this should allow us to rebuild packages without needing to increment the  patchlevel (`<version>` becomes `<version>-1`, `<version>-1` becomes `<version>-2`, etc).

In addition to simplifying the rebuild process, this eliminates the need for the patchlevel at all.
- We can rebuild packages without incrementing the patchlevel
- We can remove existing patchlevels 
  - relevant for #8196 given that we don't actually need a patchlevel anymore
  - allows us to clean up our version data for Repology. ([This](https://repology.org/projects/?inrepo=chromebrew&problematic=1) tracks all the ignored versions, although this currently only applies to where we have applied patchlevels on otherwise up-to-date packages.)

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=sweep crew update
```