### PR TITLE
Platformsh 5.0.20 => 5.0.21

### DIFF
--- a/packages/platformsh.rb
+++ b/packages/platformsh.rb
@@ -3,11 +3,11 @@ require 'package'
 class Platformsh < Package
   description 'The unified tool for managing your Platform.sh services from the command line.'
   homepage 'https://docs.platform.sh/overview/cli.html'
-  version '5.0.20'
+  version '5.0.21'
   license 'MIT'
   compatibility 'x86_64 aarch64 armv7l'
   source_url "https://github.com/platformsh/cli/releases/download/#{version}/platform_#{version}_linux_amd64.tar.gz"
-  source_sha256 'a0f732d72bc03136a5afe141ca72b472ae4381cd6c7bf4dfd45662c02a9ac08b'
+  source_sha256 '3bab32b2d63e7d18720eefdc9577ee401ea5bf61e0ce821eda4bb833082b4282'
 
   depends_on 'php83' unless File.exist? "#{CREW_PREFIX}/bin/php"
 


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l` 
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-platformsh crew update \
&& yes | crew upgrade
```