### PR TITLE
Fix boolean logic, and also file path in build_updated_packages.

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1456,7 +1456,7 @@ def upload(pkg_name = nil, pkg_version = nil, gitlab_token = nil, gitlab_token_u
                     end
       if new_tarfile.nil? || !File.file?(new_tarfile)
         puts "#{release_dir}/#{package}-#{pkg_version}-chromeos-#{arch}.#{binary_compression.nil? ? '(tar.xz|tar.zst)' : binary_compression} not found.\n".lightred
-        next
+        next arch
       end
       if binary_compression.nil?
         ext = File.extname(new_tarfile)
@@ -1485,25 +1485,27 @@ def upload(pkg_name = nil, pkg_version = nil, gitlab_token = nil, gitlab_token_u
         end
       end
       puts "Package: #{package}, Arch: #{arch}".yellow
-      puts 'Generating sha256sum ...'
+      puts
+      puts "\e[1A\e[KGenerating sha256sum ...\r".orange
       new_sha256 = Digest::SHA256.hexdigest(File.read(new_tarfile))
-      puts "Uploading #{new_tarfile} ..."
+      puts "Uploading #{new_tarfile} ...".orange if CREW_VERBOSE
       noname = new_tarfile.split("#{package}-").last
       new_version = noname.split('-chromeos').first
       new_url = "#{CREW_GITLAB_PKG_REPO}/generic/#{package}/#{new_version}_#{arch}/#{new_tarfile}".gsub("#{release_dir}/", '')
       token_label = gitlab_token.split('-').first == 'glpat' ? 'PRIVATE-TOKEN' : 'DEPLOY-TOKEN'
 
       if `curl -sI #{new_url}`.lines.first.split[1] == '200'
-        puts "\n#{new_tarfile} has already been uploaded.\nPlease change the #{package} package version from #{new_version} and try again.\n".lightred
+        puts "\n#{File.basename(new_tarfile)} has already been uploaded.\nPlease change the #{package} package version from #{new_version} and try again.\n".lightred
         if Package.agree_default_no('Do you want to overwrite the existing upload instead')
+          puts "\e[1A\e[KOverwriting existing upload...\r".orange
           crewlog "#{arch} = #{new_sha256}"
           binary_sha256_hash[arch.to_sym] = new_sha256
         else
-          puts 'Will NOT overwite the existing upload.'.orange
+          puts "\e[1A\e[KWill NOT overwite the existing upload.\r".orange
           upstream_sha256 = `curl -Ls #{new_url} | sha256sum`.chomp.split.first
           crewlog "#{arch} = #{upstream_sha256}"
           binary_sha256_hash[arch.to_sym] = upstream_sha256
-          next
+          next arch
         end
       else
         crewlog "#{arch} = #{new_sha256}"
@@ -1511,7 +1513,9 @@ def upload(pkg_name = nil, pkg_version = nil, gitlab_token = nil, gitlab_token_u
       end
 
       puts "curl -# --header \"#{token_label}: #{gitlab_token}\" --upload-file \"#{new_tarfile}\" \"#{new_url}\" | cat" if CREW_VERBOSE
+      puts "\e[1A\e[KUploading...\r".orange
       output = `curl -# --header "#{token_label}: #{gitlab_token}" --upload-file "#{new_tarfile}" "#{new_url}" | cat`.chomp
+      puts "\e[1A\e[KChecking upload...\r".orange
       if output.include?('201 Created')
         puts "curl -Ls #{new_url} | sha256sum" if CREW_VERBOSE
         upstream_sha256 = `curl -Ls #{new_url} | sha256sum`.chomp.split.first
@@ -1531,6 +1535,9 @@ def upload(pkg_name = nil, pkg_version = nil, gitlab_token = nil, gitlab_token_u
         next
       end
     end
+
+    # Generate new or replacement binary_sha256 block.
+    puts "\e[1A\e[KGenerating binary_sha256 block for package file...\r".orange
     binary_sha256_block = ''
     binary_sha256_block << "\n  binary_sha256({\n"
     unless binary_sha256_hash[:armv7l].nil?
@@ -1562,6 +1569,7 @@ def upload(pkg_name = nil, pkg_version = nil, gitlab_token = nil, gitlab_token_u
       binary_sha256_block_with_bc = "#{file.match(bc_re)}\n#{binary_sha256_block}"
       File.write(pkg_file, file.gsub(bc_re, binary_sha256_block_with_bc))
     end
+    puts "\e[1A\e[KUploads complete for #{package}.\r".orange
 
     # Upload python wheels if we are dealing with a pip package, but only
     # if a gitlab token username is set. (The generic repo does not

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.52.7' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.52.8' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -69,14 +69,16 @@ class Package
   end
 
   def self.agree_default_no(message = nil)
+    # This defaults to false.
     Timeout.timeout(CREW_AGREE_TIMEOUT_SECONDS) do
       return agree_with_default("#{message} (yes/NO)?", true, default: 'n')
     end
   rescue Timeout::Error
-    return true
+    return false
   end
 
   def self.agree_default_yes(message = nil)
+    # This defaults to true.
     Timeout.timeout(CREW_AGREE_TIMEOUT_SECONDS) do
       return agree_with_default("#{message} (YES/no)?", true, default: 'y')
     end
@@ -93,10 +95,10 @@ class Package
       abort "Cannot identify #{config_object}.".lightred
     end
     if agree_default_no("Would you like to remove the config #{identifier}: #{config_object}")
-      puts "#{config_object} saved.".lightgreen
-    else
       FileUtils.rm_rf config_object
       puts "#{config_object} removed.".lightgreen
+    else
+      puts "#{config_object} saved.".lightgreen
     end
   end
 

--- a/tools/build_updated_packages.rb
+++ b/tools/build_updated_packages.rb
@@ -184,7 +184,7 @@ updated_packages.each do |pkg|
     else
       puts "#{name.capitalize} #{@version} needs builds uploaded for: #{build.join(' ')}".lightblue
     end
-    system "yes | crew build -f #{pkg}" if build.include?(ARCH) && !File.file?("release/#{ARCH}#{name}-#{@version}-chromeos-#{ARCH}.#{@binary_compression}") && agree_default_yes("\nWould you like to build #{name} #{@version}")
-    system "crew upload #{name}" if build.include?(ARCH) && File.file?("release/#{ARCH}#{name}-#{@version}-chromeos-#{ARCH}.#{@binary_compression}") && agree_default_yes("\nWould you like to upload #{name} #{@version}")
+    system "yes | crew build -f #{pkg}" if build.include?(ARCH) && !File.file?("release/#{ARCH}/#{name}-#{@version}-chromeos-#{ARCH}.#{@binary_compression}") && agree_default_yes("\nWould you like to build #{name} #{@version}")
+    system "crew upload #{name}" if build.include?(ARCH) && File.file?("release/#{ARCH}/#{name}-#{@version}-chromeos-#{ARCH}.#{@binary_compression}") && agree_default_yes("\nWould you like to upload #{name} #{@version}")
   end
 end


### PR DESCRIPTION
- Also make upload display a little nicer using ansi codes to redraw replacing transient info messages. (This is already used in the pip update script.)
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=boolean crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
