### PR TITLE
Fix installs by moving ruby-libversion to buildessential from core.

### DIFF
--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -3,7 +3,7 @@ require 'package'
 class Buildessential < Package
   description 'A collection of tools essential to compile and build software.'
   homepage 'SKIP'
-  version '1.35'
+  version '1.36'
   license 'GPL-3+'
   compatibility 'all'
 
@@ -166,15 +166,17 @@ class Buildessential < Package
   depends_on 'zstd'
 
   # Ruby gems
+  # Add ruby_concurrent_ruby
+  depends_on 'ruby_concurrent_ruby'
   # Needed for irb
   depends_on 'ruby_debug'
+  # For crew debugging.
+  depends_on 'ruby_pry_byebug'
   # Add rubocop for linting packages. (This also installs the
   # rubocop config file.)
   depends_on 'ruby_rubocop'
-  # Add ruby_concurrent_ruby
-  depends_on 'ruby_concurrent_ruby'
-  # For crew debugging.
-  depends_on 'ruby_pry_byebug'
+  # crew check -V breaks without this.
+  depends_on 'ruby_ruby_libversion'
 
   # Code quality
   depends_on 'py3_pre_commit'

--- a/packages/core.rb
+++ b/packages/core.rb
@@ -3,7 +3,7 @@ require 'package'
 class Core < Package
   description 'Core Chromebrew Packages.'
   homepage 'https://github.com/chromebrew/chromebrew'
-  version '2.8'
+  version '2.9'
   license 'GPL-3+'
   compatibility 'all'
 
@@ -82,8 +82,6 @@ class Core < Package
   depends_on 'ruby_concurrent_ruby'
   # For use in ruby prompts.
   depends_on 'ruby_highline'
-  # crew check -V breaks without this.
-  depends_on 'ruby_ruby_libversion'
   # This contains the debugger config files.
   depends_on 'ruby_pry'
   depends_on 'slang'

--- a/packages/ruby_ruby_libversion.rb
+++ b/packages/ruby_ruby_libversion.rb
@@ -8,5 +8,7 @@ class Ruby_ruby_libversion < RUBY
   compatibility 'all'
   source_url 'SKIP'
 
+  depends_on 'libversion' # R
+
   no_compile_needed
 end


### PR DESCRIPTION
Fixes #10450 

- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=install crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
