### PR TITLE
glibc 2.37 patchelf workaround for ChromeOS broken glibc 2.37 & fix upgrades for is_fake pkgs

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1284,13 +1284,10 @@ def install
   end
 
   # Add to installed packages list in devices.json, but remove first if it is already there.
-  if PackageUtils.installed?(@pkg.name)
-    crewlog "Removing package #{@pkg.name} from device.json since a version is already marked as installed."
-    @device[:installed_packages].delete_if { |entry| entry[:name] == @pkg.name }
-  end
   crewlog "Adding package #{@pkg.name} to device.json."
-  @device[:installed_packages].push(name: @pkg.name, version: @pkg.version, sha256: PackageUtils.get_sha256(@pkg, build_from_source: @opt_source))
+  @device[:installed_packages].delete_if { |entry| entry[:name] == @pkg.name } and @device[:installed_packages].push(name: @pkg.name, version: @pkg.version, sha256: PackageUtils.get_sha256(@pkg, build_from_source: @opt_source))
   save_json(@device)
+  crewlog "#{@pkg.name} in device.json after install: #{`jq --arg key '#{@pkg.name}' -e '.installed_packages[] | select(.name == $key )' #{File.join(CREW_CONFIG_PATH, 'device.json')}`}" if Kernel.system 'which jq', %i[out err] => File::NULL
 end
 
 def resolve_dependencies_and_build

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -176,7 +176,7 @@ when 'x86_64'
 end
 
 CREW_LINKER = ENV.fetch('CREW_LINKER', 'mold')
-CREW_GLIBC_OVERRIDE_LINKER_FLAGS = (ARCH == 'x86_64' && LIBC_VERSION.to_f >= 2.35) ? " #{File.join(CREW_LIB_PREFIX, 'libC.so.6')} " : ''
+CREW_GLIBC_OVERRIDE_LINKER_FLAGS = ARCH == 'x86_64' && LIBC_VERSION.to_f >= 2.35 ? " #{File.join(CREW_LIB_PREFIX, 'libC.so.6')} " : ''
 CREW_LINKER_FLAGS = ENV.fetch('CREW_LINKER_FLAGS', CREW_GLIBC_OVERRIDE_LINKER_FLAGS)
 
 CREW_CORE_FLAGS           = "-O2 -pipe -ffat-lto-objects -fPIC #{CREW_ARCH_FLAGS} -fuse-ld=#{CREW_LINKER} #{CREW_LINKER_FLAGS}"

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -2,7 +2,7 @@
 # Defines common constants used in different parts of crew
 require 'etc'
 
-CREW_VERSION = '1.49.13'
+CREW_VERSION = '1.50.0'
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]
@@ -175,8 +175,9 @@ when 'x86_64'
   CREW_ARCH_FLAGS = CREW_ARCH_FLAGS_OVERRIDE.to_s.empty? ? '' : CREW_ARCH_FLAGS_OVERRIDE
 end
 
-CREW_LINKER       = ENV.fetch('CREW_LINKER', 'mold')
-CREW_LINKER_FLAGS = ENV.fetch('CREW_LINKER_FLAGS', '')
+CREW_LINKER = ENV.fetch('CREW_LINKER', 'mold')
+CREW_GLIBC_OVERRIDE_LINKER_FLAGS = (ARCH == 'x86_64' && LIBC_VERSION.to_f >= 2.35) ? " #{File.join(CREW_LIB_PREFIX, 'libC.so.6')} " : ''
+CREW_LINKER_FLAGS = ENV.fetch('CREW_LINKER_FLAGS', CREW_GLIBC_OVERRIDE_LINKER_FLAGS)
 
 CREW_CORE_FLAGS           = "-O2 -pipe -ffat-lto-objects -fPIC #{CREW_ARCH_FLAGS} -fuse-ld=#{CREW_LINKER} #{CREW_LINKER_FLAGS}"
 CREW_COMMON_FLAGS         = "#{CREW_CORE_FLAGS} -flto=auto"

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -196,15 +196,15 @@ if (ARCH == 'x86_64') && (LIBC_VERSION.to_f >= 2.36)
   # Link the system libc.so.6 to also require our renamed libC.so.6
   # which provides the float128 functions strtof128, strfromf128,
   # and __strtof128_nan.
