### PR TITLE
mysql 8.4.2-icu75.1 -> 9.0.1

### DIFF
--- a/manifest/x86_64/m/mysql.filelist
+++ b/manifest/x86_64/m/mysql.filelist
@@ -92,6 +92,7 @@
 /usr/local/lib/mysql/plugin/component_test_sensitive_system_variables.so
 /usr/local/lib/mysql/plugin/component_test_server_telemetry_metrics.so
 /usr/local/lib/mysql/plugin/component_test_server_telemetry_traces.so
+/usr/local/lib/mysql/plugin/component_test_session_var_service.so
 /usr/local/lib/mysql/plugin/component_test_status_var_reader.so
 /usr/local/lib/mysql/plugin/component_test_status_var_service.so
 /usr/local/lib/mysql/plugin/component_test_status_var_service_int.so
@@ -179,7 +180,7 @@
 /usr/local/lib64/libmysqlclient.a
 /usr/local/lib64/libmysqlclient.so
 /usr/local/lib64/libmysqlclient.so.24
-/usr/local/lib64/libmysqlclient.so.24.0.2
+/usr/local/lib64/libmysqlclient.so.24.1.1
 /usr/local/lib64/libmysqlservices.a
 /usr/local/lib64/pkgconfig/mysqlclient.pc
 /usr/local/share/aclocal/mysql.m4

--- a/packages/mysql.rb
+++ b/packages/mysql.rb
@@ -3,22 +3,21 @@ require 'buildsystems/cmake'
 class Mysql < CMake
   description "MySQL Community Edition is a freely downloadable version of the world's most popular open source database"
   homepage 'https://www.mysql.com/'
-  version '8.4.2-icu75.1'
+  version '9.0.1'
   license 'GPL-2'
   compatibility 'x86_64' # Only 64-bit platforms are supported, so this will work on aarch64 userspaces once those are supported.
-  min_glibc '2.37'
-  source_url 'https://cdn.mysql.com/Downloads/MySQL-8.4/mysql-8.4.2.tar.gz'
-  source_sha256 '5657a78dc86bf0bf2227e0b05f8de5a2c447a816a112ffa26fa70083bcbe9814'
+  source_url 'https://github.com/mysql/mysql-server.git'
+  git_hashtag "mysql-#{version}"
   binary_compression 'tar.zst'
 
   binary_sha256({
-     x86_64: '5ce6d8be4a2660d05b7ec4892b09f17a7236881fcc34f9756c6102c5d2539791'
+     x86_64: '78f197a0cc31d6657bc682cbbb5be958326872eef0b35d93d7633f59646265d8'
   })
 
   depends_on 'boost' => :build
   depends_on 'gcc_lib' # R
   depends_on 'glibc_lib' # R
-  depends_on 'icu4c' => :build
+  depends_on 'icu4c', '== 75.1'
   depends_on 'libcyrussasl' => :build
   depends_on 'libedit' # R
   depends_on 'libtirpc' # R
@@ -30,14 +29,6 @@ class Mysql < CMake
   depends_on 'rpcsvc_proto' => :build
   depends_on 'zlib' # R
   depends_on 'zstd' # R
-
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/bash.d"
-    File.write "#{CREW_DEST_PREFIX}/etc/bash.d/01-mysql", <<~EOF
-      [ -x #{CREW_PREFIX}/bin/mysql.server ] && #{CREW_PREFIX}/bin/mysql.server start
-    EOF
-  end
 
   def self.postinstall
     FileUtils.mkdir_p "#{CREW_PREFIX}/var/mysql/data"
@@ -93,4 +84,10 @@ class Mysql < CMake
         -DWITH_UNIT_TESTS=OFF" # Since we don't currently run the tests, there's no point in building them.
   # 52/136 Test  #52: merge_small_tests ..................................***Failed   62.42 sec
   # run_tests
+  cmake_install_extras do
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/etc/bash.d"
+    File.write "#{CREW_DEST_PREFIX}/etc/bash.d/01-mysql", <<~EOF
+      [ -x #{CREW_PREFIX}/bin/mysql.server ] && #{CREW_PREFIX}/bin/mysql.server start
+    EOF
+  end
 end

--- a/packages/rpcsvc_proto.rb
+++ b/packages/rpcsvc_proto.rb
@@ -3,17 +3,17 @@ require 'buildsystems/autotools'
 class Rpcsvc_proto < Autotools
   description 'rpcsvc protocol definitions from glibc'
   homepage 'https://github.com/thkukuk/rpcsvc-proto'
-  version '1.4.4'
+  version '1.4.4-1'
   license 'BSD-3'
   compatibility 'all'
   source_url 'https://github.com/thkukuk/rpcsvc-proto.git'
-  git_hashtag "v#{version}"
+  git_hashtag "v#{version.split('-').first}"
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '6df631b717d3da06be71951de63a13f9b23b45e1941fdee2debd4987d0c57f2b',
-     armv7l: '6df631b717d3da06be71951de63a13f9b23b45e1941fdee2debd4987d0c57f2b',
-       i686: 'bcc9dd7be42858dbc5fe0de2eb6d6e83dd6422e87dfdaa3f2d6f3493f6eda3c9',
-     x86_64: 'b4bd2ddd9fc77695b6e00ed433a0e9d149792b113ad057ed1bdf4271525d689a'
+    aarch64: 'b80f415e923ea6ab32490b069a19c6a6bd78e2c45b7abb0f97e451c52ad9ff49',
+     armv7l: 'b80f415e923ea6ab32490b069a19c6a6bd78e2c45b7abb0f97e451c52ad9ff49',
+       i686: '39fd2d0e9d1066c1a35569b831b9ddd8cf51c28eef4b9e56fd08dfb43790406c',
+     x86_64: '39e69c11f4adb6b7aa2e4f4f894a40a49e430f66db4b383b569041555d3e9d37'
   })
 end


### PR DESCRIPTION
## Description
Updates mysql to 9.0.1, moves the icu version requirement to the depends_on call.

## Additional information
We should try and avoid using `min_glibc` unless it is 100% necessary, as this cuts off tons of devices. We should really only be using `min_glibc` on precompiled proprietary binary packages where we can't do anything about the glibc requirements. I'll go through packages and fix them, but i'd appreciate it if we stopped adding these requirements when there is no reason for them.

##
Builds:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->

##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=1really crew update \
&& yes | crew upgrade
```
