### PR TITLE
Add all variant of `google_chrome`, renamed `chrome` to better match upstream

### DIFF
--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -34,6 +34,7 @@ pkg_update_arr = [
   { pkg_name: 'btrfsprogs', pkg_rename: 'btrfs_progs', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' },
   { pkg_name: 'bz2', pkg_rename: 'bzip2', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' },
   { pkg_name: 'bz3', pkg_rename: 'bzip3', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' },
+  { pkg_name: 'chrome', pkg_rename: 'google_chrome', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' },
   { pkg_name: 'codium', pkg_rename: 'vscodium', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' },
   { pkg_name: 'dstat', pkg_rename: 'py3_dool', pkg_deprecated: nil, comments: 'Following upstream rename.' },
   { pkg_name: 'epydoc', pkg_rename: nil, pkg_deprecated: true, comments: 'Abandoned upstream, only supports Python 2.' },

--- a/packages/google_chrome.rb
+++ b/packages/google_chrome.rb
@@ -1,13 +1,14 @@
 require 'package'
 
-class Chrome < Package
+class Google_chrome < Package
+  @update_channel = 'stable'
   description 'Google Chrome is a fast, easy to use, and secure web browser.'
   homepage 'https://www.google.com/chrome/'
   version '127.0.6533.88-1'
   license 'google-chrome'
   compatibility 'x86_64'
-  min_glibc '2.29'
-  source_url "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_#{version}_amd64.deb"
+  min_glibc '2.25'
+  source_url "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-#{@update_channel}/google-chrome-#{@update_channel}_#{@version}_amd64.deb"
   source_sha256 'd25f5c89d3453b475ccb35b2e270c3fce18540304b5f1f5a3d5aba8a80e4a8ad'
 
   depends_on 'nspr'
@@ -25,11 +26,11 @@ class Chrome < Package
     FileUtils.mv 'usr/share', CREW_DEST_PREFIX
     FileUtils.mv 'opt/google/chrome', "#{CREW_DEST_PREFIX}/share"
 
-    FileUtils.ln_s '../share/chrome/google-chrome', "#{CREW_DEST_PREFIX}/bin/google-chrome-stable"
-    FileUtils.ln_s '../share/chrome/google-chrome', "#{CREW_DEST_PREFIX}/bin/google-chrome"
+    FileUtils.ln_s "../share/chrome/google-chrome-#{@update_channel}", "#{CREW_DEST_PREFIX}/bin/google-chrome-#{@update_channel}"
+    FileUtils.ln_s "../share/chrome/google-chrome-#{@update_channel}", "#{CREW_DEST_PREFIX}/bin/google-chrome"
   end
 
   def self.postinstall
-    ExitMessage.add "\nType 'google-chrome' to get started.\n".lightblue
+    ExitMessage.add "\nType 'google-chrome-#{@update_channel}' to get started.\n".lightblue
   end
 end

--- a/packages/google_chrome_beta.rb
+++ b/packages/google_chrome_beta.rb
@@ -1,0 +1,35 @@
+require 'package'
+
+class Google_chrome_beta < Package
+  @update_channel = 'beta'
+  description 'Google Chrome is a fast, easy to use, and secure web browser. (Beta Channel)'
+  homepage 'https://www.google.com/chrome/'
+  version '128.0.6613.18-1'
+  license 'google-chrome'
+  compatibility 'x86_64'
+  min_glibc '2.25'
+  source_url "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-#{@update_channel}/google-chrome-#{@update_channel}_#{@version}_amd64.deb"
+  source_sha256 'ca9bce2d3c8b6b2e092f28a73af01e7d95de093108ab40609e0390d0dd1a4ba3'
+
+  depends_on 'nspr'
+  depends_on 'cairo'
+  depends_on 'gtk3'
+  depends_on 'expat'
+  depends_on 'cras'
+
+  no_compile_needed
+  no_shrink
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+
+    FileUtils.mv 'usr/share', CREW_DEST_PREFIX
+    FileUtils.mv "opt/google/chrome-#{@update_channel}", "#{CREW_DEST_PREFIX}/share"
+
+    FileUtils.ln_s "../share/chrome/google-chrome-#{@update_channel}", "#{CREW_DEST_PREFIX}/bin/google-chrome-#{@update_channel}"
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nType 'google-chrome-#{@update_channel}' to get started.\n".lightblue
+  end
+end

--- a/packages/google_chrome_unstable.rb
+++ b/packages/google_chrome_unstable.rb
@@ -1,0 +1,35 @@
+require 'package'
+
+class Google_chrome_unstable < Package
+  @update_channel = 'unstable'
+  description 'Google Chrome is a fast, easy to use, and secure web browser. (Dev Channel)'
+  homepage 'https://www.google.com/chrome/'
+  version '129.0.6628.3-1'
+  license 'google-chrome'
+  compatibility 'x86_64'
+  min_glibc '2.25'
+  source_url "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-#{@update_channel}/google-chrome-#{@update_channel}_#{@version}_amd64.deb"
+  source_sha256 '04ecad6568443416e347833cd9733b9866bb5b0465e34a93d6442eb75bc51d26'
+
+  depends_on 'nspr'
+  depends_on 'cairo'
+  depends_on 'gtk3'
+  depends_on 'expat'
+  depends_on 'cras'
+
+  no_compile_needed
+  no_shrink
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+
+    FileUtils.mv 'usr/share', CREW_DEST_PREFIX
+    FileUtils.mv "opt/google/chrome-#{@update_channel}", "#{CREW_DEST_PREFIX}/share"
+
+    FileUtils.ln_s "../share/chrome/google-chrome-#{@update_channel}", "#{CREW_DEST_PREFIX}/bin/google-chrome-#{@update_channel}"
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nType 'google-chrome-#{@update_channel}' to get started.\n".lightblue
+  end
+end


### PR DESCRIPTION
## Changes
- Added `google_chrome_unstable` and `google_chrome_beta`
- Renamed  `chrome` to `google-chrome` to better match upstream
- Corrected minimum glibc version to `2.25`:
```
$ objdump -T ~/MyFiles/chrome | grep GLIBC | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -Vu 
2.2.5
..snip...
2.25
```