### PR TITLE
Github_cli 2.54.0 => 2.55.0

### DIFF
--- a/packages/github_cli.rb
+++ b/packages/github_cli.rb
@@ -3,7 +3,7 @@ require 'package'
 class Github_cli < Package
   description 'Official Github CLI tool'
   homepage 'https://cli.github.com/'
-  version '2.54.0'
+  version '2.55.0'
   license 'MIT'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Github_cli < Package
      x86_64: "https://github.com/cli/cli/releases/download/v#{version}/gh_#{version}_linux_amd64.tar.gz"
   })
   source_sha256({
-    aarch64: 'cd53809273ad6011fdd98e0244c5c2276b15f3dd1294e4715627ebd4f9c6e0f1',
-     armv7l: 'cd53809273ad6011fdd98e0244c5c2276b15f3dd1294e4715627ebd4f9c6e0f1',
-       i686: '5675606eaa8ab683477a137f73dad7f25e4e0efb2e4e22538d63d68ac764ec3d',
-     x86_64: 'c4441b2acfb63feb5fc37a346b0a0a66080d657397f1eb81e3025961dcb06dd3'
+    aarch64: '7a7f496e4e952867582fcbbd959b8a7cbbfdf715625e396e03f3f2fbd97f26da',
+     armv7l: '7a7f496e4e952867582fcbbd959b8a7cbbfdf715625e396e03f3f2fbd97f26da',
+       i686: 'cbb7537847a35da76c588f8376b8c6e44ba2e16cd6d7133144b1b494ee80027f',
+     x86_64: '49700b3fedb5bfcbef696fe9f1f69091ceb9caf2d40bd872b5028c451efc52bc'
   })
 
   no_compile_needed


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-github_cli crew update \
&& yes | crew upgrade
```