### PR TITLE
Use Package.load_package instead of require_relative in package files to avoid global scope conflicts

### DIFF
--- a/packages/a52.rb
+++ b/packages/a52.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'liba52'
+Package.load_package("#{__dir__}/liba52.rb")
 
 class A52 < Package
   description Liba52.description

--- a/packages/acli.rb
+++ b/packages/acli.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'acquia_cli'
+Package.load_package("#{__dir__}/acquia_cli.rb")
 
 class Acli < Package
   description Acquia_cli.description

--- a/packages/asciidoctor.rb
+++ b/packages/asciidoctor.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'ruby_asciidoctor'
+Package.load_package("#{__dir__}/ruby_asciidoctor.rb")
 
 class Asciidoctor < Package
   description Ruby_asciidoctor.description

--- a/packages/at_spi2_atk.rb
+++ b/packages/at_spi2_atk.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'at_spi2_core'
+Package.load_package("#{__dir__}/at_spi2_core.rb")
 
 class At_spi2_atk < Package
   description At_spi2_core.description

--- a/packages/atk.rb
+++ b/packages/atk.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'at_spi2_core'
+Package.load_package("#{__dir__}/at_spi2_core.rb")
 
 class Atk < Package
   description At_spi2_core.description

--- a/packages/avocado.rb
+++ b/packages/avocado.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'avocado_framework'
+Package.load_package("#{__dir__}/avocado_framework.rb")
 
 class Avocado < Package
   description Avocado_framework.description

--- a/packages/az.rb
+++ b/packages/az.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'py3_azure_cli'
+Package.load_package("#{__dir__}/py3_azure_cli.rb")
 
 class Az < Package
   description Py3_azure_cli.description

--- a/packages/azure_cli.rb
+++ b/packages/azure_cli.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'py3_azure_cli'
+Package.load_package("#{__dir__}/py3_azure_cli.rb")
 
 class Azure_cli < Package
   description Py3_azure_cli.description

--- a/packages/cairomm.rb
+++ b/packages/cairomm.rb
@@ -1,6 +1,6 @@
 require 'package'
-require_relative 'cairomm_1_0'
-require_relative 'cairomm_1_16'
+Package.load_package("#{__dir__}/cairomm_1_0.rb")
+Package.load_package("#{__dir__}/cairomm_1_16.rb")
 
 class Cairomm < Package
   description Cairomm_1_0.description

--- a/packages/desktop_file_utilities.rb
+++ b/packages/desktop_file_utilities.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'desktop_file_utils'
+Package.load_package("#{__dir__}/desktop_file_utils.rb")
 
 class Desktop_file_utilities < Package
   description Desktop_file_utils.description

--- a/packages/difft.rb
+++ b/packages/difft.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'difftastic'
+Package.load_package("#{__dir__}/difftastic.rb")
 
 class Difft < Package
   description Difftastic.description

--- a/packages/gcc.rb
+++ b/packages/gcc.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'gcc_build'
+Package.load_package("#{__dir__}/gcc_build.rb")
 
 class Gcc < Package
   description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, and Go.'

--- a/packages/gcc_dev.rb
+++ b/packages/gcc_dev.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'gcc_build'
+Package.load_package("#{__dir__}/gcc_build.rb")
 
 class Gcc_dev < Package
   description 'The GNU Compiler Collection: Everything (excepting libraries aside from libgccjit)'

--- a/packages/gcc_lib.rb
+++ b/packages/gcc_lib.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'gcc_build'
+Package.load_package("#{__dir__}/gcc_build.rb")
 
 class Gcc_lib < Package
   description 'GCC shared libs except libgccjit'

--- a/packages/gcr.rb
+++ b/packages/gcr.rb
@@ -1,6 +1,6 @@
 require 'package'
-require_relative 'gcr_3'
-require_relative 'gcr_4'
+Package.load_package("#{__dir__}/gcr_3.rb")
+Package.load_package("#{__dir__}/gcr_4.rb")
 
 class Gcr < Package
   description Gcr_3.description

--- a/packages/gh.rb
+++ b/packages/gh.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'github_cli'
+Package.load_package("#{__dir__}/github_cli.rb")
 
 class Gh < Package
   description Github_cli.description

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -1,10 +1,10 @@
 require 'package'
