### PR TITLE
bz2 archives can't be extracted with 'tar -Izstd', so fix in crew

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -598,10 +598,10 @@ def unpack(meta)
       when /\.zip$/i
         puts "Unpacking archive using 'unzip', this may take a while..."
         system 'unzip', (CREW_VERBOSE ? '-v' : '-qq'), '-d', @extract_dir, meta[:filename], exception: true
-      when /\.(tar(\.bz2))$/i
+      when /\.(tar(\.bz2)?|tbz)$/i
         puts "Unpacking archive using 'tar', this may take a while..."
         system 'tar', "-x#{@verbose}f", meta[:filename], '-C', @extract_dir, exception: true
-      when /\.(tar(\.(gz|bz2|xz|lzma|lz))?|tgz|tbz|txz|tpxz)$/i
+      when /\.(tar(\.(gz|xz|lzma|lz))?|tgz|txz|tpxz)$/i
         puts "Unpacking archive using 'tar', this may take a while..."
         if Kernel.system('zstd --help 2>/dev/null| grep -q lzma', %i[out err] => File::NULL)
           system 'tar', '-Izstd', "-x#{@verbose}f", meta[:filename], '-C', @extract_dir, exception: true

--- a/bin/crew
+++ b/bin/crew
@@ -598,6 +598,9 @@ def unpack(meta)
       when /\.zip$/i
         puts "Unpacking archive using 'unzip', this may take a while..."
         system 'unzip', (CREW_VERBOSE ? '-v' : '-qq'), '-d', @extract_dir, meta[:filename], exception: true
+      when /\.(tar(\.bz2))$/i
+        puts "Unpacking archive using 'tar', this may take a while..."
+        system 'tar', "-x#{@verbose}f", meta[:filename], '-C', @extract_dir, exception: true
       when /\.(tar(\.(gz|bz2|xz|lzma|lz))?|tgz|tbz|txz|tpxz)$/i
         puts "Unpacking archive using 'tar', this may take a while..."
         if Kernel.system('zstd --help 2>/dev/null| grep -q lzma', %i[out err] => File::NULL)

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -2,7 +2,7 @@
 # Defines common constants used in different parts of crew
 require 'etc'
 
-CREW_VERSION = '1.49.12'
+CREW_VERSION = '1.49.13'
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]


### PR DESCRIPTION
This fixes extracting `.tar.bz2` source archives, for packages like `zotero`.

Works properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=extractfix crew update
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
