### PR TITLE
Rebuild qt5_base for icu75.1, update qbittorrent, adjust qmake buildsystem

### DIFF
--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -28,9 +28,9 @@ jobs:
             echo "ALL_CHANGED FILES: ${ALL_CHANGED_FILES}." && \
             export CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES} | sed -e 's,packages/,,g' -e 's,\.rb,,g' | sort)" && \
             echo "CHANGED PACKAGES: ${CHANGED_PACKAGES}." && \
-            export GLIBC_227_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do if ! grep -q min_glibc packages/$i.rb; then echo $i ; else grep min_glibc packages/$i.rb | tr -d \' | awk '{exit $2 < 2.27}' || echo $i ; fi ; done | xargs)" && \
+            export GLIBC_227_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do if ! grep -q min_glibc packages/$i.rb; then echo $i ; else grep min_glibc packages/$i.rb | tr -d \' | awk '{exit $2 <= 2.27}' || echo $i ; fi ; done | xargs)" && \
             echo "PR #${PR_NUMBER} has these possibly Glibc 2.27 compatible packages: ${GLIBC_227_COMPATIBLE_PACKAGES}" && \
-            export GLIBC_237_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do grep min_glibc packages/$i.rb | tr -d \' | awk '{exit $2 < 2.37}' || echo $i ; done | xargs)" && \
+            export GLIBC_237_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do grep min_glibc packages/$i.rb | tr -d \' | awk '{exit $2 <= 2.37}' || echo $i ; done | xargs)" && \
             echo "PR #${PR_NUMBER} has these possibly Glibc 2.37 compatible packages: ${GLIBC_237_COMPATIBLE_PACKAGES}" && \
             export X86_64_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do grep -q "compatibility.*all\|x86_64" packages/${p}.rb && echo ${p}; done | xargs)" && \
             echo "PR #${PR_NUMBER} has these x86_64 compatible packages: ${X86_64_PACKAGES}" && \
@@ -61,9 +61,9 @@ jobs:
             echo "ALL_CHANGED FILES: ${ALL_CHANGED_FILES}." && \
             export CHANGED_PACKAGES="$(echo ${ALL_CHANGED_FILES} | sed -e 's,packages/,,g' -e 's,\.rb,,g' | sort)" && \
             echo "CHANGED PACKAGES: ${CHANGED_PACKAGES}." && \
-            export GLIBC_227_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do if ! grep -q min_glibc packages/$i.rb; then echo $i ; else grep min_glibc packages/$i.rb | tr -d \' | awk '{exit $2 < 2.27}' || echo $i ; fi ; done | xargs)" && \
+            export GLIBC_227_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do if ! grep -q min_glibc packages/$i.rb; then echo $i ; else grep min_glibc packages/$i.rb | tr -d \' | awk '{exit $2 <= 2.27}' || echo $i ; fi ; done | xargs)" && \
             echo "PR #${PR_NUMBER} has these possibly Glibc 2.27 compatible packages: ${GLIBC_227_COMPATIBLE_PACKAGES}" && \
-            export GLIBC_237_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do grep min_glibc packages/$i.rb | tr -d \' | awk '{exit $2 < 2.37}' || echo $i ; done | xargs)" && \
+            export GLIBC_237_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do grep min_glibc packages/$i.rb | tr -d \' | awk '{exit $2 <= 2.37}' || echo $i ; done | xargs)" && \
             echo "PR #${PR_NUMBER} has these possibly Glibc 2.37 compatible packages: ${GLIBC_237_COMPATIBLE_PACKAGES}" && \
             export X86_64_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do grep -q "compatibility.*all\|x86_64" packages/${p}.rb && echo ${p}; done | xargs)" && \
             echo "PR #${PR_NUMBER} has these x86_64 compatible packages: ${X86_64_PACKAGES}" && \

--- a/lib/buildsystems/qmake.rb
+++ b/lib/buildsystems/qmake.rb
@@ -4,7 +4,7 @@ class Qmake < Package
   property :qmake_build_extras, :qmake_install_extras
 
   def self.build
