### PR TITLE
Edge 128.0.2739.79-1 => 129.0.2792.52-1

### DIFF
--- a/packages/edge.rb
+++ b/packages/edge.rb
@@ -3,12 +3,12 @@ require 'package'
 class Edge < Package
   description 'Microsoft Edge is the fast and secure browser'
   homepage 'https://www.microsoft.com/en-us/edge'
-  version '128.0.2739.79-1'
+  version '129.0.2792.52-1'
   license 'MIT'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_#{version}_amd64.deb"
-  source_sha256 '6238024b9d240927b76bb199021fe6e804d04759b61992638871755f5cc444f5'
+  source_sha256 'b62aba3f00eb1fc65cb5fc83cdaf56dd63ac8fb340aefe17c8c3c6594edf5bb0'
 
   depends_on 'at_spi2_core'
   depends_on 'libcom_err'


### PR DESCRIPTION
Tested & (not) Working properly:
- [x] `x86_64` Unable to launch in hatch m126 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-edge crew update \
&& yes | crew upgrade
```