### PR TITLE
Let last_update_check use lib/const.rb last data modification time if git isn't setup yet during install.

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1924,8 +1924,7 @@ end
 
 load_json
 
-@last_update_check = `stat -c %Y #{File.join(CREW_LIB_PATH, '.git/FETCH_HEAD')}`.chomp.to_i
-@last_update_check = @last_update_check.blank? ? 0 : @last_update_check
+@last_update_check = File.file?(File.join(CREW_LIB_PATH, '.git/FETCH_HEAD')) ? `stat -c %Y #{File.join(CREW_LIB_PATH, '.git/FETCH_HEAD')}`.chomp.to_i : `stat -c %Y #{File.join(CREW_LIB_PATH, 'lib/const.rb')}`.chomp.to_i
 crewlog("The last update was #{time_difference(@last_update_check, Time.now.to_i)} ago.")
 puts "It has been more than #{CREW_UPDATE_CHECK_INTERVAL} day#{CREW_UPDATE_CHECK_INTERVAL < 2 ? '' : 's'} since crew was last updated. Please run 'crew update'".lightpurple if Time.now.to_i - @last_update_check > (CREW_UPDATE_CHECK_INTERVAL * 3600 * 24)
 command_name = args.select { |k, v| v && command?(k) }.keys[0]

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -2,7 +2,7 @@
 # Defines common constants used in different parts of crew
 require 'etc'
 
-CREW_VERSION = '1.50.2'
+CREW_VERSION = '1.50.3'
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]


### PR DESCRIPTION
Fixes this:

![Screenshot_20240813-123654.png](https://github.com/user-attachments/assets/1eec1225-786f-4e55-a17d-f82c05d1800a)


##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=install-update-msg-fix crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