-    system 'qmake'
+    system "QMAKE_CXX='g++ #{ARCH == 'x86_64' && LIBC_VERSION.to_f >= 2.35 ? File.join(CREW_LIB_PREFIX, 'libC.so.6').to_s : ''}' qmake"
     system 'make'
     @qmake_build_extras&.call
   end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -2,7 +2,7 @@
 # Defines common constants used in different parts of crew
 require 'etc'
 
-CREW_VERSION = '1.50.7'
+CREW_VERSION = '1.50.8'
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]

--- a/manifest/armv7l/q/qbittorrent.filelist
+++ b/manifest/armv7l/q/qbittorrent.filelist
@@ -27,4 +27,4 @@
 /usr/local/share/icons/hicolor/scalable/status/qbittorrent-tray-light.svg
 /usr/local/share/icons/hicolor/scalable/status/qbittorrent-tray.svg
 /usr/local/share/man/man1/qbittorrent.1.zst
-/usr/local/share/metainfo/org.qbittorrent.qBittorrent.appdata.xml
+/usr/local/share/metainfo/org.qbittorrent.qBittorrent.metainfo.xml

--- a/manifest/x86_64/q/qbittorrent.filelist
+++ b/manifest/x86_64/q/qbittorrent.filelist
@@ -27,4 +27,4 @@
 /usr/local/share/icons/hicolor/scalable/status/qbittorrent-tray-light.svg
 /usr/local/share/icons/hicolor/scalable/status/qbittorrent-tray.svg
 /usr/local/share/man/man1/qbittorrent.1.zst
-/usr/local/share/metainfo/org.qbittorrent.qBittorrent.appdata.xml
+/usr/local/share/metainfo/org.qbittorrent.qBittorrent.metainfo.xml

--- a/packages/nlopt.rb
+++ b/packages/nlopt.rb
@@ -1,0 +1,30 @@
+# Adapted from Arch Linux nlopt PKGBUILD at:
+# https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=nlopt
+
+require 'buildsystems/cmake'
+
+class Nlopt < CMake
+  description 'nonlinear optimization library'
+  homepage 'http://ab-initio.mit.edu/wiki/index.php/NLopt'
+  version '2.8.0'
+  license 'LGPL'
+  compatibility 'x86_64 aarch64 armv7l'
+  source_url 'https://github.com/stevengj/nlopt.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+    aarch64: 'a5bf199ecc5efc14f09291e63e5a76f203f5eeed5ccf439e33dddedd869ea9db',
+     armv7l: 'a5bf199ecc5efc14f09291e63e5a76f203f5eeed5ccf439e33dddedd869ea9db',
+     x86_64: '1496c02e877846e402cd8de0fabc917e1912ca9b73f977861fd58fc272be2e6f'
+  })
+
+  depends_on 'gcc_lib' # R
+  depends_on 'glibc_lib' # R
+  depends_on 'guile' => :build
+  depends_on 'octave' # R
+  depends_on 'py3_numpy' => :build
+  depends_on 'swig' => :build
+
+  cmake_options '-DNLOPT_MATLAB=OFF -DNLOPT_CXX=ON -DNLOPT_SWIG=OFF -DNLOPT_LINK_PYTHON=OFF'
+end

--- a/packages/obs.rb
+++ b/packages/obs.rb
@@ -20,7 +20,7 @@ class Obs < Package
   depends_on 'jansson'
   depends_on 'libmbedtls'
   depends_on 'luajit'
-  depends_on 'qtsvg'
+  depends_on 'qt5_svg'
   depends_on 'qtx11extras'
   depends_on 'v4l_utils'
   depends_on 'xdg_base'

--- a/packages/obs.rb
+++ b/packages/obs.rb
@@ -21,7 +21,7 @@ class Obs < Package
   depends_on 'libmbedtls'
   depends_on 'luajit'
   depends_on 'qt5_svg'
