### PR TITLE
Fix repology workflow again by installing highline

### DIFF
--- a/.github/workflows/Repology.yml
+++ b/.github/workflows/Repology.yml
@@ -11,6 +11,8 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3.4'
+      - name: Install highline
+        run: gem install highline
       - name: Configure git
         run: |
           git config --global user.name 'github-actions[bot]'


### PR DESCRIPTION

## Description
this is the most fragile action ever

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=rightehn crew update \
&& yes | crew upgrade
```

truly this embodies the spirit of github consequences as opposed to github actions