### PR TITLE
Handbrake => 1.8.2, update unit test workflow.

### DIFF
--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -46,21 +46,21 @@ jobs:
             fi
 
             # If a package has a compatibility of 'all' or one that includes 'x86_64', add it to x86_64_PACKAGES.
-            export x86_64_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q \"compatibility.*all\|x86_64\" packages/${i}.rb && echo ${i}; done | xargs)"
+            export x86_64_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q "compatibility.*all\|x86_64" packages/${i}.rb && echo ${i}; done | xargs)"
             if [[ -n ${x86_64_PACKAGES} ]]; then
               echo "x86_64_PACKAGES=${x86_64_PACKAGES}" >> $GITHUB_ENV
               echo "PR #${{ github.event.pull_request.number }} has these x86_64 compatible packages: ${x86_64_PACKAGES}"
             fi
 
             ## If a package has a compatibility of 'all' or one that includes 'armv7l', add it to ARMV7L_PACKAGES.
-            export ARMV7L_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q \"compatibility.*all\|armv7l\" packages/${i}.rb && echo ${i}; done | xargs)"
+            export ARMV7L_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q "compatibility.*all\|armv7l" packages/${i}.rb && echo ${i}; done | xargs)"
             if [[ -n ${ARMV7L_PACKAGES} ]]; then
               echo "ARMV7L_PACKAGES=${ARMV7L_PACKAGES}" >> $GITHUB_ENV
               echo "PR #${{ github.event.pull_request.number }} has these armv7l compatible packages: ${ARMV7L_PACKAGES}"
             fi
 
             ## If a package has a compatibility of 'all' or one that includes 'i686', add it to i686_PACKAGES.
-            export i686_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q \"compatibility.*all\|i686\" packages/${i}.rb && echo ${i}; done | xargs)"
+            export i686_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q "compatibility.*all\|i686" packages/${i}.rb && echo ${i}; done | xargs)"
             if [[ -n ${i686_PACKAGES} ]]; then
               echo "i686_PACKAGES=${i686_PACKAGES}" >> $GITHUB_ENV
               echo "PR #${{ github.event.pull_request.number }} has these i686 compatible packages: ${i686_PACKAGES}"

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -74,7 +74,7 @@ jobs:
             esac
       - name: Run unit tests
         run: |
-             if [[ -z ${NON_PKG_CHANGED_FILES} ]] && [[ $PLATFORM == 'linux/arm/v7' ]] && [ -n "${ARMV7L_PACKAGES+1}" ]; then
+             if [[ -z ${NON_PKG_CHANGED_FILES} ]] && [[ $PLATFORM == 'linux/arm/v7' ]] && [[ -z ${ARMV7L_PACKAGES} ]]; then
                # Run the arm container if there are non-package changed files,
                # but otherwise do not run the arm container if there are no packages compatible with armv7l.
                exit 0

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -31,30 +31,30 @@ jobs:
             echo "NON_PKG_CHANGED_FILES=$(echo "${{ steps.non-pkg-changed-files.outputs.all_changed_files }}" | xargs)" >> $GITHUB_ENV
       - name: Determine glibc and architecture package compatibility
         run: |
-            # If a package doesnt have a min_glibc value, or if its below 2.27, add it to the list
+            # If a package doesnt have a min_glibc value, or if its below 2.27, add it to GLIBC_227_COMPATIBLE_PACKAGES
             export GLIBC_227_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do if grep -q min_glibc packages/${i}.rb; then grep min_glibc packages/${i}.rb | tr -d \' | awk '{exit $2 <= 2.27}' || echo ${i} ; else echo ${i} ; fi ; done | xargs)"
             [[ ${GLIBC_227_COMPATIBLE_PACKAGES} ]] && echo "GLIBC_227_COMPATIBLE_PACKAGES=${GLIBC_227_COMPATIBLE_PACKAGES}" >> $GITHUB_ENV
             [[ ${GLIBC_227_COMPATIBLE_PACKAGES} ]] && echo "PR #${{ github.event.pull_request.number }} has these possibly Glibc 2.27 compatible packages: ${GLIBC_227_COMPATIBLE_PACKAGES}"
 
             # If a package doesnt have a min_glibc value, or if its below 2.37, add it to GLIBC_237_COMPATIBLE_PACKAGES
