### PR TITLE
Rename autotools constants to fall in line with the rest of crew

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -55,7 +55,7 @@ Preset constants are shown below:
 - `#{CREW_LIB_PREFIX}` - The `LIB` prefix used by `crew` - Equal to `#{CREW_PREFIX}/lib` - `#{CREW_PREFIX}/lib64` on `amd64`
 - `#{CREW_DEST_DIR}` - The`DESTDIR` variable used by `crew` - Equal to `#{CREW_PREFIX}/tmp/crew/dest`
 - `#{CREW_DEST_PREFIX}` - The`DESTDIR` variable prefix used by `crew` - Equal to `#{CREW_DEST_DIR}/usr/local`
-- `#{CREW_OPTIONS}` - The preset options for `./congifure` - <sup>[Equals](#eq)</sup>
+- `#{CREW_CONFIGURE_OPTIONS}` - The preset options for `./congifure` - <sup>[Equals](#eq)</sup>
 - `#{CREW_MAN_PREFIX}` - Useful for building man pages - Equal to `#{CREW_PREFIX}/share/man`
 - `#{CREW_DEST_LIB_PREFIX}` - The `DESTDIR` `LIB` prefix - Equal to `#{CREW_DEST_PREFIX}/lib` - `#{CREW_DEST_PREFIX}/lib64` on `amd64`
 - `#{CREW_DEST_HOME}` - The `DESTDIR` home variable - Equal to `#{CREW_DEST}/#{HOME}`
@@ -147,7 +147,7 @@ end
 
 NOTE: All rules can have exceptions, if ***REQUIRED***, exceptions to the rules should be avoided at all costs.
 
-<a name="eq">`CREW_OPTIONS`</a>: Equal to `--prefix=/usr/local --libdir=/usr/local/lib --mandir=/usr/local/share/man --disable-dependency-tracking --build=armv7l-cros-linux-gnueabihf --host=armv7l-cros-linux-gnueabihf --target=armv7l-cros-linux-gnueabihf --program-prefix='' --program-suffix=''`
+<a name="eq">`CREW_CONFIGURE_OPTIONS`</a>: Equal to `--prefix=/usr/local --libdir=/usr/local/lib --mandir=/usr/local/share/man --disable-dependency-tracking --program-prefix='' --program-suffix=''`
 
 Any additionally required resources for ChromeOS or ChromeBooks can be found [here](https://github.com/chromebrew/chromebrew/wiki/Links)
 

--- a/lib/buildsystems/autotools.rb
+++ b/lib/buildsystems/autotools.rb
@@ -24,7 +24,7 @@ class Autotools < Package
         system 'filefix'
       end
       @mold_linker_prefix_cmd = CREW_LINKER == 'mold' ? 'mold -run ' : ''
-      system "#{@pre_configure_options} #{@mold_linker_prefix_cmd}./configure #{CREW_OPTIONS} #{@configure_options}"
+      system "#{@pre_configure_options} #{@mold_linker_prefix_cmd}./configure #{CREW_CONFIGURE_OPTIONS} #{@configure_options}"
     end
     system 'make'
     @build_extras&.call

--- a/lib/buildsystems/autotools.rb
+++ b/lib/buildsystems/autotools.rb
@@ -2,7 +2,7 @@ require 'fileutils'
 require 'package'
 
 class Autotools < Package
-  property :configure_options, :pre_configure_options, :build_extras, :install_extras
+  property :configure_options, :pre_configure_options, :configure_build_extras, :configure_install_extras
 
   def self.build
     unless File.file?('Makefile') && CREW_CACHE_BUILD

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -238,7 +238,7 @@ CREW_ENV_FNO_LTO_OPTIONS_HASH ||= {
 # parse from hash to shell readable string
 CREW_ENV_FNO_LTO_OPTIONS ||= CREW_ENV_FNO_LTO_OPTIONS_HASH.map { |k, v| "#{k}=\"#{v}\"" }.join(' ')
 
-CREW_OPTIONS ||= <<~OPT.chomp
+CREW_CONFIGURE_OPTIONS ||= <<~OPT.chomp
   --prefix=#{CREW_PREFIX} \
   --libdir=#{CREW_LIB_PREFIX} \
   --mandir=#{CREW_MAN_PREFIX} \

--- a/packages/aalib.rb
+++ b/packages/aalib.rb
@@ -34,7 +34,7 @@ class Aalib < Package
 
   def self.build
     system 'autoreconf -fiv'
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
             --with-x \
             --with-x11-driver \
             --with-slang-driver"

--- a/packages/acpi.rb
+++ b/packages/acpi.rb
@@ -18,7 +18,7 @@ class Acpi < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/aircrack_ng.rb
+++ b/packages/aircrack_ng.rb
@@ -31,7 +31,7 @@ class Aircrack_ng < Package
     system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto' \
       LDFLAGS='-flto=auto' \
       ./configure \
-      #{CREW_OPTIONS} \
+      #{CREW_CONFIGURE_OPTIONS} \
       --program-prefix='' --program-suffix='' \
       --with-lto \
       --with-experimental=yes \

--- a/packages/alpine.rb
+++ b/packages/alpine.rb
@@ -29,7 +29,7 @@ class Alpine < Package
 
   def self.build
     system "./configure \
-           #{CREW_OPTIONS} \
+           #{CREW_CONFIGURE_OPTIONS} \
            --with-ssl-dir=#{CREW_PREFIX}/etc/ssl \
            --with-ssl-include-dir=#{CREW_PREFIX}/include \
            --with-ssl-lib-dir=#{CREW_LIB_PREFIX} \

--- a/packages/alsa_lib.rb
+++ b/packages/alsa_lib.rb
@@ -23,7 +23,7 @@ class Alsa_lib < Autotools
   def self.build
     @py_ver = `python -c "import sys; version = '.'.join(map(str, sys.version_info[:2])) ; print(version)"`.chomp
     system 'autoreconf -fiv'
-    system "mold -run ./configure #{CREW_OPTIONS} \
+    system "mold -run ./configure #{CREW_CONFIGURE_OPTIONS} \
        --without-debug \
        --disable-maintainer-mode \
        --with-pythonlibs=-lpython#{@py_ver} \

--- a/packages/anagram.rb
+++ b/packages/anagram.rb
@@ -21,7 +21,7 @@ class Anagram < Package
   depends_on 'glibc' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
 
     @_anagram_wrapper = <<~ANAGRAM_WRAPPER_EOF

--- a/packages/aria2.rb
+++ b/packages/aria2.rb
@@ -24,7 +24,7 @@ class Aria2 < Package
 
   def self.build
     system 'autoreconf -fiv'
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
               --with-libnettle \
               --with-libgcrypt \
               --without-libssh2 \

--- a/packages/aribb25.rb
+++ b/packages/aribb25.rb
@@ -20,7 +20,7 @@ class Aribb25 < Package
 
   def self.build
     system 'autoreconf -fiv'
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/asciidoc.rb
+++ b/packages/asciidoc.rb
@@ -26,7 +26,7 @@ class Asciidoc < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/autoconf213.rb
+++ b/packages/autoconf213.rb
@@ -21,7 +21,7 @@ class Autoconf213 < Package
 
   def self.build
     system "env #{CREW_ENV_OPTIONS} \
-      ./configure #{CREW_OPTIONS} \
+      ./configure #{CREW_CONFIGURE_OPTIONS} \
       --infodir=#{CREW_PREFIX}/share/info \
       --program-suffix=-2.13 \
       --datadir=#{CREW_PREFIX}/share/autoconf213"

--- a/packages/autoconf_archive.rb
+++ b/packages/autoconf_archive.rb
@@ -18,7 +18,7 @@ class Autoconf_archive < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/automake.rb
+++ b/packages/automake.rb
@@ -20,7 +20,7 @@ class Automake < Package
   depends_on 'autoconf'
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/autossh.rb
+++ b/packages/autossh.rb
@@ -20,7 +20,7 @@ class Autossh < Package
   depends_on 'openssh'
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
             --with-ssh=$(which ssh)"
     system 'make'
   end

--- a/packages/bash.rb
+++ b/packages/bash.rb
@@ -29,7 +29,7 @@ class Bash < Autotools
     --without-bash-malloc \
     --with-installed-readline'
 
-  install_extras do
+  configure_install_extras do
     FileUtils.ln_s "#{CREW_PREFIX}/bin/bash", "#{CREW_DEST_PREFIX}/bin/sh"
   end
 end

--- a/packages/bdftopcf.rb
+++ b/packages/bdftopcf.rb
@@ -19,7 +19,7 @@ class Bdftopcf < Package
   depends_on 'libxfont'
 
   def self.build
-    system "./configure #{CREW_OPTIONS} "
+    system "./configure #{CREW_CONFIGURE_OPTIONS} "
     system "make -j#{CREW_NPROC}"
   end
 

--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -44,7 +44,7 @@ class Binutils < Package
     # https://sourceware.org/bugzilla/show_bug.cgi?id=30006
     Dir.mkdir 'build'
     Dir.chdir 'build' do
-      system "../configure #{CREW_OPTIONS} \
+      system "../configure #{CREW_CONFIGURE_OPTIONS} \
         --disable-bootstrap \
         --disable-gdb \
         --disable-gdbserver \

--- a/packages/bitmap.rb
+++ b/packages/bitmap.rb
@@ -18,7 +18,7 @@ class Bitmap < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/bluefish.rb
+++ b/packages/bluefish.rb
@@ -33,7 +33,7 @@ class Bluefish < Package
 
   def self.build
     system 'filefix'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
     @bluefish = <<~EOF
       alias bluefish="WAYLAND_DISPLAY=wayland-0 DISPLAY='' GDK_BACKEND=wayland #{CREW_PREFIX}/bin/bluefish"

--- a/packages/bmon.rb
+++ b/packages/bmon.rb
@@ -13,7 +13,7 @@ class Bmon < Package
 
   def self.build
     system 'autoreconf -fiv'
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
             --without-ncurses \
             --with-ncursesw"
     system 'make'

--- a/packages/bridge_utils.rb
+++ b/packages/bridge_utils.rb
@@ -26,7 +26,7 @@ class Bridge_utils < Package
   def self.build
     system 'autoreconf -fvi'
     system "./configure \
-      #{CREW_OPTIONS} \
+      #{CREW_CONFIGURE_OPTIONS} \
       --sbindir=#{CREW_PREFIX}/bin \
       --sysconfdir=#{CREW_PREFIX}/etc"
     system 'make'

--- a/packages/bubblewrap.rb
+++ b/packages/bubblewrap.rb
@@ -28,7 +28,7 @@ class Bubblewrap < Package
   def self.build
     system './configure --help'
     system "env #{CREW_ENV_OPTIONS} \
-      ./configure #{CREW_OPTIONS} \
+      ./configure #{CREW_CONFIGURE_OPTIONS} \
       --disable-maintainer-mode \
       --with-priv-mode=setuid \
       --enable-sudo"

--- a/packages/cadaver.rb
+++ b/packages/cadaver.rb
@@ -19,7 +19,7 @@ class Cadaver < Package
   depends_on 'neon'
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/catatonit.rb
+++ b/packages/catatonit.rb
@@ -31,7 +31,7 @@ class Catatonit < Package
 
   def self.build
     system 'autoreconf -fiv'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make V=1'
   end
 

--- a/packages/cdparanoia.rb
+++ b/packages/cdparanoia.rb
@@ -31,7 +31,7 @@ class Cdparanoia < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make -j1'
   end
 

--- a/packages/cfitsio.rb
+++ b/packages/cfitsio.rb
@@ -26,7 +26,7 @@ class Cfitsio < Autotools
     system "CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      ./configure #{CREW_OPTIONS} --enable-reentrant"
+      ./configure #{CREW_CONFIGURE_OPTIONS} --enable-reentrant"
     system 'make shared'
     system 'make utils'
   end

--- a/packages/chrpath.rb
+++ b/packages/chrpath.rb
@@ -18,7 +18,7 @@ class Chrpath < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/consolekit.rb
+++ b/packages/consolekit.rb
@@ -26,7 +26,7 @@ class Consolekit < Package
   def self.build
     system "env #{CREW_ENV_OPTIONS} \
       ./autogen.sh  \
-      #{CREW_OPTIONS} \
+      #{CREW_CONFIGURE_OPTIONS} \
       --sysconfdir=#{CREW_PREFIX}/etc  \
       --sbindir=#{CREW_PREFIX}/usr/bin  \
       --with-rundir=/run  \

--- a/packages/coreutils.rb
+++ b/packages/coreutils.rb
@@ -36,7 +36,7 @@ class Coreutils < Autotools
 
   def self.build
     year2038 = ARCH == 'x86_64' ? '' : ' --disable-year2038'
-    options = CREW_OPTIONS + year2038
+    options = CREW_CONFIGURE_OPTIONS + year2038
     system "./configure #{options}"
     system 'make'
     arch = <<~EOF

--- a/packages/cras.rb
+++ b/packages/cras.rb
@@ -55,7 +55,7 @@ ctl.!default {
 _EOF_'
       system './git_prepare.sh'
       if ARCH == 'i686'
-        system "CFLAGS='-fuse-ld=lld -msse2' ./configure #{CREW_OPTIONS} \
+        system "CFLAGS='-fuse-ld=lld -msse2' ./configure #{CREW_CONFIGURE_OPTIONS} \
           --disable-alsa-plugin \
           --disable-webrtc-apm \
           --enable-sse42 \
@@ -63,7 +63,7 @@ _EOF_'
           --enable-avx2
           --enable-fma"
       else
-        system "CFLAGS='-fuse-ld=lld' ./configure #{CREW_OPTIONS} \
+        system "CFLAGS='-fuse-ld=lld' ./configure #{CREW_CONFIGURE_OPTIONS} \
           --disable-alsa-plugin \
           --disable-webrtc-apm \
           --enable-sse42 \

--- a/packages/crun.rb
+++ b/packages/crun.rb
@@ -130,7 +130,7 @@ class Crun < Package
   def self.build
     @disable_criu = ARCH == 'x86_64' ? '' : '--disable-criu'
     system './autogen.sh'
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       #{@disable_criu} \
       --disable-systemd \
       --enable-shared \

--- a/packages/cunit.rb
+++ b/packages/cunit.rb
@@ -33,7 +33,7 @@ class Cunit < Package
   def self.build
     system 'autoupdate'
     system 'autoreconf -fiv'
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS} \
             --enable-automated \
             --enable-basic \
             --enable-console \

--- a/packages/cups.rb
+++ b/packages/cups.rb
@@ -32,7 +32,7 @@ class Cups < Package
 
   def self.build
     @buildoverride = %w[armv7l aarch64].include?(ARCH) ? 'CC=clang CXX=clang++ LD=mold CUPS_LINKER=mold' : ''
-    system "#{@buildoverride} ./configure #{CREW_OPTIONS} \
+    system "#{@buildoverride} ./configure #{CREW_CONFIGURE_OPTIONS} \
       --enable-libusb"
     system 'make'
     File.write 'startcupsd', <<~EOF

--- a/packages/dash.rb
+++ b/packages/dash.rb
@@ -20,7 +20,7 @@ class Dash < Package
   depends_on 'libedit'
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --with-libedit"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --with-libedit"
     system 'make'
   end
 

--- a/packages/datamash.rb
+++ b/packages/datamash.rb
@@ -18,7 +18,7 @@ class Datamash < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/dbus_glib.rb
+++ b/packages/dbus_glib.rb
@@ -20,7 +20,7 @@ class Dbus_glib < Package
   depends_on 'glib'
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/ddrescue.rb
+++ b/packages/ddrescue.rb
@@ -18,7 +18,7 @@ class Ddrescue < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
             --enable-non-posix"
     system 'make'
   end

--- a/packages/desktop_file_utils.rb
+++ b/packages/desktop_file_utils.rb
@@ -18,7 +18,7 @@ class Desktop_file_utils < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/diffutils.rb
+++ b/packages/diffutils.rb
@@ -21,7 +21,7 @@ class Diffutils < Package
   depends_on 'libsigsegv'
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/djvulibre.rb
+++ b/packages/djvulibre.rb
@@ -28,7 +28,7 @@ class Djvulibre < Package
   depends_on 'glibc' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --disable-desktopfiles"
     system 'make'
   end

--- a/packages/docbook2x.rb
+++ b/packages/docbook2x.rb
@@ -21,7 +21,7 @@ class Docbook2x < Package
   depends_on 'glibc' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/dosbox.rb
+++ b/packages/dosbox.rb
@@ -21,7 +21,7 @@ class Dosbox < Package
   depends_on 'sommelier'
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/dosbox_x.rb
+++ b/packages/dosbox_x.rb
@@ -23,7 +23,7 @@ class Dosbox_x < Package
 
   def self.patch
     system 'filefix'
-    system "sed -i 's,--prefix=/usr,#{CREW_OPTIONS},' build"
+    system "sed -i 's,--prefix=/usr,#{CREW_CONFIGURE_OPTIONS},' build"
   end
 
   def self.build

--- a/packages/dosfstools.rb
+++ b/packages/dosfstools.rb
@@ -18,7 +18,7 @@ class Dosfstools < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --enable-compat-symlinks"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --enable-compat-symlinks"
     system 'make'
   end
 

--- a/packages/e2fsprogs.rb
+++ b/packages/e2fsprogs.rb
@@ -22,7 +22,7 @@ class E2fsprogs < Package
   depends_on 'util_linux' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS}\
+    system "./configure #{CREW_CONFIGURE_OPTIONS}\
       --enable-elf-shlibs \
       --enable-lto \
       --disable-libblkid \

--- a/packages/editres.rb
+++ b/packages/editres.rb
@@ -18,7 +18,7 @@ class Editres < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/enchant.rb
+++ b/packages/enchant.rb
@@ -25,7 +25,7 @@ class Enchant < Package
     system './bootstrap'
     system "env CFLAGS='-flto=auto -ltinfo' CXXFLAGS='-flto=auto' \
         LDFLAGS='-flto=auto' \
-        ./configure #{CREW_OPTIONS} \
+        ./configure #{CREW_CONFIGURE_OPTIONS} \
         --with-hunspell \
         --with-aspell"
     system 'make'

--- a/packages/encodings.rb
+++ b/packages/encodings.rb
@@ -19,7 +19,7 @@ class Encodings < Package
   depends_on 'mkfontscale'
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --with-fontrootdir=#{CREW_PREFIX}/share/fonts"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --with-fontrootdir=#{CREW_PREFIX}/share/fonts"
     system "sed -e 's|^\(encodings_DATA = $(DATA_FILES)\).*|\1|' -i Makefile" # Found in xbps-src
     system 'make'
   end

--- a/packages/enet.rb
+++ b/packages/enet.rb
@@ -19,7 +19,7 @@ class Enet < Package
 
   def self.build
     system 'autoreconf -vfi'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/ethtool.rb
+++ b/packages/ethtool.rb
@@ -24,7 +24,7 @@ class Ethtool < Package
 
   def self.build
     system "#{CREW_ENV_OPTIONS} \
-             ./configure #{CREW_OPTIONS} \
+             ./configure #{CREW_CONFIGURE_OPTIONS} \
              --mandir=#{CREW_MAN_PREFIX} \
              --sbindir=#{CREW_PREFIX}/bin"
     system 'make'

--- a/packages/exfatprogs.rb
+++ b/packages/exfatprogs.rb
@@ -21,7 +21,7 @@ class Exfatprogs < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/exo.rb
+++ b/packages/exo.rb
@@ -27,7 +27,7 @@ class Exo < Package
   end
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/faac.rb
+++ b/packages/faac.rb
@@ -25,7 +25,7 @@ class Faac < Package
   def self.build
     system 'autoreconf -vfi'
     system "env #{CREW_ENV_OPTIONS} \
-      ./configure #{CREW_OPTIONS}"
+      ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/ffmpeg.rb
+++ b/packages/ffmpeg.rb
@@ -189,7 +189,7 @@ class Ffmpeg < Package
         --enable-version3 \
         --host-cflags='#{CREW_ENV_OPTIONS_HASH['CFLAGS']} -flto=auto -fuse-ld=#{CREW_LINKER} #{@arch_cflags}' \
         --host-ldflags='#{CREW_ENV_OPTIONS_HASH['LDFLAGS']} -flto=auto' \
-        #{CREW_OPTIONS.sub(/--build=.*/, '').gsub('vfpv3-d16', 'neon').gsub('--disable-dependency-tracking', '')}"
+        #{CREW_CONFIGURE_OPTIONS.sub(/--build=.*/, '').gsub('vfpv3-d16', 'neon').gsub('--disable-dependency-tracking', '')}"
     system "env PATH=#{CREW_LIB_PREFIX}/ccache/bin:#{CREW_PREFIX}/bin:/usr/bin:/bin \
         make -j#{CREW_NPROC}"
     system 'make tools/qt-faststart'

--- a/packages/filecmd.rb
+++ b/packages/filecmd.rb
@@ -61,7 +61,7 @@ class Filecmd < Package
     Dir.chdir 'builddir-static' do
       system "env LDFLAGS+=' -static' \
       ../configure \
-        #{CREW_OPTIONS} \
+        #{CREW_CONFIGURE_OPTIONS} \
         #{@filecmd_config_opts}"
       system 'make'
     end
@@ -70,7 +70,7 @@ class Filecmd < Package
     Dir.mkdir 'builddir-dynamic'
     Dir.chdir 'builddir-dynamic' do
       system "../configure \
-        #{CREW_OPTIONS} \
+        #{CREW_CONFIGURE_OPTIONS} \
         #{@filecmd_config_opts}"
       system 'make'
     end

--- a/packages/filezilla.rb
+++ b/packages/filezilla.rb
@@ -49,7 +49,7 @@ class Filezilla < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --disable-maintainer-mode --with-pugixml=builtin"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --disable-maintainer-mode --with-pugixml=builtin"
     system 'make'
   end
 

--- a/packages/fossil.rb
+++ b/packages/fossil.rb
@@ -29,7 +29,7 @@ class Fossil < Autotools
     system "./configure --prefix=#{CREW_PREFIX}"
   end
 
-  install_extras do
+  configure_install_extras do
     FileUtils.install 'fossil.1', "#{CREW_DEST_MAN_PREFIX}/man1/fossil.1", mode: 0o644
   end
 end

--- a/packages/freetds.rb
+++ b/packages/freetds.rb
@@ -23,7 +23,7 @@ class Freetds < Package
     system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      ./configure #{CREW_OPTIONS}"
+      ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/fswatch.rb
+++ b/packages/fswatch.rb
@@ -17,7 +17,7 @@ class Fswatch < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/fuse2.rb
+++ b/packages/fuse2.rb
@@ -20,7 +20,7 @@ class Fuse2 < Package
   depends_on 'util_linux'
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
             --enable-example \
             --disable-mtab \
             --enable-util \

--- a/packages/fuse_overlayfs.rb
+++ b/packages/fuse_overlayfs.rb
@@ -26,7 +26,7 @@ class Fuse_overlayfs < Package
 
   def self.build
     system 'autoreconf -fiv'
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --sbindir=#{CREW_PREFIX}/bin"
     system 'make'
   end

--- a/packages/garcon.rb
+++ b/packages/garcon.rb
@@ -20,7 +20,7 @@ class Garcon < Package
   depends_on 'libxfce4ui'
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --disable-static --enable-gtk2 --enable-libxfce4ui"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --disable-static --enable-gtk2 --enable-libxfce4ui"
     system "make -j#{CREW_NPROC}"
   end
 

--- a/packages/gawk.rb
+++ b/packages/gawk.rb
@@ -25,7 +25,7 @@ class Gawk < Package
   depends_on 'readline' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --without-libsigsegv-prefix"
     system 'make'
   end

--- a/packages/gcc10.rb
+++ b/packages/gcc10.rb
@@ -119,7 +119,7 @@ class Gcc10 < Package
 
       unless File.file?('Makefile')
         system configure_env, <<~BUILD.chomp
-          ../configure #{CREW_OPTIONS} \
+          ../configure #{CREW_CONFIGURE_OPTIONS} \
             #{@gcc_global_opts} \
             #{@archflags} \
             --with-native-system-header-dir=#{CREW_PREFIX}/include \

--- a/packages/gcc_build.rb
+++ b/packages/gcc_build.rb
@@ -166,7 +166,7 @@ class Gcc_build < Package
         }.transform_keys(&:to_s)
 
       system configure_env, <<~BUILD.chomp
-        mold -run ../configure #{CREW_OPTIONS} \
+        mold -run ../configure #{CREW_CONFIGURE_OPTIONS} \
           #{@gcc_global_opts} \
           #{@archflags} \
           --with-native-system-header-dir=#{CREW_PREFIX}/include \

--- a/packages/gccmakedep.rb
+++ b/packages/gccmakedep.rb
@@ -18,7 +18,7 @@ class Gccmakedep < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
             --sysconfdir=#{CREW_PREFIX}/etc"
     system 'make'
   end

--- a/packages/gdb.rb
+++ b/packages/gdb.rb
@@ -45,7 +45,7 @@ class Gdb < Autotools
     FileUtils.mkdir_p 'build'
     Dir.chdir('build') do
       system "../configure \
-        #{CREW_OPTIONS} \
+        #{CREW_CONFIGURE_OPTIONS} \
         --disable-binutils \
         --disable-ld \
         --disable-nls \

--- a/packages/gdbm.rb
+++ b/packages/gdbm.rb
@@ -23,7 +23,7 @@ class Gdbm < Package
 
   def self.build
     system "mold -run ./configure \
-      #{CREW_OPTIONS}"
+      #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/ghostscript.rb
+++ b/packages/ghostscript.rb
@@ -55,7 +55,7 @@ class Ghostscript < Package
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
     system 'filefix'
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --disable-hidden-visibility \
       --disable-compile-inits \
       --enable-dynamic \

--- a/packages/glibc_build223.rb
+++ b/packages/glibc_build223.rb
@@ -231,7 +231,7 @@ class Glibc_build223 < Package
       end
       FileUtils.cp 'binutils/ld.bfd', 'binutils/ld'
       system "CFLAGS='-O2 -pipe -fno-stack-protector' ../configure \
-                 #{CREW_OPTIONS} \
+                 #{CREW_CONFIGURE_OPTIONS} \
                  --with-headers=#{CREW_PREFIX}/include \
                  --without-gd \
                  --disable-werror \

--- a/packages/glibc_build227.rb
+++ b/packages/glibc_build227.rb
@@ -239,7 +239,7 @@ class Glibc_build227 < Package
         # enable-obsolete-rpc will cause a conflict with libtirpc
         system "SYSROOT=''  CFLAGS='-O2 -fno-strict-aliasing -fno-stack-protector -march=armv7-a+fp' \
                 LD=ld ../configure \
-                #{CREW_OPTIONS} \
+                #{CREW_CONFIGURE_OPTIONS} \
                 --with-headers=#{CREW_PREFIX}/include \
                 ac_cv_lib_cap_cap_init=no \
                 --disable-sanity-checks \
@@ -261,7 +261,7 @@ class Glibc_build227 < Package
       when 'x86_64'
         File.write('configparms', "slibdir=#{CREW_LIB_PREFIX}")
         system "CFLAGS='-O2 -pipe -fno-stack-protector' ../configure \
-                 #{CREW_OPTIONS} \
+                 #{CREW_CONFIGURE_OPTIONS} \
                  --with-headers=#{CREW_PREFIX}/include \
                  --without-gd \
                  --disable-werror \

--- a/packages/glpk.rb
+++ b/packages/glpk.rb
@@ -18,7 +18,7 @@ class Glpk < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/gnu_time.rb
+++ b/packages/gnu_time.rb
@@ -28,7 +28,7 @@ class Gnu_time < Package
 
   def self.build
     system './bootstrap --no-git --gnulib-srcdir=./gnulib'
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} --infodir=#{CREW_PREFIX}/share/info"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS} --infodir=#{CREW_PREFIX}/share/info"
     system 'make'
   end
 

--- a/packages/gnuchess.rb
+++ b/packages/gnuchess.rb
@@ -18,7 +18,7 @@ class Gnuchess < Package
   })
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS} \
               --with-readline"
     system 'make'
   end

