### PR TITLE
Zed 0.153.6 => 0.153.7

### DIFF
--- a/packages/zed.rb
+++ b/packages/zed.rb
@@ -3,12 +3,12 @@ require 'package'
 class Zed < Package
   description 'Zed is a high-performance, multiplayer code editor'
   homepage 'https://zed.dev/'
-  version '0.153.6'
+  version '0.153.7'
   license 'GPL-3, AGPL-3, Apache-2.0'
   compatibility 'x86_64'
   min_glibc '2.28'
   source_url "https://github.com/zed-industries/zed/releases/download/v#{version}/zed-linux-x86_64.tar.gz"
-  source_sha256 '43f6d9f9eb7ced5d42056c37126afbf5c477020541e002f829d39bb70f424e43'
+  source_sha256 '45a06d815b131d8d48ee5b11b00101e4d24b4c0e72722640058c22c9e0d538a8'
 
   depends_on 'alsa_lib'
   depends_on 'libbsd'


### PR DESCRIPTION
Tested & (not)  Working properly:
- [x] `x86_64` Unable  to launch in hatch m126 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-zed crew update \
&& yes | crew upgrade
```