### PR TITLE
Add get_clean_version in PackageUtils and use it in json.rb and version.rb

### DIFF
--- a/.github/workflows/Repology.yml
+++ b/.github/workflows/Repology.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Generate repology.json
         env:
           CREW_KERNEL_VERSION: 5.1
+          LIBC_VERSION: 2.37
         run: |
           ruby -Ctools json.rb
       - name: Create Pull Request

--- a/lib/package_utils.rb
+++ b/lib/package_utils.rb
@@ -30,4 +30,21 @@ class PackageUtils
       return pkg.source_sha256
     end
   end
+
+  def self.get_clean_version(pkg_version)
+    # Trim kde- suffixes in qt5 packages so nothing else gets confused.
+    pkg_version.delete_prefix!('kde-')
+    # Delete -py3.12, futureproofed until Python 4
+    pkg_version.gsub!(/-py3\.\d{2}/, '')
+    # Delete -perl 5.40, futureproofed until Perl 5.100
+    pkg_version.gsub!(/-perl5\.\d{2}/, '')
+    # Delete -llvm18, futureproofed until llvm 100
+    pkg_version.gsub!(/-llvm\d{2}/, '')
+    # Delete -glibc2.39, or whatever the system glibc is.
+    pkg_version.delete_suffix!("-glibc#{LIBC_VERSION}")
+    # Delete git version tags (1.2.4-qnd73k6), avoiding overmatching and hitting things that arent git hashtags.
+    pkg_version.gsub!(/-[\w]{7}$/, '')
+
+    return pkg_version
+  end
 end

--- a/tests/lib/package_utils.rb
+++ b/tests/lib/package_utils.rb
@@ -120,4 +120,27 @@ class PackageUtilsTest < Minitest::Test
     end
     assert_equal('4444444444444444444444444444444444444444444444444444444444444444', PackageUtils.get_sha256(pkg, build_from_source: true))
   end
+
+  def test_get_clean_python_version
+    assert_equal('1.2.3', PackageUtils.get_clean_version('1.2.3-py3.12'))
+  end
+
+  def test_get_clean_perl_version
+    assert_equal('0.004.2', PackageUtils.get_clean_version('0.004.2-perl5.40'))
+  end
+
+  def test_get_clean_llvm_version
+    assert_equal('72.93', PackageUtils.get_clean_version('72.93-llvm18'))
+  end
+
+  def test_get_clean_glibc_version
+    assert_equal('9.5.18', PackageUtils.get_clean_version('9.5.18-glibc2.39'))
+  end
+
+  def test_get_clean_git_version
+    assert_equal('0.0.7', PackageUtils.get_clean_version('0.0.7-8ab26so'))
+    assert_equal('8.2.4-2', PackageUtils.get_clean_version('8.2.4-2-zh725k9'))
+    assert_equal('579-4', PackageUtils.get_clean_version('579-4-1628457'))
+    assert_equal('2.1.5-20220429', PackageUtils.get_clean_version('2.1.5-20220429'))
+  end
 end

--- a/tools/json.rb
+++ b/tools/json.rb
@@ -5,6 +5,7 @@ $LOAD_PATH.unshift '../lib'
 
 require_relative '../lib/const'
 require_relative '../lib/package'
+require_relative '../lib/package_utils'
 
 output = []
 
@@ -15,14 +16,7 @@ Dir.glob('../packages/*.rb').each do |filename|
   pkg = Package.load_package(filename)
   # Skip fake packages.
   next if pkg.is_fake?
-  # Present a useful version to Repology.
-  version = +pkg.version
-  # That starts by trimming off our language version tagging.
-  version.delete_suffix!('-py3.12')
-  version.delete_suffix!('-perl5.40')
-  version.delete_suffix!('-llvm18')
-  version.delete_suffix!("-glibc#{LIBC_VERSION}")
-  output << { name: File.basename(filename, '.rb'), description: pkg.description, homepage: pkg.homepage, version:, license: pkg.license, compatibility: pkg.compatibility }
+  output << { name: File.basename(filename, '.rb'), description: pkg.description, homepage: pkg.homepage, version: PackageUtils.get_clean_version(pkg.version), license: pkg.license, compatibility: pkg.compatibility }
 end
 
 File.write('repology.json', JSON.pretty_generate(output))

--- a/tools/version.rb
+++ b/tools/version.rb
@@ -16,6 +16,7 @@ $LOAD_PATH.unshift '../lib'
 
 require_relative '../lib/color'
 require_relative '../lib/package'
+require_relative '../lib/package_utils'
 
 def get_version(name, homepage)
   anitya_id = get_anitya_id(name, homepage)
@@ -122,16 +123,16 @@ if filelist.length.positive?
     end
 
     # Bail out if we arent verbose and so dont want to print packages that are up to date.
-    next if Libversion.version_compare2(pkg.version, upstream_version) >= 0 && !verbose
+    next if Libversion.version_compare2(PackageUtils.get_clean_version(pkg.version), upstream_version) >= 0 && !verbose
     # Print the package name.
     print pkg.name.ljust(35)
     # Print the package update status.
-    if Libversion.version_compare2(pkg.version, upstream_version) >= 0
+    if Libversion.version_compare2(PackageUtils.get_clean_version(pkg.version), upstream_version) >= 0
       print 'uptodate'.ljust(20).lightgreen
-    elsif Libversion.version_compare2(pkg.version, upstream_version) == -1
+    elsif Libversion.version_compare2(PackageUtils.get_clean_version(pkg.version), upstream_version) == -1
       print 'outdated'.ljust(20).yellow
     end
     # Print the package versions.
-    puts pkg.version.ljust(20) + upstream_version
+    puts PackageUtils.get_clean_version(pkg.version).ljust(20) + upstream_version
   end
 end


### PR DESCRIPTION
Should reduce the number of bad versions on Repology, as well as get some nicer matches for version.rb (In cases where git hashtags start with `a` and are counted as alpha versions, for example).

There are some suffixes that I haven't taken care of:
- `boost1.85` 
  - `./source_highlight.rb:  version '3.1.9-894cacd-boost1.85'`
- `gcc14`
  - `./binutils.rb:  version '2.42-gcc14'`
  - `./gdb.rb:  version '15.1-gcc14-py3.12'`
- `perl-5.36` (as opposed to the usual `perl5.36` or `5.40` or whatever)
  - `./perl_sgmls.rb:  version '1.1-perl-5.36'`
  - `./perl_text_charwidth.rb:  version '0.04-perl-5.36'`
  - `./perl_text_unidecode.rb:  version '1.30-perl-5.36'`

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=thesource crew update
```