### PR TITLE
Update filezilla packages

### DIFF
--- a/manifest/armv7l/f/filezilla.filelist
+++ b/manifest/armv7l/f/filezilla.filelist
@@ -2,10 +2,10 @@
 /usr/local/bin/fzputtygen
 /usr/local/bin/fzsftp
 /usr/local/etc/env.d/10-filezilla
-/usr/local/lib/libfzclient-commonui-private-3.65.0.so
+/usr/local/lib/libfzclient-commonui-private-3.67.1.so
 /usr/local/lib/libfzclient-commonui-private.la
 /usr/local/lib/libfzclient-commonui-private.so
-/usr/local/lib/libfzclient-private-3.65.0.so
+/usr/local/lib/libfzclient-private-3.67.1.so
 /usr/local/lib/libfzclient-private.la
 /usr/local/lib/libfzclient-private.so
 /usr/local/share/appdata/filezilla.appdata.xml
@@ -683,8 +683,6 @@
 /usr/local/share/filezilla/resources/tango/48x48/upload.png
 /usr/local/share/filezilla/resources/tango/48x48/uploadadd.png
 /usr/local/share/filezilla/resources/tango/theme.xml
-/usr/local/share/filezilla/resources/xrc/dialogs.xrc
-/usr/local/share/filezilla/resources/xrc/netconfwizard.xrc
 /usr/local/share/icons/hicolor/16x16/apps/filezilla.png
 /usr/local/share/icons/hicolor/32x32/apps/filezilla.png
 /usr/local/share/icons/hicolor/480x480/apps/filezilla.png
@@ -702,6 +700,7 @@
 /usr/local/share/locale/da/LC_MESSAGES/filezilla.mo
 /usr/local/share/locale/de/LC_MESSAGES/filezilla.mo
 /usr/local/share/locale/el/LC_MESSAGES/filezilla.mo
+/usr/local/share/locale/en/LC_MESSAGES/filezilla.mo
 /usr/local/share/locale/es/LC_MESSAGES/filezilla.mo
 /usr/local/share/locale/et/LC_MESSAGES/filezilla.mo
 /usr/local/share/locale/eu/LC_MESSAGES/filezilla.mo

--- a/manifest/armv7l/l/libfilezilla.filelist
+++ b/manifest/armv7l/l/libfilezilla.filelist
@@ -4,6 +4,7 @@
 /usr/local/include/libfilezilla/aio/xml_writer.hpp
 /usr/local/include/libfilezilla/apply.hpp
 /usr/local/include/libfilezilla/ascii_layer.hpp
+/usr/local/include/libfilezilla/basic_tls_params.hpp
 /usr/local/include/libfilezilla/buffer.hpp
 /usr/local/include/libfilezilla/encode.hpp
 /usr/local/include/libfilezilla/encryption.hpp
@@ -12,6 +13,7 @@
 /usr/local/include/libfilezilla/event_loop.hpp
 /usr/local/include/libfilezilla/file.hpp
 /usr/local/include/libfilezilla/format.hpp
+/usr/local/include/libfilezilla/forward_like.hpp
 /usr/local/include/libfilezilla/fsresult.hpp
 /usr/local/include/libfilezilla/glue/unix.hpp
 /usr/local/include/libfilezilla/glue/wx.hpp
@@ -50,6 +52,7 @@
 /usr/local/include/libfilezilla/time.hpp
 /usr/local/include/libfilezilla/tls_info.hpp
 /usr/local/include/libfilezilla/tls_layer.hpp
+/usr/local/include/libfilezilla/tls_params.hpp
 /usr/local/include/libfilezilla/tls_system_trust_store.hpp
 /usr/local/include/libfilezilla/translate.hpp
 /usr/local/include/libfilezilla/uri.hpp
@@ -57,11 +60,10 @@
 /usr/local/include/libfilezilla/version.hpp
 /usr/local/include/libfilezilla/visibility_helper.hpp
 /usr/local/include/libfilezilla/xml.hpp
-/usr/local/lib/libfilezilla.a
 /usr/local/lib/libfilezilla.la
 /usr/local/lib/libfilezilla.so
-/usr/local/lib/libfilezilla.so.40
-/usr/local/lib/libfilezilla.so.40.0.0
+/usr/local/lib/libfilezilla.so.45
+/usr/local/lib/libfilezilla.so.45.0.0
 /usr/local/lib/pkgconfig/libfilezilla.pc
 /usr/local/share/locale/an/LC_MESSAGES/libfilezilla.mo
 /usr/local/share/locale/ar/LC_MESSAGES/libfilezilla.mo