-  @libc_patch_libraries = %w[libstdc++.so.6]
-  @libc_patch_libraries.delete_if { |lib| !File.file?(File.join(CREW_LIB_PREFIX, lib)) }
-  @libc_patch_libraries.delete_if { |lib| Kernel.system "patchelf --print-needed #{File.join(CREW_LIB_PREFIX, lib)} | grep -q libC.so.6" }
+  libc_patch_libraries = %w[libstdc++.so.6]
+  libc_patch_libraries.delete_if { |lib| !File.file?(File.join(CREW_LIB_PREFIX, lib)) }
+  libc_patch_libraries.delete_if { |lib| Kernel.system "patchelf --print-needed #{File.join(CREW_LIB_PREFIX, lib)} | grep -q libC.so.6" }
 
-  return if @libc_patch_libraries.empty?
+  return if libc_patch_libraries.empty?
 
   if File.file?(File.join(CREW_LIB_PREFIX, 'libC.so.6'))
     Dir.chdir(CREW_LIB_PREFIX) do
-      @libc_patch_libraries.each do |lib|
+      libc_patch_libraries.each do |lib|
         Kernel.system "patchelf --add-needed libC.so.6 #{lib}" and Kernel.system "patchelf --remove-needed libc.so.6 #{lib}"
         puts "#{lib} patched for use with Chromebrew's glibc.".lightgreen
       end

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -189,3 +189,27 @@ end
 
 # Remove pagerenv tmp file in CREW_PACKAGES_PATH if it exists
 FileUtils.rm "#{CREW_PACKAGES_PATH}/pagerenv" if File.file?("#{CREW_PACKAGES_PATH}/pagerenv")
+
+# Handle broken system glibc affecting gcc_lib on newer x86_64 ChromeOS milestones.
+if (ARCH == 'x86_64') && (LIBC_VERSION.to_f >= 2.36)
+  abort("patchelf is needed. Please run: 'crew install patchelf && crew update'") unless File.file?(File.join(CREW_PREFIX, 'bin/patchelf'))
+  # Link the system libc.so.6 to also require our renamed libC.so.6
+  # which provides the float128 functions strtof128, strfromf128,
+  # and __strtof128_nan.
+  @libc_patch_libraries = %w[libstdc++.so.6]
+  @libc_patch_libraries.delete_if { |lib| !File.file?(File.join(CREW_LIB_PREFIX, lib)) }
+  @libc_patch_libraries.delete_if { |lib| Kernel.system "patchelf --print-needed #{File.join(CREW_LIB_PREFIX, lib)} | grep -q libC.so.6" }
+
+  return if @libc_patch_libraries.empty?
+
+  if File.file?(File.join(CREW_LIB_PREFIX, 'libC.so.6'))
+    Dir.chdir(CREW_LIB_PREFIX) do
+      @libc_patch_libraries.each do |lib|
+        Kernel.system "patchelf --add-needed libC.so.6 #{lib}" and Kernel.system "patchelf --remove-needed libc.so.6 #{lib}"
+        puts "#{lib} patched for use with Chromebrew's glibc.".lightgreen
+      end
+    end
+  else
+    puts 'The Chromebrew libC.so.6 was not found. Please reinstall glibc with this command: yes | crew reinstall glibc_lib237 && yes | crew upgrade'.lightred
+  end
+end

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -209,7 +209,5 @@ if (ARCH == 'x86_64') && (LIBC_VERSION.to_f >= 2.36)
         puts "#{lib} patched for use with Chromebrew's glibc.".lightgreen
       end
     end
-  else
-    puts 'The Chromebrew libC.so.6 was not found. Please reinstall glibc with this command: yes | crew reinstall glibc_lib237 && yes | crew upgrade'.lightred
   end
 end

--- a/manifest/armv7l/g/glibc_build237.filelist
+++ b/manifest/armv7l/g/glibc_build237.filelist
@@ -769,7 +769,6 @@
 /usr/local/lib/libm.so.6
 /usr/local/lib/libmcheck.a
 /usr/local/lib/libmemusage.so
-/usr/local/lib/libnsl.so.2
 /usr/local/lib/libnss_compat.so
 /usr/local/lib/libnss_compat.so.2
 /usr/local/lib/libnss_db.so

--- a/manifest/armv7l/g/glibc_lib237.filelist
+++ b/manifest/armv7l/g/glibc_lib237.filelist
@@ -288,7 +288,6 @@
 /usr/local/lib/libm.so.6
 /usr/local/lib/libmemusage.so
 /usr/local/lib/libmvec.so.1
-/usr/local/lib/libnsl.so.2
 /usr/local/lib/libnss_compat.so
 /usr/local/lib/libnss_compat.so.2
 /usr/local/lib/libnss_db.so