-require_relative 'glibc_build223'
-require_relative 'glibc_build227'
-require_relative 'glibc_build232'
-require_relative 'glibc_build233'
-require_relative 'glibc_build235'
-require_relative 'glibc_build237'
+Package.load_package("#{__dir__}/glibc_build223.rb")
+Package.load_package("#{__dir__}/glibc_build227.rb")
+Package.load_package("#{__dir__}/glibc_build232.rb")
+Package.load_package("#{__dir__}/glibc_build233.rb")
+Package.load_package("#{__dir__}/glibc_build235.rb")
+Package.load_package("#{__dir__}/glibc_build237.rb")
 
 class Glibc < Package
   description 'The GNU C Library project provides the core libraries for GNU/Linux systems.'

--- a/packages/glibc_dev.rb
+++ b/packages/glibc_dev.rb
@@ -1,7 +1,7 @@
 require 'package'
-require_relative 'glibc'
-require_relative 'glibc_build235'
-require_relative 'glibc_build237'
+Package.load_package("#{__dir__}/glibc.rb")
+Package.load_package("#{__dir__}/glibc_build235.rb")
+Package.load_package("#{__dir__}/glibc_build237.rb")
 
 class Glibc_dev < Package
   description 'glibc: everything except what is in glibc_lib'

--- a/packages/glibc_dev235.rb
+++ b/packages/glibc_dev235.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'glibc_build235'
+Package.load_package("#{__dir__}/glibc_build235.rb")
 
 class Glibc_dev235 < Package
   description 'glibc: everything except what is in glibc_lib'

--- a/packages/glibc_dev237.rb
+++ b/packages/glibc_dev237.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'glibc_build237'
+Package.load_package("#{__dir__}/glibc_build237.rb")
 
 class Glibc_dev237 < Package
   description 'glibc: everything except what is in glibc_lib'

--- a/packages/glibc_lib.rb
+++ b/packages/glibc_lib.rb
@@ -1,7 +1,7 @@
 require 'package'
-require_relative 'glibc'
-require_relative 'glibc_build235'
-require_relative 'glibc_build237'
+Package.load_package("#{__dir__}/glibc.rb")
+Package.load_package("#{__dir__}/glibc_build235.rb")
+Package.load_package("#{__dir__}/glibc_build237.rb")
 
 class Glibc_lib < Package
   description 'glibc libraries'

--- a/packages/glibc_lib235.rb
+++ b/packages/glibc_lib235.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'glibc_build235'
+Package.load_package("#{__dir__}/glibc_build235.rb")
 
 class Glibc_lib235 < Package
   description 'glibc libraries'

--- a/packages/glibc_lib237.rb
+++ b/packages/glibc_lib237.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'glibc_build237'
+Package.load_package("#{__dir__}/glibc_build237.rb")
 
 class Glibc_lib237 < Package
   description 'glibc libraries'

--- a/packages/glibmm.rb
+++ b/packages/glibmm.rb
@@ -1,6 +1,6 @@
 require 'package'
-require_relative 'glibmm_2_4'
-require_relative 'glibmm_2_68'
+Package.load_package("#{__dir__}/glibmm_2_4.rb")
+Package.load_package("#{__dir__}/glibmm_2_68.rb")
 
 class Glibmm < Package
   description Glibmm_2_4.description

--- a/packages/google_cloud_sdk.rb
+++ b/packages/google_cloud_sdk.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'gcloud'
+Package.load_package("#{__dir__}/gcloud.rb")
 
 class Google_cloud_sdk < Package
   description Gcloud.description

--- a/packages/gst_plugins_bad.rb
+++ b/packages/gst_plugins_bad.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'gstreamer'
+Package.load_package("#{__dir__}/gstreamer.rb")
 
 class Gst_plugins_bad < Package
   description 'Multimedia graph framework - bad plugins'

--- a/packages/gst_plugins_base.rb
+++ b/packages/gst_plugins_base.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'gstreamer'
+Package.load_package("#{__dir__}/gstreamer.rb")
 
 class Gst_plugins_base < Package
   description 'An essential, exemplary set of elements for GStreamer'

