### PR TITLE
Man_db 2.12.1 => 2.13.0

### DIFF
--- a/manifest/armv7l/m/man_db.filelist
+++ b/manifest/armv7l/m/man_db.filelist
@@ -8,11 +8,11 @@
 /usr/local/bin/whatis
 /usr/local/etc/man_db.conf
 /usr/local/etc/tmpfiles.d/man-db.conf
-/usr/local/lib/man-db/libman-2.12.1.so
+/usr/local/lib/man-db/libman-2.13.0.so
 /usr/local/lib/man-db/libman.a
 /usr/local/lib/man-db/libman.la
 /usr/local/lib/man-db/libman.so
-/usr/local/lib/man-db/libmandb-2.12.1.so
+/usr/local/lib/man-db/libmandb-2.13.0.so
 /usr/local/lib/man-db/libmandb.a
 /usr/local/lib/man-db/libmandb.la
 /usr/local/lib/man-db/libmandb.so
@@ -81,6 +81,7 @@
 /usr/local/share/locale/tr/LC_MESSAGES/man-db-gnulib.mo
 /usr/local/share/locale/tr/LC_MESSAGES/man-db.mo
 /usr/local/share/locale/uk/LC_MESSAGES/man-db-gnulib.mo
+/usr/local/share/locale/uk/LC_MESSAGES/man-db.mo
 /usr/local/share/locale/vi/LC_MESSAGES/man-db-gnulib.mo
 /usr/local/share/locale/vi/LC_MESSAGES/man-db.mo
 /usr/local/share/locale/zh_CN/LC_MESSAGES/man-db-gnulib.mo

--- a/manifest/i686/m/man_db.filelist
+++ b/manifest/i686/m/man_db.filelist
@@ -8,11 +8,11 @@
 /usr/local/bin/whatis
 /usr/local/etc/man_db.conf
 /usr/local/etc/tmpfiles.d/man-db.conf
-/usr/local/lib/man-db/libman-2.12.1.so
+/usr/local/lib/man-db/libman-2.13.0.so
 /usr/local/lib/man-db/libman.a
 /usr/local/lib/man-db/libman.la
 /usr/local/lib/man-db/libman.so
-/usr/local/lib/man-db/libmandb-2.12.1.so
+/usr/local/lib/man-db/libmandb-2.13.0.so
 /usr/local/lib/man-db/libmandb.a
 /usr/local/lib/man-db/libmandb.la
 /usr/local/lib/man-db/libmandb.so
@@ -81,6 +81,7 @@
 /usr/local/share/locale/tr/LC_MESSAGES/man-db-gnulib.mo
 /usr/local/share/locale/tr/LC_MESSAGES/man-db.mo
 /usr/local/share/locale/uk/LC_MESSAGES/man-db-gnulib.mo
+/usr/local/share/locale/uk/LC_MESSAGES/man-db.mo
 /usr/local/share/locale/vi/LC_MESSAGES/man-db-gnulib.mo
 /usr/local/share/locale/vi/LC_MESSAGES/man-db.mo
 /usr/local/share/locale/zh_CN/LC_MESSAGES/man-db-gnulib.mo

--- a/manifest/x86_64/m/man_db.filelist
+++ b/manifest/x86_64/m/man_db.filelist
@@ -8,11 +8,11 @@
 /usr/local/bin/whatis
 /usr/local/etc/man_db.conf
 /usr/local/etc/tmpfiles.d/man-db.conf
-/usr/local/lib64/man-db/libman-2.12.1.so
+/usr/local/lib64/man-db/libman-2.13.0.so
 /usr/local/lib64/man-db/libman.a
 /usr/local/lib64/man-db/libman.la
 /usr/local/lib64/man-db/libman.so
-/usr/local/lib64/man-db/libmandb-2.12.1.so
+/usr/local/lib64/man-db/libmandb-2.13.0.so
 /usr/local/lib64/man-db/libmandb.a
 /usr/local/lib64/man-db/libmandb.la
 /usr/local/lib64/man-db/libmandb.so
@@ -81,6 +81,7 @@
 /usr/local/share/locale/tr/LC_MESSAGES/man-db-gnulib.mo
 /usr/local/share/locale/tr/LC_MESSAGES/man-db.mo
 /usr/local/share/locale/uk/LC_MESSAGES/man-db-gnulib.mo
+/usr/local/share/locale/uk/LC_MESSAGES/man-db.mo
 /usr/local/share/locale/vi/LC_MESSAGES/man-db-gnulib.mo
 /usr/local/share/locale/vi/LC_MESSAGES/man-db.mo
 /usr/local/share/locale/zh_CN/LC_MESSAGES/man-db-gnulib.mo

--- a/packages/man_db.rb
+++ b/packages/man_db.rb
@@ -3,18 +3,18 @@ require 'package'
 class Man_db < Package
   description 'mandb is used to initialize or manually update index database caches that are usually maintained by man.'
   homepage 'https://man-db.nongnu.org/'
-  version '2.12.1'
+  version '2.13.0'
   license 'GPL-3'
   compatibility 'all'
-  source_url 'https://download.savannah.gnu.org/releases/man-db/man-db-2.12.1.tar.xz'
-  source_sha256 'ddee249daeb78cf92bab794ccd069cc8b575992265ea20e239e887156e880265'
+  source_url "https://download.savannah.gnu.org/releases/man-db/man-db-#{version}.tar.xz"
+  source_sha256 '82f0739f4f61aab5eb937d234de3b014e777b5538a28cbd31433c45ae09aefb9'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '007b6aa82ac63e00c9f576b570cb40cc217c3817d50355de1f414a4db199878b',
-     armv7l: '007b6aa82ac63e00c9f576b570cb40cc217c3817d50355de1f414a4db199878b',
-       i686: '8b679dfe0a15583ccb3ef19377f8fb79b27aa8ae31d9e6bb5aaa9088cd3384c8',
-     x86_64: 'e6e9d36cb3dcc908ee3f4574cda85aac6980428f2ac7e11954a4186355431a4a'
+    aarch64: '7f21547dc617f7964f81060f9228203b29eba727c47fc2d64ed952d7f3641e3b',
+     armv7l: '7f21547dc617f7964f81060f9228203b29eba727c47fc2d64ed952d7f3641e3b',
+       i686: 'a512ad68ff304bea2b22fac3eec19752ce6cf7c0563b9252299c1239bfec1cba',
+     x86_64: '882854084b75bb5646ff8f8558d0615a64554d03fd956ab250f204ce285be431'
   })
 
   no_fhs


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
##
Tests run:
```
$ for b in $(crew files man_db|grep /usr/local/bin); do $b -V; done
apropos 2.13.0
catman 2.13.0
lexgrog 2.13.0
man 2.13.0
man-recode 2.13.0
mandb 2.13.0
manpath 2.13.0
whatis 2.13.0
```
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-man_db crew update \
&& yes | crew upgrade
```