### PR TITLE
Update gtk4, libdrm, mesa, test buildsystems changes, make unit tests easier to debug

### DIFF
--- a/.github/workflows/Handoff.yml
+++ b/.github/workflows/Handoff.yml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: 0
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@v44.5.7
       - name: Get extensions of changed files
         id: changed-file-extensions
         run: |

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -28,10 +28,10 @@ jobs:
             echo "ALL_CHANGED FILES is/are ${ALL_CHANGED_FILES}." && \
             export CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES} | sed -e 's,packages/,,g' -e 's,\.rb,,g' | sort)" && \
             echo "CHANGED PACKAGES is/are ${CHANGED_PACKAGES}." && \
-            export X86_64_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do echo $(grep -l \"compatibility.*all\|x86_64\" packages/$p.rb); done | xargs)" && \
-            echo "PR #${PR_NUMBER} has these x86_64 packages: ${X86_64_PACKAGES}" && \
-            export ARMV7L_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do echo $(grep -l \"compatibility.*all\|armv7l\" packages/$p.rb); done | xargs)" && \
-            echo "PR #${PR_NUMBER} has these ARMv7L packages: ${ARMV7L_PACKAGES}" && \
+            export X86_64_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do grep -q "compatibility.*all\|x86_64" packages/$p.rb && echo $p; done | xargs)" && \
+            echo "PR #${PR_NUMBER} has these x86_64 compatible packages: ${X86_64_PACKAGES}" && \
+            export ARMV7L_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do grep -q "compatibility.*all\|armv7l" packages/$p.rb && echo $p; done | xargs)" && \
+            echo "PR #${PR_NUMBER} has these ARMv7L compatible packages: ${ARMV7L_PACKAGES}" && \
             sudo docker run --rm \
             --platform linux/amd64 -i satmandu/crewbuild:nocturne-x86_64.m90 \
             sudo -i -u chronos /bin/bash -c " \
@@ -52,10 +52,10 @@ jobs:
             echo "ALL_CHANGED FILES is/are ${ALL_CHANGED_FILES}." && \
             export CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES} | sed -e 's,packages/,,g' -e 's,\.rb,,g' | sort)" && \
             echo "CHANGED PACKAGES is/are ${CHANGED_PACKAGES}." && \
-            export X86_64_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do echo $(grep -l \"compatibility.*all\|x86_64\" packages/$p.rb); done | xargs)" && \
-            echo "PR #${PR_NUMBER} has these x86_64 packages: ${X86_64_PACKAGES}" && \
-            export ARMV7L_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do echo $(grep -l \"compatibility.*all\|armv7l\" packages/$p.rb); done | xargs)" && \
-            echo "PR #${PR_NUMBER} has these ARMv7L packages: ${ARMV7L_PACKAGES}" && \
+            export X86_64_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do grep -q "compatibility.*all\|x86_64" packages/$p.rb && echo $p; done | xargs)" && \
+            echo "PR #${PR_NUMBER} has these x86_64 compatible packages: ${X86_64_PACKAGES}" && \
+            export ARMV7L_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do grep -q "compatibility.*all\|armv7l" packages/$p.rb && echo $p; done | xargs)" && \
+            echo "PR #${PR_NUMBER} has these ARMv7L compatible packages: ${ARMV7L_PACKAGES}" && \
             [[ $ARMV7L_PACKAGES ]] || exit 0 && \
             sudo docker run --rm \
             --platform linux/arm/v7 -t satmandu/crewbuild:fievel-armv7l.m91 \

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -24,11 +24,11 @@ jobs:
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-ruby-files.outputs.all_changed_files }}
         run: |
-            echo "pwd is $(pwd)" && \
-            ls -aFl && \
             echo "ALL_CHANGED FILES is ${ALL_CHANGED_FILES}." && \
             export CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES#packages/} | tr -d '.rb' | sort)" && \
             echo "CHANGED PACKAGES is ${CHANGED_PACKAGES}." && \
