### PR TITLE
Refactor prop_test and buildsystem_test to not rely on instance variables.

### DIFF
--- a/tests/buildsystem_test
+++ b/tests/buildsystem_test
@@ -1,42 +1,49 @@
 #!/usr/bin/env ruby
 
+require_relative '../lib/const'
 require_relative '../lib/color'
+require_relative '../lib/package'
 
-def get_buildsystems(file, field)
-  return `grep ^class #{file} | cut -d' ' -f#{field} | xargs`.chomp
-end
+# Add >LOCAL< lib to LOAD_PATH so that packages can be loaded
+$LOAD_PATH.unshift File.join(CREW_LIB_PATH, 'lib')
 
-def check_buildsystem(name)
-  puts "Checking #{name} package ...".yellow
-  buildsystem = get_buildsystems("../packages/#{name}.rb", 4)
-  if @buildsystems.include?(buildsystem)
-    puts "Buildsystem test for #{name} passed.".lightgreen
+def check_buildsystem(pkg_path, verbose: false)
+  name = File.basename(pkg_path, '.rb')
+  puts "Checking #{name} package ...".yellow if verbose
+  # If the buildsystem is invalid, it will almost certainly raise a NameError when we attempt to load it.
+  begin
+    buildsystem = Package.load_package(pkg_path).superclass.to_s
+  rescue NameError => e
+    buildsystem = e.name.to_s
+  end
+  valid_buildsystems = %w[Autotools CMake Meson PERL Package Pip Python Qmake RUBY]
+
+  if valid_buildsystems.include?(buildsystem)
+    puts "Buildsystem test for #{name} passed.".lightgreen if verbose
+    return 0
   else
-    puts "#{buildsystem} is an invalid buildsystem. Valid buildsystems include #{@buildsystems.sort.join(', ')}.".lightred
+    puts "#{buildsystem} is an invalid buildsystem. Valid buildsystems include #{valid_buildsystems.join(', ')}.".lightred
     puts "Buildsystem test for #{name} failed.".lightred
-    @tofail += 1
+    return 1
   end
 end
 
-@tofail = 0
-@buildsystems = "Package #{get_buildsystems('../lib/buildsystems/*.rb', 2)}".split
-
 if ARGV[0]
-  ARGV.each do |arg|
-    if File.file? "../packages/#{arg}.rb"
-      check_buildsystem(arg)
+  ARGV.each do |name|
+    if File.file?(File.join(CREW_PACKAGES_PATH, "#{name}.rb"))
+      check_buildsystem(File.join(CREW_PACKAGES_PATH, "#{name}.rb"), verbose: true)
     else
-      puts "Package #{arg} not found.".lightred
+      puts "Package #{name} not found.".lightred
     end
   end
 else
-  Dir['../packages/*.rb'].each do |filename|
-    name = File.basename(filename, '.rb')
-    check_buildsystem(name)
+  failed_packages = 0
+  Dir["#{CREW_PACKAGES_PATH}/*.rb"].each do |filename|
+    failed_packages += check_buildsystem(filename)
   end
 
-  if @tofail.positive?
-    puts "\n#{@tofail} packages failed buildsystem tests.".lightred
+  if failed_packages.positive?
+    puts "\n#{failed_packages} packages failed buildsystem tests.".lightred
     exit(1)
   else
     puts "\nAll packages passed buildsystem tests.".lightgreen

--- a/tests/prop_test
+++ b/tests/prop_test
@@ -7,66 +7,57 @@ require_relative '../lib/package'
 # Add >LOCAL< lib to LOAD_PATH so that packages can be loaded
 $LOAD_PATH.unshift File.join(CREW_LIB_PATH, 'lib')
 
-def check_properties(name)
-  puts "Checking #{name} package ...".yellow
+def check_properties(pkg, verbose: false)
+  puts "Checking #{pkg.name} package ...".yellow if verbose
   # List out all the possible failure states
-  empty_description = @pkg.description.to_s.empty?
-  empty_homepage = @pkg.homepage.to_s.empty?
-  empty_version = @pkg.version.to_s.empty?
-  empty_license = @pkg.license.to_s.empty?
-  empty_compatibility = @pkg.compatibility.to_s.empty?
+  empty_description = pkg.description.to_s.empty?
+  empty_homepage = pkg.homepage.to_s.empty?
+  empty_version = pkg.version.to_s.empty?
+  empty_license = pkg.license.to_s.empty?
+  empty_compatibility = pkg.compatibility.to_s.empty?
   # Certain fake packages set up to act as aliases (we should probably move on from these) do not have source_url values.
