### PR TITLE
Google_chrome 127.0.6533.119-1 =>  128.0.6613.84-1

### DIFF
--- a/manifest/x86_64/g/google_chrome.filelist
+++ b/manifest/x86_64/g/google_chrome.filelist
@@ -4,6 +4,8 @@
 /usr/local/share/chrome/CHROME_VERSION_EXTRA
 /usr/local/share/chrome/MEIPreload/manifest.json
 /usr/local/share/chrome/MEIPreload/preloaded_data.pb
+/usr/local/share/chrome/PrivacySandboxAttestationsPreloaded/manifest.json
+/usr/local/share/chrome/PrivacySandboxAttestationsPreloaded/privacy-sandbox-attestations.dat
 /usr/local/share/chrome/WidevineCdm/LICENSE
 /usr/local/share/chrome/WidevineCdm/_platform_specific/linux_x64/libwidevinecdm.so
 /usr/local/share/chrome/WidevineCdm/manifest.json

--- a/packages/google_chrome.rb
+++ b/packages/google_chrome.rb
@@ -4,12 +4,12 @@ class Google_chrome < Package
   @update_channel = 'stable'
   description 'Google Chrome is a fast, easy to use, and secure web browser.'
   homepage 'https://www.google.com/chrome/'
-  version '127.0.6533.119-1'
+  version '128.0.6613.84-1'
   license 'google-chrome'
   compatibility 'x86_64'
   min_glibc '2.28'
   source_url "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-#{@update_channel}/google-chrome-#{@update_channel}_#{@version}_amd64.deb"
-  source_sha256 '93daec10b02d38574b4a2d5d3935782ebec4d94bb9b11d7f18e2fd0560ea665e'
+  source_sha256 'e21001b470eaffc9483fa61ba54d5525d9a064d98b376a9bd1530f630dddb018'
 
   depends_on 'nss'
   depends_on 'cairo'


### PR DESCRIPTION
##
Tested & (not) Working properly:
- [x] `x86_64` Unable to launch in hatch m126 container
- [ ] `i686`
- [ ] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-google_chrome crew update \
&& yes | crew upgrade
```
