### PR TITLE
Google_chrome 127.0.6533.99-1 => 127.0.6533.119-1

### DIFF
--- a/packages/google_chrome.rb
+++ b/packages/google_chrome.rb
@@ -4,12 +4,12 @@ class Google_chrome < Package
   @update_channel = 'stable'
   description 'Google Chrome is a fast, easy to use, and secure web browser.'
   homepage 'https://www.google.com/chrome/'
-  version '127.0.6533.99-1'
+  version '127.0.6533.119-1'
   license 'google-chrome'
   compatibility 'x86_64'
   min_glibc '2.25'
   source_url "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-#{@update_channel}/google-chrome-#{@update_channel}_#{@version}_amd64.deb"
-  source_sha256 'a4c18b49a8b80bf5e27c5911994a13446ff77444c62575a125b7b0b5bfeccd58'
+  source_sha256 '93daec10b02d38574b4a2d5d3935782ebec4d94bb9b11d7f18e2fd0560ea665e'
 
   depends_on 'nss'
   depends_on 'cairo'


### PR DESCRIPTION
##
Tested & (not) Working properly:
- [x] `x86_64` Does not launch in hatch m126 container
- [ ] `i686`
- [ ] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-google_chrome crew update \
&& yes | crew upgrade
```
