### PR TITLE
Allow for crew download to handle is_fake packages.

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -447,6 +447,17 @@ def upgrade(*pkgs, build_from_source: false)
 end
 
 def download
+  if ARGV.intersect?(%w[download]) && @pkg.is_fake?
+    return if CREW_FORCE
+    fake_pkg_deplist = @pkg.get_deps_list(return_attr: true).flat_map(&:keys).uniq
+    puts "Will download the following packages: #{fake_pkg_deplist.join(' ')}".orange
+    fake_pkg_deplist.each do |fake_pkg_dep|
+      system "crew download -f #{fake_pkg_dep}"
+    end
+
+    return
+  end
+
   url = PackageUtils.get_url(@pkg, build_from_source: @opt_source || @pkg.build_from_source)
   source = @pkg.source?(@device[:architecture])
 

--- a/bin/crew
+++ b/bin/crew
@@ -447,17 +447,6 @@ def upgrade(*pkgs, build_from_source: false)
 end
 
 def download
-  if ARGV.intersect?(%w[download]) && @pkg.is_fake?
-    return if CREW_FORCE
-    fake_pkg_deplist = @pkg.get_deps_list(return_attr: true).flat_map(&:keys).uniq
-    puts "Will download the following packages: #{fake_pkg_deplist.join(' ')}".orange
-    fake_pkg_deplist.each do |fake_pkg_dep|
-      system "crew download -f #{fake_pkg_dep}"
-    end
-
-    return
-  end
-
   url = PackageUtils.get_url(@pkg, build_from_source: @opt_source || @pkg.build_from_source)
   source = @pkg.source?(@device[:architecture])
 
@@ -1753,7 +1742,31 @@ def download_command(args)
     search @pkg_name
     @pkg.build_from_source = true if @opt_source
     print_current_package CREW_VERBOSE
-    download
+    if ARGV.intersect?(%w[download]) && @pkg.is_fake?
+      fake_pkg_deplist = @pkg.get_deps_list(return_attr: true).flat_map(&:keys).uniq
+      until fake_pkg_deplist.blank?
+        puts "Will download the following packages: #{fake_pkg_deplist.join(' ')}".orange
+        fake_pkg_deplist.each_with_index do |fake_pkg_dep, index|
+          @pkg_name = fake_pkg_dep
+          search @pkg_name
+          @pkg.build_from_source = true if @opt_source
+          if @pkg.is_fake?
+            puts "Expanding #{fake_pkg_dep}...".lightpurple
+            expanded_pkg_list = @pkg.get_deps_list(return_attr: true).flat_map(&:keys).uniq
+            fake_pkg_deplist.push(*expanded_pkg_list)
+            fake_pkg_deplist.delete(@pkg_name)
+            next fake_pkg_dep
+          end
+          total_files_to_check = fake_pkg_deplist.length
+          numlength = total_files_to_check.to_s.length
+          puts "[#{(index + 1).to_s.rjust(numlength)}/#{total_files_to_check}] Downloading #{fake_pkg_dep}...".blue
+          download
+          fake_pkg_deplist.delete(@pkg_name)
+        end
+      end
+    else
+      download
+    end
   end
 end
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.53.9' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.54.0' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]


### PR DESCRIPTION
- This just allows for download of dependencies in `is_fake` packages.

Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=is_fake_download crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
