### PR TITLE
Remove old runtime dependencies when running getrealdeps.rb

### DIFF
--- a/packages/ffmpeg.rb
+++ b/packages/ffmpeg.rb
@@ -32,19 +32,16 @@ class Ffmpeg < Package
   depends_on 'intel_media_sdk' if ARCH == 'x86_64' && CREW_IS_INTEL # R
   depends_on 'jack' # R
   depends_on 'ladspa' # ?
-  depends_on 'leptonica' # R
   depends_on 'libaom' # R
   depends_on 'libass' # R
   depends_on 'libavc1394' # R
   depends_on 'libbluray' # R
   depends_on 'libdc1394' => :build
   depends_on 'libdrm' # R
-  depends_on 'libfdk_aac' => :build
   depends_on 'libfdk_aac' # R
   depends_on 'libfrei0r' => :build
   depends_on 'libglvnd' # R
   depends_on 'libiec61883' # R
-  depends_on 'libjpeg_turbo' # R
   depends_on 'libjxl' # R
   depends_on 'libmodplug' # R
   depends_on 'libmp3lame' # R
@@ -69,11 +66,9 @@ class Ffmpeg < Package
   depends_on 'libxvid' # R
   depends_on 'libxv' # R
   depends_on 'lilv' # R
-  depends_on 'mesa' # R
   depends_on 'nasm' => :build
   depends_on 'openal' # ?
   depends_on 'openjpeg' # R
-  depends_on 'openmp' # R
   depends_on 'openssl' # R
   depends_on 'opus' # R
   depends_on 'pipewire' # R
@@ -81,15 +76,9 @@ class Ffmpeg < Package
   depends_on 'rav1e' # R
   depends_on 'rtmpdump' # R
   depends_on 'rubberband' # R
-  depends_on 'serd' # R
   depends_on 'snappy' # R
-  depends_on 'sord' # R
   depends_on 'speex' # R
-  depends_on 'sratom' # R
-  depends_on 'srt' # R
-  depends_on 'tesseract' # R
   depends_on 'v4l_utils' # R
-  depends_on 'vidstab' # R
   depends_on 'vmaf' # R
   depends_on 'wavpack' # ?
   depends_on 'xzutils' # R

--- a/tools/getrealdeps.rb
+++ b/tools/getrealdeps.rb
@@ -107,6 +107,9 @@ def main(pkg)
   pkgdeps = pkgdeps.map { |i| i.gsub(/glibc_build.*/, 'glibc') }.uniq
   pkgdeps = pkgdeps.map { |i| i.gsub(/glibc_lib.*/, 'glibc_lib') }.uniq.map(&:strip).reject(&:empty?)
 
+  # Leave early if we didn't find any dependencies.
+  return if pkgdeps.empty?
+
   # Look for missing runtime dependencies.
   missingpkgdeps = pkgdeps.reject { |i| File.read("#{CREW_PREFIX}/lib/crew/packages/#{pkg}.rb").include?("depends_on '#{i}'") unless File.read("#{CREW_PREFIX}/lib/crew/packages/#{pkg}.rb").include?("depends_on '#{i}' => :build") }
 
@@ -115,15 +118,15 @@ def main(pkg)
     puts "  depends_on '#{i}' # R"
   end
 
-  if missingpkgdeps.length.positive?
-    puts "\nPackage file #{pkg}.rb is missing these runtime library dependencies:"
-    missingpkgdeps.each do |i|
-      puts "  depends_on '#{i}' # R"
-    end
-  end
+  # Leave if we didn't find any missing dependencies.
+  return if missingpkgdeps.empty?
+  puts "\nPackage file #{pkg}.rb is missing these runtime library dependencies:"
+  puts "  depends_on '#{missingpkgdeps.join("' # R\n  depends_on '")}' # R"
 
-  # Add missing dependencies to the package.
   missingpkgdeps.each do |adddep|
+    puts "  depends_on '#{adddep}' # R"
+
+    # Add missing dependencies to the package.
     puts "\n Adding deps: #{adddep}"
     gawk_cmd = if File.foreach("#{CREW_PREFIX}/lib/crew/packages/#{pkg}.rb").grep(/depends_on/).any?
                  # This files contains dependencies already, so add new deps after existing dependencies.
@@ -134,6 +137,27 @@ def main(pkg)
                end
     system(gawk_cmd)
   end
+
+  # Check for and delete old runtime dependencies.
+  # Its unsafe to do this with other dependencies, because the packager might know something we don't.
+  lines_to_delete = {}
+  File.readlines("#{CREW_PREFIX}/lib/crew/packages/#{pkg}.rb").each_with_index do |line, line_number|
+    # Find all the explicitly marked runtime dependencies.
+    dep = line.match(/  depends_on '(.*)' # R/)
+    # Basically just a nil check, but this way we avoid matching twice.
+    next unless dep
+    # Skip unless the runtime dependency in the package does not match the runtime dependencies we've found.
+    next unless pkgdeps.none?(dep[1])
+    # Skip if we're dealing with a glibc, glibc_lib or gcc_lib dependency-- these are architecture dependent sometimes?
+    next if %w[glibc glibc_lib gcc_lib].include?(dep[1])
+    # Record the line content as the key and the line number (incremented by one because the index starts at 0) as the value.
+    lines_to_delete[line] = line_number + 1
+  end
+  # Leave if there aren't any old runtime dependencies.
+  return if lines_to_delete.empty?
+  puts "\nPackage file #{pkg}.rb has these outdated runtime library dependencies:"
+  puts lines_to_delete.keys
+  system("gawk -i inplace 'NR != #{lines_to_delete.values.join(' && NR != ')}' #{CREW_PREFIX}/lib/crew/packages/#{pkg}.rb")
 end
 
 ARGV.each do |package|


### PR DESCRIPTION
## Description
the lists of runtime dependencies for some packages are pretty long-- some of them r just left over from when the package used to depend on something at runtime.

we don't touch anything without `# R`, because the packager added that manually so we don't know enough to delete it, but anything added by `getrealdeps.rb` can be deleted by it because we have the same amount of information.

i have ran this on ffmpeg as an example, and also manually deleted the `libfdk_aac` dependency because it was, to the best of my understanding, triggering a bug where if a dependency is present both as a build and runtime dependency `getrealdeps.rb` fails to see that it is already there.

I have WIP plans for a larger refactor and integration of `getrealdeps.rb`, but I thought it best to split this out as it will have beneficial effects the quicker it gets into the build process.

##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=flow crew update \
&& yes | crew upgrade
```
