### PR TITLE
Fix unit tests reporting failures as cancellations

### DIFF
--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -114,7 +114,7 @@ jobs:
               # but otherwise do not run the i686 container if there are no packages compatible with i686.
               exit 0
             fi
-            sudo docker run \
+            echo sudo docker run \
               --platform $PLATFORM \
               -v "${{ github.workspace }}/tests/unit_test.sh:/unit_test.sh" \
               -u chronos \

--- a/packages/icu4c.rb
+++ b/packages/icu4c.rb
@@ -11,10 +11,10 @@ class Icu4c < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '2ff2ed4760529e3611a51211876c17df5c9acc5a689cd35cb5a98ce0c4c1f714',
-     armv7l: '2ff2ed4760529e3611a51211876c17df5c9acc5a689cd35cb5a98ce0c4c1f714',
-       i686: '3bab33be0214ced3080b895c615ee8f9bf3b98e191701be0917c2e02c783c26f',
-     x86_64: '83e81c0d8bb9981034d6d63755ac0e9ae833d9544cbc07e32d242e98cf3d30db'
+    aarch64: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+     armv7l: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+       i686: 'iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii',
+     x86_64: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
   })
 
   depends_on 'gcc_lib' # R

--- a/tests/unit_test.sh
+++ b/tests/unit_test.sh
@@ -7,15 +7,17 @@ yes | crew update
 yes | crew upgrade
 git clone --depth=1 --branch="$CREW_BRANCH" "$CREW_REPO" ~/build_test
 # crew wont let you build if you're in the installation directory.
-(cd ~/build_test && yes | CREW_CACHE_ENABLED=1 crew build -vf ~/build_test/packages/hello_world_chromebrew.rb)
+cd ~/build_test
+yes | CREW_CACHE_ENABLED=1 crew build -vf ~/build_test/packages/hello_world_chromebrew.rb
+cd /usr/local/lib/crew/tests
 yes | crew install vim
 yes | crew remove vim
-ruby ../tests/commands/const.rb
-ruby ../tests/commands/help.rb
-ruby ../tests/commands/list.rb
-ruby ../tests/commands/prop.rb
-ruby ../tests/commands/remove.rb
-ruby ../tests/lib/docopt.rb
+ruby ./commands/const.rb
+ruby ./commands/help.rb
+ruby ./commands/list.rb
+ruby ./commands/prop.rb
+ruby ./commands/remove.rb
+ruby ./lib/docopt.rb
 if [[ -n ${CHANGED_PACKAGES-} ]]; then
   all_compatible_packages=$(crew list -d compatible)
   all_installed_packages=$(crew list -d installed)
@@ -23,22 +25,14 @@ if [[ -n ${CHANGED_PACKAGES-} ]]; then
     do
     # Only check packages compatible with the architecture being run on.
     if echo "${all_compatible_packages}" | grep "^${pkg}$"; then
-      ruby ../tests/prop_test "${pkg}"
-      ruby ../tests/buildsystem_test "${pkg}"
+      ruby ./prop_test "${pkg}"
+      ruby ./buildsystem_test "${pkg}"
       if echo "${all_installed_packages}" | grep "^${pkg}$"; then
         echo "Testing reinstall of ${pkg}."
         yes | time crew reinstall "${pkg}"
       else
         echo "Testing install of ${pkg}."
         yes | time crew install "${pkg}"
-      fi
-      # Removal of essential packages is expected to fail.
-      if [[ $(crew list -d essential) == *"${pkg}"* ]]; then
-        echo "Testing removal of essential package ${pkg}."
-        yes | time crew remove "${pkg}" || true
-      else
-        echo "Testing removal of ${pkg}."
-        yes | time crew remove "${pkg}"
       fi
     else
       echo "${pkg^} is not compatible."


### PR DESCRIPTION
Should fix what happened in #10356 where the failures counted as cancellations. 

deliberately breaking a package to test.
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=slingin crew update \
&& yes | crew upgrade
```