### PR TITLE
fix: checksum for librsvg

### DIFF
--- a/packages/librsvg.rb
+++ b/packages/librsvg.rb
@@ -11,7 +11,7 @@ class Librsvg < Autotools
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '7e6aac5bc990a85aa112c6843c9c6b486b2d8386aebbaeb1a5ba4bf193cc83f4',
+    aarch64: '59dafc0bb05dafb25e81da2aad87b9f37f4da703503fac40efdcc4667937f018',
      armv7l: '59dafc0bb05dafb25e81da2aad87b9f37f4da703503fac40efdcc4667937f018',
      x86_64: '5301c32f54d047e3684bbd9b1aa3bb4555c700397ad129928112a8eeb7966736'
   })

--- a/packages/librsvg.rb
+++ b/packages/librsvg.rb
@@ -12,7 +12,7 @@ class Librsvg < Autotools
 
   binary_sha256({
     aarch64: '7e6aac5bc990a85aa112c6843c9c6b486b2d8386aebbaeb1a5ba4bf193cc83f4',
-     armv7l: '7e6aac5bc990a85aa112c6843c9c6b486b2d8386aebbaeb1a5ba4bf193cc83f4',
+     armv7l: '59dafc0bb05dafb25e81da2aad87b9f37f4da703503fac40efdcc4667937f018',
      x86_64: '5301c32f54d047e3684bbd9b1aa3bb4555c700397ad129928112a8eeb7966736'
   })
 

--- a/packages/librsvg.rb
+++ b/packages/librsvg.rb
@@ -13,7 +13,7 @@ class Librsvg < Autotools
   binary_sha256({
     aarch64: '7e6aac5bc990a85aa112c6843c9c6b486b2d8386aebbaeb1a5ba4bf193cc83f4',
      armv7l: '7e6aac5bc990a85aa112c6843c9c6b486b2d8386aebbaeb1a5ba4bf193cc83f4',
-     x86_64: 'a8ebeac12cc8d9c5f37b239b0ebb56e584f4589d341814fb35ad6eab232767a0'
+     x86_64: '5301c32f54d047e3684bbd9b1aa3bb4555c700397ad129928112a8eeb7966736'
   })
 
   depends_on 'cairo' # R


### PR DESCRIPTION
## Description
Fix `librsvg` checksum mismatch during installation.
## Additional information
Appeare during installation of `geany`.

##
Builds:
- [x] `x86_64`
- [ ] `i686`
- [x] `armv7l`
##
Tested & Working properly:
- [x] `x86_64`
- [ ] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/shogi-dojo/chromebrew.git CREW_BRANCH=fix-svg-lib-checksum crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
