### PR TITLE
Wp_cli 2.10.0 => 2.11.0

### DIFF
--- a/packages/wp_cli.rb
+++ b/packages/wp_cli.rb
@@ -3,11 +3,11 @@ require 'package'
 class Wp_cli < Package
   description 'The command line interface for WordPress'
   homepage 'https://wp-cli.org/'
-  version '2.10.0'
+  version '2.11.0'
   license 'LGPL-3'
   compatibility 'x86_64 aarch64 armv7l'
-  source_url 'https://github.com/wp-cli/wp-cli/releases/download/v2.10.0/wp-cli-2.10.0.phar'
-  source_sha256 '4c6a93cecae7f499ca481fa7a6d6d4299c8b93214e5e5308e26770dbfd3631df'
+  source_url "https://github.com/wp-cli/wp-cli/releases/download/v#{version}/wp-cli-#{version}.phar"
+  source_sha256 'a39021ac809530ea607580dbf93afbc46ba02f86b6cffd03de4b126ca53079f6'
 
   depends_on 'php83' unless File.exist? "#{CREW_PREFIX}/bin/php"
 


### PR DESCRIPTION
##
Tested & Working properly:
- [x] `x86_64`
- [ ] `i686`
- [x] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-wp_cli crew update \
&& yes | crew upgrade
```
