### PR TITLE
Rebuild binutils with gcc 14, update gdb to 15.1

### DIFF
--- a/manifest/armv7l/g/gdb.filelist
+++ b/manifest/armv7l/g/gdb.filelist
@@ -10,11 +10,11 @@
 /usr/local/include/gdb/jit-reader.h
 /usr/local/include/plugin-api.h
 /usr/local/include/symcat.h
-/usr/local/lib/libbfd-2.41.50.so
+/usr/local/lib/libbfd-2.42.50.so
 /usr/local/lib/libbfd.a
 /usr/local/lib/libbfd.la
 /usr/local/lib/libbfd.so
-/usr/local/lib/libopcodes-2.41.50.so
+/usr/local/lib/libopcodes-2.42.50.so
 /usr/local/lib/libopcodes.a
 /usr/local/lib/libopcodes.la
 /usr/local/lib/libopcodes.so
@@ -24,6 +24,7 @@
 /usr/local/share/gdb/python/gdb/command/__init__.py
 /usr/local/share/gdb/python/gdb/command/explore.py
 /usr/local/share/gdb/python/gdb/command/frame_filters.py
+/usr/local/share/gdb/python/gdb/command/missing_debug.py
 /usr/local/share/gdb/python/gdb/command/pretty_printers.py
 /usr/local/share/gdb/python/gdb/command/prompt.py
 /usr/local/share/gdb/python/gdb/command/type_printers.py
@@ -57,6 +58,7 @@
 /usr/local/share/gdb/python/gdb/function/as_string.py
 /usr/local/share/gdb/python/gdb/function/caller_is.py
 /usr/local/share/gdb/python/gdb/function/strfns.py
+/usr/local/share/gdb/python/gdb/missing_debug.py
 /usr/local/share/gdb/python/gdb/printer/__init__.py
 /usr/local/share/gdb/python/gdb/printer/bound_registers.py
 /usr/local/share/gdb/python/gdb/printing.py
@@ -71,6 +73,7 @@
 /usr/local/share/gdb/syscalls/freebsd.xml
 /usr/local/share/gdb/syscalls/gdb-syscalls.dtd
 /usr/local/share/gdb/syscalls/i386-linux.xml
+/usr/local/share/gdb/syscalls/loongarch-linux.xml
 /usr/local/share/gdb/syscalls/mips-n32-linux.xml
 /usr/local/share/gdb/syscalls/mips-n64-linux.xml
 /usr/local/share/gdb/syscalls/mips-o32-linux.xml

--- a/manifest/i686/g/gdb.filelist
+++ b/manifest/i686/g/gdb.filelist
@@ -10,11 +10,11 @@
 /usr/local/include/gdb/jit-reader.h
 /usr/local/include/plugin-api.h
 /usr/local/include/symcat.h
-/usr/local/lib/libbfd-2.41.50.so
+/usr/local/lib/libbfd-2.42.50.so
 /usr/local/lib/libbfd.a
 /usr/local/lib/libbfd.la
 /usr/local/lib/libbfd.so
-/usr/local/lib/libopcodes-2.41.50.so
+/usr/local/lib/libopcodes-2.42.50.so
 /usr/local/lib/libopcodes.a
 /usr/local/lib/libopcodes.la
 /usr/local/lib/libopcodes.so
@@ -24,6 +24,7 @@
 /usr/local/share/gdb/python/gdb/command/__init__.py
 /usr/local/share/gdb/python/gdb/command/explore.py
 /usr/local/share/gdb/python/gdb/command/frame_filters.py
+/usr/local/share/gdb/python/gdb/command/missing_debug.py
 /usr/local/share/gdb/python/gdb/command/pretty_printers.py
 /usr/local/share/gdb/python/gdb/command/prompt.py
 /usr/local/share/gdb/python/gdb/command/type_printers.py
@@ -57,6 +58,7 @@
 /usr/local/share/gdb/python/gdb/function/as_string.py
 /usr/local/share/gdb/python/gdb/function/caller_is.py
 /usr/local/share/gdb/python/gdb/function/strfns.py
+/usr/local/share/gdb/python/gdb/missing_debug.py
 /usr/local/share/gdb/python/gdb/printer/__init__.py
 /usr/local/share/gdb/python/gdb/printer/bound_registers.py
 /usr/local/share/gdb/python/gdb/printing.py
