### PR TITLE
Properly rename pygobject to py3_pygobject in depends_on calls

### DIFF
--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -120,6 +120,7 @@ jobs:
               -u chronos \
               -e CHANGED_PACKAGES="$CHANGED_PACKAGES" \
               -e LD_LIBRARY_PATH="/usr/local/lib$LIB_SUFFIX" \
+              -e GCONV_PATH="/usr/local/lib$LIB_SUFFIX/gconv" \
               -e CREW_REPO="${{ github.event.pull_request.head.repo.clone_url }}" \
               -e CREW_BRANCH="${{ github.head_ref }}" \
               "satmandu/crewbuild:$CONTAINER" \

--- a/packages/bleachbit.rb
+++ b/packages/bleachbit.rb
@@ -16,7 +16,7 @@ class Bleachbit < Package
      x86_64: '9fce1a604d77059c43980dae5cbe13c3779b88e9e58ab164e49223ec3901c7cf'
   })
 
-  depends_on 'pygobject'
+  depends_on 'py3_pygobject'
   depends_on 'gtk3'
   depends_on 'sommelier'
   depends_on 'py3_mock' => :build # for checks

--- a/packages/dia.rb
+++ b/packages/dia.rb
@@ -33,7 +33,7 @@ class Dia < Meson
   depends_on 'optipng' => :build
   depends_on 'pango' # R
   depends_on 'poppler' # R
-  depends_on 'pygobject' # R
+  depends_on 'py3_pygobject' # R
   depends_on 'py3_six' => :build
   depends_on 'python3' # R
   depends_on 'swig1' => :build

--- a/packages/gedit.rb
+++ b/packages/gedit.rb
@@ -33,7 +33,7 @@ class Gedit < Meson
   depends_on 'libpeas' # R
   depends_on 'pango' # R
   depends_on 'py3_lxml' => :build
-  depends_on 'pygobject' => :build
+  depends_on 'py3_pygobject' => :build
   depends_on 'tepl_6' # R
   depends_on 'vala' => :build
   depends_on 'yelp_tools' => :build

--- a/packages/gimp.rb
+++ b/packages/gimp.rb
@@ -78,7 +78,7 @@ class Gimp < Meson
   depends_on 'poppler' # R
   depends_on 'py3_gi_docgen' => :build
   depends_on 'py3_pycairo' # L
-  depends_on 'pygobject' # L
+  depends_on 'py3_pygobject' # L
   depends_on 'pygtk' => :build
   depends_on 'shared_mime_info' => :build
   depends_on 'vala' => :build

--- a/packages/glade.rb
+++ b/packages/glade.rb
@@ -27,7 +27,7 @@ class Glade < Meson
   depends_on 'harfbuzz' # R
   depends_on 'libxml2' # R
   depends_on 'pango' # R
-  depends_on 'pygobject' => :build
+  depends_on 'py3_pygobject' => :build
   depends_on 'python3' # R
 
   gnome

--- a/packages/gnome_text_editor.rb
+++ b/packages/gnome_text_editor.rb
@@ -41,7 +41,7 @@ class Gnome_text_editor < Meson
   depends_on 'pango' # R
   depends_on 'pcre2' # R
   depends_on 'pcre' => :build
-  depends_on 'pygobject' => :build
+  depends_on 'py3_pygobject' => :build
   depends_on 'sassc' => :build
   depends_on 'vala' => :build
   depends_on 'vulkan_icd_loader' # R

--- a/packages/gst_editing_services.rb
+++ b/packages/gst_editing_services.rb
@@ -20,7 +20,7 @@ class Gst_editing_services < Package
   depends_on 'gobject_introspection' => :build
   depends_on 'gstreamer'
   depends_on 'gtk_doc' => :build
-  depends_on 'pygobject' => :build
+  depends_on 'py3_pygobject' => :build
 
   def self.build
     system "meson setup #{CREW_MESON_OPTIONS} \

--- a/packages/gstreamer.rb
+++ b/packages/gstreamer.rb
@@ -102,7 +102,7 @@ class Gstreamer < Meson
   depends_on 'pipewire' # R
   depends_on 'pulseaudio' # R
   depends_on 'py3_setuptools' => :build
-  depends_on 'pygobject' # R
+  depends_on 'py3_pygobject' # R
   depends_on 'python3' # R
   depends_on 'qt5_base' => :build # otherwise this becomes circular
   depends_on 'qt5_declarative' => :build # otherwise this becomes circular