--- a/manifest/x86_64/g/glibc_build237.filelist
+++ b/manifest/x86_64/g/glibc_build237.filelist
@@ -757,6 +757,7 @@
 /usr/local/lib64/libBrokenLocale.a
 /usr/local/lib64/libBrokenLocale.so
 /usr/local/lib64/libBrokenLocale.so.1
+/usr/local/lib64/libC.so.6
 /usr/local/lib64/libanl.a
 /usr/local/lib64/libanl.so
 /usr/local/lib64/libanl.so.1
@@ -769,9 +770,6 @@
 /usr/local/lib64/libcrypt.a
 /usr/local/lib64/libcrypt.so
 /usr/local/lib64/libcrypt.so.1
-/usr/local/lib64/libcrypt.so.1.1.0
-/usr/local/lib64/libcrypt.so.2
-/usr/local/lib64/libcrypt.so.2.0.0
 /usr/local/lib64/libdl.a
 /usr/local/lib64/libdl.so.2
 /usr/local/lib64/libg.a
@@ -784,7 +782,6 @@
 /usr/local/lib64/libmvec.a
 /usr/local/lib64/libmvec.so
 /usr/local/lib64/libmvec.so.1
-/usr/local/lib64/libnsl.so.2
 /usr/local/lib64/libnss_compat.so
 /usr/local/lib64/libnss_compat.so.2
 /usr/local/lib64/libnss_db.so

--- a/manifest/x86_64/g/glibc_lib237.filelist
+++ b/manifest/x86_64/g/glibc_lib237.filelist
@@ -275,6 +275,7 @@
 /usr/local/lib64/ld-linux-x86-64.so.2
 /usr/local/lib64/libBrokenLocale.so
 /usr/local/lib64/libBrokenLocale.so.1
+/usr/local/lib64/libC.so.6
 /usr/local/lib64/libanl.so
 /usr/local/lib64/libanl.so.1
 /usr/local/lib64/libc.so
@@ -283,16 +284,12 @@
 /usr/local/lib64/libc_malloc_debug.so.0
 /usr/local/lib64/libcrypt.so
 /usr/local/lib64/libcrypt.so.1
-/usr/local/lib64/libcrypt.so.1.1.0
-/usr/local/lib64/libcrypt.so.2
-/usr/local/lib64/libcrypt.so.2.0.0
 /usr/local/lib64/libdl.so.2
 /usr/local/lib64/libm.so
 /usr/local/lib64/libm.so.6
 /usr/local/lib64/libmemusage.so
 /usr/local/lib64/libmvec.so
 /usr/local/lib64/libmvec.so.1
-/usr/local/lib64/libnsl.so.2
 /usr/local/lib64/libnss_compat.so
 /usr/local/lib64/libnss_compat.so.2
 /usr/local/lib64/libnss_db.so

--- a/packages/glibc_build237.rb
+++ b/packages/glibc_build237.rb
@@ -243,8 +243,8 @@ class Glibc_build237 < Package
           # Link our libm to also require our renamed libC.so.6
           # which provides the float128 functions strtof128, strfromf128,
           # and __strtof128_nan.
-          @libc_patch_libraries = %w[libm.so.6]
-          @libc_patch_libraries.each do |lib|
+          libc_patch_libraries = %w[libm.so.6]
+          libc_patch_libraries.each do |lib|
             system "patchelf --replace-needed libc.so.6 libC.so.6 #{lib}"
           end
         end
@@ -274,15 +274,15 @@ class Glibc_build237 < Package
       # Link the system libc.so.6 to also require our renamed libC.so.6
       # which provides the float128 functions strtof128, strfromf128,
       # and __strtof128_nan.
-      @libc_patch_libraries = %w[libc.so.6 libm.so.6 libstdc++.so.6]
-      @libc_patch_libraries.delete_if { |lib| !File.file?(File.join(CREW_LIB_PREFIX, lib)) }
-      @libc_patch_libraries.delete_if { |lib| Kernel.system "patchelf --print-needed #{File.join(CREW_LIB_PREFIX, lib)} | grep -q libC.so.6" }
+      libc_patch_libraries = %w[libc.so.6 libm.so.6 libstdc++.so.6]
+      libc_patch_libraries.delete_if { |lib| !File.file?(File.join(CREW_LIB_PREFIX, lib)) }
+      libc_patch_libraries.delete_if { |lib| Kernel.system "patchelf --print-needed #{File.join(CREW_LIB_PREFIX, lib)} | grep -q libC.so.6" }
 
