### PR TITLE
Update nftables and libnftnl dependency

### DIFF
--- a/packages/libnftnl.rb
+++ b/packages/libnftnl.rb
@@ -4,17 +4,17 @@ class Libnftnl < Autotools
   description 'libnftnl is a userspace library providing a low-level netlink programming interface (API) to the in-kernel nf_tables subsystem.'
   homepage 'https://netfilter.org/projects/libnftnl/'
   license 'GPL-2'
-  version '1.2.7'
+  version '1.2.8'
   compatibility 'all'
   source_url "https://netfilter.org/projects/libnftnl/files/libnftnl-#{version}.tar.xz"
-  source_sha256 '9122774f968093d5c0bacddd67de480f31fa4073405a7fc058a34b0f387aecb3'
+  source_sha256 '37fea5d6b5c9b08de7920d298de3cdc942e7ae64b1a3e8b880b2d390ae67ad95'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'e063c6205897f01460d0fa1692cdc458197588f483332f90e8f88f75f890c420',
-     armv7l: 'e063c6205897f01460d0fa1692cdc458197588f483332f90e8f88f75f890c420',
-       i686: '1377c81d11c0c7c5a32b0c75a72b54ecc2ad3f5c46cee733ba24d3dfb027f79f',
-     x86_64: '534d939421b14d0063b07af88ba7251b8255d122aa197303334a7726576d683a'
+    aarch64: '7c093a2a0cbee0292fb2e0d41bc54181b79e8105bbebb076782a9c160c6d6006',
+     armv7l: '7c093a2a0cbee0292fb2e0d41bc54181b79e8105bbebb076782a9c160c6d6006',
+       i686: 'c003b4116ed6c4a5e2f9abc8400f96a4312e16446d957a0a3f2865541b2cb982',
+     x86_64: '2a276eb55a9671e9314dd161e5605e8719222ff37b4beda1668614816309686f'
   })
 
   depends_on 'glibc' # R

--- a/packages/nftables.rb
+++ b/packages/nftables.rb
@@ -6,17 +6,17 @@ require 'buildsystems/autotools'
 class Nftables < Autotools
   description 'Netfilter tables userspace tools'
   homepage 'https://netfilter.org/projects/nftables/'
-  version '1.1.0'
+  version '1.1.1'
   license 'GPL2'
   compatibility 'x86_64 aarch64 armv7l'
   source_url "https://netfilter.org/projects/nftables/files/nftables-#{version}.tar.xz"
-  source_sha256 'ef3373294886c5b607ee7be82c56a25bc04e75f802f8e8adcd55aac91eb0aa24'
+  source_sha256 '6358830f3a64f31e39b0ad421d7dadcd240b72343ded48d8ef13b8faf204865a'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '25b41af243ada6343ee8805e2e50b8dfcba33a6c65ef9f66c40fb6003146e3a0',
-     armv7l: '25b41af243ada6343ee8805e2e50b8dfcba33a6c65ef9f66c40fb6003146e3a0',
-     x86_64: 'bd633d09e225c49097d1e5f10bb97fd3371cb75c4b498ef8df4f6a6e5b7b2cc4'
+    aarch64: '9ef8444cc26ca8958a118ab23214ee1c93e4c8a82be3d3ee9d94378665b29bba',
+     armv7l: '9ef8444cc26ca8958a118ab23214ee1c93e4c8a82be3d3ee9d94378665b29bba',
+     x86_64: '64193fb122b88b0aa0c66fa65ac20c9e10aaafb55b40f459b204b08c785b4b19'
   })
 
   depends_on 'asciidoc' => :build


### PR DESCRIPTION
All tests passed.
- Libnftnl 1.2.7 => 1.2.8
- Nftables 1.1.0 => 1.1.1
##
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l` 
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-nftables crew update \
&& yes | crew upgrade
```