-  empty_source_url = @pkg.source_url.to_s.empty? && !@pkg.is_fake?
-  both_binary_compression_and_no_compile_needed = @pkg.no_compile_needed? && !@pkg.binary_compression.to_s.empty?
-  non_skip_source_url_and_no_source_build = @pkg.no_source_build? && !@pkg.source_url.eql?('SKIP')
+  empty_source_url = pkg.source_url.to_s.empty? && !pkg.is_fake?
+  both_binary_compression_and_no_compile_needed = pkg.no_compile_needed? && !pkg.binary_compression.to_s.empty?
+  non_skip_source_url_and_no_source_build = pkg.no_source_build? && !pkg.source_url.eql?('SKIP')
 
   # Tell the user what specific test fiailed.
-  puts "#{name} is missing a description.".lightred if empty_description
-  puts "#{name} is missing a homepage.".lightred if empty_homepage
-  puts "#{name} is missing a version.".lightred if empty_version
-  puts "#{name} is missing a license.".lightred if empty_license
-  puts "#{name} is missing a compatibility.".lightred if empty_compatibility
-  puts "#{name} is missing a source_url.".lightred if empty_source_url
-  puts "#{name} has a binary_compression value and a no_compile_needed value." if both_binary_compression_and_no_compile_needed
-  puts "#{name} has a non-SKIP source_url and a no_source_build value." if non_skip_source_url_and_no_source_build
+  puts "#{pkg.name} is missing a description.".lightred if empty_description
+  puts "#{pkg.name} is missing a homepage.".lightred if empty_homepage
+  puts "#{pkg.name} is missing a version.".lightred if empty_version
+  puts "#{pkg.name} is missing a license.".lightred if empty_license
+  puts "#{pkg.name} is missing a compatibility.".lightred if empty_compatibility
+  puts "#{pkg.name} is missing a source_url.".lightred if empty_source_url
+  puts "#{pkg.name} has a binary_compression value and a no_compile_needed value." if both_binary_compression_and_no_compile_needed
+  puts "#{pkg.name} has a non-SKIP source_url and a no_source_build value." if non_skip_source_url_and_no_source_build
 
   # Check that if the tests passed.
   if empty_description || empty_homepage || empty_version || empty_license || empty_compatibility || empty_source_url || both_binary_compression_and_no_compile_needed || non_skip_source_url_and_no_source_build
-    puts "Property tests for #{name} failed.".lightred
-    @tofail += 1
+    puts "Property tests for #{pkg.name} failed.".lightred
+    return 1
   else
-    puts "Property tests for #{name} passed.".lightgreen
+    puts "Property tests for #{pkg.name} passed.".lightgreen if verbose
+    return 0
   end
 end
 
-@tofail = 0
-
-warn_level = $VERBOSE
-$VERBOSE = nil
-
 if ARGV[0]
-  ARGV.each do |arg|
-    next if %w[-V --version].include?(arg)
-    if File.file? "../packages/#{arg}.rb"
-      @pkg = Package.load_package("../packages/#{arg}.rb")
-      check_properties(arg)
+  ARGV.each do |name|
+    if File.file?(File.join(CREW_PACKAGES_PATH, "#{name}.rb"))
+      check_properties(Package.load_package(File.join(CREW_PACKAGES_PATH, "#{name}.rb")), verbose: true)
     else
-      puts "Package #{arg} not found.".lightred
+      puts "Package #{name} not found.".lightred
     end
   end
 else
-  Dir['../packages/*.rb'].each do |filename|
-    @pkg = Package.load_package(filename)
-    name = File.basename(filename, '.rb').gsub('_', '-')
-    check_properties(name)
+  failed_packages = 0
+  Dir["#{CREW_PACKAGES_PATH}/*.rb"].each do |filename|
+    failed_packages += check_properties(Package.load_package(filename))
   end
 
-  if @tofail.positive?
-    puts "\n#{@tofail} packages failed property tests.".lightred
+  if failed_packages.positive?
+    puts "\n#{failed_packages} packages failed property tests.".lightred
     exit(1)
   else
     puts "\nAll packages passed property tests.".lightgreen
   end
 end
-
-$VERBOSE = warn_level


### PR DESCRIPTION
## Description
more smaller chunks of refactoring 

## Additional information
Performance comparison in `buildsystem_test`, running it on all files.
```
# Before
...
All packages passed buildsystem tests.

real    0m6.341s
user    0m7.919s
sys     0m1.257s
```

```
# After
All packages passed buildsystem tests.

real    0m0.498s
user    0m0.442s
sys     0m0.056s
```

the speed boost here comes from dropping `get_buildsystems` as the method for finding the class of a file, using built-in ruby functionality instead. additionally, a static list of the available buildsystems saves us from the remaining grep call, as well as dropping the need to sort it on errors.

we will need to update the list of buildsystems if we add a new one, but i think its worth a 20x speedup.

##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=projectregula8.2 crew update \
&& yes | crew upgrade
```