-      return if @libc_patch_libraries.empty?
+      return if libc_patch_libraries.empty?
 
       if File.file?(File.join(CREW_LIB_PREFIX, 'libC.so.6'))
         Dir.chdir(CREW_LIB_PREFIX) do
-          @libc_patch_libraries.each do |lib|
+          libc_patch_libraries.each do |lib|
             Kernel.system "patchelf --add-needed libC.so.6 #{lib}" and Kernel.system "patchelf --remove-needed libc.so.6 #{lib}"
             puts "#{lib} patched for use with Chromebrew's glibc.".lightgreen
           end

--- a/packages/glibc_build237.rb
+++ b/packages/glibc_build237.rb
@@ -252,7 +252,7 @@ class Glibc_build237 < Package
     end
     # Only save libnsl.so.2, since libnsl.so.1 is provided by perl
     # For this to work, build on a M107 or newer container.
-    FileUtils.cp File.realpath("#{CREW_DEST_LIB_PREFIX}/libnsl.so.1"), "#{CREW_DEST_LIB_PREFIX}/libnsl.so.2" if LIBC_VERSION >= 2.35
+    FileUtils.cp File.realpath("#{CREW_DEST_LIB_PREFIX}/libnsl.so.1"), "#{CREW_DEST_LIB_PREFIX}/libnsl.so.2" if LIBC_VERSION.to_f >= 2.35
     FileUtils.rm_f "#{CREW_DEST_LIB_PREFIX}/libnsl.so"
     FileUtils.rm_f "#{CREW_DEST_LIB_PREFIX}/libnsl.so.1"
 
@@ -268,7 +268,7 @@ class Glibc_build237 < Package
 
   def self.postinstall
     # Handle broken system glibc affecting system glibc and libm.so.6 on newer x86_64 ChromeOS milestones.
-    if (ARCH == 'x86_64') && (LIBC_VERSION >= 2.35)
+    if (ARCH == 'x86_64') && (LIBC_VERSION.to_f >= 2.35)
       FileUtils.cp "/#{ARCH_LIB}/libc.so.6", File.join(CREW_LIB_PREFIX, 'libc.so.6.system') and FileUtils.mv File.join(CREW_LIB_PREFIX, 'libc.so.6.system'), File.join(CREW_LIB_PREFIX, 'libc.so.6')
       puts "patchelf is needed. Please run: 'crew install patchelf ; crew postinstall #{name}'".lightred unless File.file?(File.join(CREW_PREFIX, 'bin/patchelf'))
       # Link the system libc.so.6 to also require our renamed libC.so.6

--- a/packages/glibc_build237.rb
+++ b/packages/glibc_build237.rb
@@ -270,7 +270,7 @@ class Glibc_build237 < Package
     # Handle broken system glibc affecting system glibc and libm.so.6 on newer x86_64 ChromeOS milestones.
     if (ARCH == 'x86_64') && (LIBC_VERSION.to_f >= 2.35)
       FileUtils.cp "/#{ARCH_LIB}/libc.so.6", File.join(CREW_LIB_PREFIX, 'libc.so.6.system') and FileUtils.mv File.join(CREW_LIB_PREFIX, 'libc.so.6.system'), File.join(CREW_LIB_PREFIX, 'libc.so.6')
-      abort("patchelf is needed. Please run: 'crew install patchelf ; crew postinstall #{name}'") unless File.file?(File.join(CREW_PREFIX, 'bin/patchelf'))
+      puts "patchelf is needed. Please run: 'crew install patchelf ; crew postinstall #{name}'".lightred unless File.file?(File.join(CREW_PREFIX, 'bin/patchelf'))
       # Link the system libc.so.6 to also require our renamed libC.so.6
       # which provides the float128 functions strtof128, strfromf128,
       # and __strtof128_nan.
@@ -287,8 +287,6 @@ class Glibc_build237 < Package
             puts "#{lib} patched for use with Chromebrew's glibc.".lightgreen
           end
         end
-      else
-        abort('The Chromebrew libC.so.6 was not found. Please reinstall glibc.')
       end
     end
 

--- a/packages/glibc_build237.rb
+++ b/packages/glibc_build237.rb
@@ -274,7 +274,7 @@ class Glibc_build237 < Package
       # Link the system libc.so.6 to also require our renamed libC.so.6
       # which provides the float128 functions strtof128, strfromf128,
       # and __strtof128_nan.