--- a/packages/gst_plugins_good.rb
+++ b/packages/gst_plugins_good.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'gstreamer'
+Package.load_package("#{__dir__}/gstreamer.rb")
 
 class Gst_plugins_good < Package
   description 'Multimedia graph framework - good plugins'

--- a/packages/gtksourceview.rb
+++ b/packages/gtksourceview.rb
@@ -1,7 +1,7 @@
 require 'package'
-require_relative 'gtksourceview_3'
-require_relative 'gtksourceview_4'
-require_relative 'gtksourceview_5'
+Package.load_package("#{__dir__}/gtksourceview_3.rb")
+Package.load_package("#{__dir__}/gtksourceview_4.rb")
+Package.load_package("#{__dir__}/gtksourceview_5.rb")
 
 class Gtksourceview < Package
   description Gtksourceview_3.description

--- a/packages/gucharmap.rb
+++ b/packages/gucharmap.rb
@@ -1,5 +1,5 @@
 require 'buildsystems/meson'
-require_relative 'unicode_character_database'
+Package.load_package("#{__dir__}/unicode_character_database.rb")
 
 class Gucharmap < Meson
   description 'GNOME Character Map, based on the Unicode Character Database.'

--- a/packages/harfbuzz.rb
+++ b/packages/harfbuzz.rb
@@ -1,7 +1,7 @@
 require 'buildsystems/meson'
-require_relative 'cairo'
-require_relative 'fontconfig'
-require_relative 'freetype'
+Package.load_package("#{__dir__}/cairo.rb")
+Package.load_package("#{__dir__}/fontconfig.rb")
+Package.load_package("#{__dir__}/freetype.rb")
 # build order: harfbuzz => freetype => fontconfig => cairo => pango
 
 class Harfbuzz < Meson

--- a/packages/hg.rb
+++ b/packages/hg.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'py3_mercurial'
+Package.load_package("#{__dir__}/py3_mercurial.rb")
 
 class Hg < Package
   description Py3_mercurial.description

--- a/packages/hunspell.rb
+++ b/packages/hunspell.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'hunspell_en_us'
+Package.load_package("#{__dir__}/hunspell_en_us.rb")
 
 class Hunspell < Package
   description 'Hunspell is a spell checker and morphological analyzer library'

--- a/packages/imagemagick.rb
+++ b/packages/imagemagick.rb
@@ -1,6 +1,6 @@
 require 'package'
-require_relative 'imagemagick6'
-require_relative 'imagemagick7'
+Package.load_package("#{__dir__}/imagemagick6.rb")
+Package.load_package("#{__dir__}/imagemagick7.rb")
 
 class Imagemagick < Package
   description Imagemagick7.description

--- a/packages/libclc.rb
+++ b/packages/libclc.rb
@@ -2,7 +2,7 @@
 # https://github.com/archlinux/svntogit-packages/raw/packages/libclc/trunk/PKGBUILD
 
 require 'package'
-require_relative 'llvm18_build'
+Package.load_package("#{__dir__}/llvm18_build.rb")
 
 class Libclc < Package
   description 'Library requirements of the OpenCL C programming language'

--- a/packages/libcurl.rb
+++ b/packages/libcurl.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'curl'
+Package.load_package("#{__dir__}/curl.rb")
 
 class Libcurl < Package
   description Curl.description

--- a/packages/libressl.rb
+++ b/packages/libressl.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'openssl'
+Package.load_package("#{__dir__}/openssl.rb")
 
 class Libressl < Package
   description 'LibreSSL is a version of the TLS/crypto stack forked from OpenSSL in 2014, with goals of modernizing the codebase, improving security, and applying best practice development processes.'

--- a/packages/libssp.rb
+++ b/packages/libssp.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'gcc_build'
+Package.load_package("#{__dir__}/gcc_build.rb")
 
 class Libssp < Package
   description 'Libssp is a part of the GCC toolkit.'

--- a/packages/libuuid.rb
+++ b/packages/libuuid.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'util_linux'
+Package.load_package("#{__dir__}/util_linux.rb")
 
 class Libuuid < Package
   description 'Portable UUID C library. Bundled with util_linux.'

