### PR TITLE
Vivaldi 6.9.3447.48-1 => 6.9.3447.51-1

### DIFF
--- a/manifest/armv7l/v/vivaldi.filelist
+++ b/manifest/armv7l/v/vivaldi.filelist
@@ -207,7 +207,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/adblocker_resources/redirectable_resources.json
 /usr/local/share/vivaldi/resources/vivaldi/background-bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/background-common-bundle.js
-/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-560cd6c4877abbf0d034ce785ccddfba.js
+/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-743bab1744c9c3b8cbd9546c247ac8c5.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle-mailreader-worker.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/components/mail/mail.html
@@ -241,6 +241,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/es-PE.json
 /usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/es-VE.json
 /usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/fallback-partner-ids.json
+/usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/fr-BE.json
 /usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/fr-FR.json
 /usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/id-ID.json
 /usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/is-IS.json
@@ -249,6 +250,8 @@
 /usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/mk-SG.json
 /usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/my-MY.json
 /usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/nb-NO.json
+/usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/nl-BE.json
+/usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/nl-NL.json
 /usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/nn-NO.json
 /usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/partners-locale-map.json
 /usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/partners.json
@@ -319,8 +322,10 @@
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/berlingske_dk.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/biobiochile_cl.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/blocket_se.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/favicons/bol.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/bookingcom_com.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/bt_dk.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/favicons/buienradar.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/carrefour_fr.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/cdiscount_com.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/cdon_com.png
@@ -382,6 +387,8 @@
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/ndtv_com.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/news_abs-cbn_com.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/news_com_au.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/favicons/nos.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/favicons/npo.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/nvidia.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/onliner_by.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/ostrovok_ru.png
@@ -401,7 +408,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/sapo_pt.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/setn_com.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/seznam.png
-/usr/local/share/vivaldi/resources/vivaldi/resources/favicons/shein_com.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/favicons/shein.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/shopee_pl.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/spiegel_de.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/spotify.png
@@ -412,6 +419,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/submarino_com_br.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/target_com.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/telegraf_com_ua.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/favicons/temu.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/theguardian_com.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/tidal.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/unext_jp.png
@@ -484,9 +492,11 @@
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_ben_prothomalo.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_bestbuy.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_blick.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_bol.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_booking.com.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_br_americanas.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_bs_klix.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_buienradar.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_by_21vek.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_by_5element.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_by_citydog.png
@@ -639,6 +649,8 @@
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_nl_cw_curacaocr.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_no_bonprix.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_no_cdon.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_nos.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_npo.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_nz_stuff.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_outlook.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_overstock.png
@@ -673,6 +685,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_ru_tutu.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_ru_yandex.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_ru_yandex_games.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_shein.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_si_lankanews.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_simplygames.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_sk_auktality.png
@@ -690,6 +703,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_target.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_techcrunch.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_ted.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_temu.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_th_sanook.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_tr_cnnturk.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_tr_haberturk.png

--- a/manifest/x86_64/v/vivaldi.filelist
+++ b/manifest/x86_64/v/vivaldi.filelist
@@ -207,7 +207,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/adblocker_resources/redirectable_resources.json
 /usr/local/share/vivaldi/resources/vivaldi/background-bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/background-common-bundle.js
-/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-077b1f841e5fec83e2058a7bde82cfe1.js
+/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-5e5fc05618043701a1e2605248894ced.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle-mailreader-worker.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/components/mail/mail.html
@@ -241,6 +241,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/es-PE.json
 /usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/es-VE.json
 /usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/fallback-partner-ids.json
+/usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/fr-BE.json
 /usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/fr-FR.json
 /usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/id-ID.json
 /usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/is-IS.json
@@ -249,6 +250,8 @@
 /usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/mk-SG.json
 /usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/my-MY.json
 /usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/nb-NO.json
+/usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/nl-BE.json
+/usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/nl-NL.json
 /usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/nn-NO.json
 /usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/partners-locale-map.json
 /usr/local/share/vivaldi/resources/vivaldi/default-bookmarks/partners.json
@@ -319,8 +322,10 @@
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/berlingske_dk.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/biobiochile_cl.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/blocket_se.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/favicons/bol.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/bookingcom_com.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/bt_dk.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/favicons/buienradar.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/carrefour_fr.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/cdiscount_com.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/cdon_com.png
@@ -382,6 +387,8 @@
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/ndtv_com.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/news_abs-cbn_com.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/news_com_au.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/favicons/nos.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/favicons/npo.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/nvidia.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/onliner_by.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/ostrovok_ru.png
@@ -401,7 +408,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/sapo_pt.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/setn_com.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/seznam.png
-/usr/local/share/vivaldi/resources/vivaldi/resources/favicons/shein_com.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/favicons/shein.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/shopee_pl.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/spiegel_de.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/spotify.png
@@ -412,6 +419,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/submarino_com_br.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/target_com.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/telegraf_com_ua.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/favicons/temu.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/theguardian_com.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/tidal.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/favicons/unext_jp.png
@@ -484,9 +492,11 @@
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_ben_prothomalo.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_bestbuy.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_blick.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_bol.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_booking.com.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_br_americanas.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_bs_klix.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_buienradar.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_by_21vek.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_by_5element.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_by_citydog.png
@@ -639,6 +649,8 @@
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_nl_cw_curacaocr.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_no_bonprix.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_no_cdon.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_nos.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_npo.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_nz_stuff.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_outlook.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_overstock.png
@@ -673,6 +685,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_ru_tutu.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_ru_yandex.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_ru_yandex_games.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_shein.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_si_lankanews.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_simplygames.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_sk_auktality.png
@@ -690,6 +703,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_target.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_techcrunch.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_ted.png
+/usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_temu.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_th_sanook.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_tr_cnnturk.png
 /usr/local/share/vivaldi/resources/vivaldi/resources/sd_thumbnails/sd_tr_haberturk.png

--- a/packages/vivaldi.rb
+++ b/packages/vivaldi.rb
@@ -3,7 +3,7 @@ require 'package'
 class Vivaldi < Package
   description 'Vivaldi is a new browser that blocks unwanted ads, protects you from trackers, and puts you in control with unique built-in features.'
   homepage 'https://vivaldi.com/'
-  version '6.9.3447.48-1'
+  version '6.9.3447.51-1'
   license 'Vivaldi'
   compatibility 'x86_64 aarch64 armv7l'
   min_glibc '2.29'
@@ -23,10 +23,10 @@ class Vivaldi < Package
   case ARCH
   when 'aarch64', 'armv7l'
     arch = 'armhf'
-    source_sha256 '555f3a51c9831c709356ec67de9dc7092f3e412cb4ef3f86824aa95f9b066e9d'
+    source_sha256 '0604e4265062e8f58f998e2d16981645fffdbedc4b9b9cfee11507aae0921f20'
   when 'x86_64'
     arch = 'amd64'
-    source_sha256 '9a12420985cff5ec80f18aae499b279b9a34e15998e4d47054ce6f2aa6dd919b'
+    source_sha256 'fe2ce28004fd7aa860c60628b0ca03a0f200d2b3827983a8b448da8a00536b39'
   end
 
   source_url "https://downloads.vivaldi.com/stable/vivaldi-stable_#{version}_#{arch}.deb"


### PR DESCRIPTION
Tested & (not) Working properly:
- [x] `x86_64` Unable to launch in hatch m128 container
- [x] `armv7l`  Unable to launch in strongbad m128  container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-vivaldi crew update \
&& yes | crew upgrade
```