### PR TITLE
Brave 1.69.153 => 1.69.160

### DIFF
--- a/packages/brave.rb
+++ b/packages/brave.rb
@@ -3,12 +3,12 @@ require 'package'
 class Brave < Package
   description 'Next generation Brave browser for macOS, Windows, Linux, Android.'
   homepage 'https://brave.com/'
-  version '1.69.153'
+  version '1.69.160'
   license 'MPL-2'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://github.com/brave/brave-browser/releases/download/v#{version}/brave-browser-#{version}-linux-amd64.zip"
-  source_sha256 '71091b6362685055f6e2f299c4410a92110dae500ab3bfbeca98d1dfef34b0ae'
+  source_sha256 '5e151a239bf0f7f24644f5c3e986bd2ad190a738c12a02c4b79f69f4f9ba859a'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & (not) Working properly:
- [x] `x86_64` Unable to launch in hatch m126 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-brave crew update \
&& yes | crew upgrade
```