### PR TITLE
docker-systemctl-replacement 9cbe1a0 -> 1.5.8066, hyphen 73dd29 -> 2.8.8-73dd296, Inxi 811a19 -> 3.3.35-1, libXdmcp 4a71fdf -> 1.1.5, py3_snowballstemmer 2.1.0-py3.12 -> 2.2.0-py3.12, libstemmer 78c149 -> 2.2.0

### DIFF
--- a/manifest/armv7l/i/inxi.filelist
+++ b/manifest/armv7l/i/inxi.filelist
@@ -1,2 +1,2 @@
 /usr/local/bin/inxi
-/usr/local/man/man1/inxi.1.gz
+/usr/local/share/man/man1/inxi.1.zst

--- a/manifest/armv7l/l/libstemmer.filelist
+++ b/manifest/armv7l/l/libstemmer.filelist
@@ -1,2 +1,4 @@
 /usr/local/include/libstemmer.h
 /usr/local/lib/libstemmer.so
+/usr/local/lib/libstemmer.so.2
+/usr/local/lib/libstemmer.so.2.2.0

--- a/manifest/i686/i/inxi.filelist
+++ b/manifest/i686/i/inxi.filelist
@@ -1,2 +1,2 @@
 /usr/local/bin/inxi
-/usr/local/man/man1/inxi.1.gz
+/usr/local/share/man/man1/inxi.1.zst

--- a/manifest/i686/l/libstemmer.filelist
+++ b/manifest/i686/l/libstemmer.filelist
@@ -1,2 +1,4 @@
 /usr/local/include/libstemmer.h
 /usr/local/lib/libstemmer.so
+/usr/local/lib/libstemmer.so.2
+/usr/local/lib/libstemmer.so.2.2.0

--- a/manifest/x86_64/i/inxi.filelist
+++ b/manifest/x86_64/i/inxi.filelist
@@ -1,2 +1,2 @@
 /usr/local/bin/inxi
-/usr/local/man/man1/inxi.1.gz
+/usr/local/share/man/man1/inxi.1.zst

--- a/manifest/x86_64/l/libstemmer.filelist
+++ b/manifest/x86_64/l/libstemmer.filelist
@@ -1,2 +1,4 @@
 /usr/local/include/libstemmer.h
 /usr/local/lib64/libstemmer.so
+/usr/local/lib64/libstemmer.so.2
+/usr/local/lib64/libstemmer.so.2.2.0

--- a/packages/docker_systemctl_replacement.rb
+++ b/packages/docker_systemctl_replacement.rb
@@ -3,18 +3,18 @@ require 'package'
 class Docker_systemctl_replacement < Package
   description 'docker systemctl replacement'
   homepage 'https://github.com/gdraheim/docker-systemctl-replacement'
-  version '9cbe1a0'
+  version '1.5.8066'
   license 'EUPL'
   compatibility 'all'
   source_url 'https://github.com/gdraheim/docker-systemctl-replacement.git'
-  git_hashtag '9cbe1a00eb4bdac6ff05b96ca34ec9ed3d8fc06c'
+  git_hashtag "v#{version}"
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '018be1e2684c084bd58f80fb1a52e417c430712ea956c89bcc17d82bab472947',
-     armv7l: '018be1e2684c084bd58f80fb1a52e417c430712ea956c89bcc17d82bab472947',
-       i686: 'f72bbcc62a4ac6801d8603efd6fc19d2ac64d0f3de881fde49c7047575463054',
-     x86_64: '210280e690f7665396ea98b87af324095b3abd34e40ab904ad3ee5214a4bfbb2'
+    aarch64: '2c790c217bdb721fe75d974b263f9871d73bd5c0a4e7ba95c556bd215288effe',
+     armv7l: '2c790c217bdb721fe75d974b263f9871d73bd5c0a4e7ba95c556bd215288effe',
+       i686: '6bf951970ef5446b3673fb5cae94b78c70a7a2b7b10dd96aa2d8c21679fbd405',
+     x86_64: 'f0550490009b99c4daa6ba43bb41a45a4578c5b4fccee309b6c7189615084c60'
   })
 
   depends_on 'python3'