@@ -71,6 +73,7 @@
 /usr/local/share/gdb/syscalls/freebsd.xml
 /usr/local/share/gdb/syscalls/gdb-syscalls.dtd
 /usr/local/share/gdb/syscalls/i386-linux.xml
+/usr/local/share/gdb/syscalls/loongarch-linux.xml
 /usr/local/share/gdb/syscalls/mips-n32-linux.xml
 /usr/local/share/gdb/syscalls/mips-n64-linux.xml
 /usr/local/share/gdb/syscalls/mips-o32-linux.xml

--- a/manifest/x86_64/g/gdb.filelist
+++ b/manifest/x86_64/g/gdb.filelist
@@ -10,11 +10,11 @@
 /usr/local/include/gdb/jit-reader.h
 /usr/local/include/plugin-api.h
 /usr/local/include/symcat.h
-/usr/local/lib64/libbfd-2.41.50.so
+/usr/local/lib64/libbfd-2.42.50.so
 /usr/local/lib64/libbfd.a
 /usr/local/lib64/libbfd.la
 /usr/local/lib64/libbfd.so
-/usr/local/lib64/libopcodes-2.41.50.so
+/usr/local/lib64/libopcodes-2.42.50.so
 /usr/local/lib64/libopcodes.a
 /usr/local/lib64/libopcodes.la
 /usr/local/lib64/libopcodes.so
@@ -24,6 +24,7 @@
 /usr/local/share/gdb/python/gdb/command/__init__.py
 /usr/local/share/gdb/python/gdb/command/explore.py
 /usr/local/share/gdb/python/gdb/command/frame_filters.py
+/usr/local/share/gdb/python/gdb/command/missing_debug.py
 /usr/local/share/gdb/python/gdb/command/pretty_printers.py
 /usr/local/share/gdb/python/gdb/command/prompt.py
 /usr/local/share/gdb/python/gdb/command/type_printers.py
@@ -57,6 +58,7 @@
 /usr/local/share/gdb/python/gdb/function/as_string.py
 /usr/local/share/gdb/python/gdb/function/caller_is.py
 /usr/local/share/gdb/python/gdb/function/strfns.py
+/usr/local/share/gdb/python/gdb/missing_debug.py
 /usr/local/share/gdb/python/gdb/printer/__init__.py
 /usr/local/share/gdb/python/gdb/printer/bound_registers.py
 /usr/local/share/gdb/python/gdb/printing.py
@@ -71,6 +73,7 @@
 /usr/local/share/gdb/syscalls/freebsd.xml
 /usr/local/share/gdb/syscalls/gdb-syscalls.dtd
 /usr/local/share/gdb/syscalls/i386-linux.xml
+/usr/local/share/gdb/syscalls/loongarch-linux.xml
 /usr/local/share/gdb/syscalls/mips-n32-linux.xml
 /usr/local/share/gdb/syscalls/mips-n64-linux.xml
 /usr/local/share/gdb/syscalls/mips-o32-linux.xml

--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -5,20 +5,19 @@ require 'package'
 class Binutils < Package
   description 'The GNU Binutils are a collection of binary tools.'
   homepage 'https://www.gnu.org/software/binutils/'
-  @_ver = '2.42'
-  version @_ver
+  version '2.42-gcc14'
   license 'GPL-3+'
   compatibility 'all'
-  source_url "https://ftpmirror.gnu.org/binutils/binutils-#{@_ver}.tar.bz2"
+  source_url "https://ftpmirror.gnu.org/binutils/binutils-#{version.split('-').first}.tar.bz2"
   source_sha256 'aa54850ebda5064c72cd4ec2d9b056c294252991486350d9a97ab2a6dfdfaf12'
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'b688741aec17c9bc006b9767265b266a1422ff03664541db64dd4e26308b664d',
-     armv7l: 'b688741aec17c9bc006b9767265b266a1422ff03664541db64dd4e26308b664d',
-       i686: '94b5f0aba999a5a7858a5a0a33b76b5bd2e6fbb651f73d6b0d2ac8f1572c1083',
-     x86_64: '59b5edbada9bbfd6485e1bc20cea5aa243a6a5a9ca05b142be31713becd37a25'
+    aarch64: '40ce4ce6ddc360a78933c2ecbce2ca6baad1c44b77a086438475ea00a016f3cf',
+     armv7l: '40ce4ce6ddc360a78933c2ecbce2ca6baad1c44b77a086438475ea00a016f3cf',
+       i686: '68d138135a2dc70af167adcf46af62703d1bde60ee81ad88a07a81d41fdf6e72',
+     x86_64: 'd6e27ec544c47d3217280ea103586968e5873b0596252498d9403446371c7b83'
   })
