### PR TITLE
Adjust ruby gem installs to use begin/rescue block for gem loading

### DIFF
--- a/lib/buildsystems/ruby.rb
+++ b/lib/buildsystems/ruby.rb
@@ -63,7 +63,13 @@ class RUBY < Package
     @gem_outdated = !@gem_installed && gem_installed_anyver
     crewlog "preflight: @gem_name: #{@gem_name}, @gem_ver: #{@gem_ver}, @gem_outdated: #{@gem_outdated}, @gem_installed: #{@gem_installed} && @remote_gem_ver.to_s: #{Gem::Version.new(@remote_gem_ver.to_s)} == Gem::Version.new(@gem_ver): #{Gem::Version.new(@gem_ver)} && File.file?(@gem_filelist_path): #{File.file?(@gem_filelist_path)}"
     if @gem_installed && Gem::Version.new(@remote_gem_ver.to_s) == Gem::Version.new(@gem_ver)
-      require_gem(@gem_name)
+      begin
+        gem @gem_name
+      rescue LoadError
+        puts " -> install #{@gem_name} gem".orange
+        Gem.install(@gem_name)
+        gem @gem_name
+      end
       system "gem contents #{@gem_name} > #{@gem_filelist_path}" unless File.file?(@gem_filelist_path)
       @install_gem = false
     end

--- a/lib/buildsystems/ruby.rb
+++ b/lib/buildsystems/ruby.rb
@@ -63,6 +63,7 @@ class RUBY < Package
     @gem_outdated = !@gem_installed && gem_installed_anyver
     crewlog "preflight: @gem_name: #{@gem_name}, @gem_ver: #{@gem_ver}, @gem_outdated: #{@gem_outdated}, @gem_installed: #{@gem_installed} && @remote_gem_ver.to_s: #{Gem::Version.new(@remote_gem_ver.to_s)} == Gem::Version.new(@gem_ver): #{Gem::Version.new(@gem_ver)} && File.file?(@gem_filelist_path): #{File.file?(@gem_filelist_path)}"
     if @gem_installed && Gem::Version.new(@remote_gem_ver.to_s) == Gem::Version.new(@gem_ver)
+      # Make sure gem is installed before trying to get files from the gem...
       begin
         gem @gem_name
       rescue LoadError
@@ -71,7 +72,9 @@ class RUBY < Package
         gem @gem_name
       end
       system "gem contents #{@gem_name} > #{@gem_filelist_path}" unless File.file?(@gem_filelist_path)
-      @install_gem = false
+      @device = ConvenienceFunctions.load_symbolized_json
+      pkg_info = @device[:installed_packages].select { |pkg| pkg[:name] == name } [0]
+      @install_gem = false if Gem::Version.new(version) == pkg_info[:version]
     end
   end
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.53.4' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.53.5' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]

--- a/packages/ruby_ruby_libversion.rb
+++ b/packages/ruby_ruby_libversion.rb
@@ -3,20 +3,19 @@ require 'buildsystems/ruby'
 class Ruby_ruby_libversion < RUBY
   description 'Ruby bindings for libversion.'
   homepage 'https://github.com/Zopolis4/ruby-libversion'
-  version "1.0.0-1-#{CREW_RUBY_VER}"
+  version "1.0.0-2-#{CREW_RUBY_VER}"
   license 'MIT'
   compatibility 'all'
   source_url 'SKIP'
   binary_compression 'gem'
 
   binary_sha256({
-    aarch64: '3695d5a8f942a6586b0ec2f521a8a3ffc66e70e2cb09259a3d4a70f6e3c219b8',
-     armv7l: '3695d5a8f942a6586b0ec2f521a8a3ffc66e70e2cb09259a3d4a70f6e3c219b8',
-       i686: '7929685c52eb57310365fade401bd03a313011a136d665cfaaf902c6b8ee79b9',
-     x86_64: 'd01237a0dc9a72a6a623273eef7d4df7df333945e8c45e7f5f8e96b9d97e9855'
+    aarch64: 'b82794a10b04fa6041bdf836a300527704b87db1cbf167a545f38456899e1dcf',
+     armv7l: 'b82794a10b04fa6041bdf836a300527704b87db1cbf167a545f38456899e1dcf',
+       i686: '2b2dadb3a8d2a0289bd40558fd5d3ef8b25e31157eb9a02558369c9e47b1783b',
+     x86_64: 'ab7b4acda26268bca9fd13a88db52113ac7b99a4e906f26f41fda5f72b2beb58'
   })
 
   depends_on 'libversion' # R
   gem_compile_needed
-  no_source_build
 end


### PR DESCRIPTION
- Also rebuilds `ruby_ruby_libversion` to force reinstall for `ruby-libversion`.

Builds:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=ruby_libversion crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