@@ -26,10 +26,7 @@ class Docker_systemctl_replacement < Package
   def self.install
     # Systemd units should go in "{XDG_CONFIG_HOME}/systemd/user"
     # Units can be accessed via "systemctl status --user unitname"
-    FileUtils.mkdir_p %W[
-      #{CREW_DEST_PREFIX}/bin
-      #{CREW_DEST_PREFIX}/.config/systemd/user
-    ]
+    FileUtils.mkdir_p %W[#{CREW_DEST_PREFIX}/bin #{CREW_DEST_HOME}/.config/systemd/user]
     FileUtils.install 'files/docker/systemctl3.py', "#{CREW_DEST_PREFIX}/bin/systemctl", mode: 0o755
   end
 end

--- a/packages/hyphen.rb
+++ b/packages/hyphen.rb
@@ -1,36 +1,21 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Hyphen < Package
+class Hyphen < Autotools
   description 'hyphenation library to use converted TeX hyphenation patterns'
   homepage 'https://github.com/hunspell/hyphen'
-  version '73dd29'
+  version '2.8.8-73dd296'
   license 'GPL-2, LGPL-2.1 and MPL-1.1'
   compatibility 'all'
-  source_url 'https://github.com/hunspell/hyphen/archive/73dd2967c8e1e4f6d7334ee9e539a323d6e66cbd.tar.gz'
-  source_sha256 'd174ba8a2653e79ebd135fd2241fe87d511f9510a31e82bdf13ec21192852595'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/hunspell/hyphen.git'
+  git_hashtag '73dd2967c8e1e4f6d7334ee9e539a323d6e66cbd'
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '9c4dc3e8175ecf54eff33dca64506534b0a5e284749854ff20fc8f2b411c2442',
-     armv7l: '9c4dc3e8175ecf54eff33dca64506534b0a5e284749854ff20fc8f2b411c2442',
-       i686: 'a7a0146e845bdb5238a2f30bfca98261e4c1cc509f0f70a0a457092ad6a50346',
-     x86_64: '6bb5f68a9f8b03a56456c9e806a9baf6be49ee2298bbc0c0e0c4ef182152f79b'
+    aarch64: '7e2e2fdb83d0ffc858f50927f8119566a7709cb7644bbf1002f8e47f050e3a56',
+     armv7l: '7e2e2fdb83d0ffc858f50927f8119566a7709cb7644bbf1002f8e47f050e3a56',
+       i686: 'fceabb306364839bea4cec6d415a11e4b6b961f64eda2ade1cd5339fd57b0dd0',
+     x86_64: 'cae5691f15a004798e42721343845626363a807b0973009edcd415c33b739b5b'
   })
 
-  def self.build
-    system 'autoreconf -fvi'
-    system './configure',
-           "--prefix=#{CREW_PREFIX}",
-           "--libdir=#{CREW_LIB_PREFIX}",
-           '--disable-maintainer-mode'
-    system 'make'
-  end
-
-  def self.check
-    system 'make', 'check'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  run_tests
 end

--- a/packages/inxi.rb
+++ b/packages/inxi.rb
@@ -3,29 +3,25 @@ require 'package'
 class Inxi < Package
   description 'inxi is a full featured CLI system information tool.'
   homepage 'https://smxi.org/docs/inxi.htm'
-  version '811a19'
+  version '3.3.35-1'
   license 'GPL-3'
   compatibility 'all'
