### PR TITLE
add missing vte binaries

### DIFF
--- a/packages/vte.rb
+++ b/packages/vte.rb
@@ -11,9 +11,9 @@ class Vte < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'f2f391b5c913253e1f7f54647e2e410347ea12cc5cfb6b76e83c167ec8247f37',
-     armv7l: 'f2f391b5c913253e1f7f54647e2e410347ea12cc5cfb6b76e83c167ec8247f37',
-     x86_64: 'f7038e85f3b0ac3f50db80bca4ec6ea705b1ec9c666a74615bc0f94eb9467c56'
+    aarch64: 'd4516db006795e505a81fb52c34803fc6b0eea01a16bbbec03fd0f6546ba604f',
+     armv7l: 'd4516db006795e505a81fb52c34803fc6b0eea01a16bbbec03fd0f6546ba604f',
+     x86_64: 'f983e3b3731e062c5e0719ae5886cfb3dadb7d45ddea9ea8a22c5f07ce65a7a8'
   })
 
   depends_on 'at_spi2_core' # R


### PR DESCRIPTION
Fixes  #10305


##
Builds:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=vte_fix crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