--- a/packages/gparted.rb
+++ b/packages/gparted.rb
@@ -36,7 +36,7 @@ class Gparted < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --sbindir=#{CREW_PREFIX}/bin \
       --enable-online-resize \
       --enable-libparted-dmraid \

--- a/packages/gpm.rb
+++ b/packages/gpm.rb
@@ -24,7 +24,7 @@ class Gpm < Package
     system "env CFLAGS='-flto=auto' \
       CXXFLAGS='-flto=auto' LDFLAGS='-flto=auto' \
       ./configure \
-      #{CREW_OPTIONS} \
+      #{CREW_CONFIGURE_OPTIONS} \
       --sysconfdir=#{CREW_PREFIX}/etc \
       --sbindir=#{CREW_PREFIX}/bin"
     system 'make'

--- a/packages/graphicsmagick.rb
+++ b/packages/graphicsmagick.rb
@@ -122,7 +122,7 @@ class Graphicsmagick < Package
   end
 
   def self.build
-    system "#{CREW_ENV_OPTIONS.gsub('-mfpu=vfpv3-d16', '-mfpu=neon-fp16')} ./configure #{CREW_OPTIONS} \
+    system "#{CREW_ENV_OPTIONS.gsub('-mfpu=vfpv3-d16', '-mfpu=neon-fp16')} ./configure #{CREW_CONFIGURE_OPTIONS} \
       --with-windows-font-dir=#{CREW_PREFIX}/share/fonts/truetype/msttcorefonts \
       --with-perl=#{CREW_PREFIX}/bin/perl \
       --disable-maintainer-mode \

