### PR TITLE
Add crew-sudo as a core package on relevant milestones

### DIFF
--- a/packages/core.rb
+++ b/packages/core.rb
@@ -3,7 +3,7 @@ require 'package'
 class Core < Package
   description 'Core Chromebrew Packages.'
   homepage 'https://github.com/chromebrew/chromebrew'
-  version '2.5'
+  version '2.6'
   license 'GPL-3+'
   compatibility 'all'
 
@@ -17,6 +17,7 @@ class Core < Package
   depends_on 'ca_certificates'
   depends_on 'crew_mvdir'
   depends_on 'crew_profile_base'
+  depends_on 'crew_sudo' if CHROMEOS_RELEASE.to_i > 116
   depends_on 'e2fsprogs'
   depends_on 'elfutils'
   depends_on 'expat'


### PR DESCRIPTION
We encounter enough issues where the solution is crew-sudo that it seems not enough people know about this package, so just add it as a core package on the relevant milestones. Sudo support is needed for some packages (i..e docker) anyways.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=3twell crew update
```