### PR TITLE
Simplify zstd check in crew, rebuild zstd

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -246,7 +246,7 @@ def cache_build
       FileUtils.mv "#{build_cachefile}.sha256", "#{build_cachefile}.sha256.bak", force: true if File.file?("#{build_cachefile}.sha256")
       Dir.chdir(CREW_BREW_DIR) do
         system "tar c#{@verbose} #{pkg_build_dirname} \
-        | nice -n 20 #{CREW_PREFIX}/bin/zstd -c  --ultra --fast -f -o #{build_cachefile} -"
+        | nice -n 20 zstd -c  --ultra --fast -f -o #{build_cachefile} -"
       end
     end
     system "sha256sum #{build_cachefile} > #{build_cachefile}.sha256"
@@ -568,7 +568,7 @@ def download
           # because some builds will use that information.
           system "tar c#{@verbose} \
             $(find -mindepth 1 -maxdepth 1 -printf '%P\n') | \
-            nice -n 20 #{CREW_PREFIX}/bin/zstd -c -T0 --ultra -20 - >  \
+            nice -n 20 zstd -c -T0 --ultra -20 - >  \
             #{cachefile}"
         end
         system 'sha256sum', cachefile, out: "#{cachefile}.sha256"
@@ -1341,10 +1341,7 @@ end
 
 def archive_package(crew_archive_dest)
   # Check to see that there is a working zstd
-  if File.file?("#{CREW_PREFIX}/bin/zstd")
-    crew_prefix_zstd_available = File.file?("#{CREW_PREFIX}/bin/zstd") ? true : nil
-  end
-  if @pkg.no_zstd? || !crew_prefix_zstd_available
+  if @pkg.no_zstd? || !Kernel.system 'which zstd', %i[out err] => File::NULL
     puts 'Using xz to compress package. This may take some time.'.lightblue
     pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.tar.xz"
     Dir.chdir CREW_DEST_DIR do
@@ -1358,10 +1355,8 @@ def archive_package(crew_archive_dest)
       # decompression speed over compression speed.
       # See https://lists.archlinux.org/pipermail/arch-dev-public/2019-March/029542.html
       # Use nice so that user can (possibly) do other things during compression.
-      if crew_prefix_zstd_available
-        puts 'Using standard zstd'.lightblue if CREW_VERBOSE
-        system "tar c#{@verbose} * | nice -n 20 #{CREW_PREFIX}/bin/zstd -c -T0 --ultra -20 - > #{crew_archive_dest}/#{pkg_name}"
-      end
+      puts 'Using standard zstd'.lightblue if CREW_VERBOSE
+      system "tar c#{@verbose} * | nice -n 20 zstd -c -T0 --ultra -20 - > #{crew_archive_dest}/#{pkg_name}"
     end
   end
   system "sha256sum #{crew_archive_dest}/#{pkg_name} > #{crew_archive_dest}/#{pkg_name}.sha256"

--- a/bin/crew
+++ b/bin/crew
@@ -1340,8 +1340,8 @@ def build_package(crew_archive_dest)
 end
 
 def archive_package(crew_archive_dest)
-  # Check to see that there is a working zstd
-  if @pkg.no_zstd? || !Kernel.system 'which zstd', %i[out err] => File::NULL
+  # Only use zstd if it is available.
+  if @pkg.no_zstd? || !Kernel.system('which zstd', %i[out err] => File::NULL)
     puts 'Using xz to compress package. This may take some time.'.lightblue
     pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.tar.xz"
     Dir.chdir CREW_DEST_DIR do
@@ -1355,7 +1355,6 @@ def archive_package(crew_archive_dest)
       # decompression speed over compression speed.
       # See https://lists.archlinux.org/pipermail/arch-dev-public/2019-March/029542.html
       # Use nice so that user can (possibly) do other things during compression.
-      puts 'Using standard zstd'.lightblue if CREW_VERBOSE
       system "tar c#{@verbose} * | nice -n 20 zstd -c -T0 --ultra -20 - > #{crew_archive_dest}/#{pkg_name}"
     end
   end