--- a/packages/grep.rb
+++ b/packages/grep.rb
@@ -26,7 +26,7 @@ class Grep < Package
 
   def self.build
     system "CPPFLAGS=-DHAVE_DYNAMIC_LIBPCRE \
-      ./configure #{CREW_OPTIONS} \
+      ./configure #{CREW_CONFIGURE_OPTIONS} \
       --without-included-regex"
     system 'make'
   end

--- a/packages/gtk2.rb
+++ b/packages/gtk2.rb
@@ -52,7 +52,7 @@ class Gtk2 < Package
 
   def self.build
     system "#{CREW_ENV_OPTIONS} \
-      ./configure #{CREW_OPTIONS} --with-gdktarget=x11"
+      ./configure #{CREW_CONFIGURE_OPTIONS} --with-gdktarget=x11"
     system 'make'
   end
 

--- a/packages/gtksharp2.rb
+++ b/packages/gtksharp2.rb
@@ -47,7 +47,7 @@ class Gtksharp2 < Package
   def self.build
     system "CFLAGS='-flto=auto' CXXFLAGS='-flto=auto'
       LDFLAGS='-flto=auto' \
-      ./configure #{CREW_OPTIONS} \
+      ./configure #{CREW_CONFIGURE_OPTIONS} \
       --disable-maintainer-mode"
     system 'make'
   end

--- a/packages/gutenprint.rb
+++ b/packages/gutenprint.rb
@@ -18,7 +18,7 @@ class Gutenprint < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/handbrake.rb
+++ b/packages/handbrake.rb
@@ -72,7 +72,7 @@ class Handbrake < Package
     # with a libtool error.
     FileUtils.ln_sf "#{CREW_LIB_PREFIX}/libfribidi.la", "#{CREW_PREFIX}/lib/"
 
-    system "LDFLAGS+=' -L #{CREW_LIB_PREFIX}' ./configure #{CREW_OPTIONS} \
+    system "LDFLAGS+=' -L #{CREW_LIB_PREFIX}' ./configure #{CREW_CONFIGURE_OPTIONS} \
       --enable-x265 \
       --enable-numa \
       --enable-fdk-aac \

--- a/packages/haveged.rb
+++ b/packages/haveged.rb
@@ -18,7 +18,7 @@ class Haveged < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
             --disable-daemon \
             --enable-nistest \
             --enable-enttest \

--- a/packages/hello.rb
+++ b/packages/hello.rb
@@ -20,7 +20,7 @@ class Hello < Package
   depends_on 'glibc' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/help2man.rb
+++ b/packages/help2man.rb
@@ -18,7 +18,7 @@ class Help2man < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/homebank.rb
+++ b/packages/homebank.rb
@@ -25,7 +25,7 @@ class Homebank < Package
   depends_on 'xcb_util'
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/hplip.rb
+++ b/packages/hplip.rb
@@ -34,7 +34,7 @@ class Hplip < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --disable-network-build"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --disable-network-build"
     system 'make'
   end
 

--- a/packages/htop.rb
+++ b/packages/htop.rb
@@ -26,7 +26,7 @@ class Htop < Package
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
     system "CPPFLAGS='-I#{CREW_PREFIX}/include/ncursesw' \
-      ./configure #{CREW_OPTIONS} \
+      ./configure #{CREW_CONFIGURE_OPTIONS} \
       --disable-unicode"
     system 'make'
   end

--- a/packages/httrack.rb
+++ b/packages/httrack.rb
@@ -22,7 +22,7 @@ class Httrack < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/hwdata.rb
+++ b/packages/hwdata.rb
@@ -25,7 +25,7 @@ class Hwdata < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --datadir=#{CREW_PREFIX}/share \
       --disable-blacklist"
     system 'make'

--- a/packages/hwloc.rb
+++ b/packages/hwloc.rb
@@ -30,7 +30,7 @@ class Hwloc < Package
     system './autogen.sh'
     system 'filefix'
     system "#{CREW_ENV_OPTIONS} ./configure \
-      #{CREW_OPTIONS} \
+      #{CREW_CONFIGURE_OPTIONS} \
       --enable-plugins \
       --sysconfdir=#{CREW_PREFIX}/etc"
     system 'make'

--- a/packages/icoutils.rb
+++ b/packages/icoutils.rb
@@ -21,7 +21,7 @@ class Icoutils < Package
   depends_on 'perl'
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/icu4c.rb
+++ b/packages/icu4c.rb
@@ -23,7 +23,7 @@ class Icu4c < Package
   def self.build
     Dir.chdir 'source' do
       system "mold -run ./configure \
-        #{CREW_OPTIONS} \
+        #{CREW_CONFIGURE_OPTIONS} \
         --enable-shared \
         --disable-samples \
         --disable-tests"

--- a/packages/intltool.rb
+++ b/packages/intltool.rb
@@ -28,7 +28,7 @@ class Intltool < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/iproute2.rb
+++ b/packages/iproute2.rb
@@ -37,7 +37,7 @@ class Iproute2 < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --include_dir=#{CREW_PREFIX}/include"
     system 'make'
   end

--- a/packages/iptables.rb
+++ b/packages/iptables.rb
@@ -24,7 +24,7 @@ class Iptables < Package
 
   def self.build
     system "#{CREW_ENV_OPTIONS} \
-      ./configure #{CREW_OPTIONS} \
+      ./configure #{CREW_CONFIGURE_OPTIONS} \
       --enable-static \
       --disable-nftables"
     system 'make'

--- a/packages/jack1.rb
+++ b/packages/jack1.rb
@@ -25,7 +25,7 @@ class Jack1 < Package
       system 'git submodule init'
       system 'git submodule update'
       system './autogen.sh'
-      system "./configure #{CREW_OPTIONS}"
+      system "./configure #{CREW_CONFIGURE_OPTIONS}"
       system 'make'
     end
   end

--- a/packages/jansson.rb
+++ b/packages/jansson.rb
@@ -21,7 +21,7 @@ class Jansson < Package
     system 'autoreconf -i'
     system "env CFLAGS='-flto=auto' \
       CXXFLAGS='-flto=auto' LDFLAGS='-flto=auto' \
-      ./configure #{CREW_OPTIONS}"
+      ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/jbigkit.rb
+++ b/packages/jbigkit.rb
@@ -25,7 +25,7 @@ class Jbigkit < Package
 
   def self.build
     system 'autoreconf -fiv'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make all'
   end
 

--- a/packages/jpegoptim.rb
+++ b/packages/jpegoptim.rb
@@ -20,7 +20,7 @@ class Jpegoptim < Package
   depends_on 'libjpeg_turbo'
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
     system 'make', 'strip'
   end

--- a/packages/krb5.rb
+++ b/packages/krb5.rb
@@ -31,7 +31,7 @@ class Krb5 < Package
       @path = "#{CREW_PREFIX}/bin:" + ENV.fetch('PATH', nil)
       system "CPPFLAGS='#{@cppflags}' \
       PATH=#{@path} \
-      mold -run ./configure #{CREW_OPTIONS} \
+      mold -run ./configure #{CREW_CONFIGURE_OPTIONS} \
       --localstatedir=#{CREW_PREFIX}/var/krb5kdc \
       --enable-shared \
       --with-system-et \

--- a/packages/l_smash.rb
+++ b/packages/l_smash.rb
@@ -19,7 +19,7 @@ class L_smash < Package
 
   def self.build
     system '[ -x configure ] || ./autogen.sh'
-    system "./configure #{CREW_OPTIONS.sub(/--mandir=.*/, '')} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS.sub(/--mandir=.*/, '')} \
       --enable-shared \
       --extra-cflags='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       --extra-ldflags='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto'"

--- a/packages/lcms.rb
+++ b/packages/lcms.rb
@@ -21,7 +21,7 @@ class Lcms < Package
     system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      ./configure #{CREW_OPTIONS}"
+      ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/ldb.rb
+++ b/packages/ldb.rb
@@ -37,7 +37,7 @@ class Ldb < Package
 
   def self.build
     system "./configure \
-      #{CREW_OPTIONS.sub(/--program-suffix.*/, '')} \
+      #{CREW_CONFIGURE_OPTIONS.sub(/--program-suffix.*/, '')} \
       --localstatedir=#{CREW_PREFIX}/var \
       --sysconfdir=#{CREW_PREFIX}/etc/samba \
       --with-modulesdir=#{CREW_LIB_PREFIX}/ldb/modules \

--- a/packages/lftp.rb
+++ b/packages/lftp.rb
@@ -18,7 +18,7 @@ class Lftp < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --disable-nls --disable-dependency-tracking --with-linux-crypto"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --disable-nls --disable-dependency-tracking --with-linux-crypto"
     system 'make'
   end
 

--- a/packages/lha.rb
+++ b/packages/lha.rb
@@ -21,7 +21,7 @@ class Lha < Package
 
   def self.build
     system 'autoreconf -sif'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/liba52.rb
+++ b/packages/liba52.rb
@@ -24,7 +24,7 @@ class Liba52 < Package
 
   def self.build
     system './bootstrap'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libappindicator_gtk3.rb
+++ b/packages/libappindicator_gtk3.rb
@@ -37,7 +37,7 @@ class Libappindicator_gtk3 < Package
   def self.build
     system "#{CREW_ENV_OPTIONS.sub("CFLAGS='", "CFLAGS='-Wno-deprecated-declarations ")} \
     ./configure \
-    #{CREW_OPTIONS} \
+    #{CREW_CONFIGURE_OPTIONS} \
     --localstatedir=#{CREW_PREFIX}/var \
     --sysconfdir=#{CREW_PREFIX}/etc \
     --with-gtk=3 \

--- a/packages/libassuan.rb
+++ b/packages/libassuan.rb
@@ -25,7 +25,7 @@ class Libassuan < Package
     system "env CFLAGS='-flto=auto' \
       CXXFLAGS='-pipe -flto=auto' \
       LDFLAGS='-flto=auto' \
-      ./configure #{CREW_OPTIONS}"
+      ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libatasmart.rb
+++ b/packages/libatasmart.rb
@@ -22,7 +22,7 @@ class Libatasmart < Package
 
   def self.build
     system './autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libavc1394.rb
+++ b/packages/libavc1394.rb
@@ -20,7 +20,7 @@ class Libavc1394 < Package
   depends_on 'libraw1394'
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libblockdev.rb
+++ b/packages/libblockdev.rb
@@ -33,7 +33,7 @@ class Libblockdev < Package
 
   def self.build
     system 'filefix'
-    system "./configure #{CREW_OPTIONS} --with-gtk-doc=no"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --with-gtk-doc=no"
     system 'make'
   end
 

--- a/packages/libbluray.rb
+++ b/packages/libbluray.rb
@@ -21,7 +21,7 @@ class Libbluray < Package
   depends_on 'fontconfig'
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS} \
             --enable-optimizations \
             --disable-bdjava-jar"
     system 'make'

--- a/packages/libbytesize.rb
+++ b/packages/libbytesize.rb
@@ -20,7 +20,7 @@ class Libbytesize < Package
   depends_on 'gawk' => :build
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --with-gtk-doc=no"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --with-gtk-doc=no"
     system 'make'
   end
 

--- a/packages/libcaca.rb
+++ b/packages/libcaca.rb
@@ -50,7 +50,7 @@ class Libcaca < Package
   def self.build
     system '[ -x configure ] || ./bootstrap'
     system "./configure \
-      #{CREW_OPTIONS} \
+      #{CREW_CONFIGURE_OPTIONS} \
       --enable-gl \
       --enable-ncurses \
       --enable-network \