-  depends_on 'qtx11extras'
+  depends_on 'qt5_x11extras'
   depends_on 'v4l_utils'
   depends_on 'xdg_base'
   depends_on 'sommelier'

--- a/packages/plplot.rb
+++ b/packages/plplot.rb
@@ -1,6 +1,6 @@
-require 'package'
+require 'buildsystems/cmake'
 
-class Plplot < Package
+class Plplot < CMake
   description 'PLplot is a cross-platform software package for creating scientific plots'
   homepage 'https://plplot.sourceforge.net/'
   version '5.15.0'
@@ -16,10 +16,10 @@ class Plplot < Package
      x86_64: '6aa2d9509f13283391d604ae0e3d9ff501f0ccf3a527ac0fe6e584d20d2f30a0'
   })
 
-  depends_on 'openjdk8'
   depends_on 'libharu'
   depends_on 'lua'
   depends_on 'ocaml'
+  depends_on 'openjdk8'
   depends_on 'pango'
   depends_on 'qhull'
   depends_on 'qt5_svg'
@@ -27,29 +27,5 @@ class Plplot < Package
   depends_on 'tk'
   depends_on 'wxwidgets'
 
-  def self.build
-    Dir.mkdir 'build'
-    Dir.chdir 'build' do
-      system 'cmake',
-             '-DBUILD_TEST=ON',
-             '-DENABLE_DYNDRIVERS=OFF',
-             '-DUSE_INCRTCL_VERSION_4=ON',
-             "-DLIB_DIR=#{CREW_LIB_PREFIX}",
-             "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
-             '..'
-      system 'make'
-    end
-  end
-
-  def self.check
-    Dir.chdir 'build' do
-      # system 'ctest'
-    end
-  end
-
-  def self.install
-    Dir.chdir 'build' do
-      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    end
-  end
+  cmake_options '-DBUILD_TEST=ON -DENABLE_DYNDRIVERS=OFF -DUSE_INCRTCL_VERSION_4=ON'
 end

--- a/packages/plplot.rb
+++ b/packages/plplot.rb
@@ -22,7 +22,7 @@ class Plplot < Package
   depends_on 'ocaml'
   depends_on 'pango'
   depends_on 'qhull'
-  depends_on 'qtsvg'
+  depends_on 'qt5_svg'
   depends_on 'swig'
   depends_on 'tk'
   depends_on 'wxwidgets'

--- a/packages/plplot.rb
+++ b/packages/plplot.rb
@@ -16,7 +16,7 @@ class Plplot < Package
      x86_64: '6aa2d9509f13283391d604ae0e3d9ff501f0ccf3a527ac0fe6e584d20d2f30a0'
   })
 
-  depends_on 'jdk8'
+  depends_on 'openjdk8'
   depends_on 'libharu'
   depends_on 'lua'
   depends_on 'ocaml'

--- a/packages/qbittorrent.rb
+++ b/packages/qbittorrent.rb
@@ -6,6 +6,7 @@ class Qbittorrent < CMake
   version '4.6.6'
   license 'GPL-2'
   compatibility 'x86_64 aarch64 armv7l'
+  min_glibc '2.37'
   source_url 'https://downloads.sourceforge.net/project/qbittorrent/qbittorrent/qbittorrent-4.6.6/qbittorrent-4.6.6.tar.xz'
   source_sha256 '5f9f3e0b89861e8bae1894656f8b8f76feddb3c92e228065c8173632af6e544e'
   binary_compression 'tar.zst'

--- a/packages/qbittorrent.rb
+++ b/packages/qbittorrent.rb
@@ -3,21 +3,22 @@ require 'buildsystems/cmake'
 class Qbittorrent < CMake
   description 'Open-source software alternative to µTorrent.'
   homepage 'https://www.qbittorrent.org/'
-  version '4.6.3'
+  version '4.6.6'
   license 'GPL-2'
   compatibility 'x86_64 aarch64 armv7l'
