### PR TITLE
ffmpegthumbnailer 2.2.3-e0bf01d-1 -> 2.2.2-1b5a779 (fix fake version)

### DIFF
--- a/packages/ffmpegthumbnailer.rb
+++ b/packages/ffmpegthumbnailer.rb
@@ -1,19 +1,19 @@
-require 'package'
+require 'buildsystems/cmake'
 
-class Ffmpegthumbnailer < Package
+class Ffmpegthumbnailer < CMake
   description 'FFmpegthumbnailer is a lightweight video thumbnailer that can be used by file managers to create thumbnails for your video files.'
   homepage 'https://github.com/dirkvdb/ffmpegthumbnailer'
-  version '2.2.3-e0bf01d-1'
+  version '2.2.2-1b5a779'
   license 'GPL-2'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://github.com/dirkvdb/ffmpegthumbnailer.git'
-  git_hashtag 'e0bf01d97e0261219b06d1e560e923354949b93e'
+  git_hashtag '1b5a77983240bcf00a4ef7702c07bcd8f4e5f97c'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'c3ba003434e1a2f7ccbeaf02f71857b16a037a2c47bfb19a2b8bf05d1900357f',
-     armv7l: 'c3ba003434e1a2f7ccbeaf02f71857b16a037a2c47bfb19a2b8bf05d1900357f',
-     x86_64: '52d11863520762477c41f80ac962e0fd361a31891da7f106af31ef6cbe9aef34'
+    aarch64: 'fd757ed0f568529db3b8cf0fa804fef50710f00a513ccc5dc85c940d4f400342',
+     armv7l: 'fd757ed0f568529db3b8cf0fa804fef50710f00a513ccc5dc85c940d4f400342',
+     x86_64: 'e3093743ca3ecdc3b0638aac7c12d94bb7ec450fc07696ec20d155151f370ffb'
   })
 
   depends_on 'ffmpeg' # R
@@ -23,16 +23,5 @@ class Ffmpegthumbnailer < Package
   depends_on 'libpng' # R
   depends_on 'zlib' # R
 
-  def self.build
-    system "mold -run cmake -B builddir #{CREW_CMAKE_OPTIONS} \
-        -DENABLE_GIO=ON \
-        -DENABLE_THUMBNAILER=ON \
-        -Wno-dev \
-        -G Ninja"
-    system "#{CREW_NINJA} -C builddir"
-  end
-
-  def self.install
-    system "DESTDIR=#{CREW_DEST_DIR} #{CREW_NINJA} -C builddir install"
-  end
+  cmake_options '-DENABLE_GIO=ON -DENABLE_THUMBNAILER=ON'
 end


### PR DESCRIPTION
## Description
as enabled by the fixed pulseaudio and gstreamer

##
Builds:
- [x] `x86_64`
- [x] `armv7l`
##
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=maid crew update \
&& yes | crew upgrade
```