### PR TITLE
gperf 3.2-a02b465 -> 3.1-97c1fbc (fix fake version)

### DIFF
--- a/packages/gperf.rb
+++ b/packages/gperf.rb
@@ -3,18 +3,18 @@ require 'buildsystems/autotools'
 class Gperf < Autotools
   description 'GNU gperf is a perfect hash function generator.'
   homepage 'https://www.gnu.org/software/gperf/'
-  version '3.2-a02b465'
+  version '3.1-97c1fbc'
   license 'GPL-2'
   compatibility 'all'
-  source_url 'https://git.savannah.gnu.org/gitweb/?p=gperf.git;a=snapshot;h=a02b4653ee52990b22ad887607dcb881e1625258;sf=tgz'
-  source_sha256 '2a2634e8f04cd37f310eaa2c4736c18a21e06f435b91f66c9034a70e9d62fff9'
+  source_url 'https://git.savannah.gnu.org/git/gperf.git'
+  git_hashtag '97c1fbcc8cc00c3a56af8be8543dedc588aace0f'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '856d1b4130417459b22d5da15eee2bd04b27d6d2e52a473a5ec7add736ef34be',
-     armv7l: '856d1b4130417459b22d5da15eee2bd04b27d6d2e52a473a5ec7add736ef34be',
-       i686: '095f630631ab8126d36cd655fa2db5049625bebae5e68bba8ac443af96c42955',
-     x86_64: '7c0e8b3a2f12543adb7e5f3025c58d8059f7b98ec74529db76324e7dafa45ad6'
+    aarch64: '49b1152ce33b46afac2e25a656d28e1304283a6e3c847662dbdd80ad58cecf90',
+     armv7l: '49b1152ce33b46afac2e25a656d28e1304283a6e3c847662dbdd80ad58cecf90',
+       i686: '04ae0d6f0337cbc88935e2909074699461bf48534811b9a4b6cb22c2caa13614',
+     x86_64: 'e3876dc56fa7d9a23f2a91a15078f242f282da6f6178082e9d393a2002355d38'
   })
 
   depends_on 'gcc_lib' # R
@@ -22,11 +22,11 @@ class Gperf < Autotools
   depends_on 'wget2' => :build
 
   def self.patch
-    system 'tar --strip-components=1 -xf gitweb'
-    # doc generation requires newer tex from glibc 2.28...
+    # Documentation requires texlive, our package for which is currently not working on certain architectures or glibc versions.
     system "sed -i '/gperf.texi/d' configure.ac"
     system "sed -i 's,tests doc],tests],' configure.ac"
     system "cat configure.ac | tac | sed '/doc/,+2d' | tac > configure.ac.new && mv configure.ac.new configure.ac"
+    # For whatever reason, gperf doesn't actually support the usual `./autogen.sh && ./configure && make` build setup.
     system './autopull.sh'
   end
 end


### PR DESCRIPTION
## Description
cleaning up the fake versions
##
Builds:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=box crew update \
&& yes | crew upgrade
```