-  source_url 'https://downloads.sourceforge.net/project/qbittorrent/qbittorrent/qbittorrent-4.6.3/qbittorrent-4.6.3.tar.xz'
+  source_url 'https://downloads.sourceforge.net/project/qbittorrent/qbittorrent/qbittorrent-4.6.6/qbittorrent-4.6.6.tar.xz'
   source_sha256 '5f9f3e0b89861e8bae1894656f8b8f76feddb3c92e228065c8173632af6e544e'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'a3bb615c33f412adcf44b9284b5f9c28c45d2f05dab0d299220b28d4844d64ff',
-     armv7l: 'a3bb615c33f412adcf44b9284b5f9c28c45d2f05dab0d299220b28d4844d64ff',
-     x86_64: 'afbe852b182f0e0ca7abc58a16415da49f1ae294853436b2b5e14d50c3b8cc54'
+    aarch64: '4c30e5dab2abdba5be6e33bc1f42b9425438c9d68d02b95abba9ff65abc93da2',
+     armv7l: '4c30e5dab2abdba5be6e33bc1f42b9425438c9d68d02b95abba9ff65abc93da2',
+     x86_64: 'edc558f1067f4bfa2c4fb28fa495a1c7f3227144b3d989488f1b993a16512df8'
   })
 
   depends_on 'cmake' => :build
   depends_on 'gcc_lib' # R
+  depends_on 'glibc_lib' # R
   depends_on 'glibc' # R
   depends_on 'libtorrent' # R
   depends_on 'openssl' # R

--- a/packages/qt5_base.rb
+++ b/packages/qt5_base.rb
@@ -3,17 +3,18 @@ require 'package'
 class Qt5_base < Package
   description 'Qt Base (Core, Gui, Widgets, Network, ...)'
   homepage 'https://code.qt.io/cgit/qt/qtbase'
-  version 'kde-5.15.14-9f9a56d'
+  version 'kde-5.15.14-9f9a56d-icu75.1'
   license 'GPL-2'
   compatibility 'x86_64 aarch64 armv7l'
+  min_glibc '2.37'
   source_url 'https://invent.kde.org/qt/qt/qtbase.git'
   git_hashtag '9f9a56d750caff8b4459e7e9bf82f1f4d725f72f'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'b819c57bac88d433ffd516af06f22f197d57b0d738358206bafe6d96ee7d0bf3',
-     armv7l: 'b819c57bac88d433ffd516af06f22f197d57b0d738358206bafe6d96ee7d0bf3',
-     x86_64: '6bebd128aa79373bbe50fbd91948e02e929dc0dc644701f74428a611f000db20'
+    aarch64: '0ce34bf448b6602c0a01a7a53bcdbcbc8b9792a202ff2edf5861505d4fac7f54',
+     armv7l: '0ce34bf448b6602c0a01a7a53bcdbcbc8b9792a202ff2edf5861505d4fac7f54',
+     x86_64: '40ede8066e4ade3377b5ead1cb1e19d29764f8e2920a6796e8b923a5dc7916a2'
   })
 
   depends_on 'alsa_plugins' => :build
@@ -28,6 +29,7 @@ class Qt5_base < Package
   depends_on 'freetype' # R
   depends_on 'gcc_lib' # R
   depends_on 'gdk_pixbuf' # R
+  depends_on 'glibc_lib' # R
   depends_on 'glibc' # R
   depends_on 'glib' # R
   depends_on 'gstreamer' => :build
@@ -68,6 +70,28 @@ class Qt5_base < Package
   depends_on 'zlib' # R
   depends_on 'zstd' # R
 