-            export GLIBC_237_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do grep min_glibc packages/$i.rb | tr -d \' | awk '{exit $2 <= 2.37}' || echo $i ; done | xargs)"
+            export GLIBC_237_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do grep min_glibc packages/${i}.rb | tr -d \' | awk '{exit $2 <= 2.37}' || echo ${i} ; done | xargs)"
             [[ ${GLIBC_237_COMPATIBLE_PACKAGES} ]] && echo "GLIBC_237_COMPATIBLE_PACKAGES=${GLIBC_237_COMPATIBLE_PACKAGES}" >> $GITHUB_ENV
             [[ ${GLIBC_237_COMPATIBLE_PACKAGES} ]] && echo "PR #${{ github.event.pull_request.number }} has these possibly Glibc 2.37 compatible packages: ${GLIBC_237_COMPATIBLE_PACKAGES}"
 
             # If a package has a compatibility of 'all' or one that includes 'x86_64', add it to the list.
-            export x86_64_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do grep -q "compatibility 'all'\|compatibility '.*x86_64.*'" packages/${p}.rb && echo ${p}; done | xargs)"
-            [[ $x86_64_PACKAGES ]] && echo "x86_64_PACKAGES=${x86_64_PACKAGES}" >> $GITHUB_ENV
-            [[ $x86_64_PACKAGES ]] && echo "PR #${{ github.event.pull_request.number }} has these x86_64 compatible packages: ${x86_64_PACKAGES}"
+            export x86_64_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q \"compatibility.*all\|x86_64\" packages/${i}.rb && echo ${i}; done | xargs)"
+            [[ ${x86_64_PACKAGES} ]] && echo "x86_64_PACKAGES=${x86_64_PACKAGES}" >> $GITHUB_ENV
+            [[ ${x86_64_PACKAGES} ]] && echo "PR #${{ github.event.pull_request.number }} has these x86_64 compatible packages: ${x86_64_PACKAGES}"
 
             # If a package has a compatibility of 'all' or one that includes 'armv7l', add it to the list.
-            export ARMV7L_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do grep -q \"compatibility.*all\|armv7l\" packages/${p}.rb && echo ${p}; done | xargs)"
+            export ARMV7L_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q \"compatibility.*all\|armv7l\" packages/${i}.rb && echo ${i}; done | xargs)"
             [[ ${ARMV7L_PACKAGES} ]] && echo "ARMV7L_PACKAGES=${ARMV7L_PACKAGES}" >> $GITHUB_ENV
             [[ ${ARMV7L_PACKAGES} ]] && echo "PR #${{ github.event.pull_request.number }} has these armv7l compatible packages: ${ARMV7L_PACKAGES}"
 
             # If a package has a compatibility of 'all' or one that includes 'i686', add it to the list.
-            export i686_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do grep -q "compatibility 'all'\|compatibility '.*i686.*'" packages/${p}.rb && echo ${p}; done | xargs)"
-            [[ $i686_PACKAGES ]] && echo "i686_PACKAGES=${i686_PACKAGES}" >> $GITHUB_ENV
-            [[ $i686_PACKAGES ]] && echo "PR #${{ github.event.pull_request.number }} has these i686 compatible packages: ${i686_PACKAGES}"
+            export i686_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q \"compatibility.*all\|i686\" packages/${i}.rb && echo ${i}; done | xargs)"
+            [[ ${i686_PACKAGES} ]] && echo "i686_PACKAGES=${i686_PACKAGES}" >> $GITHUB_ENV
+            [[ ${i686_PACKAGES} ]] && echo "PR #${{ github.event.pull_request.number }} has these i686 compatible packages: ${i686_PACKAGES}"
       - name: Export target docker container to github context
         env:
           TARGET_ARCH: ${{ matrix.arch }}

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -33,28 +33,28 @@ jobs:
         run: |
             # If a package doesnt have a min_glibc value, or if its below 2.27, add it to GLIBC_227_COMPATIBLE_PACKAGES
             export GLIBC_227_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do if grep -q min_glibc packages/${i}.rb; then grep min_glibc packages/${i}.rb | tr -d \' | awk '{exit $2 <= 2.27}' || echo ${i} ; else echo ${i} ; fi ; done | xargs)"