--- a/packages/libxml2_python.rb
+++ b/packages/libxml2_python.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'py3_libxml2'
+Package.load_package("#{__dir__}/py3_libxml2.rb")
 
 class Libxml2_python < Package
   description Py3_libxml2.description

--- a/packages/libxscrnsaver.rb
+++ b/packages/libxscrnsaver.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'libxss'
+Package.load_package("#{__dir__}/libxss.rb")
 
 class Libxscrnsaver < Package
   description Libxss.description

--- a/packages/llvm.rb
+++ b/packages/llvm.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'llvm18_build'
+Package.load_package("#{__dir__}/llvm18_build.rb")
 
 class Llvm < Package
   description 'The LLVM Project is a collection of modular and reusable compiler and toolchain technologies. The optional packages clang, lld, lldb, polly, compiler-rt, libcxx, and libcxxabi are included.'

--- a/packages/llvm16_dev.rb
+++ b/packages/llvm16_dev.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'llvm16_build'
+Package.load_package("#{__dir__}/llvm16_build.rb")
 
 class Llvm16_dev < Package
   description 'LLVM: Everything except libLLVM & llvm-strip'

--- a/packages/llvm16_lib.rb
+++ b/packages/llvm16_lib.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'llvm16_build'
+Package.load_package("#{__dir__}/llvm16_build.rb")
 
 class Llvm16_lib < Package
   description 'LibLLVM and llvm-strip'

--- a/packages/llvm17_dev.rb
+++ b/packages/llvm17_dev.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'llvm17_build'
+Package.load_package("#{__dir__}/llvm17_build.rb")
 
 class Llvm17_dev < Package
   description 'LLVM: Everything except libLLVM & llvm-strip'

--- a/packages/llvm17_lib.rb
+++ b/packages/llvm17_lib.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'llvm17_build'
+Package.load_package("#{__dir__}/llvm17_build.rb")
 
 class Llvm17_lib < Package
   description 'LibLLVM and llvm-strip'

--- a/packages/llvm18_dev.rb
+++ b/packages/llvm18_dev.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'llvm18_build'
+Package.load_package("#{__dir__}/llvm18_build.rb")
 
 class Llvm18_dev < Package
   description 'LLVM: Everything except libLLVM & llvm-strip'

--- a/packages/llvm18_lib.rb
+++ b/packages/llvm18_lib.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'llvm18_build'
+Package.load_package("#{__dir__}/llvm18_build.rb")
 
 class Llvm18_lib < Package
   description 'LibLLVM and llvm-strip'

--- a/packages/llvm_build16.rb
+++ b/packages/llvm_build16.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'llvm16_build'
+Package.load_package("#{__dir__}/llvm16_build.rb")
 
 class Llvm_build16 < Package
   description 'The LLVM Project is a collection of modular and reusable compiler and toolchain technologies. The optional packages clang, lld, lldb, polly, compiler-rt, libcxx, and libcxxabi are included.'

--- a/packages/llvm_dev16.rb
+++ b/packages/llvm_dev16.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'llvm16_build'
+Package.load_package("#{__dir__}/llvm16_build.rb")
 
 class Llvm_dev16 < Package
   description 'The LLVM Project is a collection of modular and reusable compiler and toolchain technologies. The optional packages clang, lld, lldb, polly, compiler-rt, libcxx, and libcxxabi are included.'

--- a/packages/llvm_lib16.rb
+++ b/packages/llvm_lib16.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'llvm16_build'
+Package.load_package("#{__dir__}/llvm16_build.rb")
 
 class Llvm_lib16 < Package
   description 'The LLVM Project is a collection of modular and reusable compiler and toolchain technologies. The optional packages clang, lld, lldb, polly, compiler-rt, libcxx, and libcxxabi are included.'

--- a/packages/lzma.rb
+++ b/packages/lzma.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'xzutils'
+Package.load_package("#{__dir__}/xzutils.rb")
 
 class Lzma < Package
   description 'LZMA Utils are legacy data compression software with high compression ratio. Bundled with xzutils.'

--- a/packages/minizip.rb
+++ b/packages/minizip.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'zlibpkg'
+Package.load_package("#{__dir__}/zlibpkg.rb")
 
 class Minizip < Package
   description 'Minizip is a simple package to zip/unzip files, from zlib.'

