### PR TITLE
Update patchelf and add to core

### DIFF
--- a/packages/core.rb
+++ b/packages/core.rb
@@ -3,7 +3,7 @@ require 'package'
 class Core < Package
   description 'Core Chromebrew Packages.'
   homepage 'https://github.com/chromebrew/chromebrew'
-  version '2.4'
+  version '2.5'
   license 'GPL-3+'
   compatibility 'all'
 
@@ -66,6 +66,7 @@ class Core < Package
   depends_on 'nettle'
   depends_on 'openldap'
   depends_on 'openssl'
+  depends_on 'patchelf'
   depends_on 'p11kit'
   depends_on 'pcre'
   depends_on 'pcre2'

--- a/packages/patchelf.rb
+++ b/packages/patchelf.rb
@@ -3,18 +3,18 @@ require 'buildsystems/autotools'
 class Patchelf < Autotools
   description 'PatchELF is a small utility to modify the dynamic linker and RPATH of ELF executables.'
   homepage 'https://github.com/NixOS/patchelf'
-  version '0.18.0'
+  version '0.18.0-a0f5433'
   license 'GPL-3'
   compatibility 'all'
   source_url 'https://github.com/NixOS/patchelf.git'
-  git_hashtag version
+  git_hashtag 'a0f54334df36770b335c051e540ba40afcbf8378'
   binary_compression 'tar.zst'
 
   binary_sha256({
-     aarch64: '56fbe54307a6a7db9933c8e4d7b2d3c92836afd7c1c67d036a7a40d19b5a85ef',
-      armv7l: '56fbe54307a6a7db9933c8e4d7b2d3c92836afd7c1c67d036a7a40d19b5a85ef',
-        i686: '3602b232577da2b67aba8ae9069995909d38e8fb0efca5db0909df44e24e7c9e',
-      x86_64: 'a75cf598e6498555c867d1a462ef78a43f1fe8f9ca3a147f3aab33336ca90f78'
+     aarch64: '4f03e9e000bb49583d7127d54caef6ee29758693061d68d446487b6b45dba169',
+      armv7l: '4f03e9e000bb49583d7127d54caef6ee29758693061d68d446487b6b45dba169',
+        i686: '85047aedda730e0e8e4f4b3cee0b69837e9319f49ae62fdaa79ef7accc5d23b5',
+      x86_64: '8f88e3483f8ce03b708e992dc2c0dacef893b6824f057606d996761aca603c9d'
   })
 
   no_env_options
@@ -23,8 +23,11 @@ class Patchelf < Autotools
 
   def self.patch
     # Allocate PHT & SHT at the end of the *.elf file
-    downloader 'https://github.com/NixOS/patchelf/pull/544.patch', 'dbb0a0626e933e7368aaa84536bdb9cf46d4d05565e7fb5a9643154ec70c8ba1'
-    system 'patch -Np1 -i 544.patch'
+    downloader 'https://github.com/NixOS/patchelf/pull/544.diff', 'fc65c0e6bfc751a1ab91f5f87c86202834eb3b3c208c6bb1eef077e4572e4b9c'
+    system 'patch -Np1 -i 544.diff'
+    # Fix rename-dynamic-symbols.sh test
+    downloader 'https://github.com/NixOS/patchelf/pull/547.diff', '478669b8749b38defe2b835c2ece1d1ff495da6f0a899c7ac8c00f92c5ec9b2d'
+    system 'patch -Np1 -i 547.diff'
   end
 
   def self.check


### PR DESCRIPTION
- This is needed for forthcoming fixed to handle breakage on newer glibc containers.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=patchelf crew update && yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