+            export X86_64_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do echo $(grep -l \"compatibility.*all\|x86_64\" packages/$p.rb); done | xargs)" && \
+            export ARMV7L_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do echo $(grep -l \"compatibility.*all\|armv7l\" packages/$p.rb); done | xargs)" && \
             sudo docker run --rm \
             --platform linux/amd64 -i satmandu/crewbuild:nocturne-x86_64.m90 \
             sudo -i -u chronos /bin/bash -c " \
@@ -48,6 +48,9 @@ jobs:
             echo "ALL_CHANGED FILES is ${ALL_CHANGED_FILES}." && \
             export CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES#packages/} | tr -d '.rb' | sort)" && \
             echo "CHANGED PACKAGES is ${CHANGED_PACKAGES}." && \
+            export X86_64_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do echo $(grep -l \"compatibility.*all\|x86_64\" packages/$p.rb); done | xargs)" && \
+            export ARMV7L_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do echo $(grep -l \"compatibility.*all\|armv7l\" packages/$p.rb); done | xargs)" && \
+            [[ $ARMV7L_PACKAGES ]] || exit 0 && \
             sudo docker run --rm \
             --platform linux/arm/v7 -t satmandu/crewbuild:fievel-armv7l.m91 \
             sudo -i -u chronos /bin/bash -x -c " \

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -31,8 +31,8 @@ jobs:
             -e ALL_CHANGED_FILES="${ALL_CHANGED_FILES}" \
             -e CHANGED_PACKAGES="${CHANGED_PACKAGES}" \
             -i satmandu/crewbuild:m90-x86_64 \
-            sudo -i -u chronos /bin/bash -c \
-            "export ALL_CHANGED_FILES=\"${ALL_CHANGED_FILES}\" && \
+            sudo -i -u chronos /bin/bash -x -c " \
+            export ALL_CHANGED_FILES=\"${ALL_CHANGED_FILES}\" && \
             export CHANGED_PACKAGES=\"${CHANGED_PACKAGES}\" \
             echo \"CREW_REPO is ${{ github.event.pull_request.head.repo.clone_url }}\" && \
             echo \"CREW_BRANCH is ${{ github.head_ref }}\" && \
@@ -53,8 +53,8 @@ jobs:
             -e CHANGED_PACKAGES="${CHANGED_PACKAGES}" \
             sudo docker run --rm \
             --platform linux/arm/v7 -t satmandu/crewbuild:m91-armv7l \
-            sudo -i -u chronos /bin/bash -c \
-            "export ALL_CHANGED_FILES=\"${ALL_CHANGED_FILES}\" && \
+            sudo -i -u chronos /bin/bash -x -c " \
+            export ALL_CHANGED_FILES=\"${ALL_CHANGED_FILES}\" && \
             export CHANGED_PACKAGES=\"${CHANGED_PACKAGES}\" \
             echo \"CREW_REPO is ${{ github.event.pull_request.head.repo.clone_url }}\" && \
             echo \"CREW_BRANCH is ${{ github.head_ref }}\" && \

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -34,7 +34,14 @@ jobs:
             ruby ../tests/commands/const.rb && \
             ruby ../tests/commands/help.rb && \
             ruby ../tests/commands/prop.rb && \
-            ( [[ -v ALL_CHANGED_FILES ]] && [[ -n ALL_CHANGED_FILES ]] && ( for file in ${ALL_CHANGED_FILES}; do
+            ( [[ -v ALL_CHANGED_FILES ]] && [[ -n ALL_CHANGED_FILES ]] && \
+            for pkg in $(comm -12 <(crew list -d compatible | sort) <(echo ${ALL_CHANGED_FILES} | tr -d packages/ | tr -d '.rb' | sort) | tr -s \"\n\" ' ') ; \
+            do \
+            echo \"Testing install of compatible package ${pkg}\"; \
+            yes | time crew install ${pkg}; \
+            yes | time crew remove ${pkg}; \
+            done && \
+            for file in ${ALL_CHANGED_FILES}; do
               ruby ../tests/prop_test $file && \
               ruby ../tests/buildsystem_test $file ; \
             done ) || true ) && \

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -24,7 +24,12 @@ jobs:
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-ruby-files.outputs.all_changed_files }}
         run: |
-            sudo docker run --rm -t satmandu/crewbuild:m90-x86_64 sudo -i -u chronos /bin/bash -c "set -e && \
+            sudo docker run --rm \
+            -e ALL_CHANGED_FILES="${ALL_CHANGED_FILES}" \
+            -e CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES#packages/} | tr -d '.rb' | sort)" \
+            -t satmandu/crewbuild:m90-x86_64 \
+            sudo -i -u chronos /bin/bash -c \
+            "set -e && \
             echo \"CREW_REPO is ${{ github.event.pull_request.head.repo.clone_url }}\" && \
             echo \"CREW_BRANCH is ${{ github.head_ref }}\" && \
             CREW_REPO=${{ github.event.pull_request.head.repo.clone_url }} CREW_BRANCH=${{ github.head_ref }} crew update && \
@@ -35,21 +40,19 @@ jobs:
             ruby ../tests/commands/help.rb && \
             ruby ../tests/commands/prop.rb && \
             ( [[ -v ALL_CHANGED_FILES ]] && [[ -n ALL_CHANGED_FILES ]] && \
-            export changed_packages=$(echo ${ALL_CHANGED_FILES#packages/} | tr -d '.rb' | sort) ;\
-            [[ -n ${changed_packages-} ]] && ( \
-            for pkg in ${changed_packages}; \
+            [[ -n \${CHANGED_PACKAGES-} ]] && ( \
+            for pkg in \${CHANGED_PACKAGES}; \
               do \
-            export all_compatible_packages=$(crew list -d compatible) ;\
-            if $(echo ${all_compatible_packages} | grep ${pkg}); then ;\
-            (echo \"Testing install of compatible package ${pkg}\"; \
-            yes | time crew install ${pkg} && \
-            yes | time crew remove ${pkg}; \
-            fi ;\
-            done ) && \
+            export all_compatible_packages=\$(crew list -d compatible) && \
+            if \$(echo \${all_compatible_packages} | grep \${pkg}); then ;\
+            echo \"Testing install of compatible package \${pkg}\"; \
+            yes | time crew install \${pkg} && \
+            yes | time crew remove \${pkg}; \
+            fi ) && \
             for file in ${ALL_CHANGED_FILES}; do
-              ruby ../tests/prop_test $file && \
-              ruby ../tests/buildsystem_test $file ; \
-            done )) && \
+              ruby ../tests/prop_test \$file && \
+              ruby ../tests/buildsystem_test \$file ; \
+            done ) && \
             cd ~ && \
             git clone --depth=1 https://github.com/chromebrew/chromebrew.git build_test && \
             cd build_test && \

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -44,7 +44,7 @@ jobs:
             for pkg in \${CHANGED_PACKAGES}; \
               do \
             export all_compatible_packages=\$(crew list -d compatible) && \
-            if \$(echo \${all_compatible_packages} | grep \${pkg}); then ;\
+            if \$(echo \${all_compatible_packages} | grep ^\${pkg}\$); then ;\
             echo \"Testing install of compatible package \${pkg}\"; \
             yes | time crew install \${pkg} && \
             yes | time crew remove \${pkg}; \

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -46,9 +46,6 @@ jobs:
             echo "ALL_CHANGED FILES is ${ALL_CHANGED_FILES}." && \
             export CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES#packages/} | tr -d '.rb' | sort)" && \
             echo "CHANGED PACKAGES is ${CHANGED_PACKAGES}." && \
-            echo sudo docker run --rm \
-            -e ALL_CHANGED_FILES="${ALL_CHANGED_FILES}" \
-            -e CHANGED_PACKAGES="${CHANGED_PACKAGES}" \
             sudo docker run --rm \
             --platform linux/arm/v7 -t satmandu/crewbuild:fievel-armv7l.m91 \
             sudo -i -u chronos /bin/bash -x -c " \

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -24,10 +24,12 @@ jobs:
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-ruby-files.outputs.all_changed_files }}
         run: |
+            echo "ALL_CHANGED FILES is ${ALL_CHANGED_FILES}." && \
+            export CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES#packages/} | tr -d '.rb' | sort)" && \
             sudo docker run --rm \
             -e ALL_CHANGED_FILES="${ALL_CHANGED_FILES}" \
-            -e CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES#packages/} | tr -d '.rb' | sort)" \
-            -it satmandu/crewbuild:m90-x86_64 \
+            -e CHANGED_PACKAGES="${CHANGED_PACKAGES}" \
+            -i satmandu/crewbuild:m90-x86_64 \
             sudo -i -u chronos /bin/bash -c \
             "echo \"CREW_REPO is ${{ github.event.pull_request.head.repo.clone_url }}\" && \
             echo \"CREW_BRANCH is ${{ github.head_ref }}\" && \

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -37,6 +37,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
         # This is not the best way to do things, a matrix would certainly be better.
       - name: Unit Tests (armv7l)
+        env:
           ALL_CHANGED_FILES: ${{ steps.changed-ruby-files.outputs.all_changed_files }}
         run: |
             sudo docker run --rm \

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -24,12 +24,9 @@ jobs:
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-ruby-files.outputs.all_changed_files }}
         run: |
-            echo "ALL_CHANGED_FILES is ${ALL_CHANGED_FILES}" && \
-            export CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES#packages/} | tr -d '.rb' | sort)" \
-            echo "CHANGED_PACKAGES is ${CHANGED_PACKAGES}" \
             sudo docker run --rm \
             -e ALL_CHANGED_FILES="${ALL_CHANGED_FILES}" \
-            -e CHANGED_PACKAGES="${CHANGED_PACKAGES}" \
+            -e CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES#packages/} | tr -d '.rb' | sort)" \
             -t satmandu/crewbuild:m90-x86_64 \
             sudo -i -u chronos /bin/bash -c \
             "set -e && \

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -13,12 +13,12 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
       - name: Get all changed package files
         id: changed-ruby-files
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@v44.5.7
         with:
           files: |
              packages/*.rb
       - name: List all changed package files
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@v44.5.7
         if: steps.changed-ruby-files.outputs.any_changed == 'true'
       - name: Unit Tests (x86_64)
         env:

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -24,6 +24,8 @@ jobs:
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-ruby-files.outputs.all_changed_files }}
         run: |
+            echo "pwd is $(pwd)" && \
+            ls -aFl && \
             echo "ALL_CHANGED FILES is ${ALL_CHANGED_FILES}." && \
             export CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES#packages/} | tr -d '.rb' | sort)" && \
             echo "CHANGED PACKAGES is ${CHANGED_PACKAGES}." && \

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -32,7 +32,7 @@ jobs:
             "echo \"CREW_REPO is ${{ github.event.pull_request.head.repo.clone_url }}\" && \
             echo \"CREW_BRANCH is ${{ github.head_ref }}\" && \
             CREW_REPO=${{ github.event.pull_request.head.repo.clone_url }} CREW_BRANCH=${{ github.head_ref }} crew update && \
-            /usr/local/lib/crew/tests/unit-test.sh"
+            /usr/local/lib/crew/tests/unit_test.sh"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         # This is not the best way to do things, a matrix would certainly be better.

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -20,9 +20,9 @@ jobs:
       - name: List all changed package files
         uses: tj-actions/changed-files@v44
         if: steps.changed-ruby-files.outputs.any_changed == 'true'
+      - name: Unit Tests (x86_64)
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-ruby-files.outputs.all_changed_files }}
-      - name: Unit Tests (x86_64)
         run: |
             sudo docker run --rm -t satmandu/crewbuild:m90-x86_64 sudo -i -u chronos /bin/bash -c "
             echo \"CREW_REPO is ${{ github.event.pull_request.head.repo.clone_url }}\" && \

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -27,7 +27,7 @@ jobs:
             sudo docker run --rm \
             -e ALL_CHANGED_FILES="${ALL_CHANGED_FILES}" \
             -e CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES#packages/} | tr -d '.rb' | sort)" \
-            -t satmandu/crewbuild:m90-x86_64 \
+            -it satmandu/crewbuild:m90-x86_64 \
             sudo -i -u chronos /bin/bash -c \
             "echo \"CREW_REPO is ${{ github.event.pull_request.head.repo.clone_url }}\" && \
             echo \"CREW_BRANCH is ${{ github.head_ref }}\" && \
@@ -44,8 +44,7 @@ jobs:
             -e ALL_CHANGED_FILES="${ALL_CHANGED_FILES}" \
             -e CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES#packages/} | tr -d '.rb' | sort)" \
             sudo docker run --rm \
-            --platform linux/arm/v7 \
-            -t satmandu/crewbuild:m91-armv7l \
+            --platform linux/arm/v7 -t satmandu/crewbuild:m91-armv7l \
             sudo -i -u chronos /bin/bash -c \
             "echo \"CREW_REPO is ${{ github.event.pull_request.head.repo.clone_url }}\" && \
             echo \"CREW_BRANCH is ${{ github.head_ref }}\" && \

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-ruby-files.outputs.all_changed_files }}
         run: |
-            sudo docker run --rm -t satmandu/crewbuild:m90-x86_64 sudo -i -u chronos /bin/bash -c "
+            sudo docker run --rm -t satmandu/crewbuild:m90-x86_64 sudo -i -u chronos /bin/bash -c "set -e && \
             echo \"CREW_REPO is ${{ github.event.pull_request.head.repo.clone_url }}\" && \
             echo \"CREW_BRANCH is ${{ github.head_ref }}\" && \
             CREW_REPO=${{ github.event.pull_request.head.repo.clone_url }} CREW_BRANCH=${{ github.head_ref }} crew update && \
@@ -36,18 +36,20 @@ jobs:
             ruby ../tests/commands/prop.rb && \
             ( [[ -v ALL_CHANGED_FILES ]] && [[ -n ALL_CHANGED_FILES ]] && \
             export changed_packages=$(echo ${ALL_CHANGED_FILES#packages/} | tr -d '.rb' | sort) ;\
-            [[ -n ${changed_packages-} ]] && (
-            export compatible_packages=$(comm -12 <(crew list -d compatible | sort) <(echo ${changed_packages}) | tr -s \"\n\" ' ') ; \
-            [[ -n ${compatible_packages-} ]] && (for pkg in ${compatible_packages} ;\
-            do \
-            echo \"Testing install of compatible package ${pkg}\"; \
-            yes | time crew install ${pkg}; \
+            [[ -n ${changed_packages-} ]] && ( \
+            for pkg in ${changed_packages}; \
+              do \
+            export all_compatible_packages=$(crew list -d compatible) ;\
+            if $(echo ${all_compatible_packages} | grep ${pkg}); then ;\
+            (echo \"Testing install of compatible package ${pkg}\"; \
+            yes | time crew install ${pkg} && \
             yes | time crew remove ${pkg}; \
-            done ) || true && \
+            fi ;\
+            done ) && \
             for file in ${ALL_CHANGED_FILES}; do
               ruby ../tests/prop_test $file && \
               ruby ../tests/buildsystem_test $file ; \
-            done ) || true ) && \
+            done )) && \
             cd ~ && \
             git clone --depth=1 https://github.com/chromebrew/chromebrew.git build_test && \
             cd build_test && \

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -29,34 +29,10 @@ jobs:
             -e CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES#packages/} | tr -d '.rb' | sort)" \
             -t satmandu/crewbuild:m90-x86_64 \
             sudo -i -u chronos /bin/bash -c \
-            "set -e && \
-            echo \"CREW_REPO is ${{ github.event.pull_request.head.repo.clone_url }}\" && \
+            "echo \"CREW_REPO is ${{ github.event.pull_request.head.repo.clone_url }}\" && \
             echo \"CREW_BRANCH is ${{ github.head_ref }}\" && \
             CREW_REPO=${{ github.event.pull_request.head.repo.clone_url }} CREW_BRANCH=${{ github.head_ref }} crew update && \
-            yes | crew upgrade && \
-            yes | crew install vim && \
-            yes | crew remove vim && \
-            ruby ../tests/commands/const.rb && \
-            ruby ../tests/commands/help.rb && \
-            ruby ../tests/commands/prop.rb && \
-            ( [[ -v ALL_CHANGED_FILES ]] && [[ -n ALL_CHANGED_FILES ]] && \
-            [[ -n \${CHANGED_PACKAGES-} ]] && ( \
-            for pkg in \${CHANGED_PACKAGES}; \
-              do \
-            export all_compatible_packages=\$(crew list -d compatible) && \
-            if \$(echo \${all_compatible_packages} | grep ^\${pkg}\$); then \
-            echo \"Testing install of compatible package \${pkg}\" && \
-            yes | time crew install \${pkg} && \
-            yes | time crew remove \${pkg}; \
-            fi ) && \
-            for file in ${ALL_CHANGED_FILES}; do
-              ruby ../tests/prop_test \$file && \
-              ruby ../tests/buildsystem_test \$file ; \
-            done ) && \
-            cd ~ && \
-            git clone --depth=1 https://github.com/chromebrew/chromebrew.git build_test && \
-            cd build_test && \
-            yes | CREW_CACHE_ENABLED=1 crew build -vf packages/hello_world_chromebrew.rb"
+            /usr/local/lib/crew/tests/unit-test.sh"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         # This is not the best way to do things, a matrix would certainly be better.

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -29,7 +29,7 @@ jobs:
             echo "CHANGED_PACKAGES is ${CHANGED_PACKAGES}" \
             sudo docker run --rm \
             -e ALL_CHANGED_FILES="${ALL_CHANGED_FILES}" \
-            -e CHANGED_PACKAGES="$(CHANGED_PACKAGES}" \
+            -e CHANGED_PACKAGES="${CHANGED_PACKAGES}" \
             -t satmandu/crewbuild:m90-x86_64 \
             sudo -i -u chronos /bin/bash -c \
             "set -e && \

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -40,9 +40,12 @@ jobs:
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-ruby-files.outputs.all_changed_files }}
         run: |
-            sudo docker run --rm \
+            echo "ALL_CHANGED FILES is ${ALL_CHANGED_FILES}." && \
+            export CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES#packages/} | tr -d '.rb' | sort)" && \
+            echo "CHANGED PACKAGES is ${CHANGED_PACKAGES}." && \
+            echo sudo docker run --rm \
             -e ALL_CHANGED_FILES="${ALL_CHANGED_FILES}" \
-            -e CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES#packages/} | tr -d '.rb' | sort)" \
+            -e CHANGED_PACKAGES="${CHANGED_PACKAGES}" \
             sudo docker run --rm \
             --platform linux/arm/v7 -t satmandu/crewbuild:m91-armv7l \
             sudo -i -u chronos /bin/bash -c \

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -37,22 +37,16 @@ jobs:
         uses: docker/setup-qemu-action@v3
         # This is not the best way to do things, a matrix would certainly be better.
       - name: Unit Tests (armv7l)
+          ALL_CHANGED_FILES: ${{ steps.changed-ruby-files.outputs.all_changed_files }}
         run: |
-            sudo docker run --platform linux/arm/v7 --rm -t satmandu/crewbuild:m91-armv7l sudo -i -u chronos /bin/bash -c "
-            echo \"CREW_REPO is ${{ github.event.pull_request.head.repo.clone_url }}\" && \
+            sudo docker run --rm \
+            -e ALL_CHANGED_FILES="${ALL_CHANGED_FILES}" \
+            -e CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES#packages/} | tr -d '.rb' | sort)" \
+            sudo docker run --rm \
+            --platform linux/arm/v7 \
+            -t satmandu/crewbuild:m91-armv7l \
+            sudo -i -u chronos /bin/bash -c \
+            "echo \"CREW_REPO is ${{ github.event.pull_request.head.repo.clone_url }}\" && \
             echo \"CREW_BRANCH is ${{ github.head_ref }}\" && \
             CREW_REPO=${{ github.event.pull_request.head.repo.clone_url }} CREW_BRANCH=${{ github.head_ref }} crew update && \
-            yes | crew upgrade && \
-            yes | crew install vim && \
-            yes | crew remove vim && \
-            ruby ../tests/commands/const.rb && \
-            ruby ../tests/commands/help.rb && \
-            ruby ../tests/commands/prop.rb && \
-            ( [[ -v ALL_CHANGED_FILES ]] && [[ -n ALL_CHANGED_FILES ]] && ( for file in ${ALL_CHANGED_FILES}; do
-              ruby ../tests/prop_test $file && \
-              ruby ../tests/buildsystem_test $file ; \
-            done ) || true ) && \
-            cd ~ && \
-            git clone --depth=1 https://github.com/chromebrew/chromebrew.git build_test && \
-            cd build_test && \
-            yes | CREW_CACHE_ENABLED=1 crew build -f packages/hello_world_chromebrew.rb"
+            /usr/local/lib/crew/tests/unit_test.sh"

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -24,11 +24,14 @@ jobs:
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-ruby-files.outputs.all_changed_files }}
         run: |
-            echo "ALL_CHANGED FILES is ${ALL_CHANGED_FILES}." && \
+            export PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}" && \
+            echo "ALL_CHANGED FILES is/are ${ALL_CHANGED_FILES}." && \
             export CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES} | sed -e 's,packages/,,g' -e 's,\.rb,,g' | sort)" && \
-            echo "CHANGED PACKAGES is ${CHANGED_PACKAGES}." && \
+            echo "CHANGED PACKAGES is/are ${CHANGED_PACKAGES}." && \
             export X86_64_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do echo $(grep -l \"compatibility.*all\|x86_64\" packages/$p.rb); done | xargs)" && \
+            echo "PR #${PR_NUMBER} has these x86_64 packages: ${X86_64_PACKAGES}" && \
             export ARMV7L_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do echo $(grep -l \"compatibility.*all\|armv7l\" packages/$p.rb); done | xargs)" && \
+            echo "PR #${PR_NUMBER} has these ARMv7L packages: ${ARMV7L_PACKAGES}" && \
             sudo docker run --rm \
             --platform linux/amd64 -i satmandu/crewbuild:nocturne-x86_64.m90 \
             sudo -i -u chronos /bin/bash -c " \
@@ -45,11 +48,14 @@ jobs:
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-ruby-files.outputs.all_changed_files }}
         run: |
-            echo "ALL_CHANGED FILES is ${ALL_CHANGED_FILES}." && \
+            export PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}" && \
+            echo "ALL_CHANGED FILES is/are ${ALL_CHANGED_FILES}." && \
             export CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES} | sed -e 's,packages/,,g' -e 's,\.rb,,g' | sort)" && \
-            echo "CHANGED PACKAGES is ${CHANGED_PACKAGES}." && \
+            echo "CHANGED PACKAGES is/are ${CHANGED_PACKAGES}." && \
             export X86_64_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do echo $(grep -l \"compatibility.*all\|x86_64\" packages/$p.rb); done | xargs)" && \
+            echo "PR #${PR_NUMBER} has these x86_64 packages: ${X86_64_PACKAGES}" && \
             export ARMV7L_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do echo $(grep -l \"compatibility.*all\|armv7l\" packages/$p.rb); done | xargs)" && \
+            echo "PR #${PR_NUMBER} has these ARMv7L packages: ${ARMV7L_PACKAGES}" && \
             [[ $ARMV7L_PACKAGES ]] || exit 0 && \
             sudo docker run --rm \
             --platform linux/arm/v7 -t satmandu/crewbuild:fievel-armv7l.m91 \

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -26,12 +26,15 @@ jobs:
         run: |
             echo "ALL_CHANGED FILES is ${ALL_CHANGED_FILES}." && \
             export CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES#packages/} | tr -d '.rb' | sort)" && \
+            echo "CHANGED PACKAGES is ${CHANGED_PACKAGES}." && \
             sudo docker run --rm \
             -e ALL_CHANGED_FILES="${ALL_CHANGED_FILES}" \
             -e CHANGED_PACKAGES="${CHANGED_PACKAGES}" \
             -i satmandu/crewbuild:m90-x86_64 \
             sudo -i -u chronos /bin/bash -c \
-            "echo \"CREW_REPO is ${{ github.event.pull_request.head.repo.clone_url }}\" && \
+            "export ALL_CHANGED_FILES=\"${ALL_CHANGED_FILES}\" && \
+            export CHANGED_PACKAGES=\"${CHANGED_PACKAGES}\" \
+            echo \"CREW_REPO is ${{ github.event.pull_request.head.repo.clone_url }}\" && \
             echo \"CREW_BRANCH is ${{ github.head_ref }}\" && \
             CREW_REPO=${{ github.event.pull_request.head.repo.clone_url }} CREW_BRANCH=${{ github.head_ref }} crew update && \
             /usr/local/lib/crew/tests/unit_test.sh"
@@ -51,7 +54,9 @@ jobs:
             sudo docker run --rm \
             --platform linux/arm/v7 -t satmandu/crewbuild:m91-armv7l \
             sudo -i -u chronos /bin/bash -c \
-            "echo \"CREW_REPO is ${{ github.event.pull_request.head.repo.clone_url }}\" && \
+            "export ALL_CHANGED_FILES=\"${ALL_CHANGED_FILES}\" && \
+            export CHANGED_PACKAGES=\"${CHANGED_PACKAGES}\" \
+            echo \"CREW_REPO is ${{ github.event.pull_request.head.repo.clone_url }}\" && \
             echo \"CREW_BRANCH is ${{ github.head_ref }}\" && \
             CREW_REPO=${{ github.event.pull_request.head.repo.clone_url }} CREW_BRANCH=${{ github.head_ref }} crew update && \
             /usr/local/lib/crew/tests/unit_test.sh"

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -44,8 +44,8 @@ jobs:
             for pkg in \${CHANGED_PACKAGES}; \
               do \
             export all_compatible_packages=\$(crew list -d compatible) && \
-            if \$(echo \${all_compatible_packages} | grep ^\${pkg}\$); then ;\
-            echo \"Testing install of compatible package \${pkg}\"; \
+            if \$(echo \${all_compatible_packages} | grep ^\${pkg}\$); then \
+            echo \"Testing install of compatible package \${pkg}\" && \
             yes | time crew install \${pkg} && \
             yes | time crew remove \${pkg}; \
             fi ) && \

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -28,10 +28,8 @@ jobs:
             export CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES#packages/} | tr -d '.rb' | sort)" && \
             echo "CHANGED PACKAGES is ${CHANGED_PACKAGES}." && \
             sudo docker run --rm \
-            -e ALL_CHANGED_FILES="${ALL_CHANGED_FILES}" \
-            -e CHANGED_PACKAGES="${CHANGED_PACKAGES}" \
-            -i satmandu/crewbuild:m90-x86_64 \
-            sudo -i -u chronos /bin/bash -x -c " \
+            --platform linux/amd64 -i satmandu/crewbuild:nocturne-x86_64.m90 \
+            sudo -i -u chronos /bin/bash -c " \
             export ALL_CHANGED_FILES=\"${ALL_CHANGED_FILES}\" && \
             export CHANGED_PACKAGES=\"${CHANGED_PACKAGES}\" && \
             echo \"CREW_REPO is ${{ github.event.pull_request.head.repo.clone_url }}\" && \
@@ -52,7 +50,7 @@ jobs:
             -e ALL_CHANGED_FILES="${ALL_CHANGED_FILES}" \
             -e CHANGED_PACKAGES="${CHANGED_PACKAGES}" \
             sudo docker run --rm \
-            --platform linux/arm/v7 -t satmandu/crewbuild:m91-armv7l \
+            --platform linux/arm/v7 -t satmandu/crewbuild:fievel-armv7l.m91 \
             sudo -i -u chronos /bin/bash -x -c " \
             export ALL_CHANGED_FILES=\"${ALL_CHANGED_FILES}\" && \
             export CHANGED_PACKAGES=\"${CHANGED_PACKAGES}\" && \

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -25,7 +25,7 @@ jobs:
           ALL_CHANGED_FILES: ${{ steps.changed-ruby-files.outputs.all_changed_files }}
         run: |
             echo "ALL_CHANGED FILES is ${ALL_CHANGED_FILES}." && \
-            export CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES#packages/} | tr -d '.rb' | sort)" && \
+            export CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES} | sed -e 's,packages/,,g' -e 's,\.rb,,g' | sort)" && \
             echo "CHANGED PACKAGES is ${CHANGED_PACKAGES}." && \
             export X86_64_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do echo $(grep -l \"compatibility.*all\|x86_64\" packages/$p.rb); done | xargs)" && \
             export ARMV7L_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do echo $(grep -l \"compatibility.*all\|armv7l\" packages/$p.rb); done | xargs)" && \
@@ -46,7 +46,7 @@ jobs:
           ALL_CHANGED_FILES: ${{ steps.changed-ruby-files.outputs.all_changed_files }}
         run: |
             echo "ALL_CHANGED FILES is ${ALL_CHANGED_FILES}." && \
-            export CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES#packages/} | tr -d '.rb' | sort)" && \
+            export CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES} | sed -e 's,packages/,,g' -e 's,\.rb,,g' | sort)" && \
             echo "CHANGED PACKAGES is ${CHANGED_PACKAGES}." && \
             export X86_64_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do echo $(grep -l \"compatibility.*all\|x86_64\" packages/$p.rb); done | xargs)" && \
             export ARMV7L_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do echo $(grep -l \"compatibility.*all\|armv7l\" packages/$p.rb); done | xargs)" && \

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -33,7 +33,7 @@ jobs:
             -i satmandu/crewbuild:m90-x86_64 \
             sudo -i -u chronos /bin/bash -x -c " \
             export ALL_CHANGED_FILES=\"${ALL_CHANGED_FILES}\" && \
-            export CHANGED_PACKAGES=\"${CHANGED_PACKAGES}\" \
+            export CHANGED_PACKAGES=\"${CHANGED_PACKAGES}\" && \
             echo \"CREW_REPO is ${{ github.event.pull_request.head.repo.clone_url }}\" && \
             echo \"CREW_BRANCH is ${{ github.head_ref }}\" && \
             CREW_REPO=${{ github.event.pull_request.head.repo.clone_url }} CREW_BRANCH=${{ github.head_ref }} crew update && \
@@ -55,7 +55,7 @@ jobs:
             --platform linux/arm/v7 -t satmandu/crewbuild:m91-armv7l \
             sudo -i -u chronos /bin/bash -x -c " \
             export ALL_CHANGED_FILES=\"${ALL_CHANGED_FILES}\" && \
-            export CHANGED_PACKAGES=\"${CHANGED_PACKAGES}\" \
+            export CHANGED_PACKAGES=\"${CHANGED_PACKAGES}\" && \
             echo \"CREW_REPO is ${{ github.event.pull_request.head.repo.clone_url }}\" && \
             echo \"CREW_BRANCH is ${{ github.head_ref }}\" && \
             CREW_REPO=${{ github.event.pull_request.head.repo.clone_url }} CREW_BRANCH=${{ github.head_ref }} crew update && \

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -24,9 +24,12 @@ jobs:
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-ruby-files.outputs.all_changed_files }}
         run: |
+            echo "ALL_CHANGED_FILES is ${ALL_CHANGED_FILES}" && \
+            export CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES#packages/} | tr -d '.rb' | sort)" \
+            echo "CHANGED_PACKAGES is ${CHANGED_PACKAGES}" \
             sudo docker run --rm \
             -e ALL_CHANGED_FILES="${ALL_CHANGED_FILES}" \
-            -e CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES#packages/} | tr -d '.rb' | sort)" \
+            -e CHANGED_PACKAGES="$(CHANGED_PACKAGES}" \
             -t satmandu/crewbuild:m90-x86_64 \
             sudo -i -u chronos /bin/bash -c \
             "set -e && \

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -35,12 +35,15 @@ jobs:
             ruby ../tests/commands/help.rb && \
             ruby ../tests/commands/prop.rb && \
             ( [[ -v ALL_CHANGED_FILES ]] && [[ -n ALL_CHANGED_FILES ]] && \
-            for pkg in $(comm -12 <(crew list -d compatible | sort) <(echo ${ALL_CHANGED_FILES} | tr -d packages/ | tr -d '.rb' | sort) | tr -s \"\n\" ' ') ; \
+            export changed_packages=$(echo ${ALL_CHANGED_FILES#packages/} | tr -d '.rb' | sort) ;\
+            [[ -n ${changed_packages-} ]] && (
+            export compatible_packages=$(comm -12 <(crew list -d compatible | sort) <(echo ${changed_packages}) | tr -s \"\n\" ' ') ; \
+            [[ -n ${compatible_packages-} ]] && (for pkg in ${compatible_packages} ;\
             do \
             echo \"Testing install of compatible package ${pkg}\"; \
             yes | time crew install ${pkg}; \
             yes | time crew remove ${pkg}; \
-            done && \
+            done ) || true && \
             for file in ${ALL_CHANGED_FILES}; do
               ruby ../tests/prop_test $file && \
               ruby ../tests/buildsystem_test $file ; \

--- a/install.sh
+++ b/install.sh
@@ -359,8 +359,8 @@ else
   # Make the git default branch error messages go away.
   git config --global init.defaultBranch main
   # Help handle situations where GitHub is down.
-  git config --global http.lowSpeedLimit 1000
-  git config --global http.lowSpeedTime 5
+  git config http.lowSpeedLimit 1000
+  git config http.lowSpeedTime 5
 
   # Setup the folder with git information.
   git init --ref-format=reftable

--- a/install.sh
+++ b/install.sh
@@ -359,8 +359,8 @@ else
   # Make the git default branch error messages go away.
   git config --global init.defaultBranch main
   # Help handle situations where GitHub is down.
-  git config http.lowSpeedLimit 1000
-  git config http.lowSpeedTime 5
+  git config --local http.lowSpeedLimit 1000
+  git config --local http.lowSpeedTime 5
 
   # Setup the folder with git information.
   git init --ref-format=reftable

--- a/install.sh
+++ b/install.sh
@@ -358,6 +358,9 @@ else
 
   # Make the git default branch error messages go away.
   git config --global init.defaultBranch main
+  # Help handle situations where GitHub is down.
+  git config --global http.lowSpeedLimit 1000
+  git config --global http.lowSpeedTime 5
 
   # Setup the folder with git information.
   git init --ref-format=reftable

--- a/lib/buildsystems/autotools.rb
+++ b/lib/buildsystems/autotools.rb
@@ -2,7 +2,7 @@ require 'fileutils'
 require 'package'
 
 class Autotools < Package
-  property :configure_options, :pre_configure_options, :install_extras
+  property :configure_options, :pre_configure_options, :build_extras, :install_extras
 
   def self.build
     unless File.file?('Makefile') && CREW_CACHE_BUILD
@@ -27,6 +27,7 @@ class Autotools < Package
       system "#{@pre_configure_options} #{@mold_linker_prefix_cmd}./configure #{CREW_OPTIONS} #{@configure_options}"
     end
     system 'make'
+    @build_extras&.call
   end
 
   def self.install

--- a/lib/buildsystems/cmake.rb
+++ b/lib/buildsystems/cmake.rb
@@ -1,7 +1,7 @@
 require 'package'
 
 class CMake < Package
-  property :cmake_options, :pre_cmake_options
+  property :cmake_options, :pre_cmake_options, :cmake_build_extras, :cmake_install_extras
 
   def self.build
     puts "Additional cmake_options being used: #{@pre_cmake_options.nil? ? '<no pre_cmake_options>' : @pre_cmake_options} #{@cmake_options.nil? ? '<no cmake_options>' : @cmake_options}".orange
@@ -9,10 +9,12 @@ class CMake < Package
     @mold_linker_prefix_cmd = CREW_LINKER == 'mold' ? 'mold -run' : ''
     system "#{@pre_cmake_options} #{@mold_linker_prefix_cmd} cmake -B builddir -G Ninja #{@crew_cmake_options} #{@cmake_options}"
     system "#{CREW_NINJA} -C builddir"
+    @cmake_build_extras&.call
   end
 
   def self.install
     system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
+    @cmake_install_extras&.call
   end
 
   def self.check

--- a/lib/buildsystems/meson.rb
+++ b/lib/buildsystems/meson.rb
@@ -1,7 +1,7 @@
 require 'package'
 
 class Meson < Package
-  property :meson_options, :pre_meson_options, :meson_install_extras
+  property :meson_options, :pre_meson_options, :meson_build_extras, :meson_install_extras
 
   def self.build
     puts "Additional meson_options being used: #{@pre_meson_options.nil? ? '<no pre_meson_options>' : @pre_meson_options} #{@meson_options.nil? ? '<no meson_options>' : @meson_options}".orange
@@ -10,6 +10,7 @@ class Meson < Package
     system "#{@pre_meson_options} #{@mold_linker_prefix_cmd} meson setup #{@crew_meson_options} #{@meson_options} builddir"
     system 'meson configure --no-pager builddir'
     system "#{CREW_NINJA} -C builddir"
+    @meson_build_extras&.call
   end
 
   def self.install

--- a/lib/buildsystems/perl.rb
+++ b/lib/buildsystems/perl.rb
@@ -1,7 +1,7 @@
 require 'package'
 
 class PERL < Package
-  property :pre_perl_options, :perl_install_extras
+  property :pre_perl_options, :perl_build_extras, :perl_install_extras
 
   def self.prebuild
     puts "Additional pre_perl_options being used: #{@pre_perl_options.nil? ? '<no pre_perl_options>' : @pre_perl_options}".orange
@@ -12,6 +12,7 @@ class PERL < Package
   def self.build
     @mold_linker_prefix_cmd = CREW_LINKER == 'mold' ? 'mold -run' : ''
     system "#{@pre_perl_options} #{@mold_linker_prefix_cmd} make"
+    @perl_build_extras&.call
   end
 
   def self.install

--- a/lib/buildsystems/python.rb
+++ b/lib/buildsystems/python.rb
@@ -22,9 +22,11 @@ class Python < Package
     Dir.chdir(@python_build_relative_dir) do
       if File.file?('setup.py')
         puts "Python build options being used: #{PY3_SETUP_BUILD_OPTIONS} #{@python_build_options}".orange
+        puts "MAKEFLAGS=-j#{CREW_NPROC} python3 setup.py build #{PY3_SETUP_BUILD_OPTIONS} #{@python_build_options}" if CREW_VERBOSE
         system "MAKEFLAGS=-j#{CREW_NPROC} python3 setup.py build #{PY3_SETUP_BUILD_OPTIONS} #{@python_build_options}"
       else
         puts "Python build options being used: #{PY3_BUILD_OPTIONS}".orange
+        puts "MAKEFLAGS=-j#{CREW_NPROC} python3 -m build #{PY3_BUILD_OPTIONS}" if CREW_VERBOSE
         system "MAKEFLAGS=-j#{CREW_NPROC} python3 -m build #{PY3_BUILD_OPTIONS}"
       end
       @python_build_extras&.call
@@ -36,9 +38,11 @@ class Python < Package
       if File.file?('setup.py')
         @py_setup_install_options = @no_svem ? PY_SETUP_INSTALL_OPTIONS_NO_SVEM : PY_SETUP_INSTALL_OPTIONS
         puts "Python install options being used: #{@py_setup_install_options} #{@python_install_options}".orange
+        puts "MAKEFLAGS=-j#{CREW_NPROC} python3 setup.py install #{@py_setup_install_options} #{@python_install_options}" if CREW_VERBOSE
         system "MAKEFLAGS=-j#{CREW_NPROC} python3 setup.py install #{@py_setup_install_options} #{@python_install_options}"
       else
         puts "Python install options being used: #{PY3_INSTALLER_OPTIONS}".orange
+        puts "MAKEFLAGS=-j#{CREW_NPROC} python3 -m installer #{PY3_INSTALLER_OPTIONS}" if CREW_VERBOSE
         system "MAKEFLAGS=-j#{CREW_NPROC} python3 -m installer #{PY3_INSTALLER_OPTIONS}"
       end
       @python_install_extras&.call

--- a/lib/buildsystems/python.rb
+++ b/lib/buildsystems/python.rb
@@ -1,7 +1,14 @@
 require 'package'
 
 class Python < Package
-  property :python_build_options, :python_install_options, :python_install_extras, :no_svem
+  property :python_build_options, :python_install_options, :python_build_extras, :python_install_extras, :no_svem
+
+  attr_accessor :python_build_relative_dir
+
+  def initialize
+    super
+    @python_build_relative_dir = '.'
+  end
 
   def self.build
     # @required_pip_modules = %w[build installer setuptools wheel pyproject_hooks]
@@ -12,24 +19,29 @@ class Python < Package
     #    system "MAKEFLAGS=-j#{CREW_NPROC} pip install #{pip_pkg}"
     #  end
     # end
-    if File.file?('setup.py')
-      puts "Python build options being used: #{PY3_SETUP_BUILD_OPTIONS} #{@python_build_options}".orange
-      system "MAKEFLAGS=-j#{CREW_NPROC} python3 setup.py build #{PY3_SETUP_BUILD_OPTIONS} #{@python_build_options}"
-    else
-      puts "Python build options being used: #{PY3_BUILD_OPTIONS}".orange
-      system "MAKEFLAGS=-j#{CREW_NPROC} python3 -m build #{PY3_BUILD_OPTIONS}"
+    Dir.chdir(@python_build_relative_dir) do
+      if File.file?('setup.py')
+        puts "Python build options being used: #{PY3_SETUP_BUILD_OPTIONS} #{@python_build_options}".orange
+        system "MAKEFLAGS=-j#{CREW_NPROC} python3 setup.py build #{PY3_SETUP_BUILD_OPTIONS} #{@python_build_options}"
+      else
+        puts "Python build options being used: #{PY3_BUILD_OPTIONS}".orange
+        system "MAKEFLAGS=-j#{CREW_NPROC} python3 -m build #{PY3_BUILD_OPTIONS}"
+      end
+      @python_build_extras&.call
     end
   end
 
   def self.install
-    if File.file?('setup.py')
-      @py_setup_install_options = @no_svem ? PY_SETUP_INSTALL_OPTIONS_NO_SVEM : PY_SETUP_INSTALL_OPTIONS
-      puts "Python install options being used: #{@py_setup_install_options} #{@python_install_options}".orange
-      system "MAKEFLAGS=-j#{CREW_NPROC} python3 setup.py install #{@py_setup_install_options} #{@python_install_options}"
-    else
-      puts "Python install options being used: #{PY3_INSTALLER_OPTIONS}".orange
-      system "MAKEFLAGS=-j#{CREW_NPROC} python3 -m installer #{PY3_INSTALLER_OPTIONS}"
+    Dir.chdir(@python_build_relative_dir) do
+      if File.file?('setup.py')
+        @py_setup_install_options = @no_svem ? PY_SETUP_INSTALL_OPTIONS_NO_SVEM : PY_SETUP_INSTALL_OPTIONS
+        puts "Python install options being used: #{@py_setup_install_options} #{@python_install_options}".orange
+        system "MAKEFLAGS=-j#{CREW_NPROC} python3 setup.py install #{@py_setup_install_options} #{@python_install_options}"
+      else
+        puts "Python install options being used: #{PY3_INSTALLER_OPTIONS}".orange
+        system "MAKEFLAGS=-j#{CREW_NPROC} python3 -m installer #{PY3_INSTALLER_OPTIONS}"
+      end
+      @python_install_extras&.call
     end
-    @python_install_extras&.call
   end
 end

--- a/lib/buildsystems/qmake.rb
+++ b/lib/buildsystems/qmake.rb
@@ -1,11 +1,12 @@
 require 'package'
 
 class Qmake < Package
-  property :qmake_install_extras
+  property :qmake_build_extras, :qmake_install_extras
 
   def self.build
     system 'qmake'
     system 'make'
+    @qmake_build_extras&.call
   end
 
   def self.install

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -32,15 +32,15 @@ if File.exist?("#{CREW_PREFIX}/etc/env.d/00-path") && File.exist?("#{CREW_PREFIX
   FileUtils.rm "#{CREW_PREFIX}/etc/env.d/path"
 end
 
-# Set new sparse-checkout paths for commands directory
 Dir.chdir CREW_LIB_PATH do
+  # Set new sparse-checkout paths for commands directory
   system 'git sparse-checkout add commands'
   system 'git sparse-checkout reapply'
-end
 
-# Set git timeout values for situations where GitHub is down.
-system 'git config --global http.lowSpeedLimit 1000' if `git config --local http.lowSpeedLimit`.empty?
-system 'git config --global http.lowSpeedTime 5' if `git config --local http.lowSpeedTime`.empty?
+  # Set git timeout values for situations where GitHub is down.
+  system 'git config --local http.lowSpeedLimit 1000' if `git config --local http.lowSpeedLimit`.empty?
+  system 'git config --local http.lowSpeedTime 5' if `git config --local http.lowSpeedTime`.empty?
+end
 
 # Rename the binary_sha256 variable to sha256 in the device.json file
 system(" sed -i 's/binary_sha256/sha256/g' #{File.join(CREW_CONFIG_PATH, 'device.json')}")

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -39,8 +39,8 @@ Dir.chdir CREW_LIB_PATH do
 end
 
 # Set git timeout values for situations where GitHub is down.
-  system 'git config --global http.lowSpeedLimit 1000' if `git config --local http.lowSpeedLimit`.empty?
-  system 'git config --global http.lowSpeedTime 5' if `git config --local http.lowSpeedTime`.empty?
+system 'git config --global http.lowSpeedLimit 1000' if `git config --local http.lowSpeedLimit`.empty?
+system 'git config --global http.lowSpeedTime 5' if `git config --local http.lowSpeedTime`.empty?
 
 # Rename the binary_sha256 variable to sha256 in the device.json file
 system(" sed -i 's/binary_sha256/sha256/g' #{File.join(CREW_CONFIG_PATH, 'device.json')}")

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -38,6 +38,10 @@ Dir.chdir CREW_LIB_PATH do
   system 'git sparse-checkout reapply'
 end
 
+# Set git timeout values for situations where GitHub is down.
+  system 'git config --global http.lowSpeedLimit 1000' if `git config --local http.lowSpeedLimit`.empty?
+  system 'git config --global http.lowSpeedTime 5' if `git config --local http.lowSpeedTime`.empty?
+
 # Rename the binary_sha256 variable to sha256 in the device.json file
 system(" sed -i 's/binary_sha256/sha256/g' #{File.join(CREW_CONFIG_PATH, 'device.json')}")
 

--- a/manifest/armv7l/g/gtk4.filelist
+++ b/manifest/armv7l/g/gtk4.filelist
@@ -415,7 +415,7 @@
 /usr/local/lib/gtk-4.0/4.0.0/printbackends/libprintbackend-file.so
 /usr/local/lib/libgtk-4.so
 /usr/local/lib/libgtk-4.so.1
-/usr/local/lib/libgtk-4.so.1.1504.0
+/usr/local/lib/libgtk-4.so.1.1505.0
 /usr/local/lib/pkgconfig/gtk4-atspi.pc
 /usr/local/lib/pkgconfig/gtk4-broadway.pc
 /usr/local/lib/pkgconfig/gtk4-unix-print.pc

--- a/manifest/armv7l/l/libdrm.filelist
+++ b/manifest/armv7l/l/libdrm.filelist
@@ -69,3 +69,9 @@
 /usr/local/lib/pkgconfig/libdrm_radeon.pc
 /usr/local/lib/pkgconfig/libdrm_vc4.pc
 /usr/local/share/libdrm/amdgpu.ids
+/usr/local/share/man/man3/drmAvailable.3.zst
+/usr/local/share/man/man3/drmHandleEvent.3.zst
+/usr/local/share/man/man3/drmModeGetResources.3.zst
+/usr/local/share/man/man7/drm-kms.7.zst
+/usr/local/share/man/man7/drm-memory.7.zst
+/usr/local/share/man/man7/drm.7.zst

--- a/manifest/armv7l/m/mesa.filelist
+++ b/manifest/armv7l/m/mesa.filelist
@@ -24,6 +24,8 @@
 /usr/local/lib/dri/kirin_dri.so
 /usr/local/lib/dri/kms_swrast_dri.so
 /usr/local/lib/dri/komeda_dri.so
+/usr/local/lib/dri/libdril_dri.so
+/usr/local/lib/dri/libgallium_drv_video.so
 /usr/local/lib/dri/lima_dri.so
 /usr/local/lib/dri/mali-dp_dri.so
 /usr/local/lib/dri/mcde_dri.so
@@ -55,8 +57,8 @@
 /usr/local/lib/dri/v3d_dri.so
 /usr/local/lib/dri/virtio_gpu_dri.so
 /usr/local/lib/dri/virtio_gpu_drv_video.so
+/usr/local/lib/dri/vkms_dri.so
 /usr/local/lib/dri/vmwgfx_dri.so
-/usr/local/lib/dri/zink_dri.so
 /usr/local/lib/dri/zynqmp-dpsub_dri.so
 /usr/local/lib/gbm/tls/pvr_gbm.so
 /usr/local/lib/libEGL_mesa.so
@@ -65,15 +67,13 @@
 /usr/local/lib/libGLX_mesa.so
 /usr/local/lib/libGLX_mesa.so.0
 /usr/local/lib/libGLX_mesa.so.0.0.0
+/usr/local/lib/libgallium-24.2.0.so
 /usr/local/lib/libgbm.so
 /usr/local/lib/libgbm.so.1
 /usr/local/lib/libgbm.so.1.0.0
 /usr/local/lib/libglapi.so
 /usr/local/lib/libglapi.so.0
 /usr/local/lib/libglapi.so.0.0.0
-/usr/local/lib/liblua.so
-/usr/local/lib/liblua.so.5.4
-/usr/local/lib/liblua.so.5.4.6
 /usr/local/lib/libvulkan_intel.so
 /usr/local/lib/libvulkan_lvp.so
 /usr/local/lib/libxatracker.so
@@ -82,6 +82,7 @@
 /usr/local/lib/pkgconfig/dri.pc
 /usr/local/lib/pkgconfig/gbm.pc
 /usr/local/lib/pkgconfig/xatracker.pc
+/usr/local/lib/vdpau/libvdpau_gallium.so.1.0.0
 /usr/local/lib/vdpau/libvdpau_nouveau.so
 /usr/local/lib/vdpau/libvdpau_nouveau.so.1
 /usr/local/lib/vdpau/libvdpau_nouveau.so.1.0

--- a/manifest/armv7l/m/mesa.filelist
+++ b/manifest/armv7l/m/mesa.filelist
@@ -74,6 +74,9 @@
 /usr/local/lib/libglapi.so
 /usr/local/lib/libglapi.so.0
 /usr/local/lib/libglapi.so.0.0.0
+/usr/local/lib/liblua.so
+/usr/local/lib/liblua.so.5.4
+/usr/local/lib/liblua.so.5.4.6
 /usr/local/lib/libvulkan_intel.so
 /usr/local/lib/libvulkan_lvp.so
 /usr/local/lib/libxatracker.so

--- a/manifest/x86_64/g/gtk4.filelist
+++ b/manifest/x86_64/g/gtk4.filelist
@@ -415,7 +415,7 @@
 /usr/local/lib64/gtk-4.0/4.0.0/printbackends/libprintbackend-file.so
 /usr/local/lib64/libgtk-4.so
 /usr/local/lib64/libgtk-4.so.1
-/usr/local/lib64/libgtk-4.so.1.1504.0
+/usr/local/lib64/libgtk-4.so.1.1505.0
 /usr/local/lib64/pkgconfig/gtk4-atspi.pc
 /usr/local/lib64/pkgconfig/gtk4-broadway.pc
 /usr/local/lib64/pkgconfig/gtk4-unix-print.pc

--- a/manifest/x86_64/m/mesa.filelist
+++ b/manifest/x86_64/m/mesa.filelist
@@ -9,6 +9,8 @@
 /usr/local/lib64/dri/i915_dri.so
 /usr/local/lib64/dri/iris_dri.so
 /usr/local/lib64/dri/kms_swrast_dri.so
+/usr/local/lib64/dri/libdril_dri.so
+/usr/local/lib64/dri/libgallium_drv_video.so
 /usr/local/lib64/dri/nouveau_dri.so
 /usr/local/lib64/dri/nouveau_drv_video.so
 /usr/local/lib64/dri/r300_dri.so
@@ -21,7 +23,6 @@
 /usr/local/lib64/dri/virtio_gpu_dri.so
 /usr/local/lib64/dri/virtio_gpu_drv_video.so
 /usr/local/lib64/dri/vmwgfx_dri.so
-/usr/local/lib64/dri/zink_dri.so
 /usr/local/lib64/gbm/tls/amdgpu_gbm.so
 /usr/local/lib64/gbm/tls/i915_gbm.so
 /usr/local/lib64/libEGL_mesa.so
@@ -30,6 +31,7 @@
 /usr/local/lib64/libGLX_mesa.so
 /usr/local/lib64/libGLX_mesa.so.0
 /usr/local/lib64/libGLX_mesa.so.0.0.0
+/usr/local/lib64/libgallium-24.2.0.so
 /usr/local/lib64/libgbm.so
 /usr/local/lib64/libgbm.so.1
 /usr/local/lib64/libgbm.so.1.0.0
@@ -46,6 +48,7 @@
 /usr/local/lib64/pkgconfig/dri.pc
 /usr/local/lib64/pkgconfig/gbm.pc
 /usr/local/lib64/pkgconfig/xatracker.pc
+/usr/local/lib64/vdpau/libvdpau_gallium.so.1.0.0
 /usr/local/lib64/vdpau/libvdpau_nouveau.so
 /usr/local/lib64/vdpau/libvdpau_nouveau.so.1
 /usr/local/lib64/vdpau/libvdpau_nouveau.so.1.0

--- a/packages/gtk4.rb
+++ b/packages/gtk4.rb
@@ -3,7 +3,7 @@ require 'buildsystems/meson'
 class Gtk4 < Meson
   description 'GTK+ is a multi-platform toolkit for creating graphical user interfaces.'
   homepage 'https://developer.gnome.org/gtk4/'
-  version '4.15.4'
+  version '4.15.5'
   license 'LGPL-2.1'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.gnome.org/GNOME/gtk.git'
@@ -11,9 +11,9 @@ class Gtk4 < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '24afa2516f6bbbd290735f58c1cdbdcea63f832423f88abf5b0bae1bc1343f4e',
-     armv7l: '24afa2516f6bbbd290735f58c1cdbdcea63f832423f88abf5b0bae1bc1343f4e',
-     x86_64: '11dd98f1d841007c830e9a2fe9b8fe98f105db0070a0de585f64a081c154ed21'
+    aarch64: '5d67fcdbe9b84b41ec4df666ec7e94f632b8582df939adef91325f871ae0fca2',
+     armv7l: '5d67fcdbe9b84b41ec4df666ec7e94f632b8582df939adef91325f871ae0fca2',
+     x86_64: '7efdc475f5ede9b6921a9e33408fea25dd1267d9ca9320c26c358d0406b13b33'
   })
 
   # L = Logical Dependency, R = Runtime Dependency
@@ -85,11 +85,10 @@ class Gtk4 < Meson
     end
   end
 
-  def self.build
-    system "mold -run meson setup #{CREW_MESON_OPTIONS} \
-      -Dbroadway-backend=true \
+  meson_options '-Dbroadway-backend=true \
       -Dbuild-demos=false \
       -Dbuild-examples=false \
+      -Dbuild-tests=false \
       -Dbuild-testsuite=false \
       -Dcloudproviders=enabled \
       -Dgraphene:default_library=both \
@@ -98,10 +97,9 @@ class Gtk4 < Meson
       -Dmedia-gstreamer=disabled \
       -Dmutest:default_library=both \
       -Dprint-cups=auto \
-      -Dvulkan=enabled \
-      builddir"
-    system 'meson configure --no-pager builddir'
-    system "#{CREW_NINJA} -C builddir"
+      -Dvulkan=enabled'
+
+  meson_build_extras do
     File.write 'gtk4settings', <<~GTK4_CONFIG_HEREDOC
       [Settings]
       gtk-icon-theme-name = Adwaita
@@ -110,9 +108,8 @@ class Gtk4 < Meson
     GTK4_CONFIG_HEREDOC
   end
 
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
-    @xdg_config_dest_home = "#{CREW_DEST_PREFIX}/.config"
-    FileUtils.install 'gtk4settings', "#{@xdg_config_dest_home}/gtk-4.0/settings.ini", mode: 0o644
+  meson_install_extras do
+    xdg_config_dest_home = File.join(CREW_DEST_PREFIX, '.config')
+    FileUtils.install 'gtk4settings', "#{xdg_config_dest_home}/gtk-4.0/settings.ini", mode: 0o644
   end
 end

--- a/packages/libdrm.rb
+++ b/packages/libdrm.rb
@@ -3,7 +3,7 @@ require 'buildsystems/meson'
 class Libdrm < Meson
   description 'Cross-driver middleware for DRI protocol.'
   homepage 'https://dri.freedesktop.org/wiki/'
-  version '2.4.120'
+  version '2.4.122'
   license 'MIT'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.freedesktop.org/mesa/drm.git'
@@ -11,9 +11,9 @@ class Libdrm < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '1c91745b09ab0be5a92704565cbbc16bff8a2397d9d7638349a0b2bb90d1c346',
-     armv7l: '1c91745b09ab0be5a92704565cbbc16bff8a2397d9d7638349a0b2bb90d1c346',
-     x86_64: 'd6ba50ad22ddfdf576fc544a8e164a68fa8e543c13bea9bc654231b00db0a975'
+    aarch64: 'e2bc6660676c581685ea0a7ae370f04c98e68951d9967b1c4eded48c764052a3',
+     armv7l: 'e2bc6660676c581685ea0a7ae370f04c98e68951d9967b1c4eded48c764052a3',
+     x86_64: 'cf7faca3da977cde68110f3b7247a11dbf97cfc515c3abb8228e39d52aa67406'
   })
 
   depends_on 'cairo' # R

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -73,8 +73,7 @@ class Mesa < Meson
     -Dvulkan-drivers='#{ARCH == 'x86_64' ? 'amd, intel, intel_hasvk, swrast' : 'auto'}' \
     -Dvideo-codecs='all'"
 
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
+  meson_install_extras do
     # The following are hacks to keep sommelier from complaining.
     Dir.chdir("#{CREW_DEST_LIB_PREFIX}/dri") do
       FileUtils.ln_s '.', 'tls' unless File.exist?('tls')

--- a/packages/mesa.rb
+++ b/packages/mesa.rb
@@ -3,7 +3,7 @@ require 'buildsystems/meson'
 class Mesa < Meson
   description 'Open-source implementation of the OpenGL specification'
   homepage 'https://www.mesa3d.org'
-  version '24.1.5-llvm18'
+  version '24.2.0-llvm18'
   license 'MIT'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://gitlab.freedesktop.org/mesa/mesa.git'
@@ -11,9 +11,9 @@ class Mesa < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'f3148e24427181e0c0a9e1e043ff2cd20927d1b391abd625fa4a0108ebc1e717',
-     armv7l: 'f3148e24427181e0c0a9e1e043ff2cd20927d1b391abd625fa4a0108ebc1e717',
-     x86_64: 'e16ce6731e7da1d3e95013886250d149322703a796617490c31be19b9d2dda44'
+    aarch64: '2187c4e1be27af6163d4be9685ca1ea4a968fcc8630afb9f47fe46c805332d5d',
+     armv7l: '2187c4e1be27af6163d4be9685ca1ea4a968fcc8630afb9f47fe46c805332d5d',
+     x86_64: '811ea7963e98b9c82494ec4c3e69c34ed65592b98e5fa85aea610ba2941b2028'
   })
 
   depends_on 'elfutils' # R

--- a/tests/unit_test.sh
+++ b/tests/unit_test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 # This is for use as a Github CI Pull Request Unit Test.
+echo "ALL_CHANGED FILES is ${ALL_CHANGED_FILES}."
+echo "CHANGED PACKAGES is ${CHANGED_PACKAGES}."
 cd /usr/local/lib/crew/packages/
 yes | crew upgrade
 yes | crew install vim

--- a/tests/unit_test.sh
+++ b/tests/unit_test.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -e
 # This is for use as a Github CI Pull Request Unit Test.
+cd /usr/local/lib/crew/packages/
 yes | crew upgrade
 yes | crew install vim
 yes | crew remove vim

--- a/tests/unit_test.sh
+++ b/tests/unit_test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+# This is for use as a Github CI Pull Request Unit Test.
+yes | crew upgrade
+yes | crew install vim
+yes | crew remove vim
+ruby ../tests/commands/const.rb
+ruby ../tests/commands/help.rb
+ruby ../tests/commands/prop.rb
+[[ -v $ALL_CHANGED_FILES ]] && [[ -n $ALL_CHANGED_FILES ]] && (
+  [[ -n ${CHANGED_PACKAGES-} ]] && \
+    (
+    all_compatible_packages=$(crew list -d compatible)
+    for pkg in ${CHANGED_PACKAGES}
+      do
+    if echo "${all_compatible_packages}" | grep "^${pkg}$"; then
+      echo "Testing install of compatible package ${pkg}"
+      yes | time crew install "${pkg}"
+      yes | time crew remove "${pkg}"
+    fi
+    done) && \
+  for file in ${ALL_CHANGED_FILES}; do
+    ruby ../tests/prop_test "$file"
+    ruby ../tests/buildsystem_test "$file"
+  done )
+cd ~
+git clone --depth=1 https://github.com/chromebrew/chromebrew.git build_test
+cd build_test
+yes | CREW_CACHE_ENABLED=1 crew build -vf packages/hello_world_chromebrew.rb

--- a/tests/unit_test.sh
+++ b/tests/unit_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 # This is for use as a Github CI Pull Request Unit Test.
-echo "ALL_CHANGED FILES is ${ALL_CHANGED_FILES}."
-echo "CHANGED_PACKAGES is ${CHANGED_PACKAGES}."
+echo "ALL_CHANGED FILES is/are ${ALL_CHANGED_FILES}."
+echo "CHANGED_PACKAGES is/are ${CHANGED_PACKAGES}."
 cd /usr/local/lib/crew/packages/
 yes | crew upgrade
 yes | crew install vim


### PR DESCRIPTION
- Fixes GitHub CI Unit Tests and makes them easier to change.
- Updates `gtk4`, `libdrm`, and `mesa`.
- Adds build extras and install extras to all build systems.
- Adds `git` config options to handle GitHub outages such that `crew update` will hopefully return quicker.

##
Builds:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=unit_test crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
