### PR TITLE
Add options for minimal output crew update.

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -311,9 +311,10 @@ def update
   # update compatible packages
   generate_compatible
   # check for outdated installed packages
-  puts 'Checking for package updates...'
+  puts 'Checking for package updates...' unless CREW_UNATTENDED
 
   can_be_updated = 0
+  updatable_packages = []
   @device[:installed_packages].each do |package|
     search package[:name], silent: true
     unless @pkg
@@ -329,16 +330,21 @@ def update
     if different_version && !different_sha && has_sha
       unless @pkg.no_compile_needed?
         can_be_updated -= 1
-        puts "#{@pkg.name} has a version change but does not have updated binaries".yellow
+        updatable_packages.push(@pkg.name)
+        puts "#{@pkg.name} has a version change but does not have updated binaries".yellow unless CREW_UNATTENDED
       end
     elsif different_version
-      puts "#{@pkg.name} could be updated from #{package[:version]} to #{@pkg.version}"
+      updatable_packages.push(@pkg.name)
+      puts "#{@pkg.name} could be updated from #{package[:version]} to #{@pkg.version}" unless CREW_UNATTENDED
     elsif !different_version && different_sha
-      puts "#{@pkg.name} could be updated (rebuild)"
+      updatable_packages.push(@pkg.name)
+      puts "#{@pkg.name} could be updated (rebuild)" unless CREW_UNATTENDED
     end
   end
 
-  if can_be_updated.positive?
+  if CREW_UNATTENDED && can_be_updated.positive?
+    puts updatable_packages
+  elsif can_be_updated.positive?
     puts "\n#{can_be_updated} packages can be updated."
     puts 'Run `crew upgrade` to update all packages or `crew upgrade <package1> [<package2> ...]` to update specific packages.'
   else

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.54.0' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.54.1' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]
@@ -94,6 +94,7 @@ CREW_CACHE_DIR          ||= ENV.fetch('CREW_CACHE_DIR', "#{HOME}/.cache/crewcach
 CREW_CACHE_BUILD        ||= ENV.fetch('CREW_CACHE_BUILD', false) unless defined?(CREW_CACHE_BUILD)
 CREW_CACHE_FAILED_BUILD ||= ENV.fetch('CREW_CACHE_FAILED_BUILD', false) unless defined?(CREW_CACHE_FAILED_BUILD)
 CREW_NO_GIT             ||= ENV.fetch('CREW_NO_GIT', false) unless defined?(CREW_NO_GIT)
+CREW_UNATTENDED         ||= ENV.fetch('CREW_UNATTENDED', false) unless defined?(CREW_UNATTENDED)
 
 CREW_DEBUG   ||= ARGV.intersect?(%w[-D --debug]) unless defined?(CREW_DEBUG)
 CREW_FORCE   ||= ARGV.intersect?(%w[-f --force]) unless defined?(CREW_FORCE)

--- a/tools/build_updated_packages.rb
+++ b/tools/build_updated_packages.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# build_updated_packages version 1.6 (for Chromebrew)
+# build_updated_packages version 1.7 (for Chromebrew)
 # This updates the versions in python pip packages by calling
 # tools/update_python_pip_packages.rb, checks for updated ruby packages
 # by calling tools/update_ruby_gem_packages.rb, and then checks if any

--- a/tools/build_updated_packages.rb
+++ b/tools/build_updated_packages.rb
@@ -170,6 +170,8 @@ else
   updated_packages.each { |p| puts p.sub('packages/', '').sub('.rb', '').to_s.lightblue }
 end
 
+updated_packages << `CREW_NO_GIT=1 CREW_UNATTENDED=1 crew update`.chomp
+updated_packages.uniq!
 updated_packages.each do |pkg|
   name = pkg.sub('packages/', '').sub('.rb', '')
 


### PR DESCRIPTION
- The goal is to be able to pipe output of crew update without additional massage of the output.
##
Builds:
- [ ] `x86_64`
- [ ] `i686`
- [ ] `armv7l`
##
Tested & Working properly:
- [ ] `x86_64`
- [ ] `i686`
- [ ] `armv7l` <!-- (reasons why it doesn't) -->
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=build crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
