### PR TITLE
Add timeout to crew highline prompts with defaults

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.52.5' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.52.6' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]
@@ -107,6 +107,8 @@ CREW_NPROC ||= \
   end
 
 # Set following as boolean if environment variables exist.
+# Timeout for agree questions in package.rb:
+CREW_AGREE_TIMEOUT_SECONDS           ||= ENV.fetch('CREW_AGREE_TIMEOUT_SECONDS', 10) unless defined?(CREW_AGREE_TIMEOUT_SECONDS)
 CREW_CACHE_ENABLED                   ||= ENV.fetch('CREW_CACHE_ENABLED', false) unless defined?(CREW_CACHE_ENABLED)
 CREW_CONFLICTS_ONLY_ADVISORY         ||= ENV.fetch('CREW_CONFLICTS_ONLY_ADVISORY', false) unless defined?(CREW_CONFLICTS_ONLY_ADVISORY)
 # or use conflicts_ok

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -1,5 +1,6 @@
 require 'English'
 require 'json'
+require 'timeout'
 require_relative 'const'
 require_relative 'color'
 require_relative 'package_helpers'
@@ -84,11 +85,19 @@ class Package
   end
 
   def self.agree_default_no(message = nil)
-    return agree_with_default("#{message} (yes/NO)?", true, default: 'n')
+    Timeout.timeout(CREW_AGREE_TIMEOUT_SECONDS) do
+      return agree_with_default("#{message} (yes/NO)?", true, default: 'n')
+    end
+  rescue Timeout::Error
+    return true
   end
 
   def self.agree_default_yes(message = nil)
-    return agree_with_default("#{message} (YES/no)?", true, default: 'y')
+    Timeout.timeout(CREW_AGREE_TIMEOUT_SECONDS) do
+      return agree_with_default("#{message} (YES/no)?", true, default: 'y')
+    end
+  rescue Timeout::Error
+    return true
   end
 
   def self.load_package(pkg_file)

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -1,6 +1,5 @@
 require 'English'
 require 'json'
-require 'timeout'
 require_relative 'const'
 require_relative 'color'
 require_relative 'package_helpers'
@@ -26,6 +25,7 @@ def require_gem(gem_name_and_require = nil, require_override = nil)
   require requires
 end
 require_gem 'highline'
+require_gem 'timeout'
 
 def agree_with_default(yes_or_no_question_msg, character = nil, default:)
   yes_or_no_question = yes_or_no_question_msg.lightpurple
@@ -68,22 +68,6 @@ class Package
     attr_accessor :build_from_source, :cached_build, :in_build, :in_install, :in_upgrade, :name
   end
 
-  def self.agree_to_remove(config_object = nil)
-    if File.file? config_object
-      identifier = 'file'
-    elsif File.directory? config_object
-      identifier = 'directory'
-    else
-      abort "Cannot identify #{config_object}.".lightred
-    end
-    if agree_with_default("Would you like to remove the config #{identifier}: #{config_object} (YES/no)?", true, default: 'y')
-      FileUtils.rm_rf config_object
-      puts "#{config_object} removed.".lightgreen
-    else
-      puts "#{config_object} saved.".lightgreen
-    end
-  end
-
   def self.agree_default_no(message = nil)
     Timeout.timeout(CREW_AGREE_TIMEOUT_SECONDS) do
       return agree_with_default("#{message} (yes/NO)?", true, default: 'n')
@@ -98,6 +82,22 @@ class Package
     end
   rescue Timeout::Error
     return true
+  end
+
+  def self.agree_to_remove(config_object = nil)
+    if File.file? config_object
+      identifier = 'file'
+    elsif File.directory? config_object
+      identifier = 'directory'
+    else
+      abort "Cannot identify #{config_object}.".lightred
+    end
+    if agree_default_no("Would you like to remove the config #{identifier}: #{config_object}")
+      puts "#{config_object} saved.".lightgreen
+    else
+      FileUtils.rm_rf config_object
+      puts "#{config_object} removed.".lightgreen
+    end
   end
 
   def self.load_package(pkg_file)

--- a/tools/build_updated_packages.rb
+++ b/tools/build_updated_packages.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# build_updated_packages version 1.1 (for Chromebrew)
+# build_updated_packages version 1.2 (for Chromebrew)
 # This updates the versions in python pip packages by calling
 # tools/update_python_pip_packages.rb, checks for updated ruby packages
 # by calling tools/update_ruby_gem_packages.rb, and then checks if any
@@ -36,6 +36,7 @@ def require_gem(gem_name_and_require = nil, require_override = nil)
   require requires
 end
 require_gem 'highline'
+require_gem 'timeout'
 
 # The following is from lib/package_helpers.rb
 def property(*properties)
@@ -112,8 +113,12 @@ def agree_with_default(yes_or_no_question_msg, character = nil, default:)
   end
 end
 
-def agree_default_yes(message = nil)
-  return agree_with_default("#{message} (YES/no)?", true, default: 'y')
+def self.agree_default_yes(message = nil)
+  Timeout.timeout(CREW_AGREE_TIMEOUT_SECONDS) do
+    return agree_with_default("#{message} (YES/no)?", true, default: 'y')
+  end
+rescue Timeout::Error
+  return true
 end
 
 # Get all boolean properties from package.rb


### PR DESCRIPTION
- This helps with scripting crew functions...

##
Builds:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/<Please_enter_the_name_of_your_repo>/chromebrew.git CREW_BRANCH=<Please_enter_the_branch_name_for_this_PR> crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
