### PR TITLE
Fix rubocop workflow

### DIFF
--- a/.github/workflows/Rubocop.yml
+++ b/.github/workflows/Rubocop.yml
@@ -11,3 +11,5 @@ jobs:
           ruby-version: '3.2'
       - name: Rubocop
         uses: reviewdog/action-rubocop@v2
+        with:
+          fail_on_error: true

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -167,7 +167,7 @@ pkg_update_arr = [
   { pkg_name: 'meson', pkg_rename: 'mesonbuild', pkg_deprecated: nil, comments: 'Renamed to avoid conflict with buildsystems/meson.' },
   { pkg_name: 'moonbuggy', pkg_rename: 'moon_buggy', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' },
   { pkg_name: 'nping', pkg_rename: nil, pkg_deprecated: true, comments: 'Removed to avoid conflict with nmap.' },
-  { pkg_name: 'percona_boost', pkg_rename: nil, pkg_deprecated: true, comments: 'Replaced by regular boost.'},
+  { pkg_name: 'percona_boost', pkg_rename: nil, pkg_deprecated: true, comments: 'Replaced by regular boost.' },
   { pkg_name: 'percona_server', pkg_rename: nil, pkg_deprecated: true, comments: 'Replaced by mysql.'},
   { pkg_name: 'pkgconfig', pkg_rename: 'pkg_config', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' },
   { pkg_name: 'postgres', pkg_rename: 'postgresql', pkg_deprecated: nil, comments: 'Renamed to better match upstream.' },


### PR DESCRIPTION
## Description
This should hopefully stop rubocop errors from slipping by CI.

##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=ohhh crew update \
&& yes | crew upgrade
```
