### PR TITLE
Update cmake, mold, libavif, xwayland; rebuild source_highlight, texinfo

### DIFF
--- a/manifest/armv7l/l/libavif.filelist
+++ b/manifest/armv7l/l/libavif.filelist
@@ -1,13 +1,14 @@
 /usr/local/bin/avifdec
 /usr/local/bin/avifenc
 /usr/local/include/avif/avif.h
+/usr/local/include/avif/avif_cxx.h
 /usr/local/lib/cmake/libavif/libavif-config-release.cmake
 /usr/local/lib/cmake/libavif/libavif-config-version.cmake
 /usr/local/lib/cmake/libavif/libavif-config.cmake
 /usr/local/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-avif.so
 /usr/local/lib/libavif.so
 /usr/local/lib/libavif.so.16
-/usr/local/lib/libavif.so.16.0.4
+/usr/local/lib/libavif.so.16.1.0
 /usr/local/lib/pkgconfig/libavif.pc
 /usr/local/share/man/man1/avifdec.1.zst
 /usr/local/share/man/man1/avifenc.1.zst

--- a/manifest/armv7l/t/texinfo.filelist
+++ b/manifest/armv7l/t/texinfo.filelist
@@ -48,6 +48,7 @@
 /usr/local/share/locale/it/LC_MESSAGES/texinfo_document.mo
 /usr/local/share/locale/ja/LC_MESSAGES/texinfo.mo
 /usr/local/share/locale/ka/LC_MESSAGES/texinfo.mo
+/usr/local/share/locale/ka/LC_MESSAGES/texinfo_document.mo
 /usr/local/share/locale/nb/LC_MESSAGES/texinfo.mo
 /usr/local/share/locale/nl/LC_MESSAGES/texinfo.mo
 /usr/local/share/locale/nl/LC_MESSAGES/texinfo_document.mo

--- a/manifest/i686/t/texinfo.filelist
+++ b/manifest/i686/t/texinfo.filelist
@@ -48,6 +48,7 @@
 /usr/local/share/locale/it/LC_MESSAGES/texinfo_document.mo
 /usr/local/share/locale/ja/LC_MESSAGES/texinfo.mo
 /usr/local/share/locale/ka/LC_MESSAGES/texinfo.mo
+/usr/local/share/locale/ka/LC_MESSAGES/texinfo_document.mo
 /usr/local/share/locale/nb/LC_MESSAGES/texinfo.mo
 /usr/local/share/locale/nl/LC_MESSAGES/texinfo.mo
 /usr/local/share/locale/nl/LC_MESSAGES/texinfo_document.mo

--- a/manifest/x86_64/l/libavif.filelist
+++ b/manifest/x86_64/l/libavif.filelist
@@ -1,13 +1,14 @@
 /usr/local/bin/avifdec
 /usr/local/bin/avifenc
 /usr/local/include/avif/avif.h
+/usr/local/include/avif/avif_cxx.h
 /usr/local/lib64/cmake/libavif/libavif-config-release.cmake
 /usr/local/lib64/cmake/libavif/libavif-config-version.cmake
 /usr/local/lib64/cmake/libavif/libavif-config.cmake
 /usr/local/lib64/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-avif.so
 /usr/local/lib64/libavif.so
 /usr/local/lib64/libavif.so.16
-/usr/local/lib64/libavif.so.16.0.4
+/usr/local/lib64/libavif.so.16.1.0
 /usr/local/lib64/pkgconfig/libavif.pc
 /usr/local/share/man/man1/avifdec.1.zst
 /usr/local/share/man/man1/avifenc.1.zst

--- a/manifest/x86_64/t/texinfo.filelist
+++ b/manifest/x86_64/t/texinfo.filelist
@@ -48,6 +48,7 @@
 /usr/local/share/locale/it/LC_MESSAGES/texinfo_document.mo
 /usr/local/share/locale/ja/LC_MESSAGES/texinfo.mo
 /usr/local/share/locale/ka/LC_MESSAGES/texinfo.mo
+/usr/local/share/locale/ka/LC_MESSAGES/texinfo_document.mo
 /usr/local/share/locale/nb/LC_MESSAGES/texinfo.mo
 /usr/local/share/locale/nl/LC_MESSAGES/texinfo.mo
 /usr/local/share/locale/nl/LC_MESSAGES/texinfo_document.mo

--- a/packages/cmake.rb
+++ b/packages/cmake.rb
@@ -3,7 +3,7 @@ require 'buildsystems/cmake'
 class Cmake < CMake
   description 'CMake is an open-source, cross-platform family of tools designed to build, test and package software.'
   homepage 'https://cmake.org/'
