### PR TITLE
Convert zlib to tar.xz package

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -166,7 +166,7 @@ find "${CREW_LIB_PATH}" -mindepth 1 -delete
 # Download the chromebrew repository.
 curl -L --progress-bar https://github.com/"${OWNER}"/"${REPO}"/tarball/"${BRANCH}" | tar -xz --strip-components=1 -C "${CREW_LIB_PATH}"
 
-BOOTSTRAP_PACKAGES='lz4 zstd xzutils zlib crew_mvdir ruby git ca_certificates libyaml openssl'
+BOOTSTRAP_PACKAGES='lz4 zlib zstd xzutils crew_mvdir ruby git ca_certificates libyaml openssl'
 
 # Older i686 systems.
 [[ "${ARCH}" == "i686" ]] && BOOTSTRAP_PACKAGES+=' gcc_lib'

--- a/packages/minizip.rb
+++ b/packages/minizip.rb
@@ -6,7 +6,7 @@ class Minizip < Package
   homepage Zlib.homepage
   version '1.3.1'
   # When upgrading minizip, be sure to upgrade zlib in tandem.
-  puts "#{self} version differs from Zlib version #{Zlib.version}".orange if version != Zlib.version
+  puts "#{self} version differs from Zlib version #{Zlib.version.split('-').first}".orange if version != Zlib.version.split('-').first
   license Zlib.license
   compatibility 'all'
   source_url Zlib.source_url

--- a/packages/zlib.rb
+++ b/packages/zlib.rb
@@ -3,24 +3,25 @@ require 'buildsystems/cmake'
 class Zlib < CMake
   description 'zlib is a massively spiffy yet delicately unobtrusive compression library.'
   homepage 'https://zlib.net'
-  version '1.3.1' # Do not use @_ver here, it will break the installer.
+  version '1.3.1-1' # Do not use @_ver here, it will break the installer.
   # When upgrading zlib, be sure to upgrade minizip in tandem.
   # The following breaks the installer script.
   # puts "#{self} version differs from Minizip version #{Minizip.version}".orange if @_ver != Minizip.version
   license 'zlib'
   compatibility 'all'
-  source_url 'https://www.zlib.net/zlib-1.3.1.tar.gz'
+  source_url "https://www.zlib.net/zlib-#{version.split('-').first}.tar.gz"
   source_sha256 '9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23'
-  binary_compression 'tar.zst'
+  binary_compression 'tar.xz'
 
   binary_sha256({
-    aarch64: 'a5eb9bbd6dce00c096617c1db16a71dd1f590043c39519e1645d5eb9750ed88f',
-     armv7l: 'a5eb9bbd6dce00c096617c1db16a71dd1f590043c39519e1645d5eb9750ed88f',
-       i686: '1e4ae082c29430d3c081b3f9a8a66bebc9c6cfbf5912476a5ddcfc5c00edfcf2',
-     x86_64: '84abb78b6aabdcb976484173d6b8c53c25495db8a30cd729a584d56d2d66722f'
+    aarch64: '088ea9b1d7a0b4d4d99ab52d44a0e583b3d70c1fc7b12fdb07ec00fecf1c0974',
+     armv7l: '088ea9b1d7a0b4d4d99ab52d44a0e583b3d70c1fc7b12fdb07ec00fecf1c0974',
+       i686: '12af9f1f76a2010c9d4a613db6e7898e7a3ff0e3279da67643162dbf0e26bbd0',
+     x86_64: '6207497dc60b168b8e5de2d68465e27131631f810c694329cb456e7daa20fdba'
   })
 
   depends_on 'glibc' # R
+  no_zstd
 
   cmake_options "#{CREW_CMAKE_OPTIONS.gsub('-mfpu=vfpv3-d16', '-mfpu=neon-fp16')} -Wno-dev"
 


### PR DESCRIPTION
- newer arm machines no longer include an armv7l libz, so we need to add it early as a bootstrap package before we start using zstd.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=zlib_xz crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
