### PR TITLE
Opera 112.0.5197.53 => 113.0.5230.31

### DIFF
--- a/packages/opera.rb
+++ b/packages/opera.rb
@@ -3,7 +3,7 @@ require 'package'
 class Opera < Package
   description 'Opera is a multi-platform web browser based on Chromium and developed by Opera Software.'
   homepage 'https://www.opera.com/'
-  version '112.0.5197.53'
+  version '113.0.5230.31'
   license 'OPERA-2018'
   compatibility 'x86_64'
   min_glibc '2.29'
@@ -11,7 +11,7 @@ class Opera < Package
   # faster apt mirror, but only works when downloading latest version of opera
   # source_url "https://deb.opera.com/opera/pool/non-free/o/opera-stable/opera-stable_#{version}_amd64.deb"
   source_url "https://deb.opera.com/opera-stable/pool/non-free/o/opera-stable/opera-stable_#{version}_amd64.deb"
-  source_sha256 'cb3173f2837a04ccddf2ef22958e6d34f0912eb94778fef1385399b720369e4c'
+  source_sha256 'f4f3f9c3a2b21ec44f7d563b57449a048d05d418788404124f311ff384b27744'
 
   depends_on 'gtk3'
   depends_on 'gsettings_desktop_schemas'


### PR DESCRIPTION

Tested & (not) Working properly:
- [x] `x86_64` Unable to launch in hatch m126 container
- [ ] `i686`
- [ ] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-opera crew update \
&& yes | crew upgrade
```