--- a/packages/libcacard.rb
+++ b/packages/libcacard.rb
@@ -25,7 +25,7 @@ class Libcacard < Package
   def self.build
     system 'filefix'
     system "env #{CREW_ENV_OPTIONS} \
-        ./configure #{CREW_OPTIONS}"
+        ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libcanberra.rb
+++ b/packages/libcanberra.rb
@@ -90,7 +90,7 @@ class Libcanberra < Package
 
   def self.build
     system "env #{CREW_ENV_OPTIONS} \
-      ./configure #{CREW_OPTIONS} \
+      ./configure #{CREW_CONFIGURE_OPTIONS} \
       --enable-alsa \
       --enable-null \
       --disable-lynx \

--- a/packages/libcddb.rb
+++ b/packages/libcddb.rb
@@ -31,7 +31,7 @@ class Libcddb < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libcdio.rb
+++ b/packages/libcdio.rb
@@ -20,7 +20,7 @@ class Libcdio < Package
   depends_on 'libcddb'
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS} \
               --without-cdda-player \
               --enable-cxx \
               --disable-cpp-progs \

--- a/packages/libcdio_paranoia.rb
+++ b/packages/libcdio_paranoia.rb
@@ -24,7 +24,7 @@ class Libcdio_paranoia < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system " ./configure #{CREW_OPTIONS} \
+    system " ./configure #{CREW_CONFIGURE_OPTIONS} \
       --enable-cpp-progs \
       --disable-example-progs"
     system 'make'

--- a/packages/libdaemon.rb
+++ b/packages/libdaemon.rb
@@ -18,7 +18,7 @@ class Libdaemon < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libdb.rb
+++ b/packages/libdb.rb
@@ -26,7 +26,7 @@ class Libdb < Package
 
   def self.build
     Dir.chdir 'build_unix' do
-      system "mold -run ../dist/configure #{CREW_OPTIONS} \
+      system "mold -run ../dist/configure #{CREW_CONFIGURE_OPTIONS} \
       --enable-compat185 \
       --enable-cxx \
       --enable-dbm \

--- a/packages/libdc1394.rb
+++ b/packages/libdc1394.rb
@@ -21,7 +21,7 @@ class Libdc1394 < Package
   depends_on 'libusb'
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libdca.rb
+++ b/packages/libdca.rb
@@ -20,7 +20,7 @@ class Libdca < Package
   def self.build
     system 'autoupdate'
     system 'autoreconf -fiv'
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libdmraid.rb
+++ b/packages/libdmraid.rb
@@ -23,7 +23,7 @@ class Libdmraid < Package
   def self.build
     Dir.chdir '1.0.0.rc16-3/dmraid' do
       system 'autoreconf -fvi'
-      system "./configure #{CREW_OPTIONS}"
+      system "./configure #{CREW_CONFIGURE_OPTIONS}"
       system 'make || make'
     end
   end

--- a/packages/libdnet.rb
+++ b/packages/libdnet.rb
@@ -20,7 +20,7 @@ class Libdnet < Package
   depends_on 'check' => :build
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libdsm.rb
+++ b/packages/libdsm.rb
@@ -21,7 +21,7 @@ class Libdsm < Package
 
   def self.build
     system './bootstrap'
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS} \
             --with-urandom=/dev/urandom"
     system 'make'
   end

--- a/packages/libdv.rb
+++ b/packages/libdv.rb
@@ -21,7 +21,7 @@ class Libdv < Package
 
   def self.build
     system "env #{CREW_ENV_OPTIONS} \
-    ./configure #{CREW_OPTIONS}"
+    ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libdvbpsi.rb
+++ b/packages/libdvbpsi.rb
@@ -18,7 +18,7 @@ class Libdvbpsi < Package
   })
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS} \
               --enable-release"
     system 'make'
   end

--- a/packages/libdvdcss.rb
+++ b/packages/libdvdcss.rb
@@ -23,7 +23,7 @@ class Libdvdcss < Package
   depends_on 'glibc' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libdvdnav.rb
+++ b/packages/libdvdnav.rb
@@ -20,7 +20,7 @@ class Libdvdnav < Package
   depends_on 'libdvdread'
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libdvdread.rb
+++ b/packages/libdvdread.rb
@@ -18,7 +18,7 @@ class Libdvdread < Package
   })
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libedit.rb
+++ b/packages/libedit.rb
@@ -20,7 +20,7 @@ class Libedit < Package
   depends_on 'glibc' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
             CPPFLAGS=\"-I#{CREW_PREFIX}/include/ncursesw\""
     system 'make'
   end

--- a/packages/libev.rb
+++ b/packages/libev.rb
@@ -18,7 +18,7 @@ class Libev < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system "make -j#{CREW_NPROC}"
   end
 

--- a/packages/libexif.rb
+++ b/packages/libexif.rb
@@ -23,7 +23,7 @@ class Libexif < Package
     system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      ./configure #{CREW_OPTIONS} \
+      ./configure #{CREW_CONFIGURE_OPTIONS} \
      --disable-maintainer-mode"
     system 'make'
   end

--- a/packages/libfdk_aac.rb
+++ b/packages/libfdk_aac.rb
@@ -21,7 +21,7 @@ class Libfdk_aac < Package
 
   def self.build
     system 'autoreconf -fiv'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libffi.rb
+++ b/packages/libffi.rb
@@ -21,7 +21,7 @@ class Libffi < Package
 
   def self.build
     system 'autoreconf -fiv'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libfontenc.rb
+++ b/packages/libfontenc.rb
@@ -23,7 +23,7 @@ class Libfontenc < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --with-fontrootdir=#{CREW_PREFIX}/share/fonts/X11"
     system 'make'
   end

--- a/packages/libfs.rb
+++ b/packages/libfs.rb
@@ -23,7 +23,7 @@ class Libfs < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libgc.rb
+++ b/packages/libgc.rb
@@ -18,7 +18,7 @@ class Libgc < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
             --enable-static \
             --enable-shared \
             --enable-docs"

--- a/packages/libgdiplus.rb
+++ b/packages/libgdiplus.rb
@@ -39,7 +39,7 @@ class Libgdiplus < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --with-libexif \
       --with-libtiff \
       --with-jpeg \

--- a/packages/libgphoto.rb
+++ b/packages/libgphoto.rb
@@ -26,7 +26,7 @@ class Libgphoto < Package
     system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      ./configure #{CREW_OPTIONS} \
+      ./configure #{CREW_CONFIGURE_OPTIONS} \
       --with-camlibs=all,outdated"
     system 'make'
   end

--- a/packages/libice.rb
+++ b/packages/libice.rb
@@ -27,7 +27,7 @@ class Libice < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libiconv.rb
+++ b/packages/libiconv.rb
@@ -18,7 +18,7 @@ class Libiconv < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
         --includedir=#{CREW_PREFIX}/include/gnu-libiconv \
         --enable-static \
         --enable-relocatable \

--- a/packages/libiec61883.rb
+++ b/packages/libiec61883.rb
@@ -24,7 +24,7 @@ class Libiec61883 < Package
     system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto -I#{CREW_PREFIX}/include/harfbuzz' \
       CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      ./configure #{CREW_OPTIONS}"
+      ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libimagequant.rb
+++ b/packages/libimagequant.rb
@@ -22,7 +22,7 @@ class Libimagequant < Package
     system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      ./configure #{CREW_OPTIONS} --with-openmp"
+      ./configure #{CREW_CONFIGURE_OPTIONS} --with-openmp"
     system 'make all imagequant.pc'
   end
 

--- a/packages/libimobiledevice.rb
+++ b/packages/libimobiledevice.rb
@@ -27,7 +27,7 @@ class Libimobiledevice < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS} --disable-openssl"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --disable-openssl"
     system 'make'
   end
 

--- a/packages/libindicator_gtk3.rb
+++ b/packages/libindicator_gtk3.rb
@@ -31,7 +31,7 @@ class Libindicator_gtk3 < Package
     system "#{CREW_ENV_OPTIONS.sub("CFLAGS='", "CFLAGS='-Wno-deprecated-declarations ").sub("LDFLAGS='",
                                                                                             "LDFLAGS='-lm ")} \
     ./configure \
-    #{CREW_OPTIONS} \
+    #{CREW_CONFIGURE_OPTIONS} \
     --localstatedir=#{CREW_PREFIX}/var \
     --libexecdir=#{CREW_LIB_PREFIX}/libindicator \
     --sysconfdir=#{CREW_PREFIX}/etc \

--- a/packages/libkmod.rb
+++ b/packages/libkmod.rb
@@ -23,7 +23,7 @@ class Libkmod < Package
   def self.build
     system './autogen.sh'
     system 'filefix'
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
     --disable-maintainer-mode \
     --enable-python \
     --with-openssl \

--- a/packages/libksba.rb
+++ b/packages/libksba.rb
@@ -22,7 +22,7 @@ class Libksba < Package
   depends_on 'libgpg_error' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libmad.rb
+++ b/packages/libmad.rb
@@ -25,7 +25,7 @@ class Libmad < Package
   end
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS} \
             --enable-accuracy \
             --disable-debugging"
     system 'make'

--- a/packages/libmbim.rb
+++ b/packages/libmbim.rb
@@ -23,7 +23,7 @@ class Libmbim < Package
     system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
       LDFLAGS='-flto=auto' \
       ./configure \
-      #{CREW_OPTIONS} \
+      #{CREW_CONFIGURE_OPTIONS} \
       --disable-maintainer-mode"
     system 'make'
   end

--- a/packages/libmediainfo.rb
+++ b/packages/libmediainfo.rb
@@ -27,7 +27,7 @@ class Libmediainfo < Package
   end
 
   def self.build
-    system "mold -run ./SO_Compile.sh #{CREW_OPTIONS}"
+    system "mold -run ./SO_Compile.sh #{CREW_CONFIGURE_OPTIONS}"
   end
 
   def self.install

--- a/packages/libmms.rb
+++ b/packages/libmms.rb
@@ -23,7 +23,7 @@ class Libmms < Package
 
   def self.build
     system "env #{CREW_ENV_OPTIONS} \
-      ./configure #{CREW_OPTIONS}"
+      ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libmnl.rb
+++ b/packages/libmnl.rb
@@ -20,7 +20,7 @@ class Libmnl < Package
   depends_on 'glibc' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libmodplug.rb
+++ b/packages/libmodplug.rb
@@ -18,7 +18,7 @@ class Libmodplug < Package
   })
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libmpc.rb
+++ b/packages/libmpc.rb
@@ -25,7 +25,7 @@ class Libmpc < Package
 
   def self.build
     system 'autoreconf -fiv'
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libmpeg2.rb
+++ b/packages/libmpeg2.rb
@@ -25,7 +25,7 @@ class Libmpeg2 < Package
   end
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS} \
             --with-x"
     system 'make'
   end

--- a/packages/libmrss.rb
+++ b/packages/libmrss.rb
@@ -24,7 +24,7 @@ class Libmrss < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libmtp.rb
+++ b/packages/libmtp.rb
@@ -20,7 +20,7 @@ class Libmtp < Package
 
   def self.build
     system 'NOCONFIGURE=1 ./autogen.sh'
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libmypaint.rb
+++ b/packages/libmypaint.rb
@@ -29,7 +29,7 @@ class Libmypaint < Package
   def self.build
     system 'env NOCONFIGURE=1 ./autogen.sh'
     system "./configure \
-      #{CREW_OPTIONS} \
+      #{CREW_CONFIGURE_OPTIONS} \
       --disable-maintainer-mode \
       --enable-openmp \
       --enable-gegl"

--- a/packages/libnewt.rb
+++ b/packages/libnewt.rb
@@ -38,7 +38,7 @@ class Libnewt < Package
   def self.build
     system "env CFLAGS='-flto=auto' \
       CXXFLAGS='-flto=auto' LDFLAGS='-flto=auto' \
-      ./configure #{CREW_OPTIONS} \
+      ./configure #{CREW_CONFIGURE_OPTIONS} \
       --with-gpm-support"
     system 'make'
   end

--- a/packages/libnfs.rb
+++ b/packages/libnfs.rb
@@ -20,7 +20,7 @@ class Libnfs < Package
 
   def self.build
     system 'autoreconf -fiv'
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS} \
             --enable-utils"
     system 'make'
   end

--- a/packages/libnxml.rb
+++ b/packages/libnxml.rb
@@ -26,7 +26,7 @@ class Libnxml < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libostree.rb
+++ b/packages/libostree.rb
@@ -28,7 +28,7 @@ class Libostree < Package
   def self.build
     system 'env NOCONFIGURE=1 ./autogen.sh'
     system "env #{CREW_ENV_OPTIONS} \
-      ./configure #{CREW_OPTIONS} \
+      ./configure #{CREW_CONFIGURE_OPTIONS} \
       --with-curl \
       --without-libsystemd \
       --with-avahi \

--- a/packages/libotf.rb
+++ b/packages/libotf.rb
@@ -29,7 +29,7 @@ class Libotf < Package
     system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      ./configure #{CREW_OPTIONS}"
+      ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libpciaccess.rb
+++ b/packages/libpciaccess.rb
@@ -21,7 +21,7 @@ class Libpciaccess < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libpipeline.rb
+++ b/packages/libpipeline.rb
@@ -21,7 +21,7 @@ class Libpipeline < Package
 
   def self.build
     system "./configure \
-      #{CREW_OPTIONS} \
+      #{CREW_CONFIGURE_OPTIONS} \
       --enable-shared \
       --with-pic"
     system 'make'

--- a/packages/libplist.rb
+++ b/packages/libplist.rb
@@ -24,7 +24,7 @@ class Libplist < Package
       CXXFLAGS='-pipe -flto=auto' \
       LDFLAGS='-flto=auto' \
       CC=gcc \
-      ./autogen.sh #{CREW_OPTIONS}"
+      ./autogen.sh #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libqmi.rb
+++ b/packages/libqmi.rb
@@ -22,7 +22,7 @@ class Libqmi < Package
     system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
       LDFLAGS='-flto=auto' \
       ./configure \