-            [[ ${GLIBC_227_COMPATIBLE_PACKAGES} ]] && echo "GLIBC_227_COMPATIBLE_PACKAGES=${GLIBC_227_COMPATIBLE_PACKAGES}" >> $GITHUB_ENV
-            [[ ${GLIBC_227_COMPATIBLE_PACKAGES} ]] && echo "PR #${{ github.event.pull_request.number }} has these possibly Glibc 2.27 compatible packages: ${GLIBC_227_COMPATIBLE_PACKAGES}"
+            [[ ${GLIBC_227_COMPATIBLE_PACKAGES} ]] || true && echo "GLIBC_227_COMPATIBLE_PACKAGES=${GLIBC_227_COMPATIBLE_PACKAGES}" >> $GITHUB_ENV
+            [[ ${GLIBC_227_COMPATIBLE_PACKAGES} ]] || true && echo "PR #${{ github.event.pull_request.number }} has these possibly Glibc 2.27 compatible packages: ${GLIBC_227_COMPATIBLE_PACKAGES}"
 
             # If a package doesnt have a min_glibc value, or if its below 2.37, add it to GLIBC_237_COMPATIBLE_PACKAGES
             export GLIBC_237_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do grep min_glibc packages/${i}.rb | tr -d \' | awk '{exit $2 <= 2.37}' || echo ${i} ; done | xargs)"
-            [[ ${GLIBC_237_COMPATIBLE_PACKAGES} ]] && echo "GLIBC_237_COMPATIBLE_PACKAGES=${GLIBC_237_COMPATIBLE_PACKAGES}" >> $GITHUB_ENV
-            [[ ${GLIBC_237_COMPATIBLE_PACKAGES} ]] && echo "PR #${{ github.event.pull_request.number }} has these possibly Glibc 2.37 compatible packages: ${GLIBC_237_COMPATIBLE_PACKAGES}"
+            [[ ${GLIBC_237_COMPATIBLE_PACKAGES} ]] || true && echo "GLIBC_237_COMPATIBLE_PACKAGES=${GLIBC_237_COMPATIBLE_PACKAGES}" >> $GITHUB_ENV
+            [[ ${GLIBC_237_COMPATIBLE_PACKAGES} ]] || true && echo "PR #${{ github.event.pull_request.number }} has these possibly Glibc 2.37 compatible packages: ${GLIBC_237_COMPATIBLE_PACKAGES}"
 
             # If a package has a compatibility of 'all' or one that includes 'x86_64', add it to the list.
             export x86_64_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q \"compatibility.*all\|x86_64\" packages/${i}.rb && echo ${i}; done | xargs)"
-            [[ ${x86_64_PACKAGES} ]] && echo "x86_64_PACKAGES=${x86_64_PACKAGES}" >> $GITHUB_ENV
-            [[ ${x86_64_PACKAGES} ]] && echo "PR #${{ github.event.pull_request.number }} has these x86_64 compatible packages: ${x86_64_PACKAGES}"
+            [[ ${x86_64_PACKAGES} ]] || true && echo "x86_64_PACKAGES=${x86_64_PACKAGES}" >> $GITHUB_ENV
+            [[ ${x86_64_PACKAGES} ]] || true && echo "PR #${{ github.event.pull_request.number }} has these x86_64 compatible packages: ${x86_64_PACKAGES}"
 
             # If a package has a compatibility of 'all' or one that includes 'armv7l', add it to the list.
             export ARMV7L_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q \"compatibility.*all\|armv7l\" packages/${i}.rb && echo ${i}; done | xargs)"
-            [[ ${ARMV7L_PACKAGES} ]] && echo "ARMV7L_PACKAGES=${ARMV7L_PACKAGES}" >> $GITHUB_ENV
-            [[ ${ARMV7L_PACKAGES} ]] && echo "PR #${{ github.event.pull_request.number }} has these armv7l compatible packages: ${ARMV7L_PACKAGES}"
+            [[ ${ARMV7L_PACKAGES} ]] || true && echo "ARMV7L_PACKAGES=${ARMV7L_PACKAGES}" >> $GITHUB_ENV
+            [[ ${ARMV7L_PACKAGES} ]] || true && echo "PR #${{ github.event.pull_request.number }} has these armv7l compatible packages: ${ARMV7L_PACKAGES}"
 
             # If a package has a compatibility of 'all' or one that includes 'i686', add it to the list.
             export i686_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q \"compatibility.*all\|i686\" packages/${i}.rb && echo ${i}; done | xargs)"
-            [[ ${i686_PACKAGES} ]] && echo "i686_PACKAGES=${i686_PACKAGES}" >> $GITHUB_ENV
-            [[ ${i686_PACKAGES} ]] && echo "PR #${{ github.event.pull_request.number }} has these i686 compatible packages: ${i686_PACKAGES}"
+            [[ ${i686_PACKAGES} ]] || true && echo "i686_PACKAGES=${i686_PACKAGES}" >> $GITHUB_ENV
+            [[ ${i686_PACKAGES} ]] || true && echo "PR #${{ github.event.pull_request.number }} has these i686 compatible packages: ${i686_PACKAGES}"
       - name: Export target docker container to github context
         env:
           TARGET_ARCH: ${{ matrix.arch }}

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -31,30 +31,40 @@ jobs:
             echo "NON_PKG_CHANGED_FILES=$(echo "${{ steps.non-pkg-changed-files.outputs.all_changed_files }}" | xargs)" >> $GITHUB_ENV
       - name: Determine glibc and architecture package compatibility
         run: |
