### PR TITLE
lib/downloader: Refactor and add git support

### DIFF
--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -1,182 +1,168 @@
 require 'io/console'
 require 'digest/sha2'
+require 'securerandom'
+require 'resolv-replace'
+require 'net/http'
+require 'stringio'
 require 'uri'
 require_relative 'const'
 require_relative 'color'
 require_relative 'progress_bar'
 
-begin
-  require 'securerandom'
-  require 'resolv-replace'
-  require 'net/http'
-rescue RuntimeError => e
-  # hide the error message and fallback to curl if securerandom raise an error
-  if e.message == 'failed to get urandom'
-    Object.send(:remove_const, :CREW_USE_CURL)
-    CREW_USE_CURL = true
-  else
-    raise
-  end
-end
+class Downloader
+  def self.downloader(url, sha256sum, destination = File.basename(url), verbose = false)
+    # downloader: wrapper for all Chromebrew downloaders (`net/http`,`curl`...)
+    # Usage: downloader <url>, <sha256sum>, <dest::optional>, <verbose::optional>
+    #
+    #           <url>: URL that points to the target file
+    #     <sha256sum>: SHA256 checksum, verify downloaded file with given checksum
+    #   <destination>: (Optional) Output destination
+    #       <verbose>: (Optional) Verbose output
+    #
+    puts "downloader(#{url}, #{sha256sum}, #{filename}, #{verbose})" if verbose
+    uri = URI(url)
 
-def downloader(url, sha256sum, filename = File.basename(url), verbose = false)
-  # downloader: wrapper for all Chromebrew downloaders (`net/http`,`curl`...)
-  # Usage: downloader <url>, <sha256sum>, <filename::optional>, <verbose::optional>
-  #
-  #           <url>: URL that points to the target file
-  #     <sha256sum>: SHA256 checksum, verify downloaded file with given checksum
-  #      <filename>: (Optional) Output path/filename
-  #       <verbose>: (Optional) Verbose output
-  #
-  puts "downloader(#{url}, #{sha256sum}, #{filename}, #{verbose})" if verbose
-  uri = URI(url)
+    unless %w[git git+https].include?(uri.scheme)
+      dest_io = destination.eql?('-') ? StringIO.new : File.open(destination, 'wb')
+    end
 
-  if CREW_USE_CURL || !ENV['CREW_DOWNLOADER'].to_s.empty?
-    # force using external downloader if either CREW_USE_CURL or ENV['CREW_DOWNLOADER'] is set
-    puts "external_downloader(#{uri}, #{filename}, #{verbose})" if verbose
-    external_downloader(uri, filename, verbose)
-  else
     case uri.scheme
     when 'http', 'https'
       # use net/http if the url protocol is http(s)://
-      puts "http_downloader(#{uri}, #{filename}, #{verbose})" if verbose
-      http_downloader(uri, filename, verbose)
+      http_downloader(uri, dest_io, verbose)
+    when 'git', 'git+https'
+      # use git if the url protocol is git(+https)://
+      git_downloader(uri, destination, verbose)
     when 'file'
-      # use FileUtils to copy if it is a local file (the url protocol is file://)
-      if File.exist?(uri.path)
-        return FileUtils.cp(uri.path, filename)
-      else
-        abort "#{uri.path}: File not found :/".lightred
-      end
-    else
-      # use external downloader (curl by default) if the url protocol is not http(s):// or file://
-      puts "external_downloader(#{uri}, #{filename}, #{verbose})" if verbose
-      external_downloader(uri, filename, verbose)
+      # copy from filesystem if the url protocol is file://
+      file_downloader(uri, dest_io, verbose)
+    end
+
+    # verify with given checksum
+    calc_sha256sum = Digest::SHA256.hexdigest(File.read(filename))
+
+    unless sha256sum.casecmp('SKIP') || calc_sha256sum.eql?(sha256sum)
+      FileUtils.rm_f filename
+
+      warn 'Checksum mismatch :/ Try again?'.lightred, '', <<~EOT
+                              Filename: #{filename.lightblue}
+            Expected checksum (SHA256): #{sha256sum.green}
+          Calculated checksum (SHA256): #{calc_sha256sum.red}
+      EOT
+
+      exit 2
+    end
+
+    # return file content if destination is '-'
+    if %w[git git+https].none?(uri.scheme) && dest == '-'
+      # read underlying string from StringIO
+      return dest_io.string
     end
   end
 
