### PR TITLE
ansifilter 2.10 -> 2.20

### DIFF
--- a/manifest/armv7l/a/ansifilter.filelist
+++ b/manifest/armv7l/a/ansifilter.filelist
@@ -1,6 +1,9 @@
 /usr/local/bin/ansifilter
+/usr/local/share/bash-completion/completions/ansifilter
 /usr/local/share/doc/ansifilter/COPYING
-/usr/local/share/doc/ansifilter/ChangeLog
+/usr/local/share/doc/ansifilter/ChangeLog.adoc
 /usr/local/share/doc/ansifilter/INSTALL
-/usr/local/share/doc/ansifilter/README
-/usr/local/share/man/man1/ansifilter.1.gz
+/usr/local/share/doc/ansifilter/README.adoc
+/usr/local/share/fish/vendor_completions.d/ansifilter.fish
+/usr/local/share/man/man1/ansifilter.1.zst
+/usr/local/share/zsh/site-functions/_ansifilter

--- a/manifest/i686/a/ansifilter.filelist
+++ b/manifest/i686/a/ansifilter.filelist
@@ -1,6 +1,9 @@
 /usr/local/bin/ansifilter
+/usr/local/share/bash-completion/completions/ansifilter
 /usr/local/share/doc/ansifilter/COPYING
-/usr/local/share/doc/ansifilter/ChangeLog
+/usr/local/share/doc/ansifilter/ChangeLog.adoc
 /usr/local/share/doc/ansifilter/INSTALL
-/usr/local/share/doc/ansifilter/README
-/usr/local/share/man/man1/ansifilter.1.gz
+/usr/local/share/doc/ansifilter/README.adoc
+/usr/local/share/fish/vendor_completions.d/ansifilter.fish
+/usr/local/share/man/man1/ansifilter.1.zst
+/usr/local/share/zsh/site-functions/_ansifilter

--- a/manifest/x86_64/a/ansifilter.filelist
+++ b/manifest/x86_64/a/ansifilter.filelist
@@ -1,6 +1,9 @@
 /usr/local/bin/ansifilter
+/usr/local/share/bash-completion/completions/ansifilter
 /usr/local/share/doc/ansifilter/COPYING
-/usr/local/share/doc/ansifilter/ChangeLog
+/usr/local/share/doc/ansifilter/ChangeLog.adoc
 /usr/local/share/doc/ansifilter/INSTALL
-/usr/local/share/doc/ansifilter/README
-/usr/local/share/man/man1/ansifilter.1.gz
+/usr/local/share/doc/ansifilter/README.adoc
+/usr/local/share/fish/vendor_completions.d/ansifilter.fish
+/usr/local/share/man/man1/ansifilter.1.zst
+/usr/local/share/zsh/site-functions/_ansifilter

--- a/packages/ansifilter.rb
+++ b/packages/ansifilter.rb
@@ -3,28 +3,25 @@ require 'package'
 class Ansifilter < Package
   description 'Ansifilter parses common ANSI codes to remove them or to convert them to another colored text file format (HTML, TeX, LaTeX, RTF, Pango or BBCode).'
   homepage 'http://andre-simon.de/doku/ansifilter/en/ansifilter.php'
-  version '2.10'
+  version '2.20'
   license 'GPL-3+'
   compatibility 'all'
-  source_url 'http://www.andre-simon.de/zip/ansifilter-2.10.tar.bz2'
-  source_sha256 '23d2cf439d4ed4fbec8050b2826d61c244694ce06aaf8ca7d0ec1016afebee3f'
-  binary_compression 'tar.xz'
+  source_url 'https://gitlab.com/saalen/ansifilter.git'
+  git_hashtag version
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'd5a8d33520c76aeb3f13067f169300d4b959a78ef352331b14a1b70db9f44f5f',
-     armv7l: 'd5a8d33520c76aeb3f13067f169300d4b959a78ef352331b14a1b70db9f44f5f',
-       i686: 'b312b46ae42dfb60620e6f62caa5aae83bfe259e01094d84f2dd949a137eedf2',
-     x86_64: 'af4c1a4f1b9fddd1efa5dabded1664880bd25fc17b52290af956d4d5d7dedf5c'
+    aarch64: 'da375a75732ae5d4534a7278c4d40dd26d89bdf9aa3a8f7eed1f9ce38ee65905',
+     armv7l: 'da375a75732ae5d4534a7278c4d40dd26d89bdf9aa3a8f7eed1f9ce38ee65905',
+       i686: 'b42d604aa940d8ebf298958fb1a4b93b3d2dcf29b7900783c914947878e9665f',
+     x86_64: '12f6c518b5c1cf12192cde003ca0df4ce16a5bbf72dd23bddd3c34cb743cbbd4'
   })
 
   def self.build
-    system 'mv makefile Makefile'
-    system "sed -i 's,DESTDIR = ,DESTDIR = #{CREW_DEST_DIR},' Makefile"
-    system "sed -i 's,PREFIX = /usr,PREFIX = #{CREW_PREFIX},' Makefile"
-    system 'make'
+    system 'make', "PREFIX=#{CREW_PREFIX}"
   end
 
   def self.install
-    system 'make install'
+    system 'make', "PREFIX=#{CREW_PREFIX}", "DESTDIR=#{CREW_DEST_DIR}", 'install'
   end
 end


### PR DESCRIPTION
Just trying to reduce the number of sed and patch sections, a large number of which are just low-hanging fruit replacing variables in makefiles rather than using the usual environment overrides.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=moongrains crew update
```
