### PR TITLE
Edge 127.0.2651.86-1 => 127.0.2651.98-1

### DIFF
--- a/packages/edge.rb
+++ b/packages/edge.rb
@@ -3,12 +3,12 @@ require 'package'
 class Edge < Package
   description 'Microsoft Edge is the fast and secure browser'
   homepage 'https://www.microsoft.com/en-us/edge'
-  version '127.0.2651.86-1'
+  version '127.0.2651.98-1'
   license 'MIT'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_#{version}_amd64.deb"
-  source_sha256 'd4387e3a84eb8219fd02bbc49c164290b9d47f49b4aa7904b42a168c0f1021de'
+  source_sha256 'a3cd208ed322982b32e3cc25ee88e3dead61376cc9abef4667338b16e7479b61'
 
   depends_on 'at_spi2_core'
   depends_on 'libcom_err'
@@ -45,6 +45,6 @@ class Edge < Package
   end
 
   def self.postinstall
-    ExitMessage.add "\nType 'edge' to get started.\n".lightblue
+    ExitMessage.add "\nType 'edge' to get started.\n"
   end
 end


### PR DESCRIPTION
##
Tested & Working properly:
- [x] `x86_64` (does not work in x86_64 m126 container)
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-edge crew update \
&& yes | crew upgrade
```
