### PR TITLE
Remove usage of .blank? and dependency on activesupport

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -24,7 +24,6 @@ end
 require_gem('highline')
 # The json gem can break when upgrading from a much older version of ruby.
 require_gem('json')
-require_gem('activesupport', 'active_support/core_ext/object/blank')
 require 'digest/sha2'
 require 'fileutils'
 require 'tmpdir'
@@ -137,7 +136,7 @@ class ExitMessage
 end
 
 at_exit do
-  GnomePostinstall.run unless GnomePostinstall.gnome_packages.blank?
+  GnomePostinstall.run unless GnomePostinstall.gnome_packages.empty?
 
   # Print exit messages.
   ExitMessage.print

--- a/install.sh
+++ b/install.sh
@@ -334,7 +334,7 @@ ln -sfv "../lib/crew/bin/crew" "${CREW_PREFIX}/bin/"
 echo "export CREW_PREFIX=${CREW_PREFIX}" >> "${CREW_PREFIX}/etc/env.d/profile"
 
 echo_info "Installing essential ruby gems...\n"
-BOOTSTRAP_GEMS='activesupport concurrent-ruby highline'
+BOOTSTRAP_GEMS='concurrent-ruby highline'
 # shellcheck disable=SC2086
 install_ruby_gem ${BOOTSTRAP_GEMS}
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.52.0' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.52.1' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -1,4 +1,3 @@
-require 'active_support/core_ext/object/blank'
 require 'digest/sha2'
 require 'io/console'
 require 'uri'
@@ -61,7 +60,7 @@ def downloader(url, sha256sum, filename = File.basename(url), verbose = false)
 
   unless (sha256sum =~ /^SKIP$/i) || (calc_sha256sum == sha256sum)
     if CREW_FORCE
-      pkg_name = @pkg_name.blank? ? name : @pkg_name
+      pkg_name = @pkg_name.to_s.empty? ? name : @pkg_name
       puts "Updating checksum for #{filename}".lightblue
       puts "from #{sha256sum} to #{calc_sha256sum}".lightblue
       puts "in #{CREW_LOCAL_REPO_ROOT}/packages/#{pkg_name}.rb .".lightblue

--- a/packages/core.rb
+++ b/packages/core.rb
@@ -78,12 +78,12 @@ class Core < Package
   depends_on 'readline'
   depends_on 'rtmpdump'
   depends_on 'ruby'
-  depends_on 'ruby_activesupport'
+  # For use in simultaneous upx compression.
   depends_on 'ruby_concurrent_ruby'
   # For use in ruby prompts.
   depends_on 'ruby_highline'
   # This contains the debugger config files.
-  depends_on 'ruby_pry'
+  depends_on 'ruby_pry' if CREW_DEBUG
   depends_on 'slang'
   depends_on 'sqlite'
   depends_on 'uchardet'


### PR DESCRIPTION
## Description
yeah so we don't actually need to defensively program against our own code-- `gnome_packages` is initialized at line 2 of `lib/gnome.rb`, so it will never be nil, and we can just convert `@pkg_name` to a string so we don't have the `NoMethodError` problems.

also why do we have code for editing package files in `lib/downloader.rb`???

Tested & Working properly:
- [x] `x86_64`
- [ ] `i686`
- [ ] `armv7l`

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=arid crew update \
&& yes | crew upgrade
```