### PR TITLE
Add multy package

### DIFF
--- a/manifest/i686/m/multy.filelist
+++ b/manifest/i686/m/multy.filelist
@@ -1,0 +1,1 @@
+/usr/local/bin/multy

--- a/manifest/x86_64/m/multy.filelist
+++ b/manifest/x86_64/m/multy.filelist
@@ -1,0 +1,1 @@
+/usr/local/bin/multy

--- a/packages/multy.rb
+++ b/packages/multy.rb
@@ -1,0 +1,28 @@
+require 'package'
+
+class Multy < Package
+  description 'Easily deploy multi cloud infrastructure.'
+  homepage 'https://multy.dev/'
+  version '0.1.57'
+  license 'Apache-2.0'
+  compatibility 'x86_64 i686'
+  source_url({
+    x86_64: "https://github.com/multycloud/multy/releases/download/v#{version}/multy-linux-amd64.tar.gz",
+      i686: "https://github.com/multycloud/multy/releases/download/v#{version}/multy-linux-386.tar.gz"
+  })
+  source_sha256({
+    x86_64: '348fe997f026f3734a96f61c5198fe2ad10a9810dd71ab7c6971a63bf1c013fe',
+      i686: '2913857363d20d66c9a9c21f0a0cd498611e745f6d6121ebd665de833ad7118c'
+  })
+
+  no_compile_needed
+  no_shrink
+
+  def self.install
+    FileUtils.install 'multy', "#{CREW_DEST_PREFIX}/bin/multy", mode: 0o755
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nType 'multy list --help' to get started.\n".lightblue
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -5956,6 +5956,11 @@ url: https://github.com/flok99/multitail/releases
 activity: none
 ---
 kind: url
+name: multy
+url: https://github.com/multycloud/multy/releases
+activity: low
+---
+kind: url
 name: muparser
 url: https://github.com/beltoforion/muparser/releases
 activity: low


### PR DESCRIPTION
Multy - Easily deploy multi cloud infrastructure. Write cloud-agnostic config deployed across multiple clouds.  See https://multy.dev/.  Tested and working in x86_64 and i686 containers.