### PR TITLE
Signal_desktop 7.23.0 => 7.24.0

### DIFF
--- a/manifest/x86_64/s/signal_desktop.filelist
+++ b/manifest/x86_64/s/signal_desktop.filelist
@@ -106,12 +106,10 @@
 /usr/local/share/Signal/resources.pak
 /usr/local/share/Signal/resources/app-update.yml
 /usr/local/share/Signal/resources/app.asar
-/usr/local/share/Signal/resources/app.asar.unpacked/node_modules/@nodert-win10-rs4/windows.data.xml.dom/build/Release/binding.node
-/usr/local/share/Signal/resources/app.asar.unpacked/node_modules/@nodert-win10-rs4/windows.ui.notifications/build/Release/binding.node
+/usr/local/share/Signal/resources/app.asar.unpacked/node_modules/@indutny/simple-windows-notifications/build/Release/simple-windows-notifications.node
 /usr/local/share/Signal/resources/app.asar.unpacked/node_modules/@signalapp/better-sqlite3/build/Release/better_sqlite3.node
 /usr/local/share/Signal/resources/app.asar.unpacked/node_modules/@signalapp/libsignal-client/prebuilds/linux-x64/@signalapp+libsignal-client.node
 /usr/local/share/Signal/resources/app.asar.unpacked/node_modules/@signalapp/ringrtc/build/linux/libringrtc-x64.node
-/usr/local/share/Signal/resources/app.asar.unpacked/node_modules/@signalapp/windows-dummy-keystroke/build/Release/NativeExtension.node
 /usr/local/share/Signal/resources/app.asar.unpacked/node_modules/fs-xattr/build/Release/xattr.node
 /usr/local/share/Signal/resources/package-type
 /usr/local/share/Signal/signal-desktop

--- a/packages/signal_desktop.rb
+++ b/packages/signal_desktop.rb
@@ -3,12 +3,12 @@ require 'package'
 class Signal_desktop < Package
   description 'Private Messenger for Windows, Mac, and Linux'
   homepage 'https://signal.org/'
-  version '7.23.0'
+  version '7.24.0'
   license 'AGPL-3.0'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_#{version}_amd64.deb"
-  source_sha256 '1a921de713b153ea12c570ddc1b88d0568536721c757854c90cdff95c8dd0319'
+  source_sha256 'a546667b701b5ef56ebd3e78ef8f8d0e4c7dfd3a5c3095a6d03ea2881c0002a5'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & (not) Working properly:
- [x] `x86_64` Unable to launch in hatch m126 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-signal_desktop crew update \
&& yes | crew upgrade
```