-            # If a package doesnt have a min_glibc value, or if its below 2.27, add it to GLIBC_227_COMPATIBLE_PACKAGES
-            export GLIBC_227_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do if grep -q min_glibc packages/${i}.rb; then grep min_glibc packages/${i}.rb | tr -d \' | awk '{exit $2 <= 2.27}' || echo ${i} ; else echo ${i} ; fi ; done | xargs)"
-            [[ ${GLIBC_227_COMPATIBLE_PACKAGES} ]] || true && echo "GLIBC_227_COMPATIBLE_PACKAGES=${GLIBC_227_COMPATIBLE_PACKAGES}" >> $GITHUB_ENV
-            [[ ${GLIBC_227_COMPATIBLE_PACKAGES} ]] || true && echo "PR #${{ github.event.pull_request.number }} has these possibly Glibc 2.27 compatible packages: ${GLIBC_227_COMPATIBLE_PACKAGES}"
+            # If a package doesnt have a min_glibc value, or if its below 2.27, add it to GLIBC_227_COMPATIBLE_PACKAGES.
+            export GLIBC_227_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do if grep -q min_glibc packages/${i}.rb; then grep min_glibc packages/${i}.rb | tr -d \' | awk '{exit $2 <= 2.27}' || echo ${i} ; else echo ${i} ; fi ; done | xargs -r)"
+            if [[ -n ${GLIBC_227_COMPATIBLE_PACKAGES} ]]; then
+              echo "GLIBC_227_COMPATIBLE_PACKAGES=${GLIBC_227_COMPATIBLE_PACKAGES}" >> $GITHUB_ENV
+              echo "PR #${{ github.event.pull_request.number }} has these possibly Glibc 2.27 compatible packages: ${GLIBC_227_COMPATIBLE_PACKAGES}"
+            fi
 
-            # If a package doesnt have a min_glibc value, or if its below 2.37, add it to GLIBC_237_COMPATIBLE_PACKAGES
+            # If a package doesnt have a min_glibc value, or if its below 2.37, add it to GLIBC_237_COMPATIBLE_PACKAGES.
             export GLIBC_237_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do grep min_glibc packages/${i}.rb | tr -d \' | awk '{exit $2 <= 2.37}' || echo ${i} ; done | xargs)"
-            [[ ${GLIBC_237_COMPATIBLE_PACKAGES} ]] || true && echo "GLIBC_237_COMPATIBLE_PACKAGES=${GLIBC_237_COMPATIBLE_PACKAGES}" >> $GITHUB_ENV
-            [[ ${GLIBC_237_COMPATIBLE_PACKAGES} ]] || true && echo "PR #${{ github.event.pull_request.number }} has these possibly Glibc 2.37 compatible packages: ${GLIBC_237_COMPATIBLE_PACKAGES}"
+            if [[ -n ${GLIBC_237_COMPATIBLE_PACKAGES} ]]; then
+              echo "GLIBC_237_COMPATIBLE_PACKAGES=${GLIBC_237_COMPATIBLE_PACKAGES}" >> $GITHUB_ENV
+              echo "PR #${{ github.event.pull_request.number }} has these possibly Glibc 2.37 compatible packages: ${GLIBC_237_COMPATIBLE_PACKAGES}"
+            fi
 
-            # If a package has a compatibility of 'all' or one that includes 'x86_64', add it to the list.
+            # If a package has a compatibility of 'all' or one that includes 'x86_64', add it to x86_64_PACKAGES.
             export x86_64_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q \"compatibility.*all\|x86_64\" packages/${i}.rb && echo ${i}; done | xargs)"
-            [[ ${x86_64_PACKAGES} ]] || true && echo "x86_64_PACKAGES=${x86_64_PACKAGES}" >> $GITHUB_ENV
-            [[ ${x86_64_PACKAGES} ]] || true && echo "PR #${{ github.event.pull_request.number }} has these x86_64 compatible packages: ${x86_64_PACKAGES}"
+            if [[ -n ${x86_64_PACKAGES} ]]; then
+              echo "x86_64_PACKAGES=${x86_64_PACKAGES}" >> $GITHUB_ENV
+              echo "PR #${{ github.event.pull_request.number }} has these x86_64 compatible packages: ${x86_64_PACKAGES}"
+            fi
 