-  # verify with given checksum
-  calc_sha256sum = Digest::SHA256.hexdigest(File.read(filename))
+  def self.http_downloader(uri, dest_io, verbose = false)
+    # http_downloader: Downloader based on net/http library
+    ssl_error_retry = 0
 
-  unless (sha256sum =~ /^SKIP$/i) || (calc_sha256sum == sha256sum)
-    FileUtils.rm_f filename
+    # open http connection
+    Net::HTTP.start(uri.host, uri.port, {
+      max_retries: CREW_DOWNLOADER_RETRY,
+          use_ssl: uri.scheme.eql?('https'),
+      min_version: :TLS1_2,
+          ca_file: SSL_CERT_FILE,
+          ca_path: SSL_CERT_DIR
+    }) do |http|
+      http.request(Net::HTTP::Get.new(uri)) do |response|
+        case
+        when response.is_a?(Net::HTTPSuccess)
+          # Response is successful, don't abort
+        when response.is_a?(Net::HTTPRedirection) # follow HTTP redirection
+          puts <<~EOT if verbose
+            * Follow HTTP redirection: #{response['Location']}
+            *
+          EOT
 
-    warn 'Checksum mismatch :/ Try again?'.lightred, <<~EOT
-      #{''}
-                            Filename: #{filename.lightblue}
-          Expected checksum (SHA256): #{sha256sum.green}
-        Calculated checksum (SHA256): #{calc_sha256sum.red}
-    EOT
+          redirect_uri = URI(response['Location'])
 
-    exit 2
-  end
-rescue StandardError => e
-  warn e.full_message
+          # add url scheme/host for redirected url based on original url if missing
+          redirect_uri.scheme ||= uri.scheme
+          redirect_uri.host   ||= uri.host
 
-  # fallback to curl if error occurred
-  puts "external_downloader(#{uri}, #{filename}, #{verbose})" if verbose
-  external_downloader(uri, filename, verbose)
-end
-
-def http_downloader(uri, filename = File.basename(url), verbose = false)
-  # http_downloader: Downloader based on net/http library
-  ssl_error_retry = 0
-
-  # open http connection
-  Net::HTTP.start(uri.host, uri.port, {
-    max_retries: CREW_DOWNLOADER_RETRY,
-        use_ssl: uri.scheme.eql?('https'),
-    min_version: :TLS1_2,
-        ca_file: SSL_CERT_FILE,
-        ca_path: SSL_CERT_DIR
-  }) do |http|
-    http.request(Net::HTTP::Get.new(uri)) do |response|
-      case
-      when response.is_a?(Net::HTTPSuccess)
-        # Response is successful, don't abort
-      when response.is_a?(Net::HTTPRedirection) # follow HTTP redirection
-        puts <<~EOT if verbose
-          * Follow HTTP redirection: #{response['Location']}
-          *
-        EOT
-
-        redirect_uri = URI(response['Location'])
-
-        # add url scheme/host for redirected url based on original url if missing
-        redirect_uri.scheme ||= uri.scheme
-        redirect_uri.host ||= uri.host
-
-        return send(__method__, redirect_uri, filename, verbose)
-      else
-        abort "Download failed with error #{response.code}: #{response.msg}".lightred
-      end
-
-      # get target file size (should be returned by the server)
-      file_size = response['Content-Length'].to_f
-      downloaded_size = 0.0
-
-      # initialize progress bar
-      progress_bar = ProgressBar.new(file_size)
-
-      if verbose
-        warn <<~EOT
-          * Connected to #{uri.host} port #{uri.port}
-          * HTTPS: #{uri.scheme.eql?('https')}
-          *
-        EOT
-
-        # parse response's header to readable format
-        response.to_hash.each_pair { |k, v| warn "> #{k}: #{v}" }
-
-        warn "\n"
-      end
-
-      progress_bar_thread = progress_bar.show # print progress bar
-
-      # read file chunks from server, write it to filesystem
-      File.open(filename, 'wb') do |io|
-        response.read_body do |chunk|
-          downloaded_size += chunk.size # record downloaded size, used for showing progress bar
-          progress_bar.set_downloaded_size(downloaded_size, invalid_size_error: false) if file_size.positive?
-
-          io.write(chunk) # write to file
+          return send(__method__, redirect_uri, filename, verbose)
+        else
+          abort "Download failed with error #{response.code}: #{response.msg}".lightred
         end
