### PR TITLE
Opera 114.0.5282.21 => 114.0.5282.86

### DIFF
--- a/packages/opera.rb
+++ b/packages/opera.rb
@@ -3,7 +3,7 @@ require 'package'
 class Opera < Package
   description 'Opera is a multi-platform web browser based on Chromium and developed by Opera Software.'
   homepage 'https://www.opera.com/'
-  version '114.0.5282.21'
+  version '114.0.5282.86'
   license 'OPERA-2018'
   compatibility 'x86_64'
   min_glibc '2.29'
@@ -11,7 +11,7 @@ class Opera < Package
   # faster apt mirror, but only works when downloading latest version of opera
   # source_url "https://deb.opera.com/opera/pool/non-free/o/opera-stable/opera-stable_#{version}_amd64.deb"
   source_url "https://deb.opera.com/opera-stable/pool/non-free/o/opera-stable/opera-stable_#{version}_amd64.deb"
-  source_sha256 'c615bc9bc771aca084ab0d1394d9b60220d4cb368a86d574ca40ba6ac1fe7b68'
+  source_sha256 '16415e1d1f46979ccf8bee20e48b312a3bffbb6e8327cdfa47b38cd7d2804de2'
 
   depends_on 'gtk3'
   depends_on 'gsettings_desktop_schemas'


### PR DESCRIPTION
Tested & (not) Working properly:
- [x] `x86_64` Unable to launch in hatch m128 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-opera crew update \
&& yes | crew upgrade
```