### PR TITLE
Have compatibility also notice when min_glibc is too high for a package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Where available commands are:
 | files        | display installed files of package(s) |
 | help         | get information about command usage |
 | install      | install package(s) along with dependencies after prompting for confirmation |
-| list         | available, installed, compatible or incompatible packages |
+| list         | available, compatible, incompatible, essential, installed packages |
 | postinstall  | display postinstall messages of package(s) |
 | prop         | display all package boolean properties |
 | reinstall    | remove and install package(s) |

--- a/bin/crew
+++ b/bin/crew
@@ -1616,7 +1616,7 @@ def build_command(args)
       resolve_dependencies_and_build
     else
       puts 'Unable to build a fake package. Skipping build.'.lightred if @pkg.is_fake?
-      puts "Package #{@pkg.name} is not compatible with your device architecture (#{ARCH}). Skipping build.".lightred unless PackageUtils.compatible?(@pkg)
+      puts "Package #{@pkg.name} is not compatible with your device. Skipping build.".lightred unless PackageUtils.compatible?(@pkg)
       puts 'Unable to build without source. Skipping build.'.lightred unless @pkg.source?(ARCH) && @pkg.source_url.to_s.upcase != 'SKIP'
       puts 'Compile not needed. Skipping build.'.lightred if @pkg.no_compile_needed?
     end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -2,7 +2,7 @@
 # Defines common constants used in different parts of crew
 require 'etc'
 
-CREW_VERSION = '1.50.4'
+CREW_VERSION = '1.50.5'
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]

--- a/lib/package_utils.rb
+++ b/lib/package_utils.rb
@@ -25,7 +25,7 @@ class PackageUtils
   end
 
   def self.compatible?(pkg)
-    return pkg.compatibility.casecmp?('all') || pkg.compatibility.include?(ARCH)
+    return (pkg.compatibility.casecmp?('all') || pkg.compatibility.include?(ARCH)) && (pkg.min_glibc.nil? ? true : (pkg.min_glibc <= LIBC_VERSION))
   end
 
   def self.get_url(pkg, build_from_source: false)

--- a/lib/package_utils.rb
+++ b/lib/package_utils.rb
@@ -25,7 +25,7 @@ class PackageUtils
   end
 
   def self.compatible?(pkg)
-    return (pkg.compatibility.casecmp?('all') || pkg.compatibility.include?(ARCH)) && (pkg.min_glibc.nil? ? true : (pkg.min_glibc <= LIBC_VERSION))
+    return (pkg.compatibility.casecmp?('all') || pkg.compatibility.include?(ARCH)) && (pkg.min_glibc.nil? || (pkg.min_glibc <= LIBC_VERSION))
   end
 
   def self.get_url(pkg, build_from_source: false)


### PR DESCRIPTION
Fixes #10284

- Also edit README to mention `crew list essential` option.
- `crew list compatible | grep gstreamer` will be blank on the older containers...

##
Builds:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=compatible crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