-            # If a package has a compatibility of 'all' or one that includes 'armv7l', add it to the list.
+            ## If a package has a compatibility of 'all' or one that includes 'armv7l', add it to ARMV7L_PACKAGES.
             export ARMV7L_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q \"compatibility.*all\|armv7l\" packages/${i}.rb && echo ${i}; done | xargs)"
-            [[ ${ARMV7L_PACKAGES} ]] || true && echo "ARMV7L_PACKAGES=${ARMV7L_PACKAGES}" >> $GITHUB_ENV
-            [[ ${ARMV7L_PACKAGES} ]] || true && echo "PR #${{ github.event.pull_request.number }} has these armv7l compatible packages: ${ARMV7L_PACKAGES}"
+            if [[ -n ${ARMV7L_PACKAGES} ]]; then
+              echo "ARMV7L_PACKAGES=${ARMV7L_PACKAGES}" >> $GITHUB_ENV
+              echo "PR #${{ github.event.pull_request.number }} has these armv7l compatible packages: ${ARMV7L_PACKAGES}"
+            fi
 
-            # If a package has a compatibility of 'all' or one that includes 'i686', add it to the list.
+            ## If a package has a compatibility of 'all' or one that includes 'i686', add it to i686_PACKAGES.
             export i686_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q \"compatibility.*all\|i686\" packages/${i}.rb && echo ${i}; done | xargs)"
-            [[ ${i686_PACKAGES} ]] || true && echo "i686_PACKAGES=${i686_PACKAGES}" >> $GITHUB_ENV
-            [[ ${i686_PACKAGES} ]] || true && echo "PR #${{ github.event.pull_request.number }} has these i686 compatible packages: ${i686_PACKAGES}"
+            if [[ -n ${i686_PACKAGES} ]]; then
+              echo "i686_PACKAGES=${i686_PACKAGES}" >> $GITHUB_ENV
+              echo "PR #${{ github.event.pull_request.number }} has these i686 compatible packages: ${i686_PACKAGES}"
+            fi
       - name: Export target docker container to github context
         env:
           TARGET_ARCH: ${{ matrix.arch }}

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -5,7 +5,7 @@ jobs:
   container_tests:
     strategy:
       matrix:
-        arch: [x86_64, armv7l]
+        arch: [x86_64, armv7l, i686]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,20 +32,29 @@ jobs:
       - name: Determine glibc and architecture package compatibility
         run: |
             # If a package doesnt have a min_glibc value, or if its below 2.27, add it to the list
-            echo "PR #${{ github.event.pull_request.number }} has these possibly Glibc 2.27 compatible packages: $(for i in ${CHANGED_PACKAGES} ; do if ! grep -q min_glibc packages/$i.rb; then echo $i ; else grep min_glibc packages/$i.rb | tr -d \' | awk '{exit $2 <= 2.27}' || echo $i ; fi ; done | xargs)"
+            export GLIBC_227_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do if grep -q min_glibc packages/${i}.rb; then grep min_glibc packages/${i}.rb | tr -d \' | awk '{exit $2 <= 2.27}' || echo ${i} ; else echo ${i} ; fi ; done | xargs)"
+            [[ ${GLIBC_227_COMPATIBLE_PACKAGES} ]] && echo "GLIBC_227_COMPATIBLE_PACKAGES=${GLIBC_227_COMPATIBLE_PACKAGES}" >> $GITHUB_ENV
+            [[ ${GLIBC_227_COMPATIBLE_PACKAGES} ]] && echo "PR #${{ github.event.pull_request.number }} has these possibly Glibc 2.27 compatible packages: ${GLIBC_227_COMPATIBLE_PACKAGES}"
 
             # If a package doesnt have a min_glibc value, or if its below 2.37, add it to GLIBC_237_COMPATIBLE_PACKAGES
             export GLIBC_237_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do grep min_glibc packages/$i.rb | tr -d \' | awk '{exit $2 <= 2.37}' || echo $i ; done | xargs)"
-            echo "GLIBC_237_COMPATIBLE_PACKAGES=${GLIBC_237_COMPATIBLE_PACKAGES}" >> $GITHUB_ENV
-            echo "PR #${{ github.event.pull_request.number }} has these possibly Glibc 2.37 compatible packages: ${GLIBC_237_COMPATIBLE_PACKAGES}"
+            [[ ${GLIBC_237_COMPATIBLE_PACKAGES} ]] && echo "GLIBC_237_COMPATIBLE_PACKAGES=${GLIBC_237_COMPATIBLE_PACKAGES}" >> $GITHUB_ENV
+            [[ ${GLIBC_237_COMPATIBLE_PACKAGES} ]] && echo "PR #${{ github.event.pull_request.number }} has these possibly Glibc 2.37 compatible packages: ${GLIBC_237_COMPATIBLE_PACKAGES}"
 
             # If a package has a compatibility of 'all' or one that includes 'x86_64', add it to the list.
