### PR TITLE
Add gem binary build functionality and also refactor upload to use regex in lieu of sed

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1411,12 +1411,23 @@ def upload(pkg_name = nil, pkg_version = nil, gitlab_token = nil, gitlab_token_u
   abort "\nGITLAB_TOKEN environment variable not set.\n".lightred if gitlab_token.nil?
   abort "\nGITLAB_TOKEN_USERNAME environment variable not set.\n".lightred if gitlab_token_username.nil?
 
+  require_gem('tty-file')
+
   packages = pkg_name
   packages.strip!
 
   [packages].each do |package|
     pkg_file = "#{CREW_LOCAL_REPO_ROOT}/packages/#{package}.rb"
+    require 'ostruct'
+    binhash = OpenStruct.new
+    binary_compression = 'gem' if @pkg.superclass == 'RUBY'
     %w[x86_64 i686 armv7l].each do |arch|
+      pkg_hash = @pkg.binary_sha256&.key?(arch.to_sym)
+      unless pkg_hash.blank?
+        puts "#{arch}=, #{@pkg.binary_sha256[arch.to_sym]}"
+        binhash.aarch64 = @pkg.binary_sha256[arch.to_sym] if arch == 'armv7l'
+        binhash.send "#{arch}=", @pkg.binary_sha256[arch.to_sym]
+      end
       release_dir = "#{CREW_LOCAL_REPO_ROOT}/release/#{arch}"
       new_tarfile = if binary_compression.nil?
                       Dir["#{release_dir}/#{package}-#{pkg_version}-chromeos-#{arch}.{tar.xz,tar.zst}"].max_by { |f| File.mtime(f) }
@@ -1424,7 +1435,7 @@ def upload(pkg_name = nil, pkg_version = nil, gitlab_token = nil, gitlab_token_u
                       "#{release_dir}/#{package}-#{pkg_version}-chromeos-#{arch}.#{binary_compression}"
                     end
       if new_tarfile.nil? || !File.file?(new_tarfile)
-        puts "#{release_dir}/#{package}-#{pkg_version}-chromeos-#{arch}.(tar.xz|tar.zst) not found.\n".lightred
+        puts "#{release_dir}/#{package}-#{pkg_version}-chromeos-#{arch}.#{binary_compression.nil? ? '(tar.xz|tar.zst)' : binary_compression} not found.\n".lightred
         next
       end
       if binary_compression.nil?
@@ -1458,8 +1469,16 @@ def upload(pkg_name = nil, pkg_version = nil, gitlab_token = nil, gitlab_token_u
 
       if `curl -sI #{new_url}`.lines.first.split[1] == '200'
         puts "\n#{new_tarfile} has already been uploaded.\nPlease change the #{package} package version from #{new_version} and try again.\n".lightred
-        unless Package.agree_default_no('Do you want to overwrite the existing upload instead')
+        if Package.agree_default_no('Do you want to overwrite the existing upload instead')
+          puts "#{arch} = #{new_sha256}"
+          binhash.aarch64 = new_sha256 if arch == 'armv7l'
+          binhash.send "#{arch}=", new_sha256
+        else
           puts 'Will NOT overwite the existing upload.'.orange
+          upstream_sha256 = `curl -Ls #{new_url} | sha256sum`.chomp.split.first
+          puts "#{arch} = #{upstream_sha256}"
+          binhash.aarch64 = upstream_sha256 if arch == 'armv7l'
+          binhash.send "#{arch}=", upstream_sha256
           next
         end
       end
@@ -1484,41 +1503,54 @@ def upload(pkg_name = nil, pkg_version = nil, gitlab_token = nil, gitlab_token_u
         puts "#{output}. Unable to upload. Skipping binary_sha256 update in #{pkg_file}...".lightred
         next
       end
-      old_sha256 = `grep -m 1 #{arch}: #{pkg_file} 2> /dev/null`.chomp
-      if old_sha256.empty?
-        unless File.readlines(pkg_file).grep(/binary_sha256/).any?
-          if CREW_VERBOSE
-            puts "sed -e '/binary_compression/ a\\
-\\
-\\ \\ binary_sha256({' -i #{pkg_file}"
-          end
-          system "sed -e '/binary_compression/ a\\
-\\
-\\ \\ binary_sha256({' -i #{pkg_file}"
-        end
-        puts "Adding binary_sha256 to #{pkg_file}..."
-        puts "#{arch}: '#{new_sha256}'"
-        unless new_sha256.empty?
-          update_sha256(pkg_file, arch, new_sha256)
-          update_sha256(pkg_file, 'aarch64', new_sha256) if arch.eql?('armv7l')
-        end
-      else
-        old_sha256 = old_sha256.split("'")[1]
-        if old_sha256 == new_sha256
-          puts "Skipping binary_sha256 update in #{pkg_file}..."
-        else
-          puts "Updating binary_sha256 in #{pkg_file}..."
-          puts "from: #{arch}: '#{old_sha256}'"
-          puts "  to: #{arch}: '#{new_sha256}'"
-          puts "sed -i 's/#{old_sha256}/#{new_sha256}/g' #{pkg_file}" if CREW_VERBOSE
-          system "sed -i 's/#{old_sha256}/#{new_sha256}/g' #{pkg_file}"
-        end
-      end
+      # old_sha256 = `grep -m 1 #{arch}: #{pkg_file} 2> /dev/null`.chomp
+      # if old_sha256.empty?
+      # unless File.readlines(pkg_file).grep(/binary_sha256/).any?
+      # if CREW_VERBOSE
+      # puts "sed -e '/binary_compression/ a\\
+      # \\
+      # \\ \\ binary_sha256({' -i #{pkg_file}"
+      # end
+      # system "sed -e '/binary_compression/ a\\
+      # \\
+      # \\ \\ binary_sha256({' -i #{pkg_file}"
+      # end
+      # puts "Adding binary_sha256 to #{pkg_file}..."
+      # puts "#{arch}: '#{new_sha256}'"
+      # unless new_sha256.empty?
+      # update_sha256(pkg_file, arch, new_sha256)
+      # update_sha256(pkg_file, 'aarch64', new_sha256) if arch.eql?('armv7l')
+      # end
+      # else
+      # old_sha256 = old_sha256.split("'")[1]
+      # if old_sha256 == new_sha256
+      # puts "Skipping binary_sha256 update in #{pkg_file}..."
+      # else
+      # puts "Updating binary_sha256 in #{pkg_file}..."
+      # puts "from: #{arch}: '#{old_sha256}'"
+      # puts "  to: #{arch}: '#{new_sha256}'"
+      # puts "sed -i 's/#{old_sha256}/#{new_sha256}/g' #{pkg_file}" if CREW_VERBOSE
+      # system "sed -i 's/#{old_sha256}/#{new_sha256}/g' #{pkg_file}"
+      # end
+      # end
     end
+    # binhash = OpenStruct.new
+    # binhash.aarch64 = 'hasharmv7l'
+    # binhash.armv7l = 'hasharmv7l'
+    # binhash.i686 = 'hashi686'
+    # binhash.x86_64 = 'hashx86_64'
+    binary_sha256json = JSON.pretty_generate(binhash.to_h)
+    binary_hash = "\n\n  binary_sha256(#{binary_sha256json})"
+    puts binary_hash.to_s.lightgreen
+    # Remove existing binary_sha256 block.
+    system "sed -i '/binary_sha256({/,/})/d' #{pkg_file}"
+    TTY::File.inject_into_file pkg_file, binary_hash, after: /binary_compression.*$/
+
     # Upload python wheels if we are dealing with a pip package, but only
     # if a gitlab token username is set. (The generic repo does not
     # require a gitlab token username.)
-    next unless Kernel.system "grep -q \"^require 'buildsystems/pip'\" #{pkg_file}"
+    next unless @pkg.superclass == 'Pip'
+    # Kernel.system "grep -q \"^require 'buildsystems/pip'\" #{pkg_file}"
     if gitlab_token_username.nil?
       puts "\nGITLAB_TOKEN_USERNAME environment variable not set, so generated python wheels will not be uploaded.\n".lightred
       next package

--- a/bin/crew
+++ b/bin/crew
@@ -649,7 +649,7 @@ def unpack(meta)
       when /\.gem$/i
         puts "Renaming #{@gem_name} binary gem for install..."
         gem_file = "#{@gem_name}-#{@gem_ver}-#{GEM_ARCH}.gem"
-        Fileutils.mv meta[:filename], gem_file
+        Fileutils.mv meta[:filename], File.join(@extract_dir, gem_file)
       end
     end
     if meta[:source]
@@ -672,7 +672,7 @@ def unpack(meta)
       target_dir = @extract_dir
     end
     # Remove tarball to save space.
-    FileUtils.rm_f meta[:filename], verbose: @fileutils_verbose
+    FileUtils.rm_f meta[:filename], verbose: @fileutils_verbose if File.file?(meta[:filename])
   end
   return File.join(CREW_BREW_DIR, target_dir)
 end
@@ -1252,11 +1252,13 @@ def install
   if @pkg.is_fake?
     # use CREW_DEST_DIR
     dest_dir = CREW_DEST_DIR
-  # elsif @pkg.name.start_with?('ruby_')
   elsif @pkg.superclass == 'RUBY'
     meta = download
     target_dir = unpack meta
-    dest_dir = Dir.exist?(target_dir) ? target_dir : CREW_DEST_DIR
+    puts "target_dir is #{target_dir}"
+    build_and_preconfigure target_dir
+    dest_dir = CREW_DEST_DIR
+    puts "dest_dir is #{dest_dir}"
   else
     meta = download
     target_dir = unpack meta
@@ -1302,7 +1304,9 @@ def install
     # perform install process
     # if @pkg.name.start_with?('ruby_')
     if @pkg.superclass == 'RUBY'
-      @pkg.install
+      Dir.chdir(target_dir) do
+        @pkg.install
+      end
     else
       install_package dest_dir
     end
@@ -1342,9 +1346,7 @@ def resolve_dependencies_and_build
       post_install
     end
     search origin, silent: true
-    binding.pry
     build_package CREW_LOCAL_BUILD_DIR
-    binding.pry
   rescue InstallError => e
     abort "#{@pkg.name} failed to build: #{e}".lightred
   ensure
@@ -1380,15 +1382,14 @@ def build_package(crew_archive_dest)
 
   # build package from filelist, dlist and binary files in CREW_DEST_DIR
   puts 'Archiving...'
-  archive_package crew_archive_dest
+  archive_package(crew_archive_dest)
 end
 
 def archive_package(crew_archive_dest)
-  if @pkg.superclass == 'RUBY'
-    puts "Renaming #{@gem_name} gem for install..."
-    gem_file = "#{@gem_name}-#{@gem_ver}-#{GEM_ARCH}.gem"
+  if @pkg.superclass.to_s == 'RUBY'
+    gem_file = "#{@pkg.gem_name}-#{@pkg.gem_ver}-#{GEM_ARCH}.gem"
     pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.gem"
-    FileUtils.mv gem_file, File.join(crew_archive_dest, pkg_name)
+    FileUtils.mv File.join(CREW_DEST_DIR, gem_file), File.join(crew_archive_dest, pkg_name)
   # Only use zstd if it is available.
   elsif @pkg.no_zstd? || !Kernel.system('which zstd', %i[out err] => File::NULL)
     puts 'Using xz to compress package. This may take some time.'.lightblue

--- a/bin/crew
+++ b/bin/crew
@@ -1411,23 +1411,20 @@ def upload(pkg_name = nil, pkg_version = nil, gitlab_token = nil, gitlab_token_u
   abort "\nGITLAB_TOKEN environment variable not set.\n".lightred if gitlab_token.nil?
   abort "\nGITLAB_TOKEN_USERNAME environment variable not set.\n".lightred if gitlab_token_username.nil?
 
-  require_gem('tty-file')
-
   packages = pkg_name
   packages.strip!
 
   [packages].each do |package|
     pkg_file = "#{CREW_LOCAL_REPO_ROOT}/packages/#{package}.rb"
-    require 'ostruct'
-    binhash = OpenStruct.new
+    binary_sha256_hash = { armv7l: nil, i686: nil, x86_64: nil }
+    # The following is used to figure out where a non-standard
+    # binary_sha256 section might be, such as in a gcc_lib file.
+    starting_binary_sha256_hash = { armv7l: nil, i686: nil, x86_64: nil }
     binary_compression = 'gem' if @pkg.superclass == 'RUBY'
     %w[x86_64 i686 armv7l].each do |arch|
-      pkg_hash = @pkg.binary_sha256&.key?(arch.to_sym)
-      unless pkg_hash.blank?
-        puts "#{arch}=, #{@pkg.binary_sha256[arch.to_sym]}"
-        binhash.aarch64 = @pkg.binary_sha256[arch.to_sym] if arch == 'armv7l'
-        binhash.send "#{arch}=", @pkg.binary_sha256[arch.to_sym]
-      end
+      # Load existing binary_sha256 hash from the package file.
+      binary_sha256_hash[arch.to_sym] = @pkg.binary_sha256[arch.to_sym] if @pkg.binary_sha256&.key?(arch.to_sym)
+      starting_binary_sha256_hash[arch.to_sym] = @pkg.binary_sha256[arch.to_sym] if @pkg.binary_sha256&.key?(arch.to_sym)
       release_dir = "#{CREW_LOCAL_REPO_ROOT}/release/#{arch}"
       new_tarfile = if binary_compression.nil?
                       Dir["#{release_dir}/#{package}-#{pkg_version}-chromeos-#{arch}.{tar.xz,tar.zst}"].max_by { |f| File.mtime(f) }
@@ -1440,22 +1437,28 @@ def upload(pkg_name = nil, pkg_version = nil, gitlab_token = nil, gitlab_token_u
       end
       if binary_compression.nil?
         ext = File.extname(new_tarfile)
-        puts "Setting binary compression in #{pkg_file}..."
+        binary_compression = @pkg.superclass == 'RUBY' ? 'gem' : "tar#{ext}"
+        binary_compression_line = "  binary_compression '#{binary_compression}'"
+        puts "Setting binary compression in #{pkg_file} to '#{binary_compression}'..."
         # Add binary compression setting, and add the line if it doesn't exist.
-        if File.read(pkg_file).include?('binary_compression')
-          puts "sed -i \"s/binary_compression.*/binary_compression 'tar#{ext}'/\" #{pkg_file}" if CREW_VERBOSE
-          system "sed -i \"s/binary_compression.*/binary_compression 'tar#{ext}'/\" #{pkg_file}"
-        elsif File.read(pkg_file).include?('source_sha256')
-          puts "sed -i \"/source_sha256/a \\\ \\\ binary_compression 'tar#{ext}'\" #{pkg_file}" if CREW_VERBOSE
-          system "sed -i \"/source_sha256/a \\\ \\\ binary_compression 'tar#{ext}'\" #{pkg_file}"
-        elsif File.read(pkg_file).include?('git_hashtag')
-          puts "sed -i \"/git_hashtag/a \\\ \\\ binary_compression 'tar#{ext}'\" #{pkg_file}" if CREW_VERBOSE
-          system "sed -i \"/git_hashtag/a \\\ \\\ binary_compression 'tar#{ext}'\" #{pkg_file}"
-        elsif File.read(pkg_file).include?('source_url')
-          puts "sed -i \"/source_url/a \\\ \\\ binary_compression 'tar#{ext}'\" #{pkg_file}" if CREW_VERBOSE
-          system "sed -i \"/source_url/a \\\ \\\ binary_compression 'tar#{ext}'\" #{pkg_file}"
+        file = File.read(pkg_file)
+        bc_re = /^\ \ binary_compression.*/
+        source_re = /^\ \ source_sha256.*/
+        git_hashtag_re = /^\ \ git_hashtag.*/
+        source_url_re = /^\ \ source_url.*/
+        if file.match(bc_re)
+          File.write(pkg_file, file.gsub(bc_re, binary_compression_line))
+        elsif file.match(source_re)
+          source_sha256_bc_line = "#{file.match(source_re)}\n#{binary_compression_line}"
+          File.write(pkg_file, file.gsub(source_re, source_sha256_bc_line))
+        elsif file.match(git_hashtag_re)
+          git_hashtag_bc_line = "#{file.match(git_hashtag_re)}\n#{binary_compression_line}"
+          File.write(pkg_file, file.gsub(git_hashtag_re, git_hashtag_bc_line))
+        elsif file.match(source_url_re)
+          source_url_bc_line = "#{file.match(source_url_re)}\n#{binary_compression_line}"
+          File.write(pkg_file, file.gsub(source_url_re, source_url_bc_line))
         else
-          puts "Unable to tell where to add \"binary_compression 'tar#{ext}'\" to #{pkg_file}. Please add it and manually.".lightblue
+          puts "Unable to tell where to add \"#{binary_compression_line}\" to #{pkg_file}. Please add it and manually.".lightblue
         end
       end
       puts "Package: #{package}, Arch: #{arch}".yellow
@@ -1470,17 +1473,18 @@ def upload(pkg_name = nil, pkg_version = nil, gitlab_token = nil, gitlab_token_u
       if `curl -sI #{new_url}`.lines.first.split[1] == '200'
         puts "\n#{new_tarfile} has already been uploaded.\nPlease change the #{package} package version from #{new_version} and try again.\n".lightred
         if Package.agree_default_no('Do you want to overwrite the existing upload instead')
-          puts "#{arch} = #{new_sha256}"
-          binhash.aarch64 = new_sha256 if arch == 'armv7l'
-          binhash.send "#{arch}=", new_sha256
+          crewlog "#{arch} = #{new_sha256}"
+          binary_sha256_hash[arch.to_sym] = new_sha256
         else
           puts 'Will NOT overwite the existing upload.'.orange
           upstream_sha256 = `curl -Ls #{new_url} | sha256sum`.chomp.split.first
-          puts "#{arch} = #{upstream_sha256}"
-          binhash.aarch64 = upstream_sha256 if arch == 'armv7l'
-          binhash.send "#{arch}=", upstream_sha256
+          crewlog "#{arch} = #{upstream_sha256}"
+          binary_sha256_hash[arch.to_sym] = upstream_sha256
           next
         end
+      else
+        crewlog "#{arch} = #{new_sha256}"
+        binary_sha256_hash[arch.to_sym] = new_sha256
       end
 
       puts "curl -# --header \"#{token_label}: #{gitlab_token}\" --upload-file \"#{new_tarfile}\" \"#{new_url}\" | cat" if CREW_VERBOSE
@@ -1503,54 +1507,43 @@ def upload(pkg_name = nil, pkg_version = nil, gitlab_token = nil, gitlab_token_u
         puts "#{output}. Unable to upload. Skipping binary_sha256 update in #{pkg_file}...".lightred
         next
       end
-      # old_sha256 = `grep -m 1 #{arch}: #{pkg_file} 2> /dev/null`.chomp
-      # if old_sha256.empty?
-      # unless File.readlines(pkg_file).grep(/binary_sha256/).any?
-      # if CREW_VERBOSE
-      # puts "sed -e '/binary_compression/ a\\
-      # \\
-      # \\ \\ binary_sha256({' -i #{pkg_file}"
-      # end
-      # system "sed -e '/binary_compression/ a\\
-      # \\
-      # \\ \\ binary_sha256({' -i #{pkg_file}"
-      # end
-      # puts "Adding binary_sha256 to #{pkg_file}..."
-      # puts "#{arch}: '#{new_sha256}'"
-      # unless new_sha256.empty?
-      # update_sha256(pkg_file, arch, new_sha256)
-      # update_sha256(pkg_file, 'aarch64', new_sha256) if arch.eql?('armv7l')
-      # end
-      # else
-      # old_sha256 = old_sha256.split("'")[1]
-      # if old_sha256 == new_sha256
-      # puts "Skipping binary_sha256 update in #{pkg_file}..."
-      # else
-      # puts "Updating binary_sha256 in #{pkg_file}..."
-      # puts "from: #{arch}: '#{old_sha256}'"
-      # puts "  to: #{arch}: '#{new_sha256}'"
-      # puts "sed -i 's/#{old_sha256}/#{new_sha256}/g' #{pkg_file}" if CREW_VERBOSE
-      # system "sed -i 's/#{old_sha256}/#{new_sha256}/g' #{pkg_file}"
-      # end
-      # end
     end
-    # binhash = OpenStruct.new
-    # binhash.aarch64 = 'hasharmv7l'
-    # binhash.armv7l = 'hasharmv7l'
-    # binhash.i686 = 'hashi686'
-    # binhash.x86_64 = 'hashx86_64'
-    binary_sha256json = JSON.pretty_generate(binhash.to_h)
-    binary_hash = "\n\n  binary_sha256(#{binary_sha256json})"
-    puts binary_hash.to_s.lightgreen
-    # Remove existing binary_sha256 block.
-    system "sed -i '/binary_sha256({/,/})/d' #{pkg_file}"
-    TTY::File.inject_into_file pkg_file, binary_hash, after: /binary_compression.*$/
+    binary_sha256_block = ''
+    binary_sha256_block << "\n  binary_sha256({\n"
+    unless binary_sha256_hash[:armv7l].nil?
+      binary_sha256_block << "    aarch64: '#{binary_sha256_hash[:armv7l]}',\n"
+      binary_sha256_block << "     armv7l: '#{binary_sha256_hash[:armv7l]}'"
+      binary_sha256_block << if binary_sha256_hash[:i686].nil? && binary_sha256_hash[:x86_64].nil?
+                               "\n"
+                             else
+                               ",\n"
+                             end
+    end
+    unless binary_sha256_hash[:i686].nil?
+      binary_sha256_block << "       i686: '#{binary_sha256_hash[:i686]}'"
+      binary_sha256_block << if binary_sha256_hash[:x86_64].nil?
+                               "\n"
+                             else
+                               ",\n"
+                             end
+    end
+    binary_sha256_block << "     x86_64: '#{binary_sha256_hash[:x86_64]}'\n" unless binary_sha256_hash[:x86_64].nil?
+    binary_sha256_block << '  })'
+    # Replace existing binary_sha256 block (found by looking for the old hash), otherwise add it.
+    binary_sha256_block_re = /\n^\s*(binary_sha256\(\{)(((?!binary_sha256).)*)#{starting_binary_sha256_hash.compact.values.join('.*')}(((?!\}\)).)*)\}\)/m
+    file = File.read(pkg_file)
+    if file.match(binary_sha256_block_re)
+      File.write(pkg_file, file.gsub(binary_sha256_block_re, "\n#{binary_sha256_block}"))
+    else
+      bc_re = /^\ \ binary_compression.*/
+      binary_sha256_block_with_bc = "#{file.match(bc_re)}\n#{binary_sha256_block}"
+      File.write(pkg_file, file.gsub(bc_re, binary_sha256_block_with_bc))
+    end
 
     # Upload python wheels if we are dealing with a pip package, but only
     # if a gitlab token username is set. (The generic repo does not
     # require a gitlab token username.)
     next unless @pkg.superclass == 'Pip'
-    # Kernel.system "grep -q \"^require 'buildsystems/pip'\" #{pkg_file}"
     if gitlab_token_username.nil?
       puts "\nGITLAB_TOKEN_USERNAME environment variable not set, so generated python wheels will not be uploaded.\n".lightred
       next package

--- a/bin/crew
+++ b/bin/crew
@@ -1585,25 +1585,6 @@ def upload(pkg_name = nil, pkg_version = nil, gitlab_token = nil, gitlab_token_u
   end
 end
 
-def update_sha256(package, key, value)
-  case key
-  when 'aarch64'
-    leading_space = '\\ \\ \\ \\ '
-  when 'armv7l', 'x86_64'
-    leading_space = '\\ \\ \\ \\ \\ '
-  when 'i686'
-    leading_space = '\\ \\ \\ \\ \\ \\ \\ '
-  end
-  comma = key == 'x86_64' ? '\\n\\ \\ })' : ','
-  if File.readlines(package).grep(/#{key}:/).any?
-    puts "sed -e \"/#{key}:.*['\"][0-9a-f]*['\"]/c#{leading_space}#{key}: '#{value}'#{comma}\" -i #{package}" if CREW_VERBOSE
-    system "sed -e \"/#{key}:.*['\"][0-9a-f]*['\"]/c#{leading_space}#{key}: '#{value}'#{comma}\" -i #{package}"
-  else
-    puts "sed -e \"/binary_sha256.*({/a#{leading_space}#{key}: '#{value}'#{comma}\" -i #{package}" if CREW_VERBOSE
-    system "sed -e \"/binary_sha256.*({/a#{leading_space}#{key}: '#{value}'#{comma}\" -i #{package}"
-  end
-end
-
 def copy_package(pkg_name, prompt_msg = '')
   pkg_file = File.join(CREW_LOCAL_REPO_ROOT, 'packages', "#{pkg_name}.rb")
   # Use rubocop to sanitize package file, and let errors get flagged.

--- a/bin/crew
+++ b/bin/crew
@@ -470,7 +470,7 @@ def download
     next if @pkg.no_source_build? && !@pkg.in_upgrade && !@pkg.in_install
     case File.basename(filename)
     # Sources that download with our internal downloader
-    when /\.zip$/i, /\.(tar(\.(gz|bz2|xz|lzma|lz|zst))?|tgz|tbz|tpxz|txz)$/i, /\.deb$/i, /\.AppImage$/i
+    when /\.zip$/i, /\.(tar(\.(gz|bz2|xz|lzma|lz|zst))?|tgz|tbz|tpxz|txz)$/i, /\.deb$/i, /\.AppImage$/i, /\.gem$/i
       # Recall file from cache if requested
       if CREW_CACHE_ENABLED
         puts "Looking for #{@pkg.name} archive in cache".orange if CREW_VERBOSE
@@ -646,6 +646,10 @@ def unpack(meta)
         puts "Unpacking 'AppImage' archive, this may take a while..."
         FileUtils.chmod 0o755, meta[:filename], verbose: @fileutils_verbose
         system "../#{meta[:filename]}", '--appimage-extract', chdir: @extract_dir, exception: true
+      when /\.gem$/i
+        puts "Renaming #{@gem_name} binary gem for install..."
+        gem_file = "#{@gem_name}-#{@gem_ver}-#{GEM_ARCH}.gem"
+        Fileutils.mv meta[:filename], gem_file
       end
     end
     if meta[:source]
@@ -675,7 +679,9 @@ end
 
 def build_and_preconfigure(target_dir)
   Dir.chdir target_dir do
-    unless @pkg.no_compile_needed?
+    if @pkg.gem_compile_needed?
+      puts 'Building binary gem...'
+    elsif !@pkg.no_compile_needed?
       puts 'Building from source, this may take a while...'
 
       # Load musl options only if package is targeted at the musl toolchain
@@ -1236,16 +1242,21 @@ end
 
 def install
   @pkg.in_install = true
-  if !@pkg.in_upgrade && PackageUtils.installed?(@pkg.name) && !@pkg.name.start_with?('ruby_')
+  if !@pkg.in_upgrade && PackageUtils.installed?(@pkg.name) && !@pkg.superclass == 'RUBY'
     puts "Package #{@pkg.name} already installed, skipping...".lightgreen
     return
   end
 
   install_start_time = Time.now.to_i
 
-  if @pkg.is_fake? || @pkg.name.start_with?('ruby_')
+  if @pkg.is_fake?
     # use CREW_DEST_DIR
     dest_dir = CREW_DEST_DIR
+  # elsif @pkg.name.start_with?('ruby_')
+  elsif @pkg.superclass == 'RUBY'
+    meta = download
+    target_dir = unpack meta
+    dest_dir = Dir.exist?(target_dir) ? target_dir : CREW_DEST_DIR
   else
     meta = download
     target_dir = unpack meta
@@ -1289,7 +1300,8 @@ def install
     pre_install dest_dir
 
     # perform install process
-    if @pkg.name.start_with?('ruby_')
+    # if @pkg.name.start_with?('ruby_')
+    if @pkg.superclass == 'RUBY'
       @pkg.install
     else
       install_package dest_dir
@@ -1330,7 +1342,9 @@ def resolve_dependencies_and_build
       post_install
     end
     search origin, silent: true
+    binding.pry
     build_package CREW_LOCAL_BUILD_DIR
+    binding.pry
   rescue InstallError => e
     abort "#{@pkg.name} failed to build: #{e}".lightred
   ensure
@@ -1340,20 +1354,21 @@ def resolve_dependencies_and_build
       FileUtils.mkdir_p "#{CREW_BREW_DIR}/dest", verbose: @fileutils_verbose # this is a little ugly, feel free to find a better way
     end
   end
-  puts "#{@pkg.name} is built!".lightgreen
+  puts "#{@pkg.name.capitalize} is built!".lightgreen
   @resolve_dependencies_and_build = 0
 end
 
 def build_package(crew_archive_dest)
-  # download source codes and unpack it
+  # Download source code and unpack it.
   meta = download
   target_dir = unpack meta
 
-  # build from source and place binaries at CREW_DEST_DIR
+  # Build from source and place binaries in CREW_DEST_DIR.
   build_and_preconfigure target_dir
 
-  # call check method here.  this check method is called by this function only,
-  # therefore it is possible place time consuming tests in the check method.
+  # Call check method here. This check method is called by this function
+  # only, therefore it is possible to place time consuming tests in the
+  # check method.
   if Dir.exist? target_dir
     Dir.chdir target_dir do
       @pkg.check
@@ -1361,7 +1376,7 @@ def build_package(crew_archive_dest)
   end
 
   # prepare filelist and dlist at CREW_DEST_DIR
-  prepare_package CREW_DEST_DIR
+  prepare_package CREW_DEST_DIR unless @pkg.superclass == 'RUBY'
 
   # build package from filelist, dlist and binary files in CREW_DEST_DIR
   puts 'Archiving...'
@@ -1369,8 +1384,13 @@ def build_package(crew_archive_dest)
 end
 
 def archive_package(crew_archive_dest)
+  if @pkg.superclass == 'RUBY'
+    puts "Renaming #{@gem_name} gem for install..."
+    gem_file = "#{@gem_name}-#{@gem_ver}-#{GEM_ARCH}.gem"
+    pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.gem"
+    FileUtils.mv gem_file, File.join(crew_archive_dest, pkg_name)
   # Only use zstd if it is available.
-  if @pkg.no_zstd? || !Kernel.system('which zstd', %i[out err] => File::NULL)
+  elsif @pkg.no_zstd? || !Kernel.system('which zstd', %i[out err] => File::NULL)
     puts 'Using xz to compress package. This may take some time.'.lightblue
     pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.tar.xz"
     Dir.chdir CREW_DEST_DIR do
@@ -1656,7 +1676,10 @@ def build_command(args)
     # Process preflight block to see if package should be built
     pre_flight
 
-    if !@pkg.is_fake? && PackageUtils.compatible?(@pkg) && @pkg.source?(ARCH) && (@pkg.no_source_build? || @pkg.source_url.to_s.upcase != 'SKIP') && !@pkg.no_compile_needed?
+    crewlog "!@pkg.is_fake? #{!@pkg.is_fake?} && PackageUtils.compatible?(@pkg) #{PackageUtils.compatible?(@pkg)} && @pkg.source?(ARCH): #{@pkg.source?(ARCH)}"
+    crewlog "(@pkg.no_source_build? #{@pkg.no_source_build?} || @pkg.source_url.to_s.upcase != 'SKIP' #{@pkg.source_url.to_s.upcase != 'SKIP'})"
+    crewlog "!@pkg.no_compile_needed? #{!@pkg.no_compile_needed?} && @pkg.gem_compile_needed? #{@pkg.gem_compile_needed?}"
+    if !@pkg.is_fake? && PackageUtils.compatible?(@pkg) && @pkg.source?(ARCH) && (@pkg.no_source_build? || @pkg.source_url.to_s.upcase != 'SKIP') && !@pkg.no_compile_needed? && @pkg.gem_compile_needed?
       resolve_dependencies_and_build
     else
       puts 'Unable to build a fake package. Skipping build.'.lightred if @pkg.is_fake?

--- a/bin/crew
+++ b/bin/crew
@@ -647,9 +647,9 @@ def unpack(meta)
         FileUtils.chmod 0o755, meta[:filename], verbose: @fileutils_verbose
         system "../#{meta[:filename]}", '--appimage-extract', chdir: @extract_dir, exception: true
       when /\.gem$/i
-        puts "Renaming #{@gem_name} binary gem for install..."
-        gem_file = "#{@gem_name}-#{@gem_ver}-#{GEM_ARCH}.gem"
-        Fileutils.mv meta[:filename], File.join(@extract_dir, gem_file)
+        puts "Moving #{@pkg.gem_name} binary gem for install..."
+        gem_file = "#{@pkg.gem_name}-#{@pkg.gem_ver}-#{GEM_ARCH}.gem"
+        FileUtils.mv meta[:filename], File.join(@extract_dir, gem_file)
       end
     end
     if meta[:source]
@@ -1242,7 +1242,7 @@ end
 
 def install
   @pkg.in_install = true
-  if !@pkg.in_upgrade && PackageUtils.installed?(@pkg.name) && !@pkg.superclass == 'RUBY'
+  if !@pkg.in_upgrade && PackageUtils.installed?(@pkg.name) && !@pkg.superclass.to_s == 'RUBY'
     puts "Package #{@pkg.name} already installed, skipping...".lightgreen
     return
   end
@@ -1252,13 +1252,16 @@ def install
   if @pkg.is_fake?
     # use CREW_DEST_DIR
     dest_dir = CREW_DEST_DIR
-  elsif @pkg.superclass == 'RUBY'
+  elsif @pkg.superclass.to_s == 'RUBY'
     meta = download
     target_dir = unpack meta
-    puts "target_dir is #{target_dir}"
-    build_and_preconfigure target_dir
+    gem_file = "#{@pkg.gem_name}-#{@pkg.gem_ver}-#{GEM_ARCH}.gem"
+    if File.file?(File.join(target_dir, gem_file))
+      FileUtils.mv File.join(target_dir, gem_file), File.join(CREW_DEST_DIR, gem_file)
+    else
+      build_and_preconfigure target_dir
+    end
     dest_dir = CREW_DEST_DIR
-    puts "dest_dir is #{dest_dir}"
   else
     meta = download
     target_dir = unpack meta
@@ -1302,8 +1305,7 @@ def install
     pre_install dest_dir
 
     # perform install process
-    # if @pkg.name.start_with?('ruby_')
-    if @pkg.superclass == 'RUBY'
+    if @pkg.superclass.to_s == 'RUBY'
       Dir.chdir(target_dir) do
         @pkg.install
       end
@@ -1378,7 +1380,7 @@ def build_package(crew_archive_dest)
   end
 
   # prepare filelist and dlist at CREW_DEST_DIR
-  prepare_package CREW_DEST_DIR unless @pkg.superclass == 'RUBY'
+  prepare_package CREW_DEST_DIR unless @pkg.superclass.to_s == 'RUBY'
 
   # build package from filelist, dlist and binary files in CREW_DEST_DIR
   puts 'Archiving...'
@@ -1441,7 +1443,7 @@ def upload(pkg_name = nil, pkg_version = nil, gitlab_token = nil, gitlab_token_u
     # The following is used to figure out where a non-standard
     # binary_sha256 section might be, such as in a gcc_lib file.
     starting_binary_sha256_hash = { armv7l: nil, i686: nil, x86_64: nil }
-    binary_compression = 'gem' if @pkg.superclass == 'RUBY'
+    binary_compression = 'gem' if @pkg.superclass.to_s == 'RUBY'
     %w[x86_64 i686 armv7l].each do |arch|
       # Load existing binary_sha256 hash from the package file.
       binary_sha256_hash[arch.to_sym] = @pkg.binary_sha256[arch.to_sym] if @pkg.binary_sha256&.key?(arch.to_sym)
@@ -1458,7 +1460,7 @@ def upload(pkg_name = nil, pkg_version = nil, gitlab_token = nil, gitlab_token_u
       end
       if binary_compression.nil?
         ext = File.extname(new_tarfile)
-        binary_compression = @pkg.superclass == 'RUBY' ? 'gem' : "tar#{ext}"
+        binary_compression = @pkg.superclass.to_s == 'RUBY' ? 'gem' : "tar#{ext}"
         binary_compression_line = "  binary_compression '#{binary_compression}'"
         puts "Setting binary compression in #{pkg_file} to '#{binary_compression}'..."
         # Add binary compression setting, and add the line if it doesn't exist.
@@ -1564,7 +1566,7 @@ def upload(pkg_name = nil, pkg_version = nil, gitlab_token = nil, gitlab_token_u
     # Upload python wheels if we are dealing with a pip package, but only
     # if a gitlab token username is set. (The generic repo does not
     # require a gitlab token username.)
-    next unless @pkg.superclass == 'Pip'
+    next unless @pkg.superclass.to_s == 'Pip'
     if gitlab_token_username.nil?
       puts "\nGITLAB_TOKEN_USERNAME environment variable not set, so generated python wheels will not be uploaded.\n".lightred
       next package

--- a/lib/buildsystems/autotools.rb
+++ b/lib/buildsystems/autotools.rb
@@ -1,6 +1,5 @@
 require 'fileutils'
-require_relative '../const'
-require_relative '../package'
+require 'package'
 
 class Autotools < Package
   property :configure_options, :pre_configure_options, :configure_build_extras, :configure_install_extras

--- a/lib/buildsystems/cmake.rb
+++ b/lib/buildsystems/cmake.rb
@@ -1,5 +1,4 @@
-require_relative '../const'
-require_relative '../package'
+require 'package'
 
 class CMake < Package
   property :cmake_build_extras, :cmake_build_relative_dir, :cmake_install_extras, :cmake_options, :pre_cmake_options

--- a/lib/buildsystems/meson.rb
+++ b/lib/buildsystems/meson.rb
@@ -1,5 +1,4 @@
-require_relative '../const'
-require_relative '../package'
+require 'package'
 
 class Meson < Package
   property :meson_options, :pre_meson_options, :meson_build_extras, :meson_install_extras

--- a/lib/buildsystems/perl.rb
+++ b/lib/buildsystems/perl.rb
@@ -1,5 +1,4 @@
-require_relative '../const'
-require_relative '../package'
+require 'package'
 
 class PERL < Package
   property :pre_perl_options, :perl_build_extras, :perl_install_extras

--- a/lib/buildsystems/pip.rb
+++ b/lib/buildsystems/pip.rb
@@ -1,8 +1,7 @@
 Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
 require 'json'
-require_relative '../const'
-require_relative '../package'
+require 'package'
 
 class Pip < Package
   property :pip_install_extras, :pre_configure_options
@@ -40,7 +39,7 @@ class Pip < Package
     end
     puts "Installing #{@py_pkg} python module. This may take a while...".lightblue
     puts "Additional pre_configure_options being used: #{@pre_configure_options.nil? ? '<no pre_configure_options>' : @pre_configure_options}".orange
-    puts "#{@py_pkg.capitalize} is configured to install a pre-release version." if prerelease
+    puts "#{@py_pkg.capitalize} is configured to install a pre-release version." if prerelease?
     system "MAKEFLAGS=-j#{CREW_NPROC} #{@pre_configure_options} python -s -m pip install --ignore-installed -U \"#{@py_pkg}==#{@py_pkg_chromebrew_version}\" | grep -v 'Requirement already satisfied'", exception: false
 
     if @source_url == 'SKIP'

--- a/lib/buildsystems/python.rb
+++ b/lib/buildsystems/python.rb
@@ -1,5 +1,4 @@
-require_relative '../const'
-require_relative '../package'
+require 'package'
 
 class Python < Package
   property :no_svem, :python_build_extras, :python_build_options, :python_build_relative_dir, :python_install_extras, :python_install_options

--- a/lib/buildsystems/qmake.rb
+++ b/lib/buildsystems/qmake.rb
@@ -1,5 +1,4 @@
-require_relative '../const'
-require_relative '../package'
+require 'package'
 
 class Qmake < Package
   property :qmake_build_extras, :qmake_install_extras

--- a/lib/buildsystems/ruby.rb
+++ b/lib/buildsystems/ruby.rb
@@ -2,63 +2,56 @@ require 'active_support/core_ext/object/blank'
 require 'package'
 require_relative '../package_helpers'
 
+def check_gem_binary_build_needed(gem_name = nil, gem_ver = nil)
+  puts "Checking to see if gem compile for #{gem_name} is needed..."
+  @extract_dir = "#{name}.#{Time.now.utc.strftime('%Y%m%d%H%M%S')}.dir"
+  FileUtils.mkdir_p File.join(CREW_BREW_DIR, @extract_dir)
+  Dir.chdir(File.join(CREW_BREW_DIR, @extract_dir)) do
+    # Need to check if the gem has extensions. If it does, we need
+    # either a compiler or a pre-compiled binary gem.
+    system "gem fetch #{gem_name} --platform=ruby --version=#{gem_ver}"
+    system "gem unpack #{gem_name}-#{gem_ver}.gem"
+    return system "grep -q -r spec.extensions  #{gem_name}-#{gem_ver}/*.gemspec", %i[out err] => File::NULL
+  end
+end
+
+def set_vars(passed_name = nil, passed_version = nil)
+  # crewlog "Setting gem variables... name: #{passed_name}, version: #{passed_version}"
+  # This assumes the package class name starts with 'Ruby_' and
+  # version is in the form '(gem version)-ruby-(ruby version)'.
+  # For example, name 'Ruby_awesome' and version '1.0.0-ruby-3.3'.
+  @gem_name = passed_name.sub('ruby_', '').sub('_', '-')
+  @gem_ver = passed_version.split('-').first.to_s
+  @pkg_ruby_ver = passed_version.split('ruby-').last.to_s
+end
+
 class RUBY < Package
-  property :ruby_install_extras
+  property :gem_name, :gem_ver, :pkg_ruby_ver, :ruby_install_extras
 
   depends_on 'ruby'
 
+  def self.preflight
+    set_vars(name, version)
+    # crewlog "@gem_name: #{@gem_name}, @gem_ver: #{@gem_ver}, @pkg_ruby_ver: #{@pkg_ruby_ver}"
+  end
+
   def self.preinstall
-    # This assumes the package class name starts with 'Ruby_' and
-    # version is in the form '(gem version)-ruby-(ruby version)'.
-    # For example, name 'Ruby_awesome' and version '1.0.0-ruby-3.3'.
-    # puts "@pkg.name is #{@pkg.name}"
-    # puts name
     @extract_dir = "#{name}.#{Time.now.utc.strftime('%Y%m%d%H%M%S')}.dir"
-    @gem_name = name.sub('ruby_', '').sub('_', '-')
-    @gem_ver = version.split('-', 2).first.to_s
-    @ruby_ver = version.split('-', 3).last.to_s
-    puts "no_compile_needed?: #{no_compile_needed?}, compile_needed?: #{compile_needed?}"
-    unless no_compile_needed? || compile_needed?
-      puts "Checking to see if gem compile for #{@gem_name} is needed..."
-      FileUtils.mkdir_p File.join(CREW_BREW_DIR, @extract_dir)
-      Dir.chdir(File.join(CREW_BREW_DIR, @extract_dir)) do
-        # Need to check if the gem has extensions. If it does, we need
-        # a compiler or a compuled version.
-        system "gem fetch #{@gem_name} --platform=ruby --version=#{@gem_ver}"
-        system "gem unpack #{@gem_name}-#{@gem_ver}.gem"
-        @gem_compile_needed = system "grep -q -r spec.extensions  #{@gem_name}-#{@gem_ver}/*.gemspec", %i[out err] => File::NULL
-      end
-    end
+    @gem_binary_build_needed = check_gem_binary_build_needed(@gem_name, @gem_version) unless no_compile_needed? || gem_compile_needed?
+  end
+
+  def self.build
+    return if no_compile_needed?
+
+    system "gem fetch #{@gem_name} --platform=ruby --version=#{@gem_ver}"
+    system "gem unpack #{@gem_name}-#{@gem_ver}.gem"
+    system "gem compile --strip --prune #{@gem_name}-#{@gem_ver}.gem"
   end
 
   def self.install
-    puts "no_compile_needed?: #{no_compile_needed?}, @gem_compile.needed.blank?: #{@gem_compile_needed.blank?}, compile_needed?: #{compile_needed?}"
-    if !no_compile_needed? || !@gem_compile_needed.blank? || compile_needed?
-      gem_arch = case ARCH
-                 when 'x86_64'
-                   'x86_64-linux'
-                 when 'i686'
-                   'x86-linux'
-                 when 'aarch64', 'armv7l'
-                   'armv8l-linux-eabihf'
-                 end
-      binary_compression 'gem'
-      gem_file = "#{@gem_name}-#{@gem_ver}-#{gem_arch}.gem"
-      gem_url = "#{CREW_GITLAB_PKG_REPO}/generic/#{name}/#{version}_#{ARCH}/#{gem_file}"
-      FileUtils.mkdir_p File.join(CREW_BREW_DIR, @extract_dir)
-      Dir.chdir(File.join(CREW_BREW_DIR, @extract_dir)) do
-        if `curl -sI #{gem_url}`.lines.first.split[1] == '200'
-          sha256sum = PackageUtils.get_sha256(@pkg, build_from_source: false)
-          downloader gem_url, sha256sum
-        else
-          puts "Download of binary gem for #{@gem_name} from the Chromebrew repo at #{gem_url} failed...".orange
-          abort 'Buildessential will need to be installed for this gem to be built.'.lightred unless system('which gcc', %i[out err] => File::NULL)
-          system "gem fetch #{@gem_name} --platform=ruby --version=#{@gem_ver}"
-          system "gem unpack #{@gem_name}-#{@gem_ver}.gem"
-          system "gem compile --strip --prune #{@gem_name}-#{@gem_ver}.gem"
-        end
-        system "gem install -N --local #{@gem_name}-#{@gem_ver}-#{gem_arch}.gem --conservative"
-      end
+    crewlog "no_compile_needed?: #{no_compile_needed?} @gem_binary_build_needed.blank?: #{@gem_binary_build_needed.blank?}, gem_compile_needed?: #{gem_compile_needed?}"
+    if !no_compile_needed? || !@gem_binary_build_needed.blank? || gem_compile_needed?
+      system "gem install -N --local #{@gem_name}-#{@gem_ver}-#{GEM_ARCH}.gem --conservative"
     elsif Kernel.system "gem list -i \"^#{@gem_name}\$\"", %i[out err] => File::NULL
       system "gem update -N #{@gem_name} --conservative"
     else

--- a/lib/buildsystems/ruby.rb
+++ b/lib/buildsystems/ruby.rb
@@ -1,30 +1,39 @@
-require_relative '../const'
-require_relative '../package'
+require 'active_support/core_ext/object/blank'
+require 'package'
+require_relative '../package_helpers'
 
 class RUBY < Package
   property :ruby_install_extras
 
   depends_on 'ruby'
-  depends_on 'ruby_gem_compiler'
 
-  no_compile_needed
-
-  def self.install
-    puts "prerelease is #{prerelease}"
-    # puts super(singleton_methods)
+  def self.preinstall
     # This assumes the package class name starts with 'Ruby_' and
     # version is in the form '(gem version)-ruby-(ruby version)'.
     # For example, name 'Ruby_awesome' and version '1.0.0-ruby-3.3'.
+    # puts "@pkg.name is #{@pkg.name}"
+    # puts name
+    @extract_dir = "#{name}.#{Time.now.utc.strftime('%Y%m%d%H%M%S')}.dir"
     @gem_name = name.sub('ruby_', '').sub('_', '-')
-    # We only report if @gem_ver is different than the current version reported by gem.
     @gem_ver = version.split('-', 2).first.to_s
     @ruby_ver = version.split('-', 3).last.to_s
-    # Need to check if a gem has extensions. If it does, we need
-    # buildessential.
-    system "gem fetch #{@gem_name} --platform=ruby --version=#{@gem_ver}"
-    system "gem unpack #{@gem_name}-#{@gem_ver}.gem"
-    gem_extensions = system "grep -q spec.extensions  #{@gem_name}-#{@gem_ver}/#{@gem_name}.gemspec"
-    if gem_extensions
+    puts "no_compile_needed?: #{no_compile_needed?}, compile_needed?: #{compile_needed?}"
+    unless no_compile_needed? || compile_needed?
+      puts "Checking to see if gem compile for #{@gem_name} is needed..."
+      FileUtils.mkdir_p File.join(CREW_BREW_DIR, @extract_dir)
+      Dir.chdir(File.join(CREW_BREW_DIR, @extract_dir)) do
+        # Need to check if the gem has extensions. If it does, we need
+        # a compiler or a compuled version.
+        system "gem fetch #{@gem_name} --platform=ruby --version=#{@gem_ver}"
+        system "gem unpack #{@gem_name}-#{@gem_ver}.gem"
+        @gem_compile_needed = system "grep -q -r spec.extensions  #{@gem_name}-#{@gem_ver}/*.gemspec", %i[out err] => File::NULL
+      end
+    end
+  end
+
+  def self.install
+    puts "no_compile_needed?: #{no_compile_needed?}, @gem_compile.needed.blank?: #{@gem_compile_needed.blank?}, compile_needed?: #{compile_needed?}"
+    if !no_compile_needed? || !@gem_compile_needed.blank? || compile_needed?
       gem_arch = case ARCH
                  when 'x86_64'
                    'x86_64-linux'
@@ -33,15 +42,23 @@ class RUBY < Package
                  when 'aarch64', 'armv7l'
                    'armv8l-linux-eabihf'
                  end
+      binary_compression 'gem'
       gem_file = "#{@gem_name}-#{@gem_ver}-#{gem_arch}.gem"
       gem_url = "#{CREW_GITLAB_PKG_REPO}/generic/#{name}/#{version}_#{ARCH}/#{gem_file}"
-      if `curl -sI #{gem_url}`.lines.first.split[1] == '200'
-        downloader gem_url, 'SKIP'
-      else
-        abort 'Buildessential needs to be installed for this gem to be built' unless system('which gcc', %i[out err] => File::NULL)
-        system "gem compile --strip --prune #{@gem_name}-#{@gem_ver}.gem"
+      FileUtils.mkdir_p File.join(CREW_BREW_DIR, @extract_dir)
+      Dir.chdir(File.join(CREW_BREW_DIR, @extract_dir)) do
+        if `curl -sI #{gem_url}`.lines.first.split[1] == '200'
+          sha256sum = PackageUtils.get_sha256(@pkg, build_from_source: false)
+          downloader gem_url, sha256sum
+        else
+          puts "Download of binary gem for #{@gem_name} from the Chromebrew repo at #{gem_url} failed...".orange
+          abort 'Buildessential will need to be installed for this gem to be built.'.lightred unless system('which gcc', %i[out err] => File::NULL)
+          system "gem fetch #{@gem_name} --platform=ruby --version=#{@gem_ver}"
+          system "gem unpack #{@gem_name}-#{@gem_ver}.gem"
+          system "gem compile --strip --prune #{@gem_name}-#{@gem_ver}.gem"
+        end
+        system "gem install -N --local #{@gem_name}-#{@gem_ver}-#{gem_arch}.gem --conservative"
       end
-      system "gem install --local #{@gem_name}-#{@gem_ver}-#{gem_arch}.gem"
     elsif Kernel.system "gem list -i \"^#{@gem_name}\$\"", %i[out err] => File::NULL
       system "gem update -N #{@gem_name} --conservative"
     else

--- a/lib/buildsystems/ruby.rb
+++ b/lib/buildsystems/ruby.rb
@@ -36,22 +36,23 @@ class RUBY < Package
   end
 
   def self.preinstall
-    @extract_dir = "#{name}.#{Time.now.utc.strftime('%Y%m%d%H%M%S')}.dir"
+    # @extract_dir = "#{name}.#{Time.now.utc.strftime('%Y%m%d%H%M%S')}.dir"
     @gem_binary_build_needed = check_gem_binary_build_needed(@gem_name, @gem_version) unless no_compile_needed? || gem_compile_needed?
   end
 
   def self.build
     return if no_compile_needed?
 
-    system "gem fetch #{@gem_name} --platform=ruby --version=#{@gem_ver}"
-    system "gem unpack #{@gem_name}-#{@gem_ver}.gem"
-    system "gem compile --strip --prune #{@gem_name}-#{@gem_ver}.gem"
+    Kernel.system "gem fetch #{@gem_name} --platform=ruby --version=#{@gem_ver}"
+    Kernel.system "gem unpack #{@gem_name}-#{@gem_ver}.gem"
+    Kernel.system "gem compile --strip --prune #{@gem_name}-#{@gem_ver}.gem"
   end
 
   def self.install
     crewlog "no_compile_needed?: #{no_compile_needed?} @gem_binary_build_needed.blank?: #{@gem_binary_build_needed.blank?}, gem_compile_needed?: #{gem_compile_needed?}"
     if !no_compile_needed? || !@gem_binary_build_needed.blank? || gem_compile_needed?
-      system "gem install -N --local #{@gem_name}-#{@gem_ver}-#{GEM_ARCH}.gem --conservative"
+      FileUtils.cp "#{@gem_name}-#{@gem_ver}-#{GEM_ARCH}.gem", CREW_DEST_DIR if File.file?("#{@gem_name}-#{@gem_ver}-#{GEM_ARCH}.gem")
+      system "gem install -N --local #{CREW_DEST_DIR}/#{@gem_name}-#{@gem_ver}-#{GEM_ARCH}.gem --conservative"
     elsif Kernel.system "gem list -i \"^#{@gem_name}\$\"", %i[out err] => File::NULL
       system "gem update -N #{@gem_name} --conservative"
     else

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -287,13 +287,13 @@ OPT
 CREW_CMAKE_LIBSUFFIX_OPTIONS ||= "#{CREW_CMAKE_OPTIONS} -DLIB_SUFFIX=#{CREW_LIB_SUFFIX}"
 
 GEM_ARCH ||= case ARCH
-           when 'x86_64'
-             'x86_64-linux'
-           when 'i686'
-             'x86-linux'
-           when 'aarch64', 'armv7l'
-             'armv8l-linux-eabihf'
-           end
+             when 'x86_64'
+               'x86_64-linux'
+             when 'i686'
+               'x86-linux'
+             when 'aarch64', 'armv7l'
+               'armv8l-linux-eabihf'
+             end
 
 PY3_SETUP_BUILD_OPTIONS          ||= "--executable=#{CREW_PREFIX}/bin/python3"
 PY2_SETUP_BUILD_OPTIONS          ||= "--executable=#{CREW_PREFIX}/bin/python2"

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.52.4' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.52.5' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]
@@ -285,6 +285,15 @@ CREW_CMAKE_FNO_LTO_OPTIONS ||= <<~OPT.chomp
 OPT
 
 CREW_CMAKE_LIBSUFFIX_OPTIONS ||= "#{CREW_CMAKE_OPTIONS} -DLIB_SUFFIX=#{CREW_LIB_SUFFIX}"
+
+GEM_ARCH ||= case ARCH
+           when 'x86_64'
+             'x86_64-linux'
+           when 'i686'
+             'x86-linux'
+           when 'aarch64', 'armv7l'
+             'armv8l-linux-eabihf'
+           end
 
 PY3_SETUP_BUILD_OPTIONS          ||= "--executable=#{CREW_PREFIX}/bin/python3"
 PY2_SETUP_BUILD_OPTIONS          ||= "--executable=#{CREW_PREFIX}/bin/python2"

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -42,7 +42,7 @@ def agree_with_default(yes_or_no_question_msg, character = nil, default:)
 end
 
 class Package
-  boolean_property :arch_flags_override, :conflicts_ok, :git_clone_deep, :git_fetchtags, :gnome, :is_fake, :is_musl, :is_static,
+  boolean_property :arch_flags_override, :compile_needed, :conflicts_ok, :git_clone_deep, :git_fetchtags, :gnome, :is_fake, :is_musl, :is_static,
                    :no_compile_needed, :no_compress, :no_env_options, :no_fhs, :no_git_submodules, :no_links, :no_lto, :no_patchelf,
                    :no_shrink, :no_source_build, :no_strip, :no_upstream_update, :no_zstd, :patchelf, :prerelease, :print_source_bashrc, :run_tests
 

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -42,7 +42,7 @@ def agree_with_default(yes_or_no_question_msg, character = nil, default:)
 end
 
 class Package
-  boolean_property :arch_flags_override, :compile_needed, :conflicts_ok, :git_clone_deep, :git_fetchtags, :gnome, :is_fake, :is_musl, :is_static,
+  boolean_property :arch_flags_override, :conflicts_ok, :git_clone_deep, :git_fetchtags, :gem_compile_needed, :gnome, :is_fake, :is_musl, :is_static,
                    :no_compile_needed, :no_compress, :no_env_options, :no_fhs, :no_git_submodules, :no_links, :no_lto, :no_patchelf,
                    :no_shrink, :no_source_build, :no_strip, :no_upstream_update, :no_zstd, :patchelf, :prerelease, :print_source_bashrc, :run_tests
 

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -172,8 +172,6 @@ class Buildessential < Package
   depends_on 'ruby_concurrent_ruby'
   # Needed for irb
   depends_on 'ruby_debug'
-  # Needed to build binary gems
-  depends_on 'ruby_gem_compiler'
   # For crew debugging.
   depends_on 'ruby_pry_byebug'
   # Add rubocop for linting packages. (This also installs the

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -179,8 +179,6 @@ class Buildessential < Package
   # Add rubocop for linting packages. (This also installs the
   # rubocop config file.)
   depends_on 'ruby_rubocop'
-  # crew check -V breaks without this.
-  depends_on 'ruby_ruby_libversion'
 
   # Code quality
   depends_on 'py3_pre_commit'

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -3,7 +3,7 @@ require 'package'
 class Buildessential < Package
   description 'A collection of tools essential to compile and build software.'
   homepage 'SKIP'
-  version '1.37'
+  version '1.38'
   license 'GPL-3+'
   compatibility 'all'
 
@@ -172,6 +172,8 @@ class Buildessential < Package
   depends_on 'ruby_concurrent_ruby'
   # Needed for irb
   depends_on 'ruby_debug'
+  # Needed to build binary gems
+  depends_on 'ruby_gem_compiler'
   # For crew debugging.
   depends_on 'ruby_pry_byebug'
   # Add rubocop for linting packages. (This also installs the

--- a/packages/core.rb
+++ b/packages/core.rb
@@ -3,7 +3,7 @@ require 'package'
 class Core < Package
   description 'Core Chromebrew Packages.'
   homepage 'https://github.com/chromebrew/chromebrew'
-  version '2.9'
+  version '3.0'
   license 'GPL-3+'
   compatibility 'all'
 
@@ -80,6 +80,8 @@ class Core < Package
   depends_on 'ruby'
   depends_on 'ruby_activesupport'
   depends_on 'ruby_concurrent_ruby'
+  # Allows for building binary gems if necessary.
+  depends_on 'ruby_gem_compiler'
   # For use in ruby prompts.
   depends_on 'ruby_highline'
   # This contains the debugger config files.

--- a/packages/core.rb
+++ b/packages/core.rb
@@ -86,6 +86,8 @@ class Core < Package
   depends_on 'ruby_highline'
   # This contains the debugger config files.
   depends_on 'ruby_pry'
+  # crew check -V breaks without this.
+  depends_on 'ruby_ruby_libversion'
   depends_on 'slang'
   depends_on 'sqlite'
   depends_on 'uchardet'

--- a/packages/ruby.rb
+++ b/packages/ruby.rb
@@ -67,6 +67,5 @@ class Ruby < Package
     puts 'Updating ruby gems. This may take a while...'
     silent = @opt_verbose ? '' : '--silent'
     system "gem update #{silent} -N --system", exception: false
-    system 'gem pristine --all', exception: false
   end
 end

--- a/packages/ruby_debug.rb
+++ b/packages/ruby_debug.rb
@@ -9,6 +9,13 @@ class Ruby_debug < RUBY
   source_url 'SKIP'
   binary_compression 'gem'
 
+  binary_sha256({
+    aarch64: '6b7344390da0b795d379c4e95ce41242a6392324a9c1f5e27bbba9a4b01a792a',
+     armv7l: '6b7344390da0b795d379c4e95ce41242a6392324a9c1f5e27bbba9a4b01a792a',
+       i686: '149ddb718f60aba21ca7aa3370df2e650d2b316117285b29c7de158da91711f7',
+     x86_64: 'ec3e4a33ea6dd305c666c641e510b891816483116313e7c35d683b2dbcabd035'
+  })
+
   conflicts_ok
   gem_compile_needed
   no_source_build

--- a/packages/ruby_debug.rb
+++ b/packages/ruby_debug.rb
@@ -9,5 +9,5 @@ class Ruby_debug < RUBY
   source_url 'SKIP'
 
   conflicts_ok
-  no_compile_needed
+  compile_needed
 end

--- a/packages/ruby_debug.rb
+++ b/packages/ruby_debug.rb
@@ -9,5 +9,6 @@ class Ruby_debug < RUBY
   source_url 'SKIP'
 
   conflicts_ok
-  compile_needed
+  gem_compile_needed
+  no_source_build
 end

--- a/packages/ruby_debug.rb
+++ b/packages/ruby_debug.rb
@@ -7,6 +7,7 @@ class Ruby_debug < RUBY
   license 'MIT'
   compatibility 'all'
   source_url 'SKIP'
+  binary_compression 'gem'
 
   conflicts_ok
   gem_compile_needed

--- a/packages/ruby_gem_compiler.rb
+++ b/packages/ruby_gem_compiler.rb
@@ -1,0 +1,13 @@
+require 'buildsystems/ruby'
+
+class Ruby_gem_compiler < RUBY
+  description 'Gem-compiler is a plugin that helps generates binary gems from already existing ones without altering the original source code.'
+  homepage 'https://github.com/luislavena/gem-compiler'
+  version '0.9.0-ruby-3.3'
+  license 'MIT'
+  compatibility 'all'
+  source_url 'SKIP'
+
+  conflicts_ok
+  no_compile_needed
+end

--- a/packages/ruby_rubocop.rb
+++ b/packages/ruby_rubocop.rb
@@ -15,6 +15,5 @@ class Ruby_rubocop < RUBY
   depends_on 'xdg_base'
 
   conflicts_ok
-  no_compile_needed
   no_fhs
 end

--- a/packages/ruby_rubocop.rb
+++ b/packages/ruby_rubocop.rb
@@ -16,4 +16,5 @@ class Ruby_rubocop < RUBY
 
   conflicts_ok
   no_fhs
+  no_compile_needed
 end

--- a/packages/ruby_ruby_libversion.rb
+++ b/packages/ruby_ruby_libversion.rb
@@ -7,6 +7,7 @@ class Ruby_ruby_libversion < RUBY
   license 'MIT'
   compatibility 'all'
   source_url 'SKIP'
+  binary_compression 'gem'
 
   depends_on 'libversion' # R
   gem_compile_needed

--- a/packages/ruby_ruby_libversion.rb
+++ b/packages/ruby_ruby_libversion.rb
@@ -9,6 +9,13 @@ class Ruby_ruby_libversion < RUBY
   source_url 'SKIP'
   binary_compression 'gem'
 
+  binary_sha256({
+    aarch64: '694e8851a3a5f683fe2b13d3021857d13377a666681db13f9921d704fb23eead',
+     armv7l: '694e8851a3a5f683fe2b13d3021857d13377a666681db13f9921d704fb23eead',
+       i686: 'e811dc6dbf8237b43736535722d29c0a1241ce6cf6d5120a61d412d569194986',
+     x86_64: 'f52ded350de72587350361049a671e19a9d387e41ceac582a83b3d7bb50db234'
+  })
+
   depends_on 'libversion' # R
   gem_compile_needed
   no_source_build

--- a/packages/ruby_ruby_libversion.rb
+++ b/packages/ruby_ruby_libversion.rb
@@ -3,11 +3,12 @@ require 'buildsystems/ruby'
 class Ruby_ruby_libversion < RUBY
   description 'Ruby bindings for libversion.'
   homepage 'https://github.com/Zopolis4/ruby-libversion'
-  version '1.0.0-ruby-3.3'
+  version '1.0.0-1-ruby-3.3'
   license 'MIT'
   compatibility 'all'
   source_url 'SKIP'
 
   depends_on 'libversion' # R
-  compile_needed
+  gem_compile_needed
+  no_source_build
 end

--- a/packages/ruby_ruby_libversion.rb
+++ b/packages/ruby_ruby_libversion.rb
@@ -9,6 +9,5 @@ class Ruby_ruby_libversion < RUBY
   source_url 'SKIP'
 
   depends_on 'libversion' # R
-
-  no_compile_needed
+  compile_needed
 end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -7891,6 +7891,11 @@ url: https://github.com/docopt/docopt/releases
 activity: none
 ---
 kind: url
+name: ruby_gem_compiler
+url: https://github.com/luislavena/gem-compiler/releases
+activity: low
+---
+kind: url
 name: ruby_glib2
 url: https://rubygems.org/gems/glib2
 activity: medium

--- a/tools/update_ruby_gem_packages.rb
+++ b/tools/update_ruby_gem_packages.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# update_ruby_gem_packages version 1.2 (for Chromebrew)
+# update_ruby_gem_packages version 1.3 (for Chromebrew)
 # Author: Satadru Pramanik (satmandu) satadru at gmail dot com
 # Usage in root of cloned chromebrew repo:
 # tools/update_ruby_gem_packages.rb
@@ -41,7 +41,7 @@ relevant_gem_packages.each_with_index do |package, index|
   pool.post do
     gem_name = package.gsub('.rb', '').sub('ruby_', '').gsub('_', '-').gsub('packages/', '')
     puts "[#{(index + 1).to_s.rjust(numlength)}/#{total_files_to_check}] Checking rubygems for updates to #{gem_name}...".orange
-    pkg_version = `sed -n -e 's/^\ \ version //p' #{package}`.chomp.delete("'").delete('"').gsub(ruby_ver_string, '')
+    pkg_version = `sed -n -e 's/^\ \ version //p' #{package}`.chomp.delete("'").delete('"').gsub(ruby_ver_string, '').split('-').first
     gem_version = Gem.latest_spec_for(gem_name).version.to_s
     next package if gem_version.blank?
     if Gem::Version.new(gem_version) > Gem::Version.new(pkg_version)


### PR DESCRIPTION
Fixes #10483 

- `def upload` was refactored to handle binary gems, and also to use regex and gsub to add and replace the binary_sha256 blocks in package files.
- `crew` was refactored to add functionality to generate, install, and upload binary gems for gems that have extensions which need compiling. (This includes `ruby_ruby_libversion` and `ruby_debug`.)
- `buildsystems/ruby` was modified accordingly to also 
- Adds the `ruby_gem_compiler` package which is needed for building binary gems.
- Moves `ruby_ruby_libversion` from `buildessential` to `core` as it can now be installed without a compiler present.
- Removes the unecessary `require_relative` from buildsystems files.
- Removes `gem pristine` from the ruby postinstall since the root cause of the debug gem messages are from the ruby debug gem being newer than the version bundled with ruby.

##
Builds:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=gem crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