-  version '3.30.0'
+  version '3.30.1'
   license 'CMake'
   compatibility 'all'
   source_url 'https://github.com/Kitware/CMake.git'
@@ -11,10 +11,10 @@ class Cmake < CMake
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'b01f065e41137606f498cf9507136e8feaf300c2c22985cff2d66ec645df1c83',
-     armv7l: 'b01f065e41137606f498cf9507136e8feaf300c2c22985cff2d66ec645df1c83',
-       i686: '8587c62b9e69f275ab72169485c0c91788616163dba625110377c4abadfcd1af',
-     x86_64: 'b88e2684359b19cd1b4d2d14a29eb0b38a8395a84ff396455741215eba57ae74'
+    aarch64: 'bb5a41c355700949e510a83a99c021d8257a72d883e23d48f381c4e8619ac1f6',
+     armv7l: 'bb5a41c355700949e510a83a99c021d8257a72d883e23d48f381c4e8619ac1f6',
+       i686: '6715231b5cf6f4fd05a857450bf7b0a15851bc7f833f45a1ab738cba4003b4ad',
+     x86_64: 'a3eb056e1a518882f7a5bf385f7cc69b2266158a6b78d5b5c4b104d1e652fba1'
   })
 
   depends_on 'bzip2' => :build

--- a/packages/libavif.rb
+++ b/packages/libavif.rb
@@ -3,7 +3,7 @@ require 'buildsystems/cmake'
 class Libavif < CMake
   description 'Library for encoding and decoding .avif files'
   homepage 'https://github.com/AOMediaCodec/libavif'
-  version '1.0.4'
+  version '1.1.0'
   license 'BSD-2'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://github.com/AOMediaCodec/libavif.git'
@@ -11,9 +11,9 @@ class Libavif < CMake
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '201cd0bb7b76838dee1c00c007df295cda6da1b4882391b38d36341495e59861',
-     armv7l: '201cd0bb7b76838dee1c00c007df295cda6da1b4882391b38d36341495e59861',
-     x86_64: 'f171c132ed9429f7338b78b92df4fdb134855f78346bf883c03419d7a8d76057'
+    aarch64: 'a6632560338310f3909f141763e886af378a1671329d10f9bfd22310c596d50c',
+     armv7l: 'a6632560338310f3909f141763e886af378a1671329d10f9bfd22310c596d50c',
+     x86_64: '2f81bae4159dae77502f9c0c573e5b9a16156640a8c0eb23f93b5769c1c3b969'
   })
 
   depends_on 'dav1d' # R

--- a/packages/mold.rb
+++ b/packages/mold.rb
@@ -6,7 +6,7 @@ require 'buildsystems/cmake'
 class Mold < CMake
   description 'A Modern Linker'
   homepage 'https://github.com/rui314/mold'
-  version '2.32.0'
+  version '2.32.1'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/rui314/mold.git'
@@ -14,10 +14,10 @@ class Mold < CMake
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '44c82428bcf5b1d900c110650d41ccf562d3abfe486b68859cc96a386f511e05',
-     armv7l: '44c82428bcf5b1d900c110650d41ccf562d3abfe486b68859cc96a386f511e05',
-       i686: '50a97904e5db1d857f4390506ddfcf875c9699879ac2fbaeb55154a26e90dbe8',
-     x86_64: 'ba8e8d65a0e65debac4a122ab25ea64619958a34ebed361d9073a0da0c74dff6'
+    aarch64: 'dd7209850b8c4047bc8db5887220a12a174cc904bf70da3744c7278f8da8d623',
+     armv7l: 'dd7209850b8c4047bc8db5887220a12a174cc904bf70da3744c7278f8da8d623',
+       i686: '85c060e00a6f772a1cce442b3fb31c62fda957f7b3fe64b8d844bf26c605aa05',
+     x86_64: 'eab88cd2847e86fdb447fd399cec7652677a91fccc0c4a3f9b6ff52bc4b9aee8'
   })
 
   depends_on 'gcc_lib' # R

--- a/packages/source_highlight.rb
+++ b/packages/source_highlight.rb
@@ -6,7 +6,7 @@ require 'buildsystems/autotools'
 class Source_highlight < Autotools
   description 'Convert source code to syntax highlighted document'
   homepage 'https://www.gnu.org/software/src-highlite/'
-  version '3.1.9-894cacd'
+  version '3.1.9-894cacd-boost1.85'
   license 'GPL'
   compatibility 'all'
   source_url 'https://git.savannah.gnu.org/git/src-highlite.git'