-            echo "PR #${{ github.event.pull_request.number }} has these x86_64 compatible packages: $(for p in ${CHANGED_PACKAGES}; do grep -q "compatibility 'all'\|compatibility '.*x86_64.*'" packages/${p}.rb && echo ${p}; done | xargs)"
+            export x86_64_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do grep -q "compatibility 'all'\|compatibility '.*x86_64.*'" packages/${p}.rb && echo ${p}; done | xargs)"
+            [[ $x86_64_PACKAGES ]] && echo "x86_64_PACKAGES=${x86_64_PACKAGES}" >> $GITHUB_ENV
+            [[ $x86_64_PACKAGES ]] && echo "PR #${{ github.event.pull_request.number }} has these x86_64 compatible packages: ${x86_64_PACKAGES}"
 
             # If a package has a compatibility of 'all' or one that includes 'armv7l', add it to the list.
             export ARMV7L_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do grep -q \"compatibility.*all\|armv7l\" packages/${p}.rb && echo ${p}; done | xargs)"
-            echo "ARMV7L_PACKAGES=${ARMV7L_PACKAGES}" >> $GITHUB_ENV
-            echo "PR #${{ github.event.pull_request.number }} has these armv7l compatible packages: ${ARMV7L_PACKAGES}"
+            [[ ${ARMV7L_PACKAGES} ]] && echo "ARMV7L_PACKAGES=${ARMV7L_PACKAGES}" >> $GITHUB_ENV
+            [[ ${ARMV7L_PACKAGES} ]] && echo "PR #${{ github.event.pull_request.number }} has these armv7l compatible packages: ${ARMV7L_PACKAGES}"
+
+            # If a package has a compatibility of 'all' or one that includes 'i686', add it to the list.
+            export i686_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do grep -q "compatibility 'all'\|compatibility '.*i686.*'" packages/${p}.rb && echo ${p}; done | xargs)"
+            [[ $i686_PACKAGES ]] && echo "i686_PACKAGES=${i686_PACKAGES}" >> $GITHUB_ENV
+            [[ $i686_PACKAGES ]] && echo "PR #${{ github.event.pull_request.number }} has these i686 compatible packages: ${i686_PACKAGES}"
       - name: Export target docker container to github context
         env:
           TARGET_ARCH: ${{ matrix.arch }}
@@ -71,21 +80,37 @@ jobs:
               echo "PLATFORM=linux/arm/v7" >> $GITHUB_ENV
               echo "LIB_SUFFIX=" >> $GITHUB_ENV
               ;;
+              i686)
+              # There is only one i686 container based upon M58 with glibc 2.23.
+              echo "CONTAINER=alex-i686.m58" >> $GITHUB_ENV
+              echo "PLATFORM=linux/386" >> $GITHUB_ENV
+              echo "LIB_SUFFIX=" >> $GITHUB_ENV
+              ;;
             esac
       - name: Run unit tests
         run: |
