### PR TITLE
Remove need for essential_deps field in device.json

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -194,33 +194,6 @@ def set_package(pkg_path)
   @pkg.build_from_source = true if @opt_recursive
 end
 
-def generate_compatible
-  puts 'Determining package compatibility...'.orange if CREW_VERBOSE
-  @device[:compatible_packages] = []
-  Dir["#{CREW_PACKAGES_PATH}/*.rb"].each do |filename|
-    pkg_name = File.basename filename, '.rb'
-    begin
-      set_package filename
-    rescue StandardError => e
-      puts "Error with #{pkg_name}.rb: #{e}".red unless e.to_s.include?('uninitialized constant')
-    end
-    puts "Checking #{pkg_name} for compatibility.".orange if CREW_VERBOSE
-    if PackageUtils.compatible?(@pkg)
-      # add to compatible packages
-      puts "Adding #{pkg_name} #{@pkg.version} to compatible packages.".lightgreen if CREW_VERBOSE
-      @device[:compatible_packages].push(name: @pkg.name)
-    elsif CREW_VERBOSE
-      puts "#{pkg_name} is not a compatible package.".lightred
-    end
-  end
-  puts 'Determining essential dependencies from CREW_ESSENTIAL_PACKAGES...'.orange if CREW_VERBOSE
-  @device[:essential_deps] = []
-  @device[:essential_deps].concat(CREW_ESSENTIAL_PACKAGES.flat_map { |i| Package.load_package("#{i}.rb").get_deps_list }.push(*CREW_ESSENTIAL_PACKAGES).uniq.sort)
-  crewlog "Essential packages: #{@device[:essential_deps]}"
-  ConvenienceFunctions.save_json(@device)
-  puts 'Determined compatibility & which packages are essential.'.orange if CREW_VERBOSE
-end
-
 def search(pkg_name, pkg_path: File.join(CREW_PACKAGES_PATH, "#{pkg_name}.rb"), silent: false)
   begin
     return set_package(pkg_path) if File.file?(pkg_path)
@@ -311,8 +284,6 @@ def update
     load "#{CREW_LIB_PATH}/lib/fixup.rb"
   end
 
-  # update compatible packages
-  generate_compatible
   # check for outdated installed packages
   puts 'Checking for package updates...' unless CREW_UNATTENDED
 
@@ -1906,12 +1877,8 @@ def sysinfo_command(_args)
   Command.sysinfo(CREW_VERBOSE)
 end
 
-def update_command(args)
-  if args['<compatible>']
-    generate_compatible
-  else
-    update
-  end
+def update_command(_args)
+  update
 end
 
 def upgrade_command(args) = upgrade(*args['<name>'], build_from_source: @opt_source)

--- a/commands/help.rb
+++ b/commands/help.rb
@@ -123,8 +123,6 @@ class Command
         Update crew.
         Usage: crew update
         This only updates crew itself.  Use `crew upgrade` to update packages.
-        Usage: crew update compatible
-        This updates the crew package compatibility list.
       EOT
     when 'upgrade'
       puts <<~EOT

--- a/commands/list.rb
+++ b/commands/list.rb
@@ -34,7 +34,7 @@ class Command
         puts pkg_name.lightred unless PackageUtils.compatible?(pkg)
       end
     elsif essential
-      puts device_json['essential_deps'].join("\n")
+      puts CREW_ESSENTIAL_PACKAGES.join("\n")
     elsif installed
       if verbose
         installed_packages['======='] = '======='

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.56.9' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.57.0' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]
@@ -41,7 +41,10 @@ else
   HOME ||= File.join(CREW_PREFIX, Dir.home)
 end
 