-      #{CREW_OPTIONS} \
+      #{CREW_CONFIGURE_OPTIONS} \
       --disable-maintainer-mode"
     system 'make'
   end

--- a/packages/libraw.rb
+++ b/packages/libraw.rb
@@ -27,7 +27,7 @@ class Libraw < Package
   def self.build
     system 'autoreconf -fiv'
     system 'filefix'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/librevenge.rb
+++ b/packages/librevenge.rb
@@ -28,7 +28,7 @@ class Librevenge < Package
   depends_on 'zlib' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --disable-werror"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --disable-werror"
     system 'make'
   end
 

--- a/packages/libsdl.rb
+++ b/packages/libsdl.rb
@@ -42,7 +42,7 @@ class Libsdl < Package
 
   def self.build
     system "./configure \
-      #{CREW_OPTIONS}"
+      #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libseccomp.rb
+++ b/packages/libseccomp.rb
@@ -23,7 +23,7 @@ class Libseccomp < Package
   def self.build
     system './autogen.sh'
     system "./configure \
-      #{CREW_OPTIONS}"
+      #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libshine.rb
+++ b/packages/libshine.rb
@@ -11,7 +11,7 @@ class Libshine < Package
 
   def self.build
     system 'autoreconf -fiv'
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libspectre.rb
+++ b/packages/libspectre.rb
@@ -22,7 +22,7 @@ class Libspectre < Package
   depends_on 'glibc' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libssp.rb
+++ b/packages/libssp.rb
@@ -100,7 +100,7 @@ class Libssp < Package
       system "env NM=gcc-nm AR=gcc-ar RANLIB=gcc-ranlib \
         CFLAGS='#{@cflags}' CXXFLAGS='#{@cxxflags}' \
         PATH=#{@path} \
-        ../#{@gcc_name}/configure #{CREW_OPTIONS} \
+        ../#{@gcc_name}/configure #{CREW_CONFIGURE_OPTIONS} \
         #{@gcc_global_opts} \
         --enable-languages=#{@languages} \
         --program-suffix=-#{gcc_version} \

--- a/packages/libtiff.rb
+++ b/packages/libtiff.rb
@@ -43,7 +43,7 @@ class Libtiff < Package
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
     @x = ARCH == 'i686' ? '' : '--with-x --enable-webp'
-    system "#{CREW_ENV_OPTIONS.gsub('-mfpu=vfpv3-d16', '-mfpu=neon-fp16')} ./configure #{CREW_OPTIONS} \
+    system "#{CREW_ENV_OPTIONS.gsub('-mfpu=vfpv3-d16', '-mfpu=neon-fp16')} ./configure #{CREW_CONFIGURE_OPTIONS} \
       #{@x} \
       --enable-zlib \
       --enable-mdi \

--- a/packages/libtinfo.rb
+++ b/packages/libtinfo.rb
@@ -25,8 +25,8 @@ class Libtinfo < Package
     # build libncurses
     Dir.mkdir 'ncurses_build'
     Dir.chdir 'ncurses_build' do
-      # system "#{CREW_ENV_OPTIONS} ../configure #{CREW_OPTIONS} \
-      system "../configure #{CREW_OPTIONS} \
+      # system "#{CREW_ENV_OPTIONS} ../configure #{CREW_CONFIGURE_OPTIONS} \
+      system "../configure #{CREW_CONFIGURE_OPTIONS} \
           --program-prefix='' \
           --program-suffix='' \
           --with-shared \
@@ -43,8 +43,8 @@ class Libtinfo < Package
     # build libncursesw
     Dir.mkdir 'ncursesw_build'
     Dir.chdir 'ncursesw_build' do
-      # system "#{CREW_ENV_OPTIONS} ../configure #{CREW_OPTIONS} \
-      system "../configure #{CREW_OPTIONS} \
+      # system "#{CREW_ENV_OPTIONS} ../configure #{CREW_CONFIGURE_OPTIONS} \
+      system "../configure #{CREW_CONFIGURE_OPTIONS} \
           --program-prefix='' \
           --program-suffix='' \
           --with-shared \

--- a/packages/libtool.rb
+++ b/packages/libtool.rb
@@ -20,7 +20,7 @@ class Libtool < Package
   depends_on 'm4'
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
             --enable-ltdl-install"
     system 'make'
   end

--- a/packages/libusb.rb
+++ b/packages/libusb.rb
@@ -21,7 +21,7 @@ class Libusb < Package
 
   def self.build
     system "./configure \
-      #{CREW_OPTIONS}"
+      #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libusbmuxd.rb
+++ b/packages/libusbmuxd.rb
@@ -24,7 +24,7 @@ class Libusbmuxd < Package
     system "env CFLAGS='-flto=auto' \
       CXXFLAGS='-pipe -flto=auto' \
       LDFLAGS='-flto=auto' \
-      ./autogen.sh #{CREW_OPTIONS}"
+      ./autogen.sh #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libvips.rb
+++ b/packages/libvips.rb
@@ -36,7 +36,7 @@ class Libvips < Package
     system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      ./configure #{CREW_OPTIONS}"
+      ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libvorbis.rb
+++ b/packages/libvorbis.rb
@@ -20,7 +20,7 @@ class Libvorbis < Package
   depends_on 'libogg'
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libvpx.rb
+++ b/packages/libvpx.rb
@@ -25,7 +25,7 @@ class Libvpx < Package
 
   def self.build
     Dir.chdir 'build' do
-      system "../configure #{CREW_OPTIONS.sub(/--mandir=.*/, '')} \
+      system "../configure #{CREW_CONFIGURE_OPTIONS.sub(/--mandir=.*/, '')} \
         --disable-debug-libs \
         --disable-install-docs \
         --enable-ccache \

--- a/packages/libwpd.rb
+++ b/packages/libwpd.rb
@@ -33,7 +33,7 @@ class Libwpd < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --disable-static"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --disable-static"
     system 'make'
   end
 

--- a/packages/libwpg.rb
+++ b/packages/libwpg.rb
@@ -29,7 +29,7 @@ class Libwpg < Package
   depends_on 'zlib' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libx264.rb
+++ b/packages/libx264.rb
@@ -28,7 +28,7 @@ class Libx264 < Package
   end
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS} \
               --disable-avs \
               --enable-lto \
               --enable-shared \

--- a/packages/libxau.rb
+++ b/packages/libxau.rb
@@ -22,7 +22,7 @@ class Libxau < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libxcb.rb
+++ b/packages/libxcb.rb
@@ -27,7 +27,7 @@ class Libxcb < Package
 
   def self.build
     system 'filefix'
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS} \
         --enable-dri3 \
         --disable-xevie \
         --disable-devel-docs"

--- a/packages/libxcomposite.rb
+++ b/packages/libxcomposite.rb
@@ -28,7 +28,7 @@ class Libxcomposite < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libxcrypt.rb
+++ b/packages/libxcrypt.rb
@@ -22,7 +22,7 @@ class Libxcrypt < Package
     system "env CFLAGS='-flto=auto' \
       CXXFLAGS='-flto=auto' LDFLAGS='-flto=auto' \
       ./configure \
-      #{CREW_OPTIONS} \
+      #{CREW_CONFIGURE_OPTIONS} \
       --disable-static \
       --enable-hashes=strong,glibc \
       --enable-obsolete-api=no \

--- a/packages/libxcursor.rb
+++ b/packages/libxcursor.rb
@@ -25,7 +25,7 @@ class Libxcursor < Package
   depends_on 'libxdmcp' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libxdamage.rb
+++ b/packages/libxdamage.rb
@@ -27,7 +27,7 @@ class Libxdamage < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libxfce4ui.rb
+++ b/packages/libxfce4ui.rb
@@ -22,7 +22,7 @@ class Libxfce4ui < Package
   depends_on 'xfconf'
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system "make -j#{CREW_NPROC}"
   end
 

--- a/packages/libxfce4util.rb
+++ b/packages/libxfce4util.rb
@@ -26,7 +26,7 @@ class Libxfce4util < Package
   def self.build
     system <<~BUILD
       [ -x autogen.sh ] && env NOCONFIGURE='1' ./autogen.sh
-      env #{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}
+      env #{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS}
       make
     BUILD
   end

--- a/packages/libxfixes.rb
+++ b/packages/libxfixes.rb
@@ -21,7 +21,7 @@ class Libxfixes < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libxfont2.rb
+++ b/packages/libxfont2.rb
@@ -25,7 +25,7 @@ class Libxfont2 < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --disable-selective-werror"
     system 'make'
   end

--- a/packages/libxft.rb
+++ b/packages/libxft.rb
@@ -24,7 +24,7 @@ class Libxft < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libxi.rb
+++ b/packages/libxi.rb
@@ -19,7 +19,7 @@ class Libxi < Package
   depends_on 'libx11'
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libxinerama.rb
+++ b/packages/libxinerama.rb
@@ -21,7 +21,7 @@ class Libxinerama < Package
   depends_on 'libxext'
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libxkbfile.rb
+++ b/packages/libxkbfile.rb
@@ -26,7 +26,7 @@ class Libxkbfile < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libxmu.rb
+++ b/packages/libxmu.rb
@@ -32,7 +32,7 @@ class Libxmu < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libxp.rb
+++ b/packages/libxp.rb
@@ -27,7 +27,7 @@ class Libxp < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --enable-malloc0returnsnull"
     system 'make'
   end

--- a/packages/libxpresent.rb
+++ b/packages/libxpresent.rb
@@ -30,7 +30,7 @@ class Libxpresent < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libxrandr.rb
+++ b/packages/libxrandr.rb
@@ -31,7 +31,7 @@ class Libxrandr < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libxrender.rb
+++ b/packages/libxrender.rb
@@ -26,7 +26,7 @@ class Libxrender < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libxshmfence.rb
+++ b/packages/libxshmfence.rb
@@ -22,7 +22,7 @@ class Libxshmfence < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libxss.rb
+++ b/packages/libxss.rb
@@ -28,7 +28,7 @@ class Libxss < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --sysconfdir=#{CREW_PREFIX}/etc"
     system 'make'
   end

--- a/packages/libxt.rb
+++ b/packages/libxt.rb
@@ -21,7 +21,7 @@ class Libxt < Package
   patchelf
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libxtst.rb
+++ b/packages/libxtst.rb
@@ -26,7 +26,7 @@ class Libxtst < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libxv.rb
+++ b/packages/libxv.rb
@@ -27,7 +27,7 @@ class Libxv < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --sysconfdir=#{CREW_PREFIX}/etc"
     system 'make'
   end

--- a/packages/libxxf86dga.rb
+++ b/packages/libxxf86dga.rb
@@ -27,7 +27,7 @@ class Libxxf86dga < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --sysconfdir=#{CREW_PREFIX}/etc"
     system 'make'
   end

--- a/packages/libxxf86vm.rb
+++ b/packages/libxxf86vm.rb
@@ -25,7 +25,7 @@ class Libxxf86vm < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/libyaml.rb
+++ b/packages/libyaml.rb
@@ -21,7 +21,7 @@ class Libyaml < Package
   no_patchelf
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/linux_pam.rb
+++ b/packages/linux_pam.rb
@@ -22,7 +22,7 @@ class Linux_pam < Package
   depends_on 'libeconf' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --disable-selinux \
       --enable-static \
       --disable-nis"

--- a/packages/log4c.rb
+++ b/packages/log4c.rb
@@ -18,7 +18,7 @@ class Log4c < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/log4cplus.rb
+++ b/packages/log4cplus.rb
@@ -18,7 +18,7 @@ class Log4cplus < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/ltrace.rb
+++ b/packages/ltrace.rb
@@ -31,7 +31,7 @@ class Ltrace < Package
   def self.build
     system './autogen.sh'
     system 'filefix'
-    system "./configure #{CREW_OPTIONS} --disable-werror --without-elfutils --disable-maintainer-mode"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --disable-werror --without-elfutils --disable-maintainer-mode"
     system 'make'
   end
 

--- a/packages/luit.rb
+++ b/packages/luit.rb
@@ -24,7 +24,7 @@ class Luit < Package
   depends_on 'libx11' => ':build'
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --enable-fontenc"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --enable-fontenc"
     system 'make'
   end
 

--- a/packages/lxappearance.rb
+++ b/packages/lxappearance.rb
@@ -21,7 +21,7 @@ class Lxappearance < Package
   depends_on 'dbus_glib'
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --enable-gtk3 --enable-dbus"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --enable-gtk3 --enable-dbus"
     system "make -j#{CREW_NPROC}"
   end
 

--- a/packages/lzlib.rb
+++ b/packages/lzlib.rb
@@ -18,7 +18,7 @@ class Lzlib < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --enable-shared"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --enable-shared"
     system 'make'
   end
 

--- a/packages/m4.rb
+++ b/packages/m4.rb
@@ -21,7 +21,7 @@ class M4 < Package
   depends_on 'libsigsegv'
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/macchanger.rb
+++ b/packages/macchanger.rb
@@ -18,7 +18,7 @@ class Macchanger < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/mailutils.rb
+++ b/packages/mailutils.rb
@@ -21,7 +21,7 @@ class Mailutils < Package
   depends_on 'tcpwrappers'
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS} \
             --enable-ipv6 \
             --with-gnutls \
             --with-berkeley-db \

--- a/packages/make.rb
+++ b/packages/make.rb
@@ -20,7 +20,7 @@ class Make < Package
   depends_on 'glibc' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
             --enable-cross-guesses=conservative"
     system './build.sh'
   end

--- a/packages/makedepend.rb
+++ b/packages/makedepend.rb
@@ -19,7 +19,7 @@ class Makedepend < Package
   depends_on 'libx11'
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
               --without-lint"
     system 'make'
   end