--- a/manifest/x86_64/f/filezilla.filelist
+++ b/manifest/x86_64/f/filezilla.filelist
@@ -2,10 +2,10 @@
 /usr/local/bin/fzputtygen
 /usr/local/bin/fzsftp
 /usr/local/etc/env.d/10-filezilla
-/usr/local/lib64/libfzclient-commonui-private-3.65.0.so
+/usr/local/lib64/libfzclient-commonui-private-3.67.1.so
 /usr/local/lib64/libfzclient-commonui-private.la
 /usr/local/lib64/libfzclient-commonui-private.so
-/usr/local/lib64/libfzclient-private-3.65.0.so
+/usr/local/lib64/libfzclient-private-3.67.1.so
 /usr/local/lib64/libfzclient-private.la
 /usr/local/lib64/libfzclient-private.so
 /usr/local/share/appdata/filezilla.appdata.xml
@@ -683,8 +683,6 @@
 /usr/local/share/filezilla/resources/tango/48x48/upload.png
 /usr/local/share/filezilla/resources/tango/48x48/uploadadd.png
 /usr/local/share/filezilla/resources/tango/theme.xml
-/usr/local/share/filezilla/resources/xrc/dialogs.xrc
-/usr/local/share/filezilla/resources/xrc/netconfwizard.xrc
 /usr/local/share/icons/hicolor/16x16/apps/filezilla.png
 /usr/local/share/icons/hicolor/32x32/apps/filezilla.png
 /usr/local/share/icons/hicolor/480x480/apps/filezilla.png
@@ -702,6 +700,7 @@
 /usr/local/share/locale/da/LC_MESSAGES/filezilla.mo
 /usr/local/share/locale/de/LC_MESSAGES/filezilla.mo
 /usr/local/share/locale/el/LC_MESSAGES/filezilla.mo
+/usr/local/share/locale/en/LC_MESSAGES/filezilla.mo
 /usr/local/share/locale/es/LC_MESSAGES/filezilla.mo
 /usr/local/share/locale/et/LC_MESSAGES/filezilla.mo
 /usr/local/share/locale/eu/LC_MESSAGES/filezilla.mo

--- a/manifest/x86_64/l/libfilezilla.filelist
+++ b/manifest/x86_64/l/libfilezilla.filelist
@@ -4,6 +4,7 @@
 /usr/local/include/libfilezilla/aio/xml_writer.hpp
 /usr/local/include/libfilezilla/apply.hpp
 /usr/local/include/libfilezilla/ascii_layer.hpp
+/usr/local/include/libfilezilla/basic_tls_params.hpp
 /usr/local/include/libfilezilla/buffer.hpp
 /usr/local/include/libfilezilla/encode.hpp
 /usr/local/include/libfilezilla/encryption.hpp
@@ -12,6 +13,7 @@
 /usr/local/include/libfilezilla/event_loop.hpp
 /usr/local/include/libfilezilla/file.hpp
 /usr/local/include/libfilezilla/format.hpp
+/usr/local/include/libfilezilla/forward_like.hpp
 /usr/local/include/libfilezilla/fsresult.hpp
 /usr/local/include/libfilezilla/glue/unix.hpp
 /usr/local/include/libfilezilla/glue/wx.hpp
@@ -50,6 +52,7 @@
 /usr/local/include/libfilezilla/time.hpp
 /usr/local/include/libfilezilla/tls_info.hpp
 /usr/local/include/libfilezilla/tls_layer.hpp
+/usr/local/include/libfilezilla/tls_params.hpp
 /usr/local/include/libfilezilla/tls_system_trust_store.hpp
 /usr/local/include/libfilezilla/translate.hpp
 /usr/local/include/libfilezilla/uri.hpp
@@ -57,11 +60,10 @@
 /usr/local/include/libfilezilla/version.hpp
 /usr/local/include/libfilezilla/visibility_helper.hpp
 /usr/local/include/libfilezilla/xml.hpp
-/usr/local/lib64/libfilezilla.a
 /usr/local/lib64/libfilezilla.la
 /usr/local/lib64/libfilezilla.so
-/usr/local/lib64/libfilezilla.so.40
-/usr/local/lib64/libfilezilla.so.40.0.0
+/usr/local/lib64/libfilezilla.so.45
+/usr/local/lib64/libfilezilla.so.45.0.0
 /usr/local/lib64/pkgconfig/libfilezilla.pc
 /usr/local/share/locale/an/LC_MESSAGES/libfilezilla.mo
 /usr/local/share/locale/ar/LC_MESSAGES/libfilezilla.mo