-      @libc_patch_libraries = %w[libc.so.6 libm.so.6]
+      @libc_patch_libraries = %w[libc.so.6 libm.so.6 libstdc++.so.6]
       @libc_patch_libraries.delete_if { |lib| !File.file?(File.join(CREW_LIB_PREFIX, lib)) }
       @libc_patch_libraries.delete_if { |lib| Kernel.system "patchelf --print-needed #{File.join(CREW_LIB_PREFIX, lib)} | grep -q libC.so.6" }
 

--- a/packages/glibc_build237.rb
+++ b/packages/glibc_build237.rb
@@ -252,7 +252,7 @@ class Glibc_build237 < Package
     end
     # Only save libnsl.so.2, since libnsl.so.1 is provided by perl
     # For this to work, build on a M107 or newer container.
-    FileUtils.cp File.realpath("#{CREW_DEST_LIB_PREFIX}/libnsl.so.1"), "#{CREW_DEST_LIB_PREFIX}/libnsl.so.2" if LIBC_VERSION.to_f >= 2.35
+    FileUtils.cp File.realpath("#{CREW_DEST_LIB_PREFIX}/libnsl.so.1"), "#{CREW_DEST_LIB_PREFIX}/libnsl.so.2" if LIBC_VERSION >= 2.35
     FileUtils.rm_f "#{CREW_DEST_LIB_PREFIX}/libnsl.so"
     FileUtils.rm_f "#{CREW_DEST_LIB_PREFIX}/libnsl.so.1"
 
@@ -268,14 +268,14 @@ class Glibc_build237 < Package
 
   def self.postinstall
     # Handle broken system glibc affecting system glibc and libm.so.6 on newer x86_64 ChromeOS milestones.
-    if (ARCH == 'x86_64') && (LIBC_VERSION.to_f >= 2.35)
+    if (ARCH == 'x86_64') && (LIBC_VERSION >= 2.35)
       FileUtils.cp "/#{ARCH_LIB}/libc.so.6", File.join(CREW_LIB_PREFIX, 'libc.so.6.system') and FileUtils.mv File.join(CREW_LIB_PREFIX, 'libc.so.6.system'), File.join(CREW_LIB_PREFIX, 'libc.so.6')
       puts "patchelf is needed. Please run: 'crew install patchelf ; crew postinstall #{name}'".lightred unless File.file?(File.join(CREW_PREFIX, 'bin/patchelf'))
       # Link the system libc.so.6 to also require our renamed libC.so.6
       # which provides the float128 functions strtof128, strfromf128,
       # and __strtof128_nan.
       libc_patch_libraries = %w[libc.so.6 libm.so.6 libstdc++.so.6]
-      libc_patch_libraries.delete_if { |lib| !File.file?(File.join(CREW_LIB_PREFIX, lib)) }
+      libc_patch_libraries.keep_if { |lib| File.file?(File.join(CREW_LIB_PREFIX, lib)) }
       libc_patch_libraries.delete_if { |lib| Kernel.system "patchelf --print-needed #{File.join(CREW_LIB_PREFIX, lib)} | grep -q libC.so.6" }
 
       return if libc_patch_libraries.empty?

--- a/packages/glibc_dev237.rb
+++ b/packages/glibc_dev237.rb
@@ -4,16 +4,16 @@ Package.load_package("#{__dir__}/glibc_build237.rb")
 class Glibc_dev237 < Package
   description 'glibc: everything except what is in glibc_lib'
   homepage Glibc_build237.homepage
-  version '2.37'
+  version '2.37-patchelf1'
   license Glibc_build237.license
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'SKIP'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '73b6371edbfd4295465c24dbc9fb60975a4c37aff37a6eecf940d22b2727d218',
-     armv7l: '73b6371edbfd4295465c24dbc9fb60975a4c37aff37a6eecf940d22b2727d218',
-     x86_64: '9ca2f35c8325766fb20cd4cd4c02e7b46052158ca528a0807b33a8624a050de8'
+    aarch64: 'fc071b97e0eaa0e1e9b6bdad4ab378112dbef849453fbf3bc4e10e22260b1841',
+     armv7l: 'fc071b97e0eaa0e1e9b6bdad4ab378112dbef849453fbf3bc4e10e22260b1841',
+     x86_64: '72b99a7f86687958639d0935d686260f50afc45e0209ff717bbd42e4ef9d7bfb'
   })
 
   depends_on 'glibc_build237' => :build

--- a/packages/glibc_lib237.rb
+++ b/packages/glibc_lib237.rb
@@ -57,7 +57,7 @@ class Glibc_lib237 < Package
   end
 
   def self.postinstall