-             if [[ -z ${NON_PKG_CHANGED_FILES} ]] && [[ $PLATFORM == 'linux/arm/v7' ]] && [[ -z ${ARMV7L_PACKAGES} ]]; then
-               # Run the arm container if there are non-package changed files,
-               # but otherwise do not run the arm container if there are no packages compatible with armv7l.
-               exit 0
-             fi
-             sudo docker run \
-             --platform $PLATFORM \
-             -v "${{ github.workspace }}/tests/unit_test.sh:/unit_test.sh" \
-             -u chronos \
-             -e CHANGED_PACKAGES="$CHANGED_PACKAGES" \
-             -e LD_LIBRARY_PATH="/usr/local/lib$LIB_SUFFIX" \
-             -e CREW_REPO="${{ github.event.pull_request.head.repo.clone_url }}" \
-             -e CREW_BRANCH="${{ github.head_ref }}" \
-             "satmandu/crewbuild:$CONTAINER" \
-             /usr/local/bin/bash /unit_test.sh
+            if [[ -z ${NON_PKG_CHANGED_FILES} ]] && [[ $PLATFORM == 'linux/arm/v7' ]] && [[ -z ${ARMV7L_PACKAGES} ]]; then
+              # Run the arm container if there are non-package changed files,
+              # but otherwise do not run the arm container if there are no packages compatible with armv7l.
+              exit 0
+            fi
+            if [[ -z ${NON_PKG_CHANGED_FILES} ]] && [[ $PLATFORM == 'linux/amd64' ]] && [[ -z ${x86_64_PACKAGES} ]]; then
+              # Run the x86_64 container if there are non-package changed files,
+              # but otherwise do not run the x86_64 container if there are no packages compatible with x86_64.
+              exit 0
+            fi
+            if [[ -z ${NON_PKG_CHANGED_FILES} ]] && [[ $PLATFORM == 'linux/386' ]] && [[ -z ${i686_PACKAGES} ]]; then
+              # Run the i686 container if there are non-package changed files,
+              # but otherwise do not run the i686 container if there are no packages compatible with i686.
+              exit 0
+            fi
+            sudo docker run \
+              --platform $PLATFORM \
+              -v "${{ github.workspace }}/tests/unit_test.sh:/unit_test.sh" \
+              -u chronos \
+              -e CHANGED_PACKAGES="$CHANGED_PACKAGES" \
+              -e LD_LIBRARY_PATH="/usr/local/lib$LIB_SUFFIX" \
+              -e CREW_REPO="${{ github.event.pull_request.head.repo.clone_url }}" \
+              -e CREW_BRANCH="${{ github.head_ref }}" \
+              "satmandu/crewbuild:$CONTAINER" \
+              /usr/local/bin/bash /unit_test.sh

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -14,30 +14,38 @@ jobs:
       - name: Set up QEMU
         if: matrix.arch == 'armv7l'
         uses: docker/setup-qemu-action@v3.2.0
