### PR TITLE
bashdb 5.0-1.1.2-abac -> 5.0-1.1.2-1f1118d

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -438,7 +438,7 @@ def download
     puts 'No precompiled binary available for your platform, downloading source...'
   end
 
-  git = uri.scheme.eql?('git')
+  git = true unless @pkg.git_hashtag.to_s.empty?
 
   Dir.chdir CREW_BREW_DIR do
     case File.basename(filename)
@@ -497,15 +497,15 @@ def download
 
     when /^SKIP$/i
       Dir.mkdir @extract_dir
-    when /\.git$/i # Source URLs which end with .git are git sources.
-      git = true
     else
-      Dir.mkdir @extract_dir
-      downloader url, sha256sum, filename, CREW_VERBOSE
+      unless git # We don't want to download a git repository as a file.
+        Dir.mkdir @extract_dir
+        downloader url, sha256sum, filename, CREW_VERBOSE
 
-      puts "#{filename}: File downloaded.".lightgreen
+        puts "#{filename}: File downloaded.".lightgreen
 
-      FileUtils.mv filename, "#{@extract_dir}/#{filename}"
+        FileUtils.mv filename, "#{@extract_dir}/#{filename}"
+      end
     end
 
     # Handle git sources.

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -2,7 +2,7 @@
 # Defines common constants used in different parts of crew
 require 'etc'
 
-CREW_VERSION = '1.49.6'
+CREW_VERSION = '1.49.7'
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]

--- a/manifest/armv7l/b/bashdb.filelist
+++ b/manifest/armv7l/b/bashdb.filelist
@@ -150,6 +150,5 @@
 /usr/local/share/bashdb/lib/unescape.sh
 /usr/local/share/bashdb/lib/validate.sh
 /usr/local/share/bashdb/set-d-vars.sh
-/usr/local/share/info/bashdb.info.gz
-/usr/local/share/info/dir.gz
-/usr/local/share/man/man1/bashdb.1.gz
+/usr/local/share/info/bashdb.info.zst
+/usr/local/share/man/man1/bashdb.1.zst

--- a/manifest/i686/b/bashdb.filelist
+++ b/manifest/i686/b/bashdb.filelist
@@ -150,6 +150,5 @@
 /usr/local/share/bashdb/lib/unescape.sh
 /usr/local/share/bashdb/lib/validate.sh
 /usr/local/share/bashdb/set-d-vars.sh
-/usr/local/share/info/bashdb.info.gz
-/usr/local/share/info/dir.gz
-/usr/local/share/man/man1/bashdb.1.gz
+/usr/local/share/info/bashdb.info.zst
+/usr/local/share/man/man1/bashdb.1.zst

--- a/manifest/x86_64/b/bashdb.filelist
+++ b/manifest/x86_64/b/bashdb.filelist
@@ -150,6 +150,5 @@
 /usr/local/share/bashdb/lib/unescape.sh
 /usr/local/share/bashdb/lib/validate.sh
 /usr/local/share/bashdb/set-d-vars.sh
-/usr/local/share/info/bashdb.info.gz
-/usr/local/share/info/dir.gz
-/usr/local/share/man/man1/bashdb.1.gz
+/usr/local/share/info/bashdb.info.zst
+/usr/local/share/man/man1/bashdb.1.zst


### PR DESCRIPTION
Also backport some fixes from my `crew download` refactor again, so fixes #7278.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=1ugh crew update
```