--- a/install.sh
+++ b/install.sh
@@ -251,7 +251,7 @@ function extract_install () {
 
     # Extract and install.
     echo_intra "Extracting ${1} ..."
-    if [[ "${2##*.}" == "zst" ]] || zstd --help | grep -q lzma; then
+    if [[ "${2##*.}" == "zst" ]] || zstd --help 2>/dev/null| grep -q lzma; then
       tar -I zstd -xpf ../"${2}"
     else
       tar xpf ../"${2}"

--- a/install.sh
+++ b/install.sh
@@ -166,10 +166,10 @@ find "${CREW_LIB_PATH}" -mindepth 1 -delete
 # Download the chromebrew repository.
 curl -L --progress-bar https://github.com/"${OWNER}"/"${REPO}"/tarball/"${BRANCH}" | tar -xz --strip-components=1 -C "${CREW_LIB_PATH}"
 
-BOOTSTRAP_PACKAGES='zstd crew_mvdir ruby git ca_certificates libyaml openssl'
+BOOTSTRAP_PACKAGES='zstd lz4 xzutils zlib crew_mvdir ruby git ca_certificates libyaml openssl'
 
 # Older i686 systems.
-[[ "${ARCH}" == "i686" ]] && BOOTSTRAP_PACKAGES+=' zlib gcc_lib'
+[[ "${ARCH}" == "i686" ]] && BOOTSTRAP_PACKAGES+=' gcc_lib'
 
 if [[ -n "${CHROMEOS_RELEASE_CHROME_MILESTONE}" ]]; then
   # shellcheck disable=SC2231
@@ -251,8 +251,7 @@ function extract_install () {
 
     # Extract and install.
     echo_intra "Extracting ${1} ..."
-    # This could be avoided if our zstd was compiled with lzma support.
-    if [[ "${2##*.}" == "zst" ]]; then
+    if [[ "${2##*.}" == "zst" ]] || zstd --help | grep -q lzma; then
       tar -I zstd -xpf ../"${2}"
     else
       tar xpf ../"${2}"

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -2,7 +2,7 @@
 # Defines common constants used in different parts of crew
 require 'etc'
 
-CREW_VERSION = '1.49.9'
+CREW_VERSION = '1.49.10'
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]

--- a/packages/zstd.rb
+++ b/packages/zstd.rb
@@ -3,22 +3,24 @@ require 'package'
 class Zstd < Package
   description 'Zstandard - Fast real-time compression algorithm'
   homepage 'https://facebook.github.io/zstd/'
-  version '1.5.6' # Do not use @_ver here, it will break the installer.
+  version '1.5.6-1' # Do not use @_ver here, it will break the installer.
   license 'BSD or GPL-2'
   compatibility 'all'
   source_url 'https://github.com/facebook/zstd.git'
-  git_hashtag "v#{version}"
+  git_hashtag "v#{version.split('-').first}"
   binary_compression 'tar.xz'
 
   binary_sha256({
-    aarch64: 'e0d0cccc416aa8a83c36ebe48ab6121ebca71803e587f2640bb35d726431e7d5',
-     armv7l: 'e0d0cccc416aa8a83c36ebe48ab6121ebca71803e587f2640bb35d726431e7d5',
-       i686: 'c886bd35878f11eca6db0cb00fdd9dbeb7b6b4e09d3d2a99b9c52df7218b2ddf',
-     x86_64: '364c125580c760558ff0cd96989d9661159ed85a3bbdc9f2dde42e7a3bb9479b'
+    aarch64: 'fcef09c11c9fa7ce65b4c81fe3622343311bae1ea3e79d0efbd109e6d154174e',
+     armv7l: 'fcef09c11c9fa7ce65b4c81fe3622343311bae1ea3e79d0efbd109e6d154174e',
+       i686: '6a1af809ce6d0fc507b1b857b8f0803c6aded4e816d3c454e4e59b0f5ed4acca',
+     x86_64: 'bc5f4c725cf5302933a4b6aa0e6a1c7ac18b8a0da6d01654c95556eb88b5da45'
   })
 
   depends_on 'gcc_lib' # R
   depends_on 'glibc' # R
+  depends_on 'lz4' # R
+  depends_on 'xzutils' # R
   depends_on 'zlib' # R
 
   no_zstd
@@ -26,6 +28,9 @@ class Zstd < Package
   def self.build
     Dir.chdir 'build/cmake' do
       system "cmake -B builddir #{CREW_CMAKE_OPTIONS} \
+      -DZSTD_LZ4_SUPPORT=ON \
+      -DZSTD_LZMA_SUPPORT=ON \
+      -DZSTD_ZLIB_SUPPORT=ON \
       -DZSTD_BUILD_STATIC=ON \
       -DZSTD_BUILD_SHARED=ON \
       -DZSTD_LEGACY_SUPPORT=ON \


### PR DESCRIPTION
- We use complicated zstd checks inconsistently, and at this point don't need them.
- Update zstd to add compatibility with xz, lz4, and use that in install.sh.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=zstd_check crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
