### PR TITLE
Fix remove such that files from essential packages are not removed.

### DIFF
--- a/commands/remove.rb
+++ b/commands/remove.rb
@@ -60,13 +60,8 @@ class Command
           # all packages and dependent packages of CREW_ESSENTIAL_PACKAGES.
           essential_deps_exclude_froms = essential_deps.map { |i| File.file?("#{File.join(CREW_META_PATH, i.to_s)}.filelist") ? "--exclude-from=#{File.join(CREW_META_PATH, i.to_s)}.filelist" : '' }.join(' ')
 
-          # When making a list of all files from crew filelists we again
-          # ignore all files from packages and dependent packages of
-          # CREW_ESSENTIAL_PACKAGES.
-          essential_deps_excludes = essential_deps.map { |i| File.file?("#{File.join(CREW_META_PATH, i.to_s)}.filelist") ? "--exclude=#{File.join(CREW_META_PATH, i.to_s)}.filelist" : '' }.join(' ')
-
           package_files = `grep -h #{essential_deps_exclude_froms} \"^#{CREW_PREFIX}\\|^#{HOME}\" #{flist}`.split("\n").uniq.sort
-          all_other_files = `grep -h --exclude #{pkg.name}.filelist #{essential_deps_excludes} \"^#{CREW_PREFIX}\\|^#{HOME}\" #{CREW_META_PATH}/*.filelist`.split("\n").uniq.sort
+          all_other_files = `grep -h --exclude #{pkg.name}.filelist \"^#{CREW_PREFIX}\\|^#{HOME}\" #{CREW_META_PATH}/*.filelist`.split("\n").uniq.sort
 
           # We want the difference of these arrays.
           unique_to_package_files = package_files - all_other_files

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -2,7 +2,7 @@
 # Defines common constants used in different parts of crew
 require 'etc'
 
-CREW_VERSION = '1.51.0'
+CREW_VERSION = '1.51.1'
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]

--- a/tests/commands/remove.rb
+++ b/tests/commands/remove.rb
@@ -22,7 +22,7 @@ class RemoveCommandTest < Minitest::Test
     @random_essential_pkg = Package.load_package("#{@random_essential_package_name}.rb")
 
     @package_with_essential_file = 'gcc_build'
-    @essential_file = File.join(CREW_LIB_PREFIX,'libstdc++.so.6')
+    @essential_file = File.join(CREW_LIB_PREFIX, 'libstdc++.so.6')
     puts <<~PACKAGE_WITH_ESSENTIAL_FILE_REMOVAL_TEST_EOF
 
       Testing the removal of package #{@package_with_essential_file}.

--- a/tests/commands/remove.rb
+++ b/tests/commands/remove.rb
@@ -1,5 +1,6 @@
 require 'minitest/autorun'
 require_relative '../../commands/remove'
+require_relative '../../lib/const'
 require_relative '../../lib/package_utils'
 
 # Add lib to LOAD_PATH
@@ -19,6 +20,16 @@ class RemoveCommandTest < Minitest::Test
 
     ESSENTIAL_PACKAGE_REMOVAL_TEST_EOF
     @random_essential_pkg = Package.load_package("#{@random_essential_package_name}.rb")
+
+    @package_with_essential_file = 'gcc_build'
+    @essential_file = File.join(CREW_LIB_PREFIX,'libstdc++.so.6')
+    puts <<~PACKAGE_WITH_ESSENTIAL_FILE_REMOVAL_TEST_EOF
+
+      Testing the removal of package #{@package_with_essential_file}.
+      (This should succeed, but essential file #{@essential_file}
+      should not be removed.)
+
+    PACKAGE_WITH_ESSENTIAL_FILE_REMOVAL_TEST_EOF
 
     @normal_package_name = 'xxd_standalone'
     puts <<~NORMAL_PACKAGE_REMOVAL_TEST_EOF
@@ -41,13 +52,24 @@ class RemoveCommandTest < Minitest::Test
     assert_raises(SystemExit) { Command.remove(@random_essential_pkg, true) }
   end
 
+  def test_remove_package_with_essential_file
+    assert_output(true) do
+      until PackageUtils.installed?(@package_with_essential_file)
+        system "crew install -d #{@package_with_essential_file}", %i[out err] => File::NULL
+        sleep 2
+      end
+      system "crew remove -d #{@package_with_essential_file}", %i[out err] => File::NULL
+      return File.file?(@essential_file)
+    end
+  end
+
   def test_remove_normal_package
     expected_output = <<~EOT
       #{@normal_package_name} removed
     EOT
     assert_output(/^#{Regexp.escape(expected_output.chomp)}!/, nil) do
       until PackageUtils.installed?(@normal_package_name)
-        system "crew install -d #{@normal_package_name} &>/dev/null", out: File::NULL
+        system "crew install -d #{@normal_package_name}", %i[out err] => File::NULL
         sleep 2
       end
       Command.remove(@normal_pkg, true)


### PR DESCRIPTION
## Description
- The algorithm for `remove` was removing essential package files from the array of all files, so that when a difference with the files from the package was taken, the essential files were not noticed and thus not excluded from the final removal list.
- A case of this would be `libstdc++.so.6`, which is in essential package `gcc_lib`, but also in non-essential package `gcc_build`. Removing `gcc_build` was removing `libstdc++.so.6` as well.
## Additional information
- A unit test was added for this edge case as well.

##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=fix_remove crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