--- a/packages/man_db.rb
+++ b/packages/man_db.rb
@@ -38,7 +38,7 @@ class Man_db < Package
     # we can't create the user 'man'
     # the pager is not at the default location
     year2038 = ARCH == 'x86_64' ? '' : ' --disable-year2038'
-    options = CREW_OPTIONS + year2038
+    options = CREW_CONFIGURE_OPTIONS + year2038
     system "./configure #{options} \
       --disable-cache-owner \
       --disable-rpath \

--- a/packages/mawk.rb
+++ b/packages/mawk.rb
@@ -20,7 +20,7 @@ class Mawk < Package
   depends_on 'glibc' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/mediainfo.rb
+++ b/packages/mediainfo.rb
@@ -23,7 +23,7 @@ class Mediainfo < Package
   end
 
   def self.build
-    system "mold -run ./CLI_Compile.sh #{CREW_OPTIONS}"
+    system "mold -run ./CLI_Compile.sh #{CREW_CONFIGURE_OPTIONS}"
   end
 
   def self.install

--- a/packages/mediainfo_gui.rb
+++ b/packages/mediainfo_gui.rb
@@ -25,7 +25,7 @@ class Mediainfo_gui < Package
   end
 
   def self.build
-    system "./GUI_Compile.sh #{CREW_OPTIONS}"
+    system "./GUI_Compile.sh #{CREW_CONFIGURE_OPTIONS}"
   end
 
   def self.install

--- a/packages/minizip.rb
+++ b/packages/minizip.rb
@@ -25,7 +25,7 @@ class Minizip < Package
   def self.build
     Dir.chdir 'contrib/minizip' do
       system 'autoreconf -fiv'
-      system "./configure #{CREW_OPTIONS} \
+      system "./configure #{CREW_CONFIGURE_OPTIONS} \
                 --enable-demos"
       system 'make'
     end

--- a/packages/miscfiles.rb
+++ b/packages/miscfiles.rb
@@ -18,7 +18,7 @@ class Miscfiles < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
   end
 
   def self.install

--- a/packages/mjpegtools.rb
+++ b/packages/mjpegtools.rb
@@ -43,7 +43,7 @@ class Mjpegtools < Package
 
   def self.build
     system '[ -x configure ] || ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/mkfontscale.rb
+++ b/packages/mkfontscale.rb
@@ -21,7 +21,7 @@ class Mkfontscale < Package
   depends_on 'libfontenc'
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/modemmanager.rb
+++ b/packages/modemmanager.rb
@@ -23,7 +23,7 @@ class Modemmanager < Package
     system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
       LDFLAGS='-flto=auto' \
       ./configure \
-      #{CREW_OPTIONS} \
+      #{CREW_CONFIGURE_OPTIONS} \
       --with-dbus-sys-dir=#{CREW_PREFIX}/share/dbus-1 \
       --disable-maintainer-mode"
     system 'make'

--- a/packages/mono.rb
+++ b/packages/mono.rb
@@ -33,7 +33,7 @@ class Mono < Package
 
   def self.build
     system "env XMKMF=#{CREW_PREFIX}/bin/xmkmf \
-      ./configure #{CREW_OPTIONS} \
+      ./configure #{CREW_CONFIGURE_OPTIONS} \
       --disable-maintainer-mode \
       --enable-llvm \
       --enable-loadedllvm \

--- a/packages/most.rb
+++ b/packages/most.rb
@@ -22,7 +22,7 @@ class Most < Package
   depends_on 'gcc_lib' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/motif.rb
+++ b/packages/motif.rb
@@ -41,7 +41,7 @@ class Motif < Package
   depends_on 'zlib' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --with-x \
       --enable-xft \
       --enable-png \

--- a/packages/mp4v2.rb
+++ b/packages/mp4v2.rb
@@ -23,7 +23,7 @@ class Mp4v2 < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --disable-dependency-tracking --disable-debug"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --disable-dependency-tracking --disable-debug"
     system 'make'
   end
 

--- a/packages/mpc.rb
+++ b/packages/mpc.rb
@@ -23,7 +23,7 @@ class Mpc < Package
 
   def self.build
     system "./configure \
-      #{CREW_OPTIONS} \
+      #{CREW_CONFIGURE_OPTIONS} \
       --disable-maintainer-mode \
       --enable-shared"
     system 'make'

--- a/packages/mpdecimal.rb
+++ b/packages/mpdecimal.rb
@@ -21,7 +21,7 @@ class Mpdecimal < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/mpfr.rb
+++ b/packages/mpfr.rb
@@ -33,7 +33,7 @@ class Mpfr < Package
     system 'filefix'
     system 'autoreconf -fiv'
     system "./configure \
-      #{CREW_OPTIONS} \
+      #{CREW_CONFIGURE_OPTIONS} \
       --enable-shared"
     system 'make'
   end

--- a/packages/mypaint_brushes.rb
+++ b/packages/mypaint_brushes.rb
@@ -20,7 +20,7 @@ class Mypaint_brushes < Package
 
   def self.build
     system 'env NOCONFIGURE=1 ./autogen.sh'
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/mypaint_brushes_1.rb
+++ b/packages/mypaint_brushes_1.rb
@@ -20,7 +20,7 @@ class Mypaint_brushes_1 < Package
 
   def self.build
     system 'env NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/nano.rb
+++ b/packages/nano.rb
@@ -24,7 +24,7 @@ class Nano < Package
 
   def self.build
     system "mold -run \
-      ./configure #{CREW_OPTIONS} \
+      ./configure #{CREW_CONFIGURE_OPTIONS} \
       --enable-browser \
       --enable-color \
       --enable-comment \

--- a/packages/nasm.rb
+++ b/packages/nasm.rb
@@ -21,7 +21,7 @@ class Nasm < Package
     system "env CFLAGS='-flto=auto' \
       CXXFLAGS='-flto=auto' LDFLAGS='-flto=auto' \
       ./configure \
-      #{CREW_OPTIONS}"
+      #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/ndctl.rb
+++ b/packages/ndctl.rb
@@ -27,7 +27,7 @@ class Ndctl < Package
   def self.build
     system './autogen.sh'
     system 'filefix'
-    system "./configure #{CREW_OPTIONS} --without-systemd"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --without-systemd"
     system 'make'
   end
 

--- a/packages/ndisc6.rb
+++ b/packages/ndisc6.rb
@@ -18,7 +18,7 @@ class Ndisc6 < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --disable-suid-install"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --disable-suid-install"
     system 'make'
   end
 

--- a/packages/neo_matrix.rb
+++ b/packages/neo_matrix.rb
@@ -22,7 +22,7 @@ class Neo_matrix < Package
     system './autogen.sh'
     # The program name is neo-matrix for us
     # "neo" refers to different software that existed before this neo
-    system "./configure #{CREW_OPTIONS.sub '--program-suffix=\'\'', ''} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS.sub '--program-suffix=\'\'', ''} \
       --program-suffix='-matrix'"
     system 'make'
   end

--- a/packages/neon.rb
+++ b/packages/neon.rb
@@ -28,7 +28,7 @@ class Neon < Package
     system './autogen.sh'
     system 'filefix'
     system "./configure \
-            #{CREW_OPTIONS} \
+            #{CREW_CONFIGURE_OPTIONS} \
            --enable-shared=yes \
            --with-ssl=openssl"
     system 'make'

--- a/packages/nitrogen.rb
+++ b/packages/nitrogen.rb
@@ -18,7 +18,7 @@ class Nitrogen < Package
 
   def self.build
     system 'autoreconf -fi'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/nmap.rb
+++ b/packages/nmap.rb
@@ -33,7 +33,7 @@ class Nmap < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --with-libpcap=#{CREW_PREFIX} \
       --with-libpcre=#{CREW_PREFIX} \
       --with-zlib=#{CREW_PREFIX} \

--- a/packages/npth.rb
+++ b/packages/npth.rb
@@ -18,7 +18,7 @@ class Npth < Package
   })
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}"
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/oniguruma.rb
+++ b/packages/oniguruma.rb
@@ -21,7 +21,7 @@ class Oniguruma < Package
     system 'NOCONFIGURE=1 ./autogen.sh'
     system 'filefix'
     system "env #{CREW_ENV_OPTIONS} \
-      ./configure #{CREW_OPTIONS}"
+      ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/opam.rb
+++ b/packages/opam.rb
@@ -29,7 +29,7 @@ class Opam < Package
   @OPAMROOT = "#{CREW_PREFIX}/share/opam"
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system "make lib-ext all -j1 \
       OCAMLC='ocamlc -unsafe-string' \
       OCAMLOPT='ocamlopt -unsafe-string'"

--- a/packages/openbox.rb
+++ b/packages/openbox.rb
@@ -41,7 +41,7 @@ class Openbox < Package
 
   ENV['CFLAGS'] = '-lX11 -lXau'
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/openconnect.rb
+++ b/packages/openconnect.rb
@@ -24,7 +24,7 @@ class Openconnect < Package
 
   def self.build
     system "./configure \
-           #{CREW_OPTIONS} \
+           #{CREW_CONFIGURE_OPTIONS} \
            --with-vpnc-script=#{CREW_PREFIX}/etc/vpnc/vpnc-script"
     system 'make'
   end

--- a/packages/pavucontrol.rb
+++ b/packages/pavucontrol.rb
@@ -27,7 +27,7 @@ class Pavucontrol < Package
     system 'NOCONFIGURE=1 ./bootstrap.sh'
     system "env #{CREW_ENV_OPTIONS} \
     ./configure \
-    #{CREW_OPTIONS} \
+    #{CREW_CONFIGURE_OPTIONS} \
     --disable-lynx"
     system 'make'
   end

--- a/packages/pcaudiolib.rb
+++ b/packages/pcaudiolib.rb
@@ -23,7 +23,7 @@ class Pcaudiolib < Package
     system './autogen.sh'
     system "env CFLAGS='-O2 -pipe -flto=auto -fuse-ld=gold' \
                 LDFLAGS='-flto=auto' \
-            ./configure #{CREW_OPTIONS} \
+            ./configure #{CREW_CONFIGURE_OPTIONS} \
               --without-pulseaudio \
               --with-alsa \
               --without-qsa \

--- a/packages/pcre.rb
+++ b/packages/pcre.rb
@@ -22,7 +22,7 @@ class Pcre < Package
   depends_on 'readline' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --enable-shared \
       --with-pic \
       --enable-unicode-properties \

--- a/packages/pcsc_lite.rb
+++ b/packages/pcsc_lite.rb
@@ -26,7 +26,7 @@ class Pcsc_lite < Package
   end
 
   def self.build
-    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
+    system "#{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS} \
               --disable-libsystemd"
     system 'make'
   end

--- a/packages/pdfchain.rb
+++ b/packages/pdfchain.rb
@@ -23,7 +23,7 @@ class Pdfchain < Package
   depends_on 'sommelier'
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/perl_stow.rb
+++ b/packages/perl_stow.rb
@@ -20,7 +20,7 @@ class Perl_stow < Package
   depends_on 'perl_app_cpanminus' => :build
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --with-pmdir=#{CREW_PREFIX}/share/perl5/vendor_perl"
     system 'make'
   end

--- a/packages/pixz.rb
+++ b/packages/pixz.rb
@@ -33,7 +33,7 @@ class Pixz < Package
       CC=clang LD=ld.lld  CFLAGS='-flto -pipe -O3 -fuse-ld=lld -static' \
       CXXFLAGS='-flto -pipe -O3 -static' \
       LDFLAGS='-flto -static' \
-      #{CREW_OPTIONS}"
+      #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/pkg_config.rb
+++ b/packages/pkg_config.rb
@@ -31,7 +31,7 @@ class Pkg_config < Package
         CXXFLAGS='-pipe -flto=auto' LDFLAGS='-flto=auto' \
         GLIB_CFLAGS='-I#{CREW_PREFIX}/include/glib-2.0 -I#{CREW_LIB_PREFIX}/glib-2.0/include' \
         GLIB_LIBS=-lglib-2.0 \
-        ./configure #{CREW_OPTIONS} \
+        ./configure #{CREW_CONFIGURE_OPTIONS} \
         --with-pc-path=#{CREW_PREFIX}/lib/pkgconfig:#{CREW_PREFIX}/lib64/pkgconfig:#{CREW_PREFIX}/share/pkgconfig \
         --with-system-include-path=/usr/include:#{CREW_PREFIX}/include \
         --with-system-library-path=#{CREW_LIB_PREFIX} \
@@ -43,7 +43,7 @@ class Pkg_config < Package
         CXXFLAGS='-pipe -flto=auto' LDFLAGS='-flto=auto' \
         GLIB_CFLAGS='-I#{CREW_PREFIX}/include/glib-2.0 -I#{CREW_LIB_PREFIX}/glib-2.0/include' \
         GLIB_LIBS=-lglib-2.0 \
-        ./configure #{CREW_OPTIONS} \
+        ./configure #{CREW_CONFIGURE_OPTIONS} \
         --with-pc-path=#{CREW_PREFIX}/lib/pkgconfig:#{CREW_PREFIX}/share/pkgconfig \
         --with-system-include-path=/usr/include:#{CREW_PREFIX}/include \
         --with-system-library-path=#{CREW_LIB_PREFIX} \

--- a/packages/popt.rb
+++ b/packages/popt.rb
@@ -24,7 +24,7 @@ class Popt < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --disable-maintainer-mode"
     system 'make'
   end

--- a/packages/postgresql.rb
+++ b/packages/postgresql.rb
@@ -46,7 +46,7 @@ class Postgresql < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --with-gssapi \
       --with-icu \
       --with-ldap \

--- a/packages/potrace.rb
+++ b/packages/potrace.rb
@@ -21,7 +21,7 @@ class Potrace < Package
   depends_on 'zlib' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --with-libpotrace"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --with-libpotrace"
     system 'make'
   end
 

