### PR TITLE
Brave 1.68.141 => 1.69.153

### DIFF
--- a/manifest/x86_64/b/brave.filelist
+++ b/manifest/x86_64/b/brave.filelist
@@ -2,6 +2,8 @@
 /usr/local/share/brave/LICENSE
 /usr/local/share/brave/MEIPreload/manifest.json
 /usr/local/share/brave/MEIPreload/preloaded_data.pb
+/usr/local/share/brave/PrivacySandboxAttestationsPreloaded/manifest.json
+/usr/local/share/brave/PrivacySandboxAttestationsPreloaded/privacy-sandbox-attestations.dat
 /usr/local/share/brave/brave
 /usr/local/share/brave/brave-browser
 /usr/local/share/brave/brave_100_percent.pak

--- a/packages/brave.rb
+++ b/packages/brave.rb
@@ -3,12 +3,12 @@ require 'package'
 class Brave < Package
   description 'Next generation Brave browser for macOS, Windows, Linux, Android.'
   homepage 'https://brave.com/'
-  version '1.68.141'
+  version '1.69.153'
   license 'MPL-2'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://github.com/brave/brave-browser/releases/download/v#{version}/brave-browser-#{version}-linux-amd64.zip"
-  source_sha256 'aa806885e5ea1cba870a8d3104f5534aedc4185f874ef31ddc6644b0ef3f87be'
+  source_sha256 '71091b6362685055f6e2f299c4410a92110dae500ab3bfbeca98d1dfef34b0ae'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & (not) Working properly:
- [x] `x86_64` Unable to launch in hatch m126 container
- [ ] `i686`
- [ ] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-brave crew update \
&& yes | crew upgrade
```