--- a/packages/filezilla.rb
+++ b/packages/filezilla.rb
@@ -3,17 +3,19 @@ require 'package'
 class Filezilla < Package
   description 'FileZilla Client is a free FTP solution.'
   homepage 'https://filezilla-project.org/'
-  version '3.65.0-1'
+  version '3.67.1'
   license 'GPL-2'
   compatibility 'x86_64 aarch64 armv7l'
-  source_url 'https://download.filezilla-project.org/client/FileZilla_3.65.0_src.tar.xz'
-  source_sha256 'd2bce4dbaa80fe035836db19441e90befcbabdef5556e9a4b3d4dd233638bdea'
+  # NOTE: This may generate a 403 forbidden error. To receive a new source url,
+  # download from here: https://filezilla-project.org/download.php?show_all=1.
+  source_url "https://dl4.cdn.filezilla-project.org/client/FileZilla_#{version}_src.tar.xz?h=lc3XtUiYRgT_RWF74oRGPA&x=1726381543"
+  source_sha256 '10468e6ef623ad9789996df61f588ca7417d39353678313611d54f2d8131a1db'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '352fdaf2d1c2d6fd7f3487dd3650a75b6695a046b8cf14b5d5fe15f54c01b14f',
-     armv7l: '352fdaf2d1c2d6fd7f3487dd3650a75b6695a046b8cf14b5d5fe15f54c01b14f',
-     x86_64: '5f5276b73062447835af8cdc05a2e36c7f570ef3256f648389590034b796533a'
+    aarch64: 'a727d04dac75bab9bb8aeaaa1cc7b224dcba459d0c35a26dff9e6c66a7e73074',
+     armv7l: 'a727d04dac75bab9bb8aeaaa1cc7b224dcba459d0c35a26dff9e6c66a7e73074',
+     x86_64: '8917e28eabda3cee162aa13095095884536402bef4370e774f056e45d5a0b6e4'
   })
 
   depends_on 'at_spi2_core' # R

--- a/packages/libfilezilla.rb
+++ b/packages/libfilezilla.rb
@@ -3,17 +3,19 @@ require 'buildsystems/autotools'
 class Libfilezilla < Autotools
   description 'libfilezilla is a small and modern C++ library, offering some basic functionality to build high-performing, platform-independent programs.'
   homepage 'https://lib.filezilla-project.org/'
-  version '0.44.0'
+  version '0.48.1'
   license 'GPL-2+'
   compatibility 'x86_64 aarch64 armv7l'
-  source_url 'https://download.filezilla-project.org/libfilezilla/libfilezilla-0.44.0.tar.xz'
-  source_sha256 '2a8f57a06b52f6413b47d6a5dfbe7e9e31c84cc0784076f2f7e395232b0bd461'
+  # NOTE: This may generate a 403 forbidden error. To receive a new source url,
+  # download from here: https://lib.filezilla-project.org/download.php?show_all=1.
+  source_url "https://dl4.cdn.filezilla-project.org/libfilezilla/libfilezilla-#{version}.tar.xz?h=pN1wsJgaHaL--GZACTd24g&x=1726372521"
+  source_sha256 '4eea8abd456096625893b707e8db6c949e6f0466136c51c0b8ce58b5f8ef1e43'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '4539d3cf4220ea552e26d3fc7808c686849472c13d07b8f97f5ae0a2fa86d580',
-     armv7l: '4539d3cf4220ea552e26d3fc7808c686849472c13d07b8f97f5ae0a2fa86d580',
-     x86_64: '2d9ef1bca2af46802ef74fbb8962d54e931ba8c3e9543451c28993349f0ba7ad'
+    aarch64: '1009853909be5734aab4fc20f4f3938e4c35120fbc3f7860078f6d6a135662c2',
+     armv7l: '1009853909be5734aab4fc20f4f3938e4c35120fbc3f7860078f6d6a135662c2',
+     x86_64: '045d8eb31c060ea8f21819a8c4a49b9e14f8425a73c20f5ba59cb749fc07b8ce'
   })
 
   depends_on 'gcc_lib' # R


### PR DESCRIPTION
Fixes #10479.

Libfilezilla 0.44.0 => 0.48.1

Filezilla 3.65.0-1 => 3.67.1

##
Tested & Working properly:
- [x] `x86_64`
- [ ] `i686` Not supported
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-filezilla crew update \
&& yes | crew upgrade
```