--- a/packages/printproto.rb
+++ b/packages/printproto.rb
@@ -18,7 +18,7 @@ class Printproto < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/procps.rb
+++ b/packages/procps.rb
@@ -19,7 +19,7 @@ class Procps < Package
 
   def self.build
     system './autogen.sh'
-    system "CFLAGS='-I#{CREW_PREFIX}/include/ncursesw' ./configure #{CREW_OPTIONS}"
+    system "CFLAGS='-I#{CREW_PREFIX}/include/ncursesw' ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/proj.rb
+++ b/packages/proj.rb
@@ -18,7 +18,7 @@ class Proj < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/protobuf_c.rb
+++ b/packages/protobuf_c.rb
@@ -25,7 +25,7 @@ class Protobuf_c < Package
   depends_on 'gcc_lib' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/psmisc.rb
+++ b/packages/psmisc.rb
@@ -23,7 +23,7 @@ class Psmisc < Package
 
   def self.build
     system './autogen.sh'
-    system "CFLAGS+=' -I#{CREW_PREFIX}/include/ncurses' ./configure #{CREW_OPTIONS}"
+    system "CFLAGS+=' -I#{CREW_PREFIX}/include/ncurses' ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/py3_libxml2.rb
+++ b/packages/py3_libxml2.rb
@@ -26,7 +26,7 @@ class Py3_libxml2 < Package
 
   def self.build
     system 'autoreconf -fiv'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     Dir.chdir('python') do
       system "python3 setup.py build #{PY3_SETUP_BUILD_OPTIONS}"
     end

--- a/packages/pyconfigure.rb
+++ b/packages/pyconfigure.rb
@@ -18,7 +18,7 @@ class Pyconfigure < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/python3.rb
+++ b/packages/python3.rb
@@ -73,7 +73,7 @@ class Python3 < Package
 
     FileUtils.mkdir_p 'builddir'
     Dir.chdir 'builddir' do
-      system "../configure #{CREW_OPTIONS} \
+      system "../configure #{CREW_CONFIGURE_OPTIONS} \
           --with-lto \
           --with-computed-gotos \
           --enable-loadable-sqlite-extensions \

--- a/packages/qemu.rb
+++ b/packages/qemu.rb
@@ -78,7 +78,7 @@ class Qemu < Package
   def self.build
     FileUtils.mkdir_p 'build'
     Dir.chdir 'build' do
-      system "mold -run ../configure #{CREW_OPTIONS.sub(/--target.*/, '')} \
+      system "mold -run ../configure #{CREW_CONFIGURE_OPTIONS.sub(/--target.*/, '')} \
         --enable-kvm \
         --enable-lto"
       @counter = 1

--- a/packages/qqwing.rb
+++ b/packages/qqwing.rb
@@ -19,7 +19,7 @@ class Qqwing < Package
 
   def self.build
     system "env #{CREW_ENV_OPTIONS} \
-            ./configure #{CREW_OPTIONS}"
+            ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/rdfind.rb
+++ b/packages/rdfind.rb
@@ -32,7 +32,7 @@ class Rdfind < Package
 
   def self.build
     system '[ -x configure ] || autoreconf -fvi'
-    system "./configure #{CREW_OPTIONS} #{CREW_ENV_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} #{CREW_ENV_OPTIONS}"
     system 'make -s'
   end
 

--- a/packages/readline.rb
+++ b/packages/readline.rb
@@ -23,7 +23,7 @@ class Readline < Package
 
   def self.build
     system "./configure \
-      #{CREW_OPTIONS} \
+      #{CREW_CONFIGURE_OPTIONS} \
       --with-curses \
       --enable-multibyte"
     system 'make', 'SHLIB_LIBS=-Wl,--as-needed -Wl,-ltinfow -Wl,--no-as-needed'

--- a/packages/rendercheck.rb
+++ b/packages/rendercheck.rb
@@ -18,7 +18,7 @@ class Rendercheck < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/ruby.rb
+++ b/packages/ruby.rb
@@ -37,7 +37,7 @@ class Ruby < Package
     system "RUBY_TRY_CFLAGS='stack_protector=no' \
       RUBY_TRY_LDFLAGS='stack_protector=no' \
       optflags='-flto=auto -fuse-ld=#{CREW_LINKER}' \
-      mold -run ./configure #{CREW_OPTIONS} \
+      mold -run ./configure #{CREW_CONFIGURE_OPTIONS} \
       --enable-shared \
       #{ARCH == 'x86_64' ? '--enable-yjit' : ''} \
       --disable-fortify-source"

--- a/packages/rush.rb
+++ b/packages/rush.rb
@@ -18,7 +18,7 @@ class Rush < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/rxvt_unicode.rb
+++ b/packages/rxvt_unicode.rb
@@ -21,7 +21,7 @@ class Rxvt_unicode < Package
   depends_on 'sommelier'
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/sane_backends.rb
+++ b/packages/sane_backends.rb
@@ -21,7 +21,7 @@ class Sane_backends < Package
     system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      ./configure #{CREW_OPTIONS} \
+      ./configure #{CREW_CONFIGURE_OPTIONS} \
       --disable-maintainer-mode"
     system 'make'
   end

--- a/packages/sane_frontends.rb
+++ b/packages/sane_frontends.rb
@@ -23,7 +23,7 @@ class Sane_frontends < Package
     system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      ./configure #{CREW_OPTIONS} \
+      ./configure #{CREW_CONFIGURE_OPTIONS} \
       --disable-maintainer-mode"
     system 'make'
   end

--- a/packages/sassc.rb
+++ b/packages/sassc.rb
@@ -23,7 +23,7 @@ class Sassc < Package
 
   def self.build
     system 'autoreconf -i'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'mold -run make'
   end
 

--- a/packages/scrot.rb
+++ b/packages/scrot.rb
@@ -23,7 +23,7 @@ class Scrot < Package
   depends_on 'optipng'
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/shadow.rb
+++ b/packages/shadow.rb
@@ -24,7 +24,7 @@ class Shadow < Package
   depends_on 'libeconf' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --bindir=#{CREW_PREFIX}/bin \
       --sbindir=#{CREW_PREFIX}/bin \
       --enable-shared \

--- a/packages/slang.rb
+++ b/packages/slang.rb
@@ -24,7 +24,7 @@ class Slang < Package
   depends_on 'gcc_lib' # R
 
   def self.build
-    system "mold -run ./configure #{CREW_OPTIONS} --without-x"
+    system "mold -run ./configure #{CREW_CONFIGURE_OPTIONS} --without-x"
 
     # force to compile in sequential since slang Makefile doesn't work in parallel
     system 'make', '-j1'

--- a/packages/smallbasic.rb
+++ b/packages/smallbasic.rb
@@ -23,7 +23,7 @@ class Smallbasic < Package
 
   def self.build
     system 'bash ./autogen.sh && filefix'
-    system "./configure #{CREW_OPTIONS} --enable-sdl"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --enable-sdl"
     system 'make'
   end
 

--- a/packages/smartmontools.rb
+++ b/packages/smartmontools.rb
@@ -21,7 +21,7 @@ class Smartmontools < Package
 
   def self.build
     system './autogen.sh'
-    system "./configure #{CREW_OPTIONS} --with-nvme-devicescan --disable-maintainer-mode"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --with-nvme-devicescan --disable-maintainer-mode"
     system 'make'
   end
 

--- a/packages/smbclient.rb
+++ b/packages/smbclient.rb
@@ -72,7 +72,7 @@ class Smbclient < Package
   def self.build
     system './configure --help'
     system "python_LDFLAGS='' ./configure --enable-fhs \
-      #{CREW_OPTIONS.sub(/--program-suffix.*/, '')} \
+      #{CREW_CONFIGURE_OPTIONS.sub(/--program-suffix.*/, '')} \
       --sysconfdir=#{CREW_PREFIX}/etc \
       --sbindir=#{CREW_PREFIX}/bin \
       --libdir=#{CREW_LIB_PREFIX} \

--- a/packages/snort.rb
+++ b/packages/snort.rb
@@ -30,7 +30,7 @@ class Snort < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --enable-sourcefire \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --enable-sourcefire \
             --with-dnet-includes=#{CREW_PREFIX}/include/dnet \
             --with-tirpc-includes=#{CREW_PREFIX}/include/tirpc"
     system 'make'

--- a/packages/spacefm.rb
+++ b/packages/spacefm.rb
@@ -57,7 +57,7 @@ class Spacefm < Package
   end
 
   def self.build
-    system "mold -run ./configure #{CREW_OPTIONS} \
+    system "mold -run ./configure #{CREW_CONFIGURE_OPTIONS} \
       --with-gtk3 \
       --disable-maintainer-mode"
     system 'make'

--- a/packages/squashfs_tools_ng.rb
+++ b/packages/squashfs_tools_ng.rb
@@ -27,7 +27,7 @@ class Squashfs_tools_ng < Package
     system "env CFLAGS='-pipe -flto=auto' \
       CXXFLAGS='-pipe -flto=auto' \
       LDFLAGS='-flto=auto' \
-      ./configure #{CREW_OPTIONS}"
+      ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
     system 'make doxygen-doc'
   end

--- a/packages/squashfuse.rb
+++ b/packages/squashfuse.rb
@@ -27,7 +27,7 @@ class Squashfuse < Package
     system "env CFLAGS='-pipe -flto=auto' \
       CXXFLAGS='-pipe -flto=auto' \
       LDFLAGS='-flto=auto' \
-      ./configure #{CREW_OPTIONS}"
+      ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/startup_notification.rb
+++ b/packages/startup_notification.rb
@@ -28,7 +28,7 @@ class Startup_notification < Package
     system 'autoreconf --force --install'
     system "env CFLAGS='-flto=auto' \
       CXXFLAGS='-flto=auto' LDFLAGS='-flto=auto' \
-      ./configure #{CREW_OPTIONS} \
+      ./configure #{CREW_CONFIGURE_OPTIONS} \
       --localstatedir=/var \
       --sysconfdir=#{CREW_PREFIX}/etc"
     system 'make'

--- a/packages/t1lib.rb
+++ b/packages/t1lib.rb
@@ -46,7 +46,7 @@ class T1lib < Package
     system "env CFLAGS='-pipe -flto=auto' \
       CXXFLAGS='-pipe -flto=auto' \
       LDFLAGS='-flto=auto' \
-      ./configure #{CREW_OPTIONS}"
+      ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make without_doc'
   end
 

--- a/packages/talloc.rb
+++ b/packages/talloc.rb
@@ -28,7 +28,7 @@ class Talloc < Package
   depends_on 'python3' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS.sub(/--program-suffix.*/, '')} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS.sub(/--program-suffix.*/, '')} \
       --sysconfdir=#{CREW_PREFIX}/etc/samba \
       --localstatedir=#{CREW_PREFIX}/var \
       --bundled-libraries=NONE \

--- a/packages/tcl.rb
+++ b/packages/tcl.rb
@@ -25,7 +25,7 @@ class Tcl < Package
   def self.build
     FileUtils.chdir('unix') do
       @bit64 = ARCH == 'x86_64' ? 'enable' : 'disable'
-      system "./configure #{CREW_OPTIONS} --#{@bit64}-64bit"
+      system "./configure #{CREW_CONFIGURE_OPTIONS} --#{@bit64}-64bit"
       system 'make'
     end
   end

--- a/packages/tcpflow.rb
+++ b/packages/tcpflow.rb
@@ -36,7 +36,7 @@ class Tcpflow < Package
 
   def self.build
     system 'bash bootstrap.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/tcsh.rb
+++ b/packages/tcsh.rb
@@ -18,7 +18,7 @@ class Tcsh < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/tdb.rb
+++ b/packages/tdb.rb
@@ -26,7 +26,7 @@ class Tdb < Package
   depends_on 'python3' => :build
 
   def self.build
-    system "./configure #{CREW_OPTIONS.sub(/--program-suffix.*/, '')}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS.sub(/--program-suffix.*/, '')}"
     system 'make'
   end
 

--- a/packages/telepathy_glib.rb
+++ b/packages/telepathy_glib.rb
@@ -24,7 +24,7 @@ class Telepathy_glib < Package
   def self.build
     system "env #{CREW_ENV_OPTIONS} \
       ./configure \
-      #{CREW_OPTIONS} \
+      #{CREW_CONFIGURE_OPTIONS} \
       --libexecdir=#{CREW_LIB_PREFIX}/telepathy \
       --enable-vala-bindings"
     system 'make'

--- a/packages/testdisk.rb
+++ b/packages/testdisk.rb
@@ -27,7 +27,7 @@ class Testdisk < Package
   depends_on 'util_linux' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/tevent.rb
+++ b/packages/tevent.rb
@@ -28,7 +28,7 @@ class Tevent < Package
   depends_on 'talloc' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS.sub(/--program-suffix.*/, '')} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS.sub(/--program-suffix.*/, '')} \
       --sysconfdir=#{CREW_PREFIX}/etc/samba \
       --localstatedir=#{CREW_PREFIX}/var \
       --bundled-libraries=NONE \

--- a/packages/thunar.rb
+++ b/packages/thunar.rb
@@ -29,7 +29,7 @@ class Thunar < Package
   def self.build
     system <<~CONFIGURE
       #{CREW_ENV_OPTIONS} \
-      ./configure #{CREW_OPTIONS} \
+      ./configure #{CREW_CONFIGURE_OPTIONS} \
       --enable-gio-unix \
       --enable-gudev \
       --enable-exif \

--- a/packages/ticker.rb
+++ b/packages/ticker.rb
@@ -25,7 +25,7 @@ class Ticker < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS} || true" # Configure will fail
+    system "./configure #{CREW_CONFIGURE_OPTIONS} || true" # Configure will fail
     system 'make'
   end
 