-    if (ARCH == 'x86_64') && (LIBC_VERSION >= 2.35)
+    if (ARCH == 'x86_64') && (LIBC_VERSION.to_f >= 2.35)
       FileUtils.cp "/#{ARCH_LIB}/libc.so.6", File.join(CREW_LIB_PREFIX, 'libc.so.6.system') and FileUtils.mv File.join(CREW_LIB_PREFIX, 'libc.so.6.system'), File.join(CREW_LIB_PREFIX, 'libc.so.6') unless Kernel.system "patchelf --print-needed #{File.join(CREW_LIB_PREFIX, 'libc.so.6')} | grep -q libC.so.6"
       puts "patchelf is needed. Please run: 'crew install patchelf ; crew postinstall #{name}'".lightred unless File.file?(File.join(CREW_PREFIX, 'bin/patchelf'))
       # Link the system libc.so.6 to also require our renamed libC.so.6

--- a/packages/glibc_lib237.rb
+++ b/packages/glibc_lib237.rb
@@ -63,15 +63,15 @@ class Glibc_lib237 < Package
       # Link the system libc.so.6 to also require our renamed libC.so.6
       # which provides the float128 functions strtof128, strfromf128,
       # and __strtof128_nan.
-      @libc_patch_libraries = %w[libc.so.6 libm.so.6 libstdc++.so.6]
-      @libc_patch_libraries.delete_if { |lib| !File.file?(File.join(CREW_LIB_PREFIX, lib)) }
-      @libc_patch_libraries.delete_if { |lib| Kernel.system "patchelf --print-needed #{File.join(CREW_LIB_PREFIX, lib)} | grep -q libC.so.6" }
+      libc_patch_libraries = %w[libc.so.6 libm.so.6 libstdc++.so.6]
+      libc_patch_libraries.delete_if { |lib| !File.file?(File.join(CREW_LIB_PREFIX, lib)) }
+      libc_patch_libraries.delete_if { |lib| Kernel.system "patchelf --print-needed #{File.join(CREW_LIB_PREFIX, lib)} | grep -q libC.so.6" }
 
-      return if @libc_patch_libraries.empty?
+      return if libc_patch_libraries.empty?
 
       if File.file?(File.join(CREW_LIB_PREFIX, 'libC.so.6'))
         Dir.chdir(CREW_LIB_PREFIX) do
-          @libc_patch_libraries.each do |lib|
+          libc_patch_libraries.each do |lib|
             Kernel.system "patchelf --add-needed libC.so.6 #{lib}" and Kernel.system "patchelf --remove-needed libc.so.6 #{lib}"
             puts "#{lib} patched for use with Chromebrew's glibc.".lightgreen
           end

--- a/packages/glibc_lib237.rb
+++ b/packages/glibc_lib237.rb
@@ -55,4 +55,28 @@ class Glibc_lib237 < Package
       end
     end
   end
+
+  def self.postinstall
+    if (ARCH == 'x86_64') && (LIBC_VERSION.to_f >= 2.35)
+      FileUtils.cp "/#{ARCH_LIB}/libc.so.6", File.join(CREW_LIB_PREFIX, 'libc.so.6.system') and FileUtils.mv File.join(CREW_LIB_PREFIX, 'libc.so.6.system'), File.join(CREW_LIB_PREFIX, 'libc.so.6') unless Kernel.system "patchelf --print-needed #{File.join(CREW_LIB_PREFIX, 'libc.so.6')} | grep -q libC.so.6"
+      puts "patchelf is needed. Please run: 'crew install patchelf ; crew postinstall #{name}'".lightred unless File.file?(File.join(CREW_PREFIX, 'bin/patchelf'))
+      # Link the system libc.so.6 to also require our renamed libC.so.6
+      # which provides the float128 functions strtof128, strfromf128,
+      # and __strtof128_nan.
+      @libc_patch_libraries = %w[libc.so.6 libm.so.6 libstdc++.so.6]
+      @libc_patch_libraries.delete_if { |lib| !File.file?(File.join(CREW_LIB_PREFIX, lib)) }
+      @libc_patch_libraries.delete_if { |lib| Kernel.system "patchelf --print-needed #{File.join(CREW_LIB_PREFIX, lib)} | grep -q libC.so.6" }
+
+      return if @libc_patch_libraries.empty?
+
+      if File.file?(File.join(CREW_LIB_PREFIX, 'libC.so.6'))
+        Dir.chdir(CREW_LIB_PREFIX) do
+          @libc_patch_libraries.each do |lib|
+            Kernel.system "patchelf --add-needed libC.so.6 #{lib}" and Kernel.system "patchelf --remove-needed libc.so.6 #{lib}"
+            puts "#{lib} patched for use with Chromebrew's glibc.".lightgreen
+          end
+        end
+      end
+    end
+  end
 end

