### PR TITLE
Edge 127.0.2651.105-1 => 128.0.2739.42-1

### DIFF
--- a/manifest/x86_64/e/edge.filelist
+++ b/manifest/x86_64/e/edge.filelist
@@ -14,6 +14,8 @@
 /usr/local/share/menu/microsoft-edge.menu
 /usr/local/share/msedge/MEIPreload/manifest.json
 /usr/local/share/msedge/MEIPreload/preloaded_data.pb
+/usr/local/share/msedge/PrivacySandboxAttestationsPreloaded/manifest.json
+/usr/local/share/msedge/PrivacySandboxAttestationsPreloaded/privacy-sandbox-attestations.dat
 /usr/local/share/msedge/WidevineCdm/_platform_specific/linux_x64/libwidevinecdm.so
 /usr/local/share/msedge/WidevineCdm/manifest.json
 /usr/local/share/msedge/cron/microsoft-edge

--- a/packages/edge.rb
+++ b/packages/edge.rb
@@ -3,12 +3,12 @@ require 'package'
 class Edge < Package
   description 'Microsoft Edge is the fast and secure browser'
   homepage 'https://www.microsoft.com/en-us/edge'
-  version '127.0.2651.105-1'
+  version '128.0.2739.42-1'
   license 'MIT'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_#{version}_amd64.deb"
-  source_sha256 '16fa81a3296ef1e5efe7097cb6dc66b2aac1904ccc2f6b90a7145bfa892511a9'
+  source_sha256 '0307595f6127b36fab8472d857479f62c5d8053b366b9ec7c86cf693e20331e4'
 
   depends_on 'at_spi2_core'
   depends_on 'libcom_err'


### PR DESCRIPTION
Tested & (not) Working properly:
- [x] `x86_64` Unable to launch in hatch m126 container
- [ ] `i686`
- [ ] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-edge crew update \
&& yes | crew upgrade
```