-CREW_ESSENTIAL_PACKAGES ||= %w[curl gcc_lib glibc gmp lz4 ruby xzutils zlib zstd]
+# These are packages that crew needs to run-- only packages that the bin/crew needs should be required here.
+# lz4, for example, is required for zstd to have lz4 support, but this is not required to run bin/crew.
+# The LIBC_VERSION ternary is to reflect the change from glibc_build to glibc_lib as the source of essential libraries starting at glibc 2.35.
+CREW_ESSENTIAL_PACKAGES ||= %W[gcc_lib #{LIBC_VERSION.to_f > 2.34 ? "glibc_lib#{LIBC_VERSION.delete('.')}" : "glibc_build#{LIBC_VERSION.delete('.')}"} gmp ruby zlib zstd]
 
 CREW_IN_CONTAINER ||= File.exist?('/.dockerenv') || ENV.fetch('CREW_IN_CONTAINER', false) unless defined?(CREW_IN_CONTAINER)
 
@@ -354,7 +357,7 @@ CREW_DOCOPT ||= <<~DOCOPT
     crew remove [options] [-v|--verbose] <name> ...
     crew search [options] [-v|--verbose] <name> ...
     crew sysinfo [options] [-v|--verbose]
-    crew update [options] [-v|--verbose] [<compatible>]
+    crew update [options] [-v|--verbose]
     crew upgrade [options] [-k|--keep] [-s|--source] [-v|--verbose] [<name> ...]
     crew upload [options] [-v|--verbose] [<name> ...]
     crew whatprovides [options] <pattern> ...

--- a/tests/commands/list.rb
+++ b/tests/commands/list.rb
@@ -1,6 +1,6 @@
 require 'minitest/autorun'
 require_relative '../../commands/list'
-require_relative '../../lib/convenience_functions'
+require_relative '../../lib/const'
 
 # Add lib to LOAD_PATH
 $LOAD_PATH << File.join(CREW_LIB_PATH, 'lib')
@@ -8,12 +8,8 @@ $LOAD_PATH << File.join(CREW_LIB_PATH, 'lib')
 String.use_color = false
 
 class ListCommandTest < Minitest::Test
-  def setup
-    @essential_deps = ConvenienceFunctions.load_symbolized_json[:essential_deps].join("\n") + "\n".to_s
-  end
-
-  def test_list_essential_deps
-    expected_output = @essential_deps
+  def test_list_essential_packages
+    expected_output = CREW_ESSENTIAL_PACKAGES.join("\n") + "\n".to_s
     assert_output(expected_output, nil) do
       # Command.list(args['available'], args['compatible'], args['incompatible'], args['essential'], args['installed'], CREW_VERBOSE)
       Command.list(false, false, false, true, false, false)

--- a/tests/commands/remove.rb
+++ b/tests/commands/remove.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative '../../commands/remove'
 require_relative '../../lib/const'
-require_relative '../../lib/convenience_functions'
 require_relative '../../lib/package_utils'
 
 # Add lib to LOAD_PATH
@@ -12,11 +11,10 @@ String.use_color = false
 
 class RemoveCommandTest < Minitest::Test
   def setup
-    essential_deps = ConvenienceFunctions.load_symbolized_json[:essential_deps]
-    @random_essential_package_name = essential_deps[rand(0...(essential_deps.length - 1))]
+    @random_essential_package_name = CREW_ESSENTIAL_PACKAGES.sample
     puts <<~ESSENTIAL_PACKAGE_REMOVAL_TEST_EOF
 
-      Testing the removal of essential package #{@random_essential_package_name}, which was picked at random from one the essential packages: #{essential_deps.join(', ')}
+      Testing the removal of essential package #{@random_essential_package_name}, which was picked at random from one the essential packages: #{CREW_ESSENTIAL_PACKAGES.join(', ')}
       (This should fail.)
 
     ESSENTIAL_PACKAGE_REMOVAL_TEST_EOF
@@ -56,7 +54,7 @@ class RemoveCommandTest < Minitest::Test
   def test_remove_package_with_essential_file
     assert_output(true) do
       until PackageUtils.installed?(@package_with_essential_file)
-        system "crew install -d #{@package_with_essential_file}", %i[out err] => File::NULL
+        system "yes | crew install -d #{@package_with_essential_file}", %i[out err] => File::NULL
         sleep 2
       end
       system "crew remove -d #{@package_with_essential_file}", %i[out err] => File::NULL
@@ -70,7 +68,7 @@ class RemoveCommandTest < Minitest::Test
     EOT
     assert_output(/^#{Regexp.escape(expected_output.chomp)}!/, nil) do
       until PackageUtils.installed?(@normal_package_name)
-        system "crew install -d #{@normal_package_name}", %i[out err] => File::NULL
+        system "yes | crew install -d #{@normal_package_name}", %i[out err] => File::NULL
         sleep 2
       end
       Command.remove(@normal_pkg, true)


### PR DESCRIPTION
## Description
The definition of what is an 'essential' package has been confused. Essential packages are those that are absolutely required for chromebrew to run, and only chromebrew. If you remove lz4, zstd can no longer decompress `.tar.lz` binaries-- this is not required for ruby to run, and thus is not an essential package.

As such, the list of essential packages is actually quite short, and the only complexity required is in ensuring we have the right `glibc_lib_*` or `glibc_build_*` package.

##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=ughhhh crew update \
&& yes | crew upgrade
```