--- a/packages/glibc_lib237.rb
+++ b/packages/glibc_lib237.rb
@@ -4,20 +4,19 @@ Package.load_package("#{__dir__}/glibc_build237.rb")
 class Glibc_lib237 < Package
   description 'glibc libraries'
   homepage Glibc_build237.homepage
-  version '2.37-1' # Do not use @_ver here, it will break the installer.
+  version '2.37-patchelf1' # Do not use @_ver here, it will break the installer.
   license Glibc_build237.license
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'SKIP'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'efb6e1f5593f97b6fe8232e7e265911bba0f632e178f86c3f0412c1265cf2962',
-     armv7l: 'efb6e1f5593f97b6fe8232e7e265911bba0f632e178f86c3f0412c1265cf2962',
-     x86_64: '2645a7f26f0d0f007c57f296ef18c853253b98da4756f7ada840a40147c8c8ed'
+    aarch64: '7327f9e37705d2b46a2a89300c154e16aa078f93bc3a6ce69932783ce6f56e50',
+     armv7l: '7327f9e37705d2b46a2a89300c154e16aa078f93bc3a6ce69932783ce6f56e50',
+     x86_64: '37c91128508324b3f865687061e46df5f650cc634489ec9d1a96b88f5917451a'
   })
 
   depends_on 'glibc_build237' => :build
-  depends_on 'glibc' # R
 
   conflicts_ok
   no_shrink
@@ -42,10 +41,18 @@ class Glibc_lib237 < Package
       FileUtils.install @filename_target, @destpath
     end
     # Symlinks to system libraries.
-    %w[libanl.so.1 libc_malloc_debug.so.0 libc.so.6 libdl.so.2 libm.so.6
-       libmvec.so.1 libnss_dns.so.2 libnss_files.so.2 libpthread.so.0
-       libresolv.so.2 librt.so.1 libthread_db.so.1 libutil.so.1].each do |lib|
-      FileUtils.ln_sf "/#{ARCH_LIB}/#{lib}", "#{CREW_DEST_LIB_PREFIX}/#{lib}"
+    @glibc_libs = %w[libanl.so.1 libc_malloc_debug.so.0 libc.so.6 libdl.so.2 libm.so.6
+                     libmvec.so.1 libnss_dns.so.2 libnss_files.so.2 libpthread.so.0
+                     libresolv.so.2 librt.so.1 libthread_db.so.1 libutil.so.1]
+    @glibc_libs -= ['libc.so.6'] if Kernel.system("patchelf --print-needed #{File.join(CREW_LIB_PREFIX, 'libc.so.6')} | grep -q libC.so.6")
+    @glibc_libs -= ['libm.so.6'] if Kernel.system("patchelf --print-needed #{File.join(CREW_LIB_PREFIX, 'libm.so.6')} | grep -q libC.so.6")
+
+    @glibc_libs.each do |lib|
+      if ARCH == 'x86_64'
+        puts "skipping symlink of system/#{ARCH_LIB}/#{lib} into #{CREW_DEST_LIB_PREFIX}/#{lib}...".orange
+      else
+        FileUtils.ln_sf "/#{ARCH_LIB}/#{lib}", "#{CREW_DEST_LIB_PREFIX}/#{lib}"
+      end
     end
   end
 end

--- a/packages/glibc_lib237.rb
+++ b/packages/glibc_lib237.rb
@@ -41,13 +41,13 @@ class Glibc_lib237 < Package
       FileUtils.install @filename_target, @destpath
     end
     # Symlinks to system libraries.
