### PR TITLE
Add fallthrough options for newer glibc.

### DIFF
--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -38,5 +38,9 @@ class Glibc < Package
     version Glibc_build237.version
     compatibility Glibc_build237.compatibility
     depends_on 'glibc_lib237'
+  else
+    version LIBC_VERSION
+    compatibility 'x86_64 aarch64 armv7l'
+    depends_on 'glibc_fallthrough'
   end
 end

--- a/packages/glibc_fallthrough.rb
+++ b/packages/glibc_fallthrough.rb
@@ -1,0 +1,58 @@
+require 'package'
+
+class Glibc_fallthrough < Package
+  description 'The GNU C Library project provides the core libraries for GNU/Linux systems.'
+  homepage 'https://www.gnu.org/software/libc/'
+  version LIBC_VERSION
+  license 'LGPL-2.1+, BSD, HPND, ISC, inner-net, rc, and PCRE'
+  compatibility 'x86_64 aarch64 armv7l'
+  min_glibc version.split('-').first
+  max_glibc version.split('-').first
+  source_url 'SKIP'
+
+  depends_on 'gawk' => :build
+  depends_on 'filecmd' # L Fixes creating symlinks on a fresh install.
+  depends_on 'libidn2' => :build
+  depends_on 'texinfo' => :build
+  depends_on 'patchelf' # L
+
+  conflicts_ok
+  no_env_options
+  no_upstream_update
+
+  def self.postinstall
+    if File.exist?("#{CREW_LIB_PREFIX}/libc.so.6")
+      FileUtils.chmod 'u=wrx', "#{CREW_LIB_PREFIX}/libc.so.6"
+      @crew_libcvertokens = `#{CREW_LIB_PREFIX}/libc.so.6`.lines.first.chomp.split(/\s/)
+      @libc_version = @crew_libcvertokens[@crew_libcvertokens.find_index('version') + 1].sub!(/[[:punct:]]?$/, '')
+      puts "Package glibc version is #{@libc_version}.".lightblue
+    else
+      @libc_version = LIBC_VERSION
+    end
+    @libraries = %w[ld libBrokenLocale libSegFault libanl libc libcrypt
+                    libdl libm libmemusage libmvec libnsl libnss_compat libnss_db
+                    libnss_dns libnss_files libnss_hesiod libpcprofile libpthread
+                    libthread_db libresolv librlv librt libthread_db-1.0 libutil]
+    @libraries -= ['libpthread'] if Gem::Version.new(@libc_version.to_s) > Gem::Version.new('2.35')
+    @libraries -= ['libc'] if Gem::Version.new(@libc_version.to_s) > Gem::Version.new('2.35') && Kernel.system("patchelf --print-needed #{File.join(CREW_LIB_PREFIX, 'libc.so.6')} | grep -q libC.so.6")
+    @libraries -= ['libm'] if Gem::Version.new(@libc_version.to_s) > Gem::Version.new('2.35') && Kernel.system("patchelf --print-needed #{File.join(CREW_LIB_PREFIX, 'libm.so.6')} | grep -q libC.so.6")
+    Dir.chdir CREW_LIB_PREFIX do
+      puts "System glibc version is #{@libc_version}.".lightblue
+      puts 'Creating symlinks to system glibc version to prevent breakage.'.lightblue
+      case ARCH
+      when 'aarch64', 'armv7l'
+        FileUtils.ln_sf File.realpath('/lib/ld-linux-armhf.so.3'), 'ld-linux-armhf.so.3'
+      when 'x86_64'
+        FileUtils.ln_sf File.realpath('/lib64/ld-linux-x86-64.so.2'), 'ld-linux-x86-64.so.2'
+      end
+      @libraries.each do |lib|
+        # Reject entries which aren't libraries ending in .so, and which aren't files.
+        # Reject text files such as libc.so because they points to files like
+        # libc_nonshared.a, which are not provided by ChromeOS
+        Dir["{,/usr}/#{ARCH_LIB}/#{lib}.so*"].compact.select { |i| ['shared object', 'symbolic link'].any? { |j| `file #{i}`.chomp.include? j } }.each do |k|
+          FileUtils.ln_sf k, File.join(CREW_LIB_PREFIX, File.basename(k))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Try to have a fallback in case LIBC_VERSION doesn't match any glibc packages we have built.

##
Builds:
- [ ] `x86_64`
- [ ] `i686`
- [ ] `armv7l`
##
Tested & Working properly:
- [ ] `x86_64`
- [ ] `i686`
- [ ] `armv7l` <!-- (reasons why it doesn't) -->
##
- [ ] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=glibc_fallthrough crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