+  def self.patch
+    # There appears to be no way of setting QMAKE_CXX as a environment
+    # variable prepended to the configure command here.
+    if (ARCH == 'x86_64') && (Gem::Version.new(LIBC_VERSION.to_s) >= Gem::Version.new('2.37'))
+      File.write 'libC.patch', <<~LIBC_PATCH_EOF
+        diff -Npaur a/mkspecs/common/g++-base.conf b/mkspecs/common/g++-base.conf
+        --- a/mkspecs/common/g++-base.conf	2024-08-21 13:39:25.962767682 -0400
+        +++ b/mkspecs/common/g++-base.conf	2024-08-21 13:39:07.126893580 -0400
+        @@ -15,7 +15,7 @@ QMAKE_CC                = $${CROSS_COMPI
+         QMAKE_LINK_C            = $$QMAKE_CC
+         QMAKE_LINK_C_SHLIB      = $$QMAKE_CC
+
+        -QMAKE_CXX               = $${CROSS_COMPILE}g++
+        +QMAKE_CXX               = $${CROSS_COMPILE}g++ #{File.join(CREW_LIB_PREFIX, 'libC.so.6')}
+
+         QMAKE_LINK              = $$QMAKE_CXX
+         QMAKE_LINK_SHLIB        = $$QMAKE_CXX
+      LIBC_PATCH_EOF
+      system 'patch -Np1 -i libC.patch'
+    end
+  end
+
   def self.build
     system "./configure \
            --prefix=#{CREW_PREFIX}/share/Qt-5 \
@@ -84,8 +108,7 @@ class Qt5_base < Package
   def self.install
     system 'make', "INSTALL_ROOT=#{CREW_DEST_DIR}", 'install'
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
-    Dir["#{CREW_DEST_PREFIX}/share/Qt-5/bin/*"].each do |filename|
-      next unless File.executable?(filename)
+    Dir["#{CREW_DEST_PREFIX}/share/Qt-5/bin/*"].select { |f| File.executable?(f) }.each do |filename|
       FileUtils.ln_s(filename, File.join(CREW_DEST_PREFIX, 'bin', File.basename(filename)))
     end
   end

--- a/packages/stellarium.rb
+++ b/packages/stellarium.rb
@@ -1,54 +1,44 @@
-require 'package'
+require 'buildsystems/cmake'
 
-class Stellarium < Package
+class Stellarium < CMake
   description 'Stellarium is a free open source planetarium for your computer.'
   homepage 'http://stellarium.org/'
-  version '0.21.1'
+  version '24.2'
   license 'GPL-2.0'
-  compatibility 'x86_64'
-  source_url 'https://github.com/Stellarium/stellarium/releases/download/v0.21.1/stellarium-0.21.1.tar.gz'
-  source_sha256 '072309c6bc48233b39884ae558b23764d0e08eabd96b014b53d780be11a33211'
-  binary_compression 'tar.xz'
+  compatibility 'x86_64 aarch64 armv7l'
+  source_url 'https://github.com/Stellarium/stellarium.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    x86_64: '4618a03c3b1b70a05b4aef9e0aa120b1fb49e8ac5b6511de90e207b6b3cb99e2'
+    aarch64: '5d92d053882ddb66a6eeba455ede459a8ad897117603176826cc0e8804647e10',
+     armv7l: '5d92d053882ddb66a6eeba455ede459a8ad897117603176826cc0e8804647e10',
+    x86_64: '9ea039537005dafbbe3fc9faf989f4dbd7731c6f74e213d6c925b2b75a54d7d8'
   })
 
-  depends_on 'qtlocation'
-  depends_on 'qtmultimedia'
-  depends_on 'qtscript'
-  depends_on 'qtserialport'
-  depends_on 'qttools'
-  depends_on 'qtwayland'
+  depends_on 'gcc_lib' # R
+  depends_on 'glibc_lib' # R
+  depends_on 'nlopt' # R
+  depends_on 'qt5_base' # R
+  depends_on 'qt5_charts' # R
+  depends_on 'qt5_location' => :build
+  depends_on 'qt5_multimedia' # R
+  depends_on 'qt5_script' # R
+  depends_on 'qt5_serialport' # R
+  depends_on 'qt5_tools' => :build
+  depends_on 'qt5_wayland' => :build
+  depends_on 'zlib' # R
 