-    @glibc_libs = %w[libanl.so.1 libc_malloc_debug.so.0 libc.so.6 libdl.so.2 libm.so.6
+    glibc_libs = %w[libanl.so.1 libc_malloc_debug.so.0 libc.so.6 libdl.so.2 libm.so.6
                      libmvec.so.1 libnss_dns.so.2 libnss_files.so.2 libpthread.so.0
                      libresolv.so.2 librt.so.1 libthread_db.so.1 libutil.so.1]
-    @glibc_libs -= ['libc.so.6'] if Kernel.system("patchelf --print-needed #{File.join(CREW_LIB_PREFIX, 'libc.so.6')} | grep -q libC.so.6")
-    @glibc_libs -= ['libm.so.6'] if Kernel.system("patchelf --print-needed #{File.join(CREW_LIB_PREFIX, 'libm.so.6')} | grep -q libC.so.6")
+    glibc_libs -= ['libc.so.6'] if Kernel.system("patchelf --print-needed #{File.join(CREW_LIB_PREFIX, 'libc.so.6')} | grep -q libC.so.6")
+    glibc_libs -= ['libm.so.6'] if Kernel.system("patchelf --print-needed #{File.join(CREW_LIB_PREFIX, 'libm.so.6')} | grep -q libC.so.6")
 
-    @glibc_libs.each do |lib|
+    glibc_libs.each do |lib|
       if ARCH == 'x86_64'
         puts "skipping symlink of system/#{ARCH_LIB}/#{lib} into #{CREW_DEST_LIB_PREFIX}/#{lib}...".orange
       else

--- a/packages/glibc_lib237.rb
+++ b/packages/glibc_lib237.rb
@@ -42,8 +42,8 @@ class Glibc_lib237 < Package
     end
     # Symlinks to system libraries.
     glibc_libs = %w[libanl.so.1 libc_malloc_debug.so.0 libc.so.6 libdl.so.2 libm.so.6
-                     libmvec.so.1 libnss_dns.so.2 libnss_files.so.2 libpthread.so.0
-                     libresolv.so.2 librt.so.1 libthread_db.so.1 libutil.so.1]
+                    libmvec.so.1 libnss_dns.so.2 libnss_files.so.2 libpthread.so.0
+                    libresolv.so.2 librt.so.1 libthread_db.so.1 libutil.so.1]
     glibc_libs -= ['libc.so.6'] if Kernel.system("patchelf --print-needed #{File.join(CREW_LIB_PREFIX, 'libc.so.6')} | grep -q libC.so.6")
     glibc_libs -= ['libm.so.6'] if Kernel.system("patchelf --print-needed #{File.join(CREW_LIB_PREFIX, 'libm.so.6')} | grep -q libC.so.6")
 
@@ -57,14 +57,14 @@ class Glibc_lib237 < Package
   end
 
   def self.postinstall
-    if (ARCH == 'x86_64') && (LIBC_VERSION.to_f >= 2.35)
+    if (ARCH == 'x86_64') && (LIBC_VERSION >= 2.35)
       FileUtils.cp "/#{ARCH_LIB}/libc.so.6", File.join(CREW_LIB_PREFIX, 'libc.so.6.system') and FileUtils.mv File.join(CREW_LIB_PREFIX, 'libc.so.6.system'), File.join(CREW_LIB_PREFIX, 'libc.so.6') unless Kernel.system "patchelf --print-needed #{File.join(CREW_LIB_PREFIX, 'libc.so.6')} | grep -q libC.so.6"
       puts "patchelf is needed. Please run: 'crew install patchelf ; crew postinstall #{name}'".lightred unless File.file?(File.join(CREW_PREFIX, 'bin/patchelf'))
       # Link the system libc.so.6 to also require our renamed libC.so.6
       # which provides the float128 functions strtof128, strfromf128,
       # and __strtof128_nan.
       libc_patch_libraries = %w[libc.so.6 libm.so.6 libstdc++.so.6]
-      libc_patch_libraries.delete_if { |lib| !File.file?(File.join(CREW_LIB_PREFIX, lib)) }
+      libc_patch_libraries.keep_if { |lib| File.file?(File.join(CREW_LIB_PREFIX, lib)) }
       libc_patch_libraries.delete_if { |lib| Kernel.system "patchelf --print-needed #{File.join(CREW_LIB_PREFIX, lib)} | grep -q libC.so.6" }
 
       return if libc_patch_libraries.empty?


### PR DESCRIPTION
Fixes #10009 #10148

- **_DOES THIS CAUSE STACK SMASHING ERRORS on x86_64 post M-123 devices?_**

- This implements a workaround using `patchelf` to make the system glibc ([which doesn't have float128 functions enabled on x86_64](https://chromium.googlesource.com/chromiumos/overlays/chromiumos-overlay/+/refs/heads/release-R128-15964.B/sys-libs/glibc/files/local/glibc-2.37/0003-Disable-float128-support-for-x86_64-x86.patch)) fall through to _our_ glibc `libc.so.6`, renamed to `libC.so.6` which has float128 functions ( strtof128, strfromf128, and __strtof128_nan ) enabled.

- Works properly:
[x] `x86_64`
[x] `i686` (`i686` doesn't use newer glibc...)
[x] `armv7l` (`armv7l` doesn't have a broken glibc.)

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=glibc237 crew update && yes | crew upgrade
```