### PR TITLE
Audacity 3.6.1 => 3.6.2

### DIFF
--- a/manifest/x86_64/a/audacity.filelist
+++ b/manifest/x86_64/a/audacity.filelist
@@ -323,7 +323,7 @@
 /usr/local/share/audacity/plug-ins/equalabel.ny
 /usr/local/share/audacity/plug-ins/highpass.ny
 /usr/local/share/audacity/plug-ins/label-sounds.ny
-/usr/local/share/audacity/plug-ins/limiter.ny
+/usr/local/share/audacity/plug-ins/legacy-limiter.ny
 /usr/local/share/audacity/plug-ins/lowpass.ny
 /usr/local/share/audacity/plug-ins/noisegate.ny
 /usr/local/share/audacity/plug-ins/notch.ny

--- a/packages/audacity.rb
+++ b/packages/audacity.rb
@@ -3,12 +3,12 @@ require 'package'
 class Audacity < Package
   description "Audacity is the world's most popular audio editing and recording app"
   homepage 'https://www.audacityteam.org/'
-  version '3.6.1'
+  version '3.6.2'
   license 'GPL-3'
   compatibility 'x86_64'
   min_glibc '2.30'
   source_url "https://github.com/audacity/audacity/releases/download/Audacity-#{version}/audacity-linux-#{version}-x64.AppImage"
-  source_sha256 '6480ac08f983f992a93b6da78a19c3eacdf5982114d53cdc7524b94328261e9f'
+  source_sha256 'b009504d0f74b7fca7092d3c0fdb866b8894ab66473b951c2b7ed7e454282058'
 
   depends_on 'gtk3'
   depends_on 'libthai'


### PR DESCRIPTION
Tested & (not) Working properly:
- [x] `x86_64` Unable to launch in hatch m126 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-audacity crew update \
&& yes | crew upgrade
```