### PR TITLE
Add Rakefile to replace crew test and simplify unit testing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ Where available commands are:
 | remove       | remove package(s) |
 | search       | look for package(s) |
 | sysinfo      | show system information in markdown style |
-| test         | test crew command(s) |
 | update       | update crew itself |
 | upgrade      | update all or specific package(s) |
 | upload       | upload binaries for all or specific package(s) |

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,24 @@
+# The default action tests commands and libraries.
+task default: %w[command_test lib_test]
+
+# Command tests
+task :command_test do
+  ruby 'tests/commands/const.rb'
+  ruby 'tests/commands/help.rb'
+  ruby 'tests/commands/list.rb'
+  ruby 'tests/commands/prop.rb'
+  ruby 'tests/commands/remove.rb'
+  ruby 'tests/commands/whatprovides.rb'
+end
+
+# Library tests
+task :lib_test do
+  ruby 'tests/lib/docopt.rb'
+  ruby 'tests/lib/package_utils.rb'
+end
+
+# Package tests
+task :package_test do
+  ruby 'tests/prop_test'
+  ruby 'tests/buildsystem_test'
+end

--- a/bin/crew
+++ b/bin/crew
@@ -1756,30 +1756,6 @@ def sysinfo_command(_args)
   Command.sysinfo(CREW_VERBOSE)
 end
 
-def test_command(args)
-  test_commands_path = "#{CREW_LIB_PATH}/tests/commands"
-  if args['<name>'].empty?
-    Dir["#{test_commands_path}/*.rb"].each do |name|
-      basename = File.basename(name, '.rb')
-      puts "Testing #{basename} command ...".yellow
-      system("ruby #{name}")
-    end
-  else
-    args['<name>'].each do |name|
-      basename = File.basename(name, '.rb')
-      name = basename if basename != name
-      if File.file?("#{test_commands_path}/#{name}.rb")
-        Dir.chdir(test_commands_path) do
-          puts "Testing #{name} command ...".yellow
-          system("ruby #{name}.rb")
-        end
-      else
-        puts "The #{name} command or test does not exist. Test skipped.".orange
-      end
-    end
-  end
-end
-
 def update_command(args)
   if args['<compatible>']
     generate_compatible

--- a/commands/help.rb
+++ b/commands/help.rb
@@ -118,14 +118,6 @@ class Command
         Usage: crew sysinfo [-v|--verbose]
         If `-v` or `--verbose` is present, show system information with raw markdown.
       EOT
-    when 'test'
-      puts <<~EOT
-        Test crew command(s).
-        Usage: crew test [<command1> <command2> ...]
-        The crew command and associated test must exist.
-        If no commands are provided, all commands will be tested.
-        To list all commands, simply type 'crew'.
-      EOT
     when 'update'
       puts <<~EOT
         Update crew.

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.52.1' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.52.2' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]
@@ -332,7 +332,6 @@ CREW_DOCOPT ||= <<~DOCOPT
     crew remove [options] [-v|--verbose] <name> ...
     crew search [options] [-v|--verbose] <name> ...
     crew sysinfo [options] [-v|--verbose]
-    crew test [options] [-v|--verbose] [<name> ...]
     crew update [options] [-v|--verbose] [<compatible>]
     crew upgrade [options] [-k|--keep] [-s|--source] [-v|--verbose] [<name> ...]
     crew upload [options] [-v|--verbose] [<name> ...]

--- a/lib/package_utils.rb
+++ b/lib/package_utils.rb
@@ -79,7 +79,7 @@ class PackageUtils
     pkg_version.gsub!(/-perl5\.\d{2}/, '')
     # Delete -llvm18, futureproofed until llvm 100
     pkg_version.gsub!(/-llvm\d{2}/, '')
-    # Delete -glibc2.39, or whatever the system glibc is.
+    # Delete -glibc2.37, or whatever the system glibc is.
     pkg_version.delete_suffix!("-glibc#{LIBC_VERSION}")
     # Delete git version tags (1.2.4-qnd73k6), avoiding overmatching and hitting things that arent git hashtags.
     pkg_version.gsub!(/-[\w]{7}$/, '')

--- a/tests/lib/package_utils.rb
+++ b/tests/lib/package_utils.rb
@@ -157,7 +157,7 @@ class PackageUtilsTest < Minitest::Test
   end
 
   def test_get_clean_glibc_version
-    assert_equal('9.5.18', PackageUtils.get_clean_version('9.5.18-glibc2.39'))
+    assert_equal('9.5.18', PackageUtils.get_clean_version("9.5.18-glibc#{LIBC_VERSION}"))
   end
 
   def test_get_clean_git_version

--- a/tests/unit_test.sh
+++ b/tests/unit_test.sh
@@ -10,13 +10,7 @@ git clone --depth=1 --branch="$CREW_BRANCH" "$CREW_REPO" ~/build_test
 (cd ~/build_test && yes | CREW_CACHE_ENABLED=1 crew build -vf ~/build_test/packages/hello_world_chromebrew.rb)
 yes | crew install vim
 yes | crew remove vim
-ruby ../tests/commands/const.rb
-ruby ../tests/commands/help.rb
-ruby ../tests/commands/list.rb
-ruby ../tests/commands/prop.rb
-ruby ../tests/commands/remove.rb
-ruby ../tests/commands/whatprovides.rb
-ruby ../tests/lib/docopt.rb
+rake -C..
 if [[ -n ${CHANGED_PACKAGES-} ]]; then
   all_compatible_packages=$(crew list -d compatible)
   all_installed_packages=$(crew list -d installed)


### PR DESCRIPTION
## Description
As per discussions on slack, I'm splitting up my refactor PRs into smaller chunks in order to help them get reviewed.

Behavior changes:
- Replace `crew test` with a Rakefile.
  - `rake` replaces the previous behaviour of `crew test` when in the crew installation directory.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=projectregula8.1 crew update \
&& yes | crew upgrade
```