-  def self.build
-    Dir.mkdir 'builddir'
-    Dir.chdir 'builddir' do
-      system "cmake #{CREW_CMAKE_OPTIONS} -DENABLE_GPS=0 .."
-      system 'make'
-    end
-  end
-
-  def self.install
-    Dir.chdir 'builddir' do
-      system 'make', "LIBDIR=#{CREW_LIB_PREFIX}", "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    end
-  end
-
-  def self.postinstall
-    puts "\nType 'stellarium' to get started.\n".lightblue
-  end
+  cmake_options '-DENABLE_GPS=0'
 
   def self.postremove
-    config_dir = "#{HOME}/.stellarium"
-    if Dir.exist? config_dir
-      print "Would you like to remove the config directory #{config_dir}? [y/N] "
-      case $stdin.gets.chomp.downcase
-      when 'y', 'yes'
-        FileUtils.rm_rf config_dir
-        puts "#{config_dir} removed.".lightred
+    config_file = "#{HOME}/.stellarium"
+    if File.file? config_file
+      if Package.agree_with_default("Would you like to remove the #{name} config file: #{config_file}?", true, default: 'y')
+        FileUtils.rm_rf config_file
+        puts "#{config_file} removed.".lightgreen
       else
-        puts "#{config_dir} saved.".lightgreen
+        puts "#{config_file} saved.".lightgreen
       end
     end
   end

--- a/packages/stellarium.rb
+++ b/packages/stellarium.rb
@@ -33,14 +33,6 @@ class Stellarium < CMake
   cmake_options '-DENABLE_GPS=0'
 
   def self.postremove
-    config_file = "#{HOME}/.stellarium"
-    if File.file? config_file
-      if Package.agree_with_default("Would you like to remove the #{name} config file: #{config_file} (YES/no)?", true, default: 'y')
-        FileUtils.rm_rf config_file
-        puts "#{config_file} removed.".lightgreen
-      else
-        puts "#{config_file} saved.".lightgreen
-      end
-    end
+    Package.agree_to_remove("#{HOME}/.stellarium")
   end
 end

--- a/packages/stellarium.rb
+++ b/packages/stellarium.rb
@@ -6,6 +6,7 @@ class Stellarium < CMake
   version '24.2'
   license 'GPL-2.0'
   compatibility 'x86_64 aarch64 armv7l'
+  min_glibc '2.37'
   source_url 'https://github.com/Stellarium/stellarium.git'
   git_hashtag "v#{version}"
   binary_compression 'tar.zst'

--- a/packages/stellarium.rb
+++ b/packages/stellarium.rb
@@ -35,7 +35,7 @@ class Stellarium < CMake
   def self.postremove
     config_file = "#{HOME}/.stellarium"
     if File.file? config_file
-      if Package.agree_with_default("Would you like to remove the #{name} config file: #{config_file}?", true, default: 'y')
+      if Package.agree_with_default("Would you like to remove the #{name} config file: #{config_file} (YES/no)?", true, default: 'y')
         FileUtils.rm_rf config_file
         puts "#{config_file} removed.".lightgreen
       else

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -6251,6 +6251,11 @@ url: https://github.com/l3ib/nitrogen/releases
 activity: none
 ---
 kind: url
+name: nlopt
+url: https://github.com/stevengj/nlopt/releases
+activity: low
+---
+kind: url
 name: nmap
 url: https://nmap.org/dist
 activity: low


### PR DESCRIPTION
Fixes #9456 

- Adds Highline [agree_with_default ](https://github.com/JEG2/highline/issues/275#issuecomment-2303107074) to package.rb, which I am using in the stellarium postremove, and can be invoked with something like `Package.agree_with_default("Would you like to remove the #{name} config file: #{config_file} (YES/no)?", true, default: 'y')`.
- Updates `stellarium`.
- Adds `nlopt` (stellarium dep)
- Fixes `obs` and `plplot` dependencies.

- Also adjusts Unit Test workflow to properly handle `min_glibc`.
##
Builds:
- [x] `x86_64`
- [x] `armv7l`
##
Tested & Working properly:
- [ ] `x86_64`
- [ ] `armv7l` <!-- (reasons why it doesn't) -->
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=qtbase crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
