### PR TITLE
Terraform 1.9.2 => 1.9.3

### DIFF
--- a/packages/terraform.rb
+++ b/packages/terraform.rb
@@ -3,7 +3,7 @@ require 'package'
 class Terraform < Package
   description 'Terraform is a tool for building, changing, and combining infrastructure safely and efficiently.'
   homepage 'https://www.terraform.io/'
-  version '1.9.2'
+  version '1.9.3'
   license 'Apache-2.0, BSD-2, BSD-4, ECL-2.0, imagemagick, ISC, JSON, MIT, MIT-with-advertising, MPL-2.0 and unicode'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Terraform < Package
      x86_64: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_amd64.zip"
   })
   source_sha256({
-    aarch64: '58d65a85a4f9d0f7284d49e4390c1b6b4b8ad4977908021fb2e8c95e3aa23369',
-     armv7l: '58d65a85a4f9d0f7284d49e4390c1b6b4b8ad4977908021fb2e8c95e3aa23369',
-       i686: 'e4017501d1657d5c53bcf58f026be3e4372497708ab54e882900b7d16fd472eb',
-     x86_64: '8e18f9a97ac69bd9481f83bcc1aa3cb6caeb327abf22e41b25964448d2ced912'
+    aarch64: '5bfba34db649cd1c6327de9113bf449317190e9e10d9fd1e6d6a4378774d5270',
+     armv7l: '5bfba34db649cd1c6327de9113bf449317190e9e10d9fd1e6d6a4378774d5270',
+       i686: '152ef794e2aefc2f15ee78233d00808dcb9d344e001627c851ef9ad4f2db582a',
+     x86_64: '68c22a822b3e0ce88c9ddbbb5b585b3601f63fc0e7954638582b71a19d2505a4'
   })
 
   def self.install


### PR DESCRIPTION
## Description

This commit updates the Terraform CLI from version 1.9.2 to version 1.9.3.

## Additional information

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`