### PR TITLE
Fix regex in crew whatprovides.

### DIFF
--- a/commands/whatprovides.rb
+++ b/commands/whatprovides.rb
@@ -4,7 +4,7 @@ require_relative '../lib/package_utils'
 
 class Command
   def self.whatprovides(regex)
-    matched_list = `grep -R "#{regex}" #{CREW_LIB_PATH}/manifest/#{ARCH}`.lines(chomp: true).flat_map do |result|
+    matched_list = `grep -ER "#{regex}" #{CREW_LIB_PATH}/manifest/#{ARCH}`.lines(chomp: true).flat_map do |result|
       filelist, matched_file = result.split(':', 2)
       pkg_name = File.basename(filelist, '.filelist')
       pkg_name_status = File.file?(File.join(CREW_PACKAGES_PATH, "#{pkg_name}.rb")) ? pkg_name : nil

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.51.5' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.51.6' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]

--- a/tests/commands/whatprovides.rb
+++ b/tests/commands/whatprovides.rb
@@ -19,3 +19,17 @@ class WhatprovidesCommandTest < Minitest::Test
     end
   end
 end
+
+class WhatprovidesRegexTest < Minitest::Test
+  def test_whatprovides_regex
+    expected_output = <<~TEST_EOF
+      crew_profile_base: /usr/local/etc/bash.d/0-stub
+
+      Total found: 1
+    TEST_EOF
+    assert_output(expected_output, nil) do
+      # Command.whatprovides(regex)
+      Command.whatprovides('bash.d/[0-9]+\-stub$')
+    end
+  end
+end


### PR DESCRIPTION
- Also add a regex test.

Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=whatprovides crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