-  source_url 'https://github.com/smxi/inxi/archive/811a199badbacc8d54254264c51de8dc3f5c82d2.tar.gz'
-  source_sha256 'fd4d7e89166f4cd96fe91448753a1279520bc0f9ee3a2cfbd92ff4a2b1cf487a'
-  binary_compression 'tar.xz'
+  source_url 'https://codeberg.org/smxi/inxi.git'
+  git_hashtag version
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'a7605cdd62c35259dddf00c133c7af00816ed270b3326094a129f9436e65700e',
-     armv7l: 'a7605cdd62c35259dddf00c133c7af00816ed270b3326094a129f9436e65700e',
-       i686: 'c8dc00fc15d1fd8b11386b71c061746361fc5792f7bbede5ecc3a244aaf8c357',
-     x86_64: '6226f1fb5fbeb93ab9ad7237de9f1e8f21bba3e47e035f1b2776c4733972e197'
+    aarch64: '238537279b21affc02dc28973d5af2cb3db3ec4b80327389d276adeaf8bbc8f6',
+     armv7l: '238537279b21affc02dc28973d5af2cb3db3ec4b80327389d276adeaf8bbc8f6',
+       i686: '99135aa3e34c39e4d3624fbb9e1a36adfda08d53cc76fdd88772a33c27afc71a',
+     x86_64: 'dd850645b3f5ba9528257250ae2851b26c964c83b669d40a26352407f0d5c619'
   })
 
   depends_on 'gawk'
   depends_on 'perl'
 
-  def self.build
-    system "sed -i 's,/os-release,/lsb-release,g' inxi"
-  end
-
   def self.install
-    system "install -Dm755 inxi #{CREW_DEST_PREFIX}/bin/inxi"
-    system "install -Dm644 inxi.1.gz #{CREW_DEST_PREFIX}/man/man1/inxi.1.gz"
+    FileUtils.install 'inxi', "#{CREW_DEST_PREFIX}/bin/inxi", mode: 0o755
+    FileUtils.install 'inxi.1', "#{CREW_DEST_MAN_PREFIX}/man1/inxi.1", mode: 0o644
   end
 end

--- a/packages/libstemmer.rb
+++ b/packages/libstemmer.rb
@@ -3,38 +3,34 @@ require 'package'
 class Libstemmer < Package
   description 'Snowball Stemming Algorithms'
   homepage 'https://snowballstem.org/'
-  version '78c149'
+  version '2.2.0'
   license 'BSD-3'
   compatibility 'all'
-  source_url 'https://github.com/zvelo/libstemmer/archive/78c149a3a6f262a35c7f7351d3f77b725fc646cf.tar.gz'
-  source_sha256 '9bbd1bd2b7829f6bdafba97667fc795b3a80785c2285a5b73c3006b0bf3db688'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/snowballstem/snowball.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '854bc6cb2855c76b052d49fc8ac0c2dbc3766fede27ba6eac71846eef85f9351',
-     armv7l: '854bc6cb2855c76b052d49fc8ac0c2dbc3766fede27ba6eac71846eef85f9351',
-       i686: 'aa04ec939e77fcce2cbbad9498f6d13c4ccd351bfef9540fa9ef9c13c467ba94',
-     x86_64: '687765fc1f522249eef1d40b85f5a5cab1483be44710af5ba37ae9f324d16c0a'
+    aarch64: '2d882999ed5e010b974e3abb6023619ba7a879351ec8f5b6cd830f4988042cf1',
+     armv7l: '2d882999ed5e010b974e3abb6023619ba7a879351ec8f5b6cd830f4988042cf1',
+       i686: '2b1c100854db9c1030182f9e5bf02182152b5826c719509b0bb9587f8181a297',
+     x86_64: '9f5b021924d96941bc8ac9a93ecb56d06b4d4ee5cd6707eaeb98f51a5fe4bce7'
   })
 
-  def self.build
-    Dir.mkdir 'build'
-    Dir.chdir 'build' do
-      system 'cmake',
-             "-DCMAKE_INSTALL_PREFIX=#{CREW_PREFIX}",
-             '-DCMAKE_BUILD_TYPE=Release',
-             '-DBUILD_SHARED_LIBS=ON',
-             '..'
-      system 'make'
-    end
+  # https://github.com/snowballstem/snowball/issues/34
+  def self.patch
+    # [PATCH] update of #42 used to package for alpine linux
+    downloader 'https://patch-diff.githubusercontent.com/raw/snowballstem/snowball/pull/160.patch', '141e1251c10d3d2b7d668415abcc5c90662e5415921355c8a5b9916fb1ec00ba'
+    system 'git apply 160.patch'
   end
 