--- a/packages/ibus.rb
+++ b/packages/ibus.rb
@@ -46,7 +46,7 @@ class Ibus < Autotools
   depends_on 'libxi' # R
   depends_on 'libxkbcommon' # R
   depends_on 'pango' # R
-  depends_on 'pygobject' => :build
+  depends_on 'py3_pygobject' => :build
   depends_on 'qt5_base' => :build
   depends_on 'unicode_cldr' => :build
   depends_on 'unicode_emoji' => :build

--- a/packages/libgweather.rb
+++ b/packages/libgweather.rb
@@ -30,7 +30,7 @@ class Libgweather < Meson
   depends_on 'py3_gi_docgen' => :build
   depends_on 'py3_pylint' => :build
   depends_on 'py3_smartypants' => :build
-  depends_on 'pygobject' => :build
+  depends_on 'py3_pygobject' => :build
 
   gnome
 

--- a/packages/libpeas.rb
+++ b/packages/libpeas.rb
@@ -28,7 +28,7 @@ class Libpeas < Meson
   depends_on 'luajit_lgi' => :build
   depends_on 'luajit' # R
   depends_on 'py3_gi_docgen' => :build
-  depends_on 'pygobject' => :build
+  depends_on 'py3_pygobject' => :build
   depends_on 'python3' => :build
   depends_on 'python3' # R
   depends_on 'vala' => :build

--- a/packages/libpeas2.rb
+++ b/packages/libpeas2.rb
@@ -26,7 +26,7 @@ class Libpeas2 < Meson
   depends_on 'luajit_lgi' => :build
   depends_on 'luajit' # R
   depends_on 'py3_gi_docgen' => :build
-  depends_on 'pygobject' => :build
+  depends_on 'py3_pygobject' => :build
   depends_on 'python3' # R
   depends_on 'vala' => :build
 

--- a/packages/metadata_cleaner.rb
+++ b/packages/metadata_cleaner.rb
@@ -15,7 +15,7 @@ class Metadata_cleaner < Meson
   depends_on 'libadwaita' # R
   depends_on 'mesonbuild' => :build
   depends_on 'py3_mat2' # R
-  depends_on 'pygobject' # R
+  depends_on 'py3_pygobject' # R
   depends_on 'python3' # R
 
   no_compile_needed

--- a/packages/mypaint.rb
+++ b/packages/mypaint.rb
@@ -21,7 +21,7 @@ class Mypaint < Package
   depends_on 'python3' => :build
   depends_on 'mypaint_brushes'
   depends_on 'openmp'
-  depends_on 'pygobject'
+  depends_on 'py3_pygobject'
   depends_on 'librsvg'
   depends_on 'xdg_base'
   depends_on 'sommelier'

--- a/packages/py3_atspi.rb
+++ b/packages/py3_atspi.rb
@@ -20,7 +20,7 @@ class Py3_atspi < Autotools
      x86_64: 'd055212318d6d767727c4ef4b8ce3c8e2e9ebf753136b22d1e4bb0200b66985e'
   })
 
-  depends_on 'pygobject'
+  depends_on 'py3_pygobject'
   depends_on 'at_spi2_core'
   depends_on 'python3' => :build
 end

--- a/packages/py3_devedeng.rb
+++ b/packages/py3_devedeng.rb
@@ -12,7 +12,7 @@ class Py3_devedeng < Python
 
   depends_on 'python3' => :build
   depends_on 'py3_pycairo'
-  depends_on 'pygobject'
+  depends_on 'py3_pygobject'
   depends_on 'gtk3'
 
   no_compile_needed

--- a/packages/tinysparql.rb
+++ b/packages/tinysparql.rb
@@ -33,7 +33,7 @@ class Tinysparql < Meson
   depends_on 'libsoup' # R
   depends_on 'libstemmer' # R
   depends_on 'libxml2' # R
-  depends_on 'pygobject' => :build
+  depends_on 'py3_pygobject' => :build
   depends_on 'sqlite' # R
   depends_on 'util_linux' => :build
   depends_on 'vala' => :build


### PR DESCRIPTION
## Description
Cleaning up after #10414.

Fixes the crash that happens when any package depending on pygobject is loaded:
![image](https://github.com/user-attachments/assets/aad6d97c-8b87-4d63-a63b-643d08a52e52)

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=floor crew update \
&& yes | crew upgrade
```