--- a/packages/musl_toolchain.rb
+++ b/packages/musl_toolchain.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'musl_cc_toolchain'
+Package.load_package("#{__dir__}/musl_cc_toolchain.rb")
 
 class Musl_toolchain < Package
   description Musl_cc_toolchain.description

--- a/packages/node.rb
+++ b/packages/node.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'nodebrew'
+Package.load_package("#{__dir__}/nodebrew.rb")
 
 class Node < Package
   description 'As an asynchronous event driven JavaScript runtime, Node is designed to build scalable network applications.'

--- a/packages/nspr.rb
+++ b/packages/nspr.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'nss'
+Package.load_package("#{__dir__}/nss.rb")
 
 class Nspr < Package
   description 'Netscape Portable Runtime (NSPR) provides a platform-neutral API for system level and libc-like functions.'

--- a/packages/openmp.rb
+++ b/packages/openmp.rb
@@ -2,7 +2,7 @@
 # https://github.com/archlinux/svntogit-packages/raw/packages/openmp/trunk/PKGBUILD
 
 require 'package'
-require_relative 'llvm18_build'
+Package.load_package("#{__dir__}/llvm18_build.rb")
 
 class Openmp < Package
   description 'LLVM OpenMP Runtime Library'

--- a/packages/orc.rb
+++ b/packages/orc.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'gstreamer'
+Package.load_package("#{__dir__}/gstreamer.rb")
 
 class Orc < Package
   description 'Optimized Inner Loop Runtime Compiler. Bundled with gstreamer.'

--- a/packages/p7zip.rb
+++ b/packages/p7zip.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'pkg_7_zip'
+Package.load_package("#{__dir__}/pkg_7_zip.rb")
 
 class P7zip < Package
   description Pkg_7_zip.description

--- a/packages/pangomm.rb
+++ b/packages/pangomm.rb
@@ -1,6 +1,6 @@
 require 'package'
-require_relative 'pangomm_1_4'
-require_relative 'pangomm_2_48'
+Package.load_package("#{__dir__}/pangomm_1_4.rb")
+Package.load_package("#{__dir__}/pangomm_2_48.rb")
 
 class Pangomm < Package
   description Pangomm_1_4.description

--- a/packages/parallel.rb
+++ b/packages/parallel.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'moreutils'
+Package.load_package("#{__dir__}/moreutils.rb")
 
 class Parallel < Package
   description 'Run multiple programs simultaneously. Bundled with moreutils.'

--- a/packages/perl_gcstring_linebreak.rb
+++ b/packages/perl_gcstring_linebreak.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'perl_unicode_linebreak'
+Package.load_package("#{__dir__}/perl_unicode_linebreak.rb")
 
 class Perl_gcstring_linebreak < Package
   description 'UAX 14 Unicode Line Breaking Algorithm - Perl binding Unicode::LineBreak Unicode::GCString'

--- a/packages/perl_read_key.rb
+++ b/packages/perl_read_key.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'perl_term_readkey'
+Package.load_package("#{__dir__}/perl_term_readkey.rb")
 
 class Perl_read_key < Package
   description 'Term::ReadKey - A perl module for simple terminal control'

--- a/packages/perl_term_ansicolor.rb
+++ b/packages/perl_term_ansicolor.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'perl'
+Package.load_package("#{__dir__}/perl.rb")
 
 class Perl_term_ansicolor < Package
   description 'Character mode terminal access for Perl Term::ANSIColor'

--- a/packages/perl_time_hires.rb
+++ b/packages/perl_time_hires.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'perl'
+Package.load_package("#{__dir__}/perl.rb")
 
 class Perl_time_hires < Package
   description 'High resolution alarm, sleep, gettimeofday, interval timers Time::HiRes'

--- a/packages/perl_xml_sax_parserfactory.rb
+++ b/packages/perl_xml_sax_parserfactory.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'perl_xml_sax'
+Package.load_package("#{__dir__}/perl_xml_sax.rb")
 
 class Perl_xml_sax_parserfactory < Package
   description 'XML::SAX::ParserFactory is a factory class for providing an application with a Perl SAX2 XML parser.'

