### PR TITLE
Binutils 2.43-gcc14 => 2.43.1-gcc14

### DIFF
--- a/manifest/armv7l/b/binutils.filelist
+++ b/manifest/armv7l/b/binutils.filelist
@@ -105,7 +105,7 @@
 /usr/local/lib/ldscripts/armelfb_linux_eabi.xwer
 /usr/local/lib/ldscripts/stamp
 /usr/local/lib/libbfd-2.39.50.so
-/usr/local/lib/libbfd-2.43.so
+/usr/local/lib/libbfd-2.43.1.so
 /usr/local/lib/libbfd.a
 /usr/local/lib/libbfd.la
 /usr/local/lib/libbfd.so
@@ -121,7 +121,7 @@
 /usr/local/lib/libctf.so.0.0.0
 /usr/local/lib/libiberty.a
 /usr/local/lib/libopcodes-2.39.50.so
-/usr/local/lib/libopcodes-2.43.so
+/usr/local/lib/libopcodes-2.43.1.so
 /usr/local/lib/libopcodes.a
 /usr/local/lib/libopcodes.la
 /usr/local/lib/libopcodes.so

--- a/manifest/i686/b/binutils.filelist
+++ b/manifest/i686/b/binutils.filelist
@@ -167,7 +167,7 @@
 /usr/local/lib/ldscripts/elf_x86_64.xwer
 /usr/local/lib/ldscripts/stamp
 /usr/local/lib/libbfd-2.39.50.so
-/usr/local/lib/libbfd-2.43.so
+/usr/local/lib/libbfd-2.43.1.so
 /usr/local/lib/libbfd.a
 /usr/local/lib/libbfd.la
 /usr/local/lib/libbfd.so
@@ -183,7 +183,7 @@
 /usr/local/lib/libctf.so.0.0.0
 /usr/local/lib/libiberty.a
 /usr/local/lib/libopcodes-2.39.50.so
-/usr/local/lib/libopcodes-2.43.so
+/usr/local/lib/libopcodes-2.43.1.so
 /usr/local/lib/libopcodes.a
 /usr/local/lib/libopcodes.la
 /usr/local/lib/libopcodes.so

--- a/manifest/x86_64/b/binutils.filelist
+++ b/manifest/x86_64/b/binutils.filelist
@@ -167,7 +167,7 @@
 /usr/local/lib64/ldscripts/elf_x86_64.xwer
 /usr/local/lib64/ldscripts/stamp
 /usr/local/lib64/libbfd-2.39.50.so
-/usr/local/lib64/libbfd-2.43.so
+/usr/local/lib64/libbfd-2.43.1.so
 /usr/local/lib64/libbfd.a
 /usr/local/lib64/libbfd.la
 /usr/local/lib64/libbfd.so
@@ -183,7 +183,7 @@
 /usr/local/lib64/libctf.so.0.0.0
 /usr/local/lib64/libiberty.a
 /usr/local/lib64/libopcodes-2.39.50.so
-/usr/local/lib64/libopcodes-2.43.so
+/usr/local/lib64/libopcodes-2.43.1.so
 /usr/local/lib64/libopcodes.a
 /usr/local/lib64/libopcodes.la
 /usr/local/lib64/libopcodes.so

--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -5,18 +5,18 @@ require 'package'
 class Binutils < Package
   description 'The GNU Binutils are a collection of binary tools.'
   homepage 'https://www.gnu.org/software/binutils/'
-  version '2.43-gcc14'
+  version '2.43.1-gcc14'
   license 'GPL-3+'
   compatibility 'all'
   source_url "https://ftpmirror.gnu.org/binutils/binutils-#{version.split('-').first}.tar.bz2"
-  source_sha256 'fed3c3077f0df7a4a1aa47b080b8c53277593ccbb4e5e78b73ffb4e3f265e750'
+  source_sha256 'becaac5d295e037587b63a42fad57fe3d9d7b83f478eb24b67f9eec5d0f1872f'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '2495535e6fb7b8d8ed7eadd4072192cd14526f0edb111b57968aa6fc43b93a00',
-     armv7l: '2495535e6fb7b8d8ed7eadd4072192cd14526f0edb111b57968aa6fc43b93a00',
-       i686: 'd31cfcbf745167c12d286284bc46d72c56a4e43c22fa0d27c39458ec0355c88e',
-     x86_64: '2c7087344bd4eee7df8402b6a69f4e2d043163298eb37ff68b1a74dc7324dbae'
+    aarch64: '2054d452f15cb8b018453e863f04421ee5cec46da7af695ab279f0060ebbc00d',
+     armv7l: '2054d452f15cb8b018453e863f04421ee5cec46da7af695ab279f0060ebbc00d',
+       i686: '62db3f76719701daf87f4e299bfc033b8adeb39dea00a991b59a25a7b48a52e0',
+     x86_64: 'd457df70b8784a7e8ffcb641f377731d87846b8d269c4d5c8c94a1b2bf2ef361'
   })
 
   depends_on 'elfutils' # R


### PR DESCRIPTION
##
Builds:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-binutils crew update \
&& yes | crew upgrade
```
To test executables, run the following:
```
for b in $(crew files binutils|grep /usr/local/bin); do $b --version; done
```