-  binary_compression 'tar.zst'
 
   depends_on 'elfutils' # R
   depends_on 'flex' # R

--- a/packages/gdb.rb
+++ b/packages/gdb.rb
@@ -6,18 +6,18 @@ require 'buildsystems/autotools'
 class Gdb < Autotools
   description 'The GNU Debugger'
   homepage 'https://www.gnu.org/software/gdb/'
-  version '14.2-py3.12'
+  version '15.1-py3.12'
   license 'GPL3'
   compatibility 'all'
-  source_url 'https://ftpmirror.gnu.org/gnu/gdb/gdb-14.2.tar.xz'
-  source_sha256 '2d4dd8061d8ded12b6c63f55e45344881e8226105f4d2a9b234040efa5ce7772'
+  source_url 'https://ftpmirror.gnu.org/gnu/gdb/gdb-15.1.tar.xz'
+  source_sha256 '38254eacd4572134bca9c5a5aa4d4ca564cbbd30c369d881f733fb6b903354f2'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '2cc54b085cf44964eeb9e7659e149eca4fd46591a045d99dc0176b0f119b77eb',
-     armv7l: '2cc54b085cf44964eeb9e7659e149eca4fd46591a045d99dc0176b0f119b77eb',
-       i686: '66d38230ff86d7558ebeb66e9f2106a3e51c5d4456c5708acd30ef57481cf8e3',
-     x86_64: '3fe3456bd566d259f84c360ec77739fc519fc55abb354f0dc046d968060573ac'
+    aarch64: '32437749840bdb8001a61853f7092535b65a691e68626ced4187ab18ca4c0a86',
+     armv7l: '32437749840bdb8001a61853f7092535b65a691e68626ced4187ab18ca4c0a86',
+       i686: '931ad01906fb397904974c1df160866e08ca44fab46b35f403d744d5bb40b980',
+     x86_64: 'afbdb2d178c49ccdc9f638bbc4e73af2cfe22d7d0e41552996a2adf616624395'
   })
 
   depends_on 'binutils' # R
@@ -32,6 +32,7 @@ class Gdb < Autotools
   depends_on 'python3' # R
   depends_on 'readline' # R
   depends_on 'source_highlight' # R
+  depends_on 'texinfo' => :build
   depends_on 'xxhash' # R
   depends_on 'xzutils' # R
   depends_on 'zlibpkg' # R

--- a/packages/gdb.rb
+++ b/packages/gdb.rb
@@ -6,7 +6,7 @@ require 'buildsystems/autotools'
 class Gdb < Autotools
   description 'The GNU Debugger'
   homepage 'https://www.gnu.org/software/gdb/'
-  version '15.1-py3.12'
+  version '15.1-gcc14-py3.12'
   license 'GPL3'
   compatibility 'all'
   source_url "https://ftpmirror.gnu.org/gnu/gdb/gdb-#{version.split('-').first}.tar.xz"

--- a/packages/gdb.rb
+++ b/packages/gdb.rb
@@ -9,7 +9,7 @@ class Gdb < Autotools
   version '15.1-py3.12'
   license 'GPL3'
   compatibility 'all'
-  source_url 'https://ftpmirror.gnu.org/gnu/gdb/gdb-15.1.tar.xz'
+  source_url "https://ftpmirror.gnu.org/gnu/gdb/gdb-#{version.split('-').first}.tar.xz"
   source_sha256 '38254eacd4572134bca9c5a5aa4d4ca564cbbd30c369d881f733fb6b903354f2'
   binary_compression 'tar.zst'
 


### PR DESCRIPTION
Builds properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=cmake crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