--- a/packages/py3_libxml2.rb
+++ b/packages/py3_libxml2.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'libxml2'
+Package.load_package("#{__dir__}/libxml2.rb")
 
 class Py3_libxml2 < Package
   description 'Libxml2-python provides access to libxml2 and libxslt in Python.'

--- a/packages/pycairo.rb
+++ b/packages/pycairo.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'py3_pycairo'
+Package.load_package("#{__dir__}/py3_pycairo.rb")
 
 class Pycairo < Package
   description Py3_pycairo.description

--- a/packages/python27.rb
+++ b/packages/python27.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'python2'
+Package.load_package("#{__dir__}/python2.rb")
 
 class Python27 < Package
   description 'A compatibility package for python2.'

--- a/packages/qt5_webengine.rb
+++ b/packages/qt5_webengine.rb
@@ -3,7 +3,7 @@
 # & LFS build documentation at https://www.linuxfromscratch.org/blfs/view/svn/x/qtwebengine.html
 
 require 'package'
-require_relative 'qt5_base'
+Package.load_package("#{__dir__}/qt5_base.rb")
 
 class Qt5_webengine < Package
   description 'Provides support for web applications using the Chromium browser project'

--- a/packages/ragel.rb
+++ b/packages/ragel.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'harfbuzz'
+Package.load_package("#{__dir__}/harfbuzz.rb")
 
 class Ragel < Package
   description 'Ragel compiles executable finite state machines from regular languages. Now bundled with harfbuzz.'

--- a/packages/six.rb
+++ b/packages/six.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'py3_six'
+Package.load_package("#{__dir__}/py3_six.rb")
 
 class Six < Package
   description Py3_six.description

--- a/packages/stow.rb
+++ b/packages/stow.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'perl_stow'
+Package.load_package("#{__dir__}/perl_stow.rb")
 
 class Stow < Package
   description Perl_stow.description

--- a/packages/tepl.rb
+++ b/packages/tepl.rb
@@ -1,6 +1,6 @@
 require 'package'
-require_relative 'tepl_5'
-require_relative 'tepl_6'
+Package.load_package("#{__dir__}/tepl_5.rb")
+Package.load_package("#{__dir__}/tepl_6.rb")
 
 class Tepl < Package
   description Tepl_5.description

--- a/packages/tilp.rb
+++ b/packages/tilp.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'tilp2'
+Package.load_package("#{__dir__}/tilp2.rb")
 
 class Tilp < Package
   description Tilp2.description

--- a/packages/wayland_utils.rb
+++ b/packages/wayland_utils.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'wayland_info'
+Package.load_package("#{__dir__}/wayland_info.rb")
 
 class Wayland_utils < Package
   description Wayland_info.description

--- a/packages/webkit2gtk.rb
+++ b/packages/webkit2gtk.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'webkit2gtk_4'
+Package.load_package("#{__dir__}/webkit2gtk_4.rb")
 
 class Webkit2gtk < Package
   description Webkit2gtk_4.description

--- a/packages/webkit2gtk_5.rb
+++ b/packages/webkit2gtk_5.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'webkitgtk_6'
+Package.load_package("#{__dir__}/webkitgtk_6.rb")
 
 class Webkit2gtk_5 < Package
   description Webkitgtk_6.description

--- a/packages/xorg_lib.rb
+++ b/packages/xorg_lib.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'libx11'
+Package.load_package("#{__dir__}/libx11.rb")
 
 class Xorg_lib < Package
   description 'A collection of xorg libraries.'

--- a/packages/youtubedl.rb
+++ b/packages/youtubedl.rb
@@ -1,5 +1,5 @@
 require 'package'
-require_relative 'youtube_dl'
+Package.load_package("#{__dir__}/youtube_dl.rb")
 
 class Youtubedl < Package
   description Youtube_dl.description


### PR DESCRIPTION
Following on from https://github.com/chromebrew/chromebrew/pull/9859#discussion_r1633641170.

I haven't updated `openjdk.rb` or `php.rb` because this change breaks them, meaning they're probably relying on global scope when they shouldn't be.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=matilda crew update
```