+  def self.build
+    system 'make'
+  end
+
+  # https://github.com/snowballstem/snowball/issues/189
   def self.install
-    Dir.chdir 'build' do
-      system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-    end
-    Dir.chdir CREW_DEST_PREFIX do
-      FileUtils.mv 'lib', 'lib64' if ARCH == 'x86_64'
-    end
+    FileUtils.install 'include/libstemmer.h', "#{CREW_DEST_PREFIX}/include/libstemmer.h", mode: 0o644
+    FileUtils.install %w[libstemmer.so libstemmer.so.2 libstemmer.so.2.2.0], CREW_DEST_LIB_PREFIX, mode: 0o644
   end
 end

--- a/packages/libxdmcp.rb
+++ b/packages/libxdmcp.rb
@@ -1,34 +1,26 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Libxdmcp < Package
+class Libxdmcp < Autotools
   description 'The libXdmcp package contains a library implementing the X Display Manager Control Protocol.'
-  homepage 'https://www.x.org/wiki/'
-  version '4a71fdf'
+  homepage 'https://gitlab.freedesktop.org/xorg/lib/libxdmcp'
+  version '1.1.5'
   license 'MIT'
   compatibility 'all'
   source_url 'https://gitlab.freedesktop.org/xorg/lib/libxdmcp.git'
-  git_hashtag '4a71fdf6d34df67d3f1335590da6ae3050128fb2'
+  git_hashtag "libXdmcp-#{version}"
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '591a059b27c7095f45adf57a4d1ac4b045fb2e6be8ea55bac8aa2b2eef1b3c16',
-     armv7l: '591a059b27c7095f45adf57a4d1ac4b045fb2e6be8ea55bac8aa2b2eef1b3c16',
-       i686: 'a91f416ab907be4f4183b4c5da505e4d25586736b22185e3f58b64c36a1f9ca1',
-     x86_64: '553304325808a09bc564a989a1e727046000b892ce75d1dec437df7d67ade648'
+    aarch64: '7d48ce878c0b396e1b31800e3861c2081b5e29a26d4e948ac6c3dbcb9b86d8ec',
+     armv7l: '7d48ce878c0b396e1b31800e3861c2081b5e29a26d4e948ac6c3dbcb9b86d8ec',
+       i686: '2b4fe67950321efca05634b09e694a5482fa8ecfe41ee58e693cc0eba38beaba',
+     x86_64: 'e8e3832fa1f024a3546e435f028ca6c47894a32705e56fa11e2b29467ea4cd9e'
   })
 
   depends_on 'libbsd' # R
   depends_on 'libmd' # R
+  depends_on 'xorg_macros' => :build
   depends_on 'xorg_proto'
 
-  def self.build
-    system 'NOCONFIGURE=1 ./autogen.sh'
-    system 'filefix'
-    system "./configure #{CREW_OPTIONS}"
-    system 'make'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  run_tests
 end

--- a/packages/py3_snowballstemmer.rb
+++ b/packages/py3_snowballstemmer.rb
@@ -3,10 +3,11 @@ require 'buildsystems/pip'
 class Py3_snowballstemmer < Pip
   description 'Snowball stemming library collection for Python'
   homepage 'https://snowballstem.org'
-  version '2.1.0-py3.12'
+  version '2.2.0-py3.12'
   license 'BSD'
   compatibility 'all'
   source_url 'SKIP'
 
   depends_on 'py3_pystemmer'
+  depends_on 'python3'
 end


### PR DESCRIPTION
updating more packages, this time chipping away at the list of ignored versions on repology as much as I can without being able to do seamless rebuilds.

##
Builds:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
Tested & Working properly:
- [ ] `x86_64`
- [ ] `i686`
- [ ] `armv7l` <!-- (reasons why it doesn't) -->
##
No manifest changes other than inxi and libstemmer.
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=ferable crew update \
&& yes | crew upgrade
```