-      ensure
-        # stop progress bar, wait for it to terminate
-        progress_bar.progress_bar_showing = false
-        progress_bar_thread.join
+
+        # get target file size (should be returned by the server)
+        file_size = response['Content-Length'].to_f
+        downloaded_size = 0.0
+
+        # initialize progress bar
+        progress_bar = ProgressBar.new(file_size)
+
+        if verbose
+          warn <<~EOT
+            * Connected to #{uri.host} port #{uri.port}
+            * HTTPS: #{uri.scheme.eql?('https')}
+            *
+          EOT
+
+          # parse response's header to readable format
+          response.to_hash.each_pair { |k, v| warn "> #{k}: #{v}" }
+
+          warn "\n"
+        end
+
+        progress_bar_thread = progress_bar.show # print progress bar
+
+        # read file chunks from server, write it to filesystem
+        begin
+          response.read_body do |chunk|
+            downloaded_size += chunk.size # record downloaded size, used for showing progress bar
+            progress_bar.set_downloaded_size(downloaded_size, invalid_size_error: false) if file_size.positive?
+
+            dest_io.write(chunk) # write to file
+          end
+        ensure
+          # stop progress bar, wait for it to terminate
+          progress_bar.progress_bar_showing = false
+          progress_bar_thread.join
+        end
       end
     end
+  rescue OpenSSL::SSL::SSLError
+    # handle SSL errors
+    ssl_error_retry += 1
+    ssl_error_retry <= 3 ? retry : raise
   end
-rescue OpenSSL::SSL::SSLError
-  # handle SSL errors
-  ssl_error_retry += 1
-  ssl_error_retry <= 3 ? retry : raise
-end
 
-def external_downloader(uri, filename = File.basename(url), verbose = false)
-  # external_downloader: wrapper for external downloaders in CREW_DOWNLOADER (curl by default)
+  def self.git_downloader(uri, destination, verbose)
+    url_params      = URI.decode_www_form(uri.query).to_h
+    git_branch      = url_params['branch']
+    git_commit      = url_params['commit']
+    git_tag         = url_params['tag']
+    init_submodules = url_params['submodules'].eql?('1')
 
-  # default curl cmdline, CREW_DOWNLOADER should be in this format also
-  #   %<verbose>s: Will be substitute to "--verbose" if #{verbose} set to true, otherwise will be substitute to ""
-  #      %<retry>: Will be substitute to #{CREW_DOWNLOADER_RETRY}
-  #       %<url>s: Will be substitute to #{url}
-  #    %<output>s: Will be substitute to #{filename}
-  # i686 curl throws a "SSL certificate problem: self signed certificate in certificate chain" error.
-  # Only bypass this when we are using the system curl early in install.
-  @default_curl = `which curl`.chomp
-  curl_cmdline = ARCH == 'i686' && @default_curl == '/usr/bin/curl' ? 'curl %<verbose>s -kL -# --retry %<retry>s %<url>s -o %<output>s' : 'curl %<verbose>s -L -# --retry %<retry>s %<url>s -o %<output>s'
+    # remove url parameters before passing to git
+    uri.query = ''
 
-  # use CREW_DOWNLOADER if specified, use curl by default
-  downloader_cmdline = CREW_DOWNLOADER || curl_cmdline
+    FileUtils.mkdir_p destination
+    Dir.chdir(destination) do
+      system %w[git init]
+      system %w[git config advice.detachedHead false] # suppress "You are in 'detached HEAD' state" warning
+      system %W[git add remote origin #{uri}]
+      system %W[git fetch origin #{git_commit || git_tag || git_branch}]
+      system %w[git checkout FETCH_HEAD]
+      system %w[git submodule update --init] if init_submodules # also download git submodules if specified
+    end
+  end
 
-  return system(
-    format(downloader_cmdline,
-           {
-             verbose: verbose ? '--verbose' : '',
-             retry: CREW_DOWNLOADER_RETRY,
-             url: uri.to_s,
-             output: filename
-           }), exception: true
-  )
+  def self.file_downloader(uri, dest_io, verbose)
+    # use FileUtils to copy if it is a local file (the url protocol is file://)
+    if File.exist?(uri.path)
+      dest_io.write File.binread(uri.parh)
+    else
+      abort "#{uri.path}: File not found :/".lightred
+    end
+  end
 end


### PR DESCRIPTION
Part of fixing #10251 

## Changes
- Refactor `downloader.rb`, put all related functions into a class
- Add git support
- Remove external downloader support for simplifying codes
- Support returning the downloaded content directly without saving it to filesystem first