@@ -14,10 +14,10 @@ class Source_highlight < Autotools
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'c678485029181a81af5ff753941d377969c4a48faff13ae9b18b265cbab8bc46',
-     armv7l: 'c678485029181a81af5ff753941d377969c4a48faff13ae9b18b265cbab8bc46',
-       i686: 'f8e0891842693e1b20195661229e6003496cc6786a26c2c983c202ebcff375d2',
-     x86_64: '7097637eea28626fdb0d0925f6e82298df51a17e8a1373d3169895c8a9c6df9b'
+    aarch64: '244749f21be5f01c11309e77959f4da2b47936a7cdd047321a06a066c8203a06',
+     armv7l: '244749f21be5f01c11309e77959f4da2b47936a7cdd047321a06a066c8203a06',
+       i686: '1f1ccc4f04308bb23c465b6f59e6d1f3f01baed828d3eb5847922754a56bb2b8',
+     x86_64: '7fbb5ac63a8225cf47824a54965b2faffd7059384fbd1a349fc68135f173b17e'
   })
 
   depends_on 'boost' # R

--- a/packages/texinfo.rb
+++ b/packages/texinfo.rb
@@ -3,22 +3,23 @@ require 'buildsystems/autotools'
 class Texinfo < Autotools
   description 'Texinfo is the official documentation format of the GNU project.'
   homepage 'https://www.gnu.org/software/texinfo/'
-  version '7.1-perl5.38'
+  version '7.1.0.90-perl5.40'
   license 'GPL-3'
   compatibility 'all'
-  source_url 'https://ftpmirror.gnu.org/texinfo/texinfo-7.1.tar.xz'
-  source_sha256 'deeec9f19f159e046fdf8ad22231981806dac332cc372f1c763504ad82b30953'
+  source_url 'https://git.savannah.gnu.org/cgit/texinfo.git/snapshot/texinfo-c5961c61fa9c9f817f3569585fb75a3512c872de.tar.gz'
+  source_sha256 'd5058642862d0efa2ed98218fdd8830d4e018658aaa8df010d3d30a996812286'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '1993d33be6ade8fc000d23e2b5e0b91bb41da63916e7ceb31698c536bbf3f3f9',
-     armv7l: '1993d33be6ade8fc000d23e2b5e0b91bb41da63916e7ceb31698c536bbf3f3f9',
-       i686: '63815ca8dbeb9708a7e2bf1c4e611d726b567832c54f1946bbd7d2275b972066',
-     x86_64: '45efc72577b1c1a40a91d6a665085dcd6eb9c32a9e023c6d9ca7d5439b0cce96'
+    aarch64: '5f544f32ab5100a1ddd07d5b22af52246afad99a47fe1af3358e33ddce9fbb13',
+     armv7l: '5f544f32ab5100a1ddd07d5b22af52246afad99a47fe1af3358e33ddce9fbb13',
+       i686: '3b88d3d6409604c7fbe06013c895e1c02758b6bf8d40025e77ccd749f63ff079',
+     x86_64: '89242d4e2e146c41de85e8e3641fa53422cc3ef29f8464b7357c7e3df0ab8ad2'
   })
 
   depends_on 'glibc_lib' # R
   depends_on 'glibc' # R
+  depends_on 'libunistring' # R
   depends_on 'ncurses' # R
   depends_on 'perl' # L
   depends_on 'perl_locale_messages' # L

--- a/packages/xwayland.rb
+++ b/packages/xwayland.rb
@@ -3,7 +3,7 @@ require 'buildsystems/meson'
 class Xwayland < Meson
   description 'X server configured to work with weston or sommelier'
   homepage 'https://x.org/wiki/'
-  version '24.1.0'
+  version '24.1.1'
   license 'MIT-with-advertising, ISC, BSD-3, BSD and custom'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.freedesktop.org/xorg/xserver.git'
@@ -11,9 +11,9 @@ class Xwayland < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'de42846f823a9774acb9ec70c763471b6b3da55f3231bcbc8b0848b443bb5207',
-     armv7l: 'de42846f823a9774acb9ec70c763471b6b3da55f3231bcbc8b0848b443bb5207',
-     x86_64: 'd7d45282f308e558df074965d2e477b90fa0b4740ec49f270a3ab9954b1e7c52'
+    aarch64: 'a4519bdccf53e54ce5deb8f4ef305215b1a4a4f616c0010e63735d09a9c7b58c',
+     armv7l: 'a4519bdccf53e54ce5deb8f4ef305215b1a4a4f616c0010e63735d09a9c7b58c',
+     x86_64: '75294270a6cc629d3cefa2faf9231ce8b5adb89ce7dd3ce7dbea1f1fc843b22e'
   })
 
   no_env_options


### PR DESCRIPTION
`texinfo` rebuild with current `perl` & `source_highlight` with current `boost` is needed for `binutils` & `gdb` builds.

Builds properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=cmake crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