--- a/packages/tk.rb
+++ b/packages/tk.rb
@@ -32,7 +32,7 @@ class Tk < Package
     FileUtils.chdir('unix') do
       @bit64 = ARCH == 'x86_64' ? 'enable' : 'disable'
       system "./configure \
-          #{CREW_OPTIONS} \
+          #{CREW_CONFIGURE_OPTIONS} \
           --with-tcl=#{CREW_LIB_PREFIX} \
           --enable-threads \
           --#{@bit64}-64bit"

--- a/packages/trousers.rb
+++ b/packages/trousers.rb
@@ -24,7 +24,7 @@ class Trousers < Package
   def self.build
     system './bootstrap.sh'
     system "mold -run ./configure \
-      #{CREW_OPTIONS} \
+      #{CREW_CONFIGURE_OPTIONS} \
       --with-gui=none"
     system 'make'
   end

--- a/packages/twm.rb
+++ b/packages/twm.rb
@@ -19,7 +19,7 @@ class Twm < Package
   depends_on 'xorg_server'
 
   def self.build
-    system "./configure  #{CREW_OPTIONS}"
+    system "./configure  #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/ucl.rb
+++ b/packages/ucl.rb
@@ -22,7 +22,7 @@ class Ucl < Package
 
   def self.build
     system "env CFLAGS='-pipe -std=gnu90 -fPIC -flto=auto' \
-      ./configure #{CREW_OPTIONS} \
+      ./configure #{CREW_CONFIGURE_OPTIONS} \
       --enable-shared \
       --enable-static"
     system 'make'

--- a/packages/udisks2.rb
+++ b/packages/udisks2.rb
@@ -24,7 +24,7 @@ class Udisks2 < Package
 
   def self.build
     system 'filefix'
-    system "./configure #{CREW_OPTIONS} --disable-man"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --disable-man"
     system 'make'
   end
 

--- a/packages/unixodbc.rb
+++ b/packages/unixodbc.rb
@@ -21,7 +21,7 @@ class Unixodbc < Package
     system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
       LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE -flto=auto' \
-      ./configure #{CREW_OPTIONS} \
+      ./configure #{CREW_CONFIGURE_OPTIONS} \
       --disable-maintainer-mode"
     system 'make'
   end

--- a/packages/usbredir.rb
+++ b/packages/usbredir.rb
@@ -25,7 +25,7 @@ class Usbredir < Package
   def self.build
     system 'autoreconf -fi'
     system "env #{CREW_ENV_OPTIONS} \
-      ./configure #{CREW_OPTIONS} \
+      ./configure #{CREW_CONFIGURE_OPTIONS} \
       --sbindir=#{CREW_PREFIX}/bin"
     system 'make'
   end

--- a/packages/usbutils.rb
+++ b/packages/usbutils.rb
@@ -22,7 +22,7 @@ class Usbutils < Package
   def self.build
     system 'NOCONFIGURE=1 ./autogen.sh'
     system "env #{CREW_ENV_OPTIONS} \
-    ./configure #{CREW_OPTIONS}"
+    ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/vala.rb
+++ b/packages/vala.rb
@@ -42,7 +42,7 @@ class Vala < Package
     end
 
     system "VALAC=#{Dir.pwd}/bootstrap_install/bin/valac mold -run ./autogen.sh \
-      #{CREW_OPTIONS} \
+      #{CREW_CONFIGURE_OPTIONS} \
       --disable-maintainer-mode \
       --disable-valadoc"
     system 'make'

--- a/packages/volume_key.rb
+++ b/packages/volume_key.rb
@@ -33,7 +33,7 @@ associated command-line tool, named volume_key.'
     system 'autoconf'
     system 'autoheader'
     system 'automake --add-missing'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/w3m.rb
+++ b/packages/w3m.rb
@@ -22,7 +22,7 @@ class W3m < Package
   depends_on 'mailutils'
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
             --with-imagelib='gdk-pixbuf-2.0 imlib2' \
             --with-editor=$(which vi) \
             --with-mailer=$(which mail) \

--- a/packages/webrtc_audio_processing.rb
+++ b/packages/webrtc_audio_processing.rb
@@ -25,7 +25,7 @@ class Webrtc_audio_processing < Package
     system "env CFLAGS='-flto=auto' CXXFLAGS='-flto=auto -std=c++17' \
      LDFLAGS='-flto=auto' \
      ./configure \
-     #{CREW_OPTIONS}"
+     #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/which.rb
+++ b/packages/which.rb
@@ -18,7 +18,7 @@ class Which < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/wine.rb
+++ b/packages/wine.rb
@@ -58,7 +58,7 @@ class Wine < Package
     FileUtils.mkdir_p 'wine64-build'
     Dir.chdir 'wine64-build' do
       unless File.file?('Makefile')
-        system "../configure #{CREW_OPTIONS} \
+        system "../configure #{CREW_CONFIGURE_OPTIONS} \
           --enable-win64 \
           --disable-maintainer-mode \
           --with-gstreamer \

--- a/packages/wmctrl.rb
+++ b/packages/wmctrl.rb
@@ -33,7 +33,7 @@ class Wmctrl < Package
   def self.build
     system "env CFLAGS='-pipe -flto=auto' CXXFLAGS='-pipe -flto=auto' \
       LDFLAGS='-flto=auto' \
-      ./configure #{CREW_OPTIONS}"
+      ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/wol.rb
+++ b/packages/wol.rb
@@ -20,7 +20,7 @@ class Wol < Package
   depends_on 'glibc' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/wput.rb
+++ b/packages/wput.rb
@@ -25,7 +25,7 @@ class Wput < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/wxwidgets.rb
+++ b/packages/wxwidgets.rb
@@ -69,7 +69,7 @@ class Wxwidgets < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --with-gtk=3 \
       --with-opengl \
       --enable-unicode \

--- a/packages/wxwidgets30.rb
+++ b/packages/wxwidgets30.rb
@@ -54,7 +54,7 @@ class Wxwidgets30 < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --with-gtk=3 \
       --with-opengl \
       --enable-unicode \

--- a/packages/wxwidgets31.rb
+++ b/packages/wxwidgets31.rb
@@ -65,7 +65,7 @@ class Wxwidgets31 < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --with-gtk=3 \
       --with-opengl \
       --enable-unicode \

--- a/packages/xauth.rb
+++ b/packages/xauth.rb
@@ -23,7 +23,7 @@ class Xauth < Package
   depends_on 'glibc' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
            --enable-ipv6 \
            --enable-tcp-transport \
            --enable-unix-transport \

--- a/packages/xcb_util_cursor.rb
+++ b/packages/xcb_util_cursor.rb
@@ -30,7 +30,7 @@ class Xcb_util_cursor < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/xcb_util_xrm.rb
+++ b/packages/xcb_util_xrm.rb
@@ -18,7 +18,7 @@ class Xcb_util_xrm < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/xclock.rb
+++ b/packages/xclock.rb
@@ -27,7 +27,7 @@ class Xclock < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/xdg_dbus_proxy.rb
+++ b/packages/xdg_dbus_proxy.rb
@@ -18,7 +18,7 @@ class Xdg_dbus_proxy < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --disable-maintainer-mode --disable-man"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --disable-maintainer-mode --disable-man"
     system 'make'
   end
 

--- a/packages/xdpyinfo.rb
+++ b/packages/xdpyinfo.rb
@@ -35,7 +35,7 @@ class Xdpyinfo < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/xfce4_dev_tools.rb
+++ b/packages/xfce4_dev_tools.rb
@@ -26,7 +26,7 @@ class Xfce4_dev_tools < Package
   def self.build
     system <<~BUILD
       [ -x autogen.sh ] && env NOCONFIGURE='1' ./autogen.sh
-      env #{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS}
+      env #{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS}
       make
     BUILD
   end

--- a/packages/xfce4_panel.rb
+++ b/packages/xfce4_panel.rb
@@ -30,7 +30,7 @@ class Xfce4_panel < Package
   def self.build
     system <<~BUILD
       [ -x autogen.sh ] && env NOCONFIGURE='1' ./autogen.sh
-      env #{CREW_ENV_OPTIONS} ./configure #{CREW_OPTIONS} \
+      env #{CREW_ENV_OPTIONS} ./configure #{CREW_CONFIGURE_OPTIONS} \
         --disable-static \
         --enable-gio-unix
 

--- a/packages/xfce4_terminal.rb
+++ b/packages/xfce4_terminal.rb
@@ -26,7 +26,7 @@ class Xfce4_terminal < Package
   depends_on 'mesa'
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system "make -j#{CREW_NPROC}"
   end
 

--- a/packages/xfconf.rb
+++ b/packages/xfconf.rb
@@ -22,7 +22,7 @@ class Xfconf < Package
   depends_on 'vala' => :build
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --enable-gsettings-backend"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --enable-gsettings-backend"
     system "make -j#{CREW_NPROC}"
   end
 

--- a/packages/xfsprogs.rb
+++ b/packages/xfsprogs.rb
@@ -27,7 +27,7 @@ class Xfsprogs < Package
 
   def self.build
     system 'make configure'
-    system "DEBUG=-DNDEBUG ./configure #{CREW_OPTIONS}"
+    system "DEBUG=-DNDEBUG ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/xhost.rb
+++ b/packages/xhost.rb
@@ -26,7 +26,7 @@ class Xhost < Package
            --enable-tcp-transport \
            --enable-unix-transport \
            --enable-local-transport \
-           #{CREW_OPTIONS}"
+           #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/xinit.rb
+++ b/packages/xinit.rb
@@ -23,7 +23,7 @@ class Xinit < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/xkbcomp.rb
+++ b/packages/xkbcomp.rb
@@ -20,7 +20,7 @@ class Xkbcomp < Package
   depends_on 'xcb_util'
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/xmessage.rb
+++ b/packages/xmessage.rb
@@ -23,7 +23,7 @@ class Xmessage < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/xmlcatmgr.rb
+++ b/packages/xmlcatmgr.rb
@@ -18,7 +18,7 @@ class Xmlcatmgr < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/xorg_cf_files.rb
+++ b/packages/xorg_cf_files.rb
@@ -20,7 +20,7 @@ class Xorg_cf_files < Package
   depends_on 'font_util'
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
             --sysconfdir=#{CREW_PREFIX}/etc"
     system 'make'
   end

--- a/packages/xorg_xeyes.rb
+++ b/packages/xorg_xeyes.rb
@@ -31,7 +31,7 @@ class Xorg_xeyes < Package
   depends_on 'libxcb' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/xorg_xlsfonts.rb
+++ b/packages/xorg_xlsfonts.rb
@@ -24,7 +24,7 @@ class Xorg_xlsfonts < Package
   depends_on 'xorg_macros' => ':build'
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/xorg_xset.rb
+++ b/packages/xorg_xset.rb
@@ -27,7 +27,7 @@ class Xorg_xset < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
     --without-fontcache \
     --without-xf86misc"
     system 'make'

--- a/packages/xprop.rb
+++ b/packages/xprop.rb
@@ -21,7 +21,7 @@ class Xprop < Package
 
   def self.build
     system '[ -x configure ] || NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/xrdb.rb
+++ b/packages/xrdb.rb
@@ -22,7 +22,7 @@ class Xrdb < Package
 
   def self.build
     system 'NOCONFIGURE=1 ./autogen.sh'
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/xterm.rb
+++ b/packages/xterm.rb
@@ -42,7 +42,7 @@ class Xterm < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
       --disable-imake \
       --enable-16bit-chars \
       --enable-256-color \

--- a/packages/yara.rb
+++ b/packages/yara.rb
@@ -19,7 +19,7 @@ class Yara < Package
 
   def self.build
     system './bootstrap.sh'
-    system "YACC=bison ./configure #{CREW_OPTIONS}"
+    system "YACC=bison ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/yasm.rb
+++ b/packages/yasm.rb
@@ -22,7 +22,7 @@ class Yasm < Package
   def self.build
     system "env CFLAGS='-pipe -flto=auto' CPPFLAGS='-pipe -flto=auto' \
       LDFLAGS='-flto=auto' \
-      ./configure #{CREW_OPTIONS}"
+      ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/zimg.rb
+++ b/packages/zimg.rb
@@ -24,7 +24,7 @@ class Zimg < Package
     system "env CFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE #{@lto}' \
       CXXFLAGS='-pipe -fno-stack-protector -U_FORTIFY_SOURCE #{@lto}' \
       LDFLAGS='-fno-stack-protector -U_FORTIFY_SOURCE  #{@lto}' \
-      ./configure #{CREW_OPTIONS}"
+      ./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 

--- a/packages/zsh.rb
+++ b/packages/zsh.rb
@@ -25,7 +25,7 @@ class Zsh < Package
   depends_on 'pcre' # R
 
   def self.build
-    system "./configure #{CREW_OPTIONS} \
+    system "./configure #{CREW_CONFIGURE_OPTIONS} \
             --enable-zsh-mem \
             --enable-pcre \
             --enable-cap \

--- a/packages/zsync.rb
+++ b/packages/zsync.rb
@@ -23,7 +23,7 @@ class Zsync < Package
   end
 
   def self.build
-    system "./configure #{CREW_OPTIONS} --disable-maintainer-mode"
+    system "./configure #{CREW_CONFIGURE_OPTIONS} --disable-maintainer-mode"
     system 'make'
   end
 

--- a/packages/zzuf.rb
+++ b/packages/zzuf.rb
@@ -18,7 +18,7 @@ class Zzuf < Package
   })
 
   def self.build
-    system "./configure #{CREW_OPTIONS}"
+    system "./configure #{CREW_CONFIGURE_OPTIONS}"
     system 'make'
   end
 


### PR DESCRIPTION
## Description
As far as I can tell, these are legacies from when crew only had constants for autotools, so there was no need to name them specially.

## Additional information
oh the CI is gonna take FOREVER on this because its gonna have to reinstall every package huh
maybe we should get a solution that only reinstalls packages if they have new binaries or smth


### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=parity crew update \
&& yes | crew upgrade
```