+      - name: Get non-pkg changed files
+        id: non-pkg-changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files_ignore: packages/*.rb
       - name: Get all changed package files
         id: changed-ruby-files
         uses: tj-actions/changed-files@v45
         with:
-          files: |
-             packages/*.rb
+          files: packages/*.rb
       - name: Export variables to github context
         run: |
             # Convert "packages/foo.rb packages/bar.rb" (from steps.changed-ruby-files.outputs.all_changed_files) into "foo bar"
             echo "CHANGED_PACKAGES=$(echo "${{ steps.changed-ruby-files.outputs.all_changed_files }}" | xargs basename -s .rb | xargs)" >> $GITHUB_ENV
+            echo "NON_PKG_CHANGED_FILES=$(echo "${{ steps.non-pkg-changed-files.outputs.all_changed_files }}" | xargs)" >> $GITHUB_ENV
       - name: Determine glibc and architecture package compatibility
         run: |
             # If a package doesnt have a min_glibc value, or if its below 2.27, add it to the list
             echo "PR #${{ github.event.pull_request.number }} has these possibly Glibc 2.27 compatible packages: $(for i in ${CHANGED_PACKAGES} ; do if ! grep -q min_glibc packages/$i.rb; then echo $i ; else grep min_glibc packages/$i.rb | tr -d \' | awk '{exit $2 <= 2.27}' || echo $i ; fi ; done | xargs)"
 
             # If a package doesnt have a min_glibc value, or if its below 2.37, add it to GLIBC_237_COMPATIBLE_PACKAGES
-            echo "GLIBC_237_COMPATIBLE_PACKAGES=$(for i in ${CHANGED_PACKAGES} ; do grep min_glibc packages/$i.rb | tr -d \' | awk '{exit $2 <= 2.37}' || echo $i ; done | xargs)" >> $GITHUB_ENV
+            export GLIBC_237_COMPATIBLE_PACKAGES="$(for i in ${CHANGED_PACKAGES} ; do grep min_glibc packages/$i.rb | tr -d \' | awk '{exit $2 <= 2.37}' || echo $i ; done | xargs)"
+            echo "GLIBC_237_COMPATIBLE_PACKAGES=${GLIBC_237_COMPATIBLE_PACKAGES}" >> $GITHUB_ENV
             echo "PR #${{ github.event.pull_request.number }} has these possibly Glibc 2.37 compatible packages: ${GLIBC_237_COMPATIBLE_PACKAGES}"
 
             # If a package has a compatibility of 'all' or one that includes 'x86_64', add it to the list.
             echo "PR #${{ github.event.pull_request.number }} has these x86_64 compatible packages: $(for p in ${CHANGED_PACKAGES}; do grep -q "compatibility 'all'\|compatibility '.*x86_64.*'" packages/${p}.rb && echo ${p}; done | xargs)"
 
             # If a package has a compatibility of 'all' or one that includes 'armv7l', add it to the list.
-            echo "PR #${{ github.event.pull_request.number }} has these armv7l compatible packages: $(for p in ${CHANGED_PACKAGES}; do grep -q "compatibility 'all'\|compatibility '.*armv7l.*'" packages/${p}.rb && echo ${p}; done | xargs)"
+            export ARMV7L_PACKAGES="$(for p in ${CHANGED_PACKAGES}; do grep -q \"compatibility.*all\|armv7l\" packages/${p}.rb && echo ${p}; done | xargs)"
+            echo "ARMV7L_PACKAGES=${ARMV7L_PACKAGES}" >> $GITHUB_ENV
+            echo "PR #${{ github.event.pull_request.number }} has these armv7l compatible packages: ${ARMV7L_PACKAGES}"
       - name: Export target docker container to github context
         env:
           TARGET_ARCH: ${{ matrix.arch }}
@@ -66,6 +74,11 @@ jobs:
             esac
       - name: Run unit tests
         run: |
+             if [[ -z ${NON_PKG_CHANGED_FILES} ]] && [[ $PLATFORM == 'linux/arm/v7' ]] && [ -n "${ARMV7L_PACKAGES+1}" ]; then
+               # Run the arm container if there are non-package changed files,
+               # but otherwise do not run the arm container if there are no packages compatible with armv7l.
+               exit 0
+             fi
              sudo docker run \
              --platform $PLATFORM \
              -v "${{ github.workspace }}/tests/unit_test.sh:/unit_test.sh" \

--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -46,21 +46,21 @@ jobs:
             fi
 
             # If a package has a compatibility of 'all' or one that includes 'x86_64', add it to x86_64_PACKAGES.
-            export x86_64_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q "compatibility.*all\|x86_64" packages/${i}.rb && echo ${i}; done | xargs)"
+            export x86_64_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q "[[:space:]]compatibility.*all\|[[:space:]]compatibility.*x86_64" packages/${i}.rb && echo ${i}; done | xargs)"
             if [[ -n ${x86_64_PACKAGES} ]]; then
               echo "x86_64_PACKAGES=${x86_64_PACKAGES}" >> $GITHUB_ENV
               echo "PR #${{ github.event.pull_request.number }} has these x86_64 compatible packages: ${x86_64_PACKAGES}"
             fi
 
             ## If a package has a compatibility of 'all' or one that includes 'armv7l', add it to ARMV7L_PACKAGES.
-            export ARMV7L_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q "compatibility.*all\|armv7l" packages/${i}.rb && echo ${i}; done | xargs)"
+            export ARMV7L_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q "[[:space:]]compatibility.*all\|[[:space:]]compatibility.*armv7l" packages/${i}.rb && echo ${i}; done | xargs)"
             if [[ -n ${ARMV7L_PACKAGES} ]]; then
               echo "ARMV7L_PACKAGES=${ARMV7L_PACKAGES}" >> $GITHUB_ENV
               echo "PR #${{ github.event.pull_request.number }} has these armv7l compatible packages: ${ARMV7L_PACKAGES}"
             fi
 
             ## If a package has a compatibility of 'all' or one that includes 'i686', add it to i686_PACKAGES.
-            export i686_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q "compatibility.*all\|i686" packages/${i}.rb && echo ${i}; done | xargs)"
+            export i686_PACKAGES="$(for i in ${CHANGED_PACKAGES}; do grep -q "[[:space:]]compatibility.*all\|[[:space:]]compatibility.*i686" packages/${i}.rb && echo ${i}; done | xargs)"
             if [[ -n ${i686_PACKAGES} ]]; then
               echo "i686_PACKAGES=${i686_PACKAGES}" >> $GITHUB_ENV
               echo "PR #${{ github.event.pull_request.number }} has these i686 compatible packages: ${i686_PACKAGES}"


### PR DESCRIPTION
Fixes #10340 (Specifically missing handbrake binaries as mentioned.)

- Mea culpa... I hadn't built the binaries when I updated the handbrake package file, because I was focused upon fixing builds on the Glibc 2.37 systems, and then forgot.

- This also adjusts the unit test workflow to only run the arm container if there are armv7l compatible packages changes or changes to non-package files.

##
Builds:
- [x] `x86_64`
- [ ] `i686`
- [ ] `armv7l`
##
Tested & Working properly:
- [ ] `x86_64`
- [ ] `i686`
- [ ] `armv7l` <!-- (reasons why it doesn't) -->
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=handbrake crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
