### PR TITLE
Ruby gem install adjustments.

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -143,6 +143,12 @@ end
 at_exit do
   GnomePostinstall.run unless GnomePostinstall.gnome_packages.blank?
 
+  # Do gem cleanups all at once if needed.
+  unless @gems_needing_cleanup.blank?
+    puts "Running gem cleanup for gems: #{@gems_needing_cleanup.join(' ')}".orange
+    system "gem cleanup #{@gems_needing_cleanup.join(' ')}"
+  end
+
   # Print exit messages.
   ExitMessage.print
 end
@@ -253,52 +259,54 @@ end
 def update
   abort "'crew update' is used to update crew itself. Use 'crew upgrade <package1> [<package2> ...]' to update specific packages.".orange if @pkg_name
 
-  # The following is used in fixup.rb to determine if crew update needs to
-  # be run again.
-  @crew_const_git_commit = `git -C #{CREW_LIB_PATH} log -n1 --oneline #{CREW_LIB_PATH}/lib/const.rb`.split.first
+  unless CREW_NO_GIT
+    # The following is used in fixup.rb to determine if crew update needs to
+    # be run again.
+    @crew_const_git_commit = `git -C #{CREW_LIB_PATH} log -n1 --oneline #{CREW_LIB_PATH}/lib/const.rb`.split.first
 
-  unless Dir.exist?(File.join(CREW_LIB_PATH, '.git'))
-    puts 'Fixing Chromebrew system git repo clone...'.orange
-    system(<<~GIT_REPAIR_COMMANDS, chdir: CREW_LIB_PATH, %i[out err] => File::NULL)
-      ## Run the git setup commands used in install.sh.
-      # Make the git default branch error messages go away.
-      git config --global init.defaultBranch main
-      # Setup the dir with git information.
-      git init --ref-format=reftable
-      git remote add origin #{CREW_REPO}
-      # Help handle situations where GitHub is down.
-      git config --local http.lowSpeedLimit 1000
-      git config --local http.lowSpeedTime 5
-      # Checkout, overwriting local files.
-      git fetch --all
-      git checkout -f master
-      git reset --hard origin/#{CREW_BRANCH}
-    GIT_REPAIR_COMMANDS
+    unless Dir.exist?(File.join(CREW_LIB_PATH, '.git'))
+      puts 'Fixing Chromebrew system git repo clone...'.orange
+      system(<<~GIT_REPAIR_COMMANDS, chdir: CREW_LIB_PATH, %i[out err] => File::NULL)
+        ## Run the git setup commands used in install.sh.
+        # Make the git default branch error messages go away.
+        git config --global init.defaultBranch main
+        # Setup the dir with git information.
+        git init --ref-format=reftable
+        git remote add origin #{CREW_REPO}
+        # Help handle situations where GitHub is down.
+        git config --local http.lowSpeedLimit 1000
+        git config --local http.lowSpeedTime 5
+        # Checkout, overwriting local files.
+        git fetch --all
+        git checkout -f master
+        git reset --hard origin/#{CREW_BRANCH}
+      GIT_REPAIR_COMMANDS
+    end
+
+    system(<<~GIT_UPDATE_COMMANDS, chdir: CREW_LIB_PATH, exception: true)
+      ## Update crew from git.
+      # Set sparse-checkout folders.
+      git sparse-checkout set packages manifest/#{ARCH} lib commands bin crew tests tools
+      git sparse-checkout reapply
+      git fetch #{CREW_REPO} #{CREW_BRANCH}
+      git reset --hard FETCH_HEAD
+    GIT_UPDATE_COMMANDS
+    system(<<~GIT_RESTORE_MTIME_COMMAND, chdir: CREW_LIB_PATH, exception: true) if File.file?("#{CREW_PREFIX}/bin/git-restore-mtime")
+      # Set the mtime on each file in git to the date the file was added,
+      # not to the date of the last git pull.
+      git-restore-mtime -sq 2>/dev/null
+    GIT_RESTORE_MTIME_COMMAND
+
+    if Time.now.to_i - @last_update_check > (CREW_UPDATE_CHECK_INTERVAL * 3600 * 24)
+      puts 'Updating RubyGems.'.orange
+      system 'gem update -N --system'
+      system 'gem cleanup'
+    end
+    puts 'Package lists, crew, and library updated.'
+
+    # Do any fixups necessary after crew has updated from git.
+    load "#{CREW_LIB_PATH}/lib/fixup.rb"
   end
-
-  system(<<~GIT_UPDATE_COMMANDS, chdir: CREW_LIB_PATH, exception: true)
-    ## Update crew from git.
-    # Set sparse-checkout folders.
-    git sparse-checkout set packages manifest/#{ARCH} lib commands bin crew tests tools
-    git sparse-checkout reapply
-    git fetch #{CREW_REPO} #{CREW_BRANCH}
-    git reset --hard FETCH_HEAD
-  GIT_UPDATE_COMMANDS
-  system(<<~GIT_RESTORE_MTIME_COMMAND, chdir: CREW_LIB_PATH, exception: true) if File.file?("#{CREW_PREFIX}/bin/git-restore-mtime")
-    # Set the mtime on each file in git to the date the file was added,
-    # not to the date of the last git pull.
-    git-restore-mtime -sq 2>/dev/null
-  GIT_RESTORE_MTIME_COMMAND
-
-  if Time.now.to_i - @last_update_check > (CREW_UPDATE_CHECK_INTERVAL * 3600 * 24)
-    puts 'Updating RubyGems.'.orange
-    system 'gem update -N --system'
-    system 'gem cleanup'
-  end
-  puts 'Package lists, crew, and library updated.'
-
-  # Do any fixups necessary after crew has updated from git.
-  load "#{CREW_LIB_PATH}/lib/fixup.rb"
 
   # update compatible packages
   generate_compatible

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.53.8' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.53.9' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]
@@ -93,6 +93,7 @@ CREW_DEST_HOME          ||= File.join(CREW_DEST_DIR, HOME)
 CREW_CACHE_DIR          ||= ENV.fetch('CREW_CACHE_DIR', "#{HOME}/.cache/crewcache") unless defined?(CREW_CACHE_DIR)
 CREW_CACHE_BUILD        ||= ENV.fetch('CREW_CACHE_BUILD', false) unless defined?(CREW_CACHE_BUILD)
 CREW_CACHE_FAILED_BUILD ||= ENV.fetch('CREW_CACHE_FAILED_BUILD', false) unless defined?(CREW_CACHE_FAILED_BUILD)
+CREW_NO_GIT             ||= ENV.fetch('CREW_NO_GIT', false) unless defined?(CREW_NO_GIT)
 
 CREW_DEBUG   ||= ARGV.intersect?(%w[-D --debug]) unless defined?(CREW_DEBUG)
 CREW_FORCE   ||= ARGV.intersect?(%w[-f --force]) unless defined?(CREW_FORCE)


### PR DESCRIPTION
- Also adds tweaks for a forthcoming adjustment to build_updates that uses `crew update` to get changed files that need updates. (This requires passing`CREW_NO_GIT=1` to crew at the command line to avoid using a git pull...)
- Goal is to try to minimize calls to rubygems during gem installs...

- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=rubycrew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
