### PR TITLE
Use ptools to enable the use of File.which in lieu of the various usages of which we have now.

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -21,12 +21,14 @@ def require_gem(gem_name_and_require = nil, require_override = nil)
              end
   require requires
 end
+require_gem('activesupport', 'active_support/core_ext/object/blank')
 require_gem('highline')
 # The json gem can break when upgrading from a much older version of ruby.
 require_gem('json')
-require_gem('activesupport', 'active_support/core_ext/object/blank')
+require_gem('ptools')
 require 'digest/sha2'
 require 'fileutils'
+require 'mkmf'
 require 'tmpdir'
 require 'uri'
 begin
@@ -883,7 +885,7 @@ def prepare_package(destdir)
     abort 'Exiting due to above errors.'.lightred if errors
 
     # Make sure the package file has runtime dependencies added properly.
-    system "#{CREW_LIB_PATH}/tools/getrealdeps.rb --use-crew-dest-dir #{@pkg.name}", exception: true if Kernel.system('which gawk', %i[out err] => File::NULL) && Kernel.system('which upx', %i[out err] => File::NULL) && !@pkg.no_compile_needed?
+    system "#{CREW_LIB_PATH}/tools/getrealdeps.rb --use-crew-dest-dir #{@pkg.name}", exception: true if File.which('gawk') && File.which('upx') && !@pkg.no_compile_needed?
     # create directory list
     # Remove CREW_PREFIX and HOME from the generated directorylist.
     crew_prefix_escaped = CREW_PREFIX.gsub('/', '\/')
@@ -1347,7 +1349,7 @@ def install
   crewlog "Adding package #{@pkg.name} to device.json."
   @device[:installed_packages].delete_if { |entry| entry[:name] == @pkg.name } and @device[:installed_packages].push(name: @pkg.name, version: @pkg.version, sha256: PackageUtils.get_sha256(@pkg, build_from_source: @opt_source))
   ConvenienceFunctions.save_json(@device)
-  crewlog "#{@pkg.name} in device.json after install: #{`jq --arg key '#{@pkg.name}' -e '.installed_packages[] | select(.name == $key )' #{File.join(CREW_CONFIG_PATH, 'device.json')}`}" if Kernel.system 'which jq', %i[out err] => File::NULL
+  crewlog "#{@pkg.name} in device.json after install: #{`jq --arg key '#{@pkg.name}' -e '.installed_packages[] | select(.name == $key )' #{File.join(CREW_CONFIG_PATH, 'device.json')}`}" if File.which('jq')
   @pkg.in_install = false
 end
 
@@ -1411,7 +1413,7 @@ def archive_package(crew_archive_dest)
     pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.gem"
     FileUtils.mv File.join(CREW_DEST_DIR, gem_file), File.join(crew_archive_dest, pkg_name)
   # Only use zstd if it is available.
-  elsif @pkg.no_zstd? || !Kernel.system('which zstd', %i[out err] => File::NULL)
+  elsif @pkg.no_zstd? || !File.which('zstd')
     puts 'Using xz to compress package. This may take some time.'.lightblue
     pkg_name = "#{@pkg.name}-#{@pkg.version}-chromeos-#{@device[:architecture]}.tar.xz"
     Dir.chdir CREW_DEST_DIR do

--- a/install.sh
+++ b/install.sh
@@ -339,7 +339,7 @@ gem update --no-update-sources -N --system
 gem cleanup
 
 echo_info "Installing essential ruby gems...\n"
-BOOTSTRAP_GEMS='activesupport concurrent-ruby highline'
+BOOTSTRAP_GEMS='activesupport concurrent-ruby highline ptools'
 # shellcheck disable=SC2086
 install_ruby_gem ${BOOTSTRAP_GEMS}
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.54.3' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.54.4' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -25,6 +25,7 @@ def require_gem(gem_name_and_require = nil, require_override = nil)
   require requires
 end
 require_gem('activesupport', 'active_support/core_ext/object/blank')
+require_gem('ptools')
 
 begin
   require 'securerandom'
@@ -193,7 +194,7 @@ def external_downloader(uri, filename = File.basename(url), verbose = false)
   #    %<output>s: Will be substitute to #{filename}
   # i686 curl throws a "SSL certificate problem: self signed certificate in certificate chain" error.
   # Only bypass this when we are using the system curl early in install.
-  @default_curl = `which curl`.chomp
+  @default_curl = File.which('curl')
   curl_cmdline = ARCH == 'i686' && @default_curl == '/usr/bin/curl' ? 'curl %<verbose>s -kL -# --retry %<retry>s %<url>s -o %<output>s' : 'curl %<verbose>s -L -# --retry %<retry>s %<url>s -o %<output>s'
 
   # use CREW_DOWNLOADER if specified, use curl by default

--- a/packages/core.rb
+++ b/packages/core.rb
@@ -3,7 +3,7 @@ require 'package'
 class Core < Package
   description 'Core Chromebrew Packages.'
   homepage 'https://github.com/chromebrew/chromebrew'
-  version '3.2'
+  version '3.3'
   license 'GPL-3+'
   compatibility 'all'
 
@@ -85,6 +85,8 @@ class Core < Package
   depends_on 'ruby_gem_compiler'
   # For use in ruby prompts.
   depends_on 'ruby_highline'
+  # Adds File.which
+  depends_on 'ruby_ptools'
   # This contains the debugger config files.
   depends_on 'ruby_pry'
   # crew check -V breaks without this.

--- a/packages/py3_setuptools.rb
+++ b/packages/py3_setuptools.rb
@@ -1,4 +1,5 @@
 require 'buildsystems/python'
+require 'ptools'
 
 class Py3_setuptools < Python
   description 'Setuptools is the python build system from the Python Packaging Authority.'
@@ -23,7 +24,7 @@ class Py3_setuptools < Python
   conflicts_ok
 
   def self.prebuild
-    if Kernel.system('which zstd', %i[out err] => File::NULL)
+    if File.which('zstd')
       system 'python3 -m pip uninstall setuptools -y', exception: false
       system 'python3 -m pip install -I --force-reinstall --no-deps setuptools', exception: false
     end

--- a/packages/ruby_ptools.rb
+++ b/packages/ruby_ptools.rb
@@ -1,7 +1,7 @@
 require 'buildsystems/ruby'
 
 class Ruby_ptools < RUBY
-  description "The ptools (power tools) library is an additional set of commands for the File class based on Unix command line tools."
+  description 'The ptools (power tools) library is an additional set of commands for the File class based on Unix command line tools.'
   homepage 'https://github.com/djberg96/ptools'
   version "1.5.0-#{CREW_RUBY_VER}"
   license 'Apache-2.0'

--- a/packages/ruby_ptools.rb
+++ b/packages/ruby_ptools.rb
@@ -1,0 +1,13 @@
+require 'buildsystems/ruby'
+
+class Ruby_ptools < RUBY
+  description "The ptools (power tools) library is an additional set of commands for the File class based on Unix command line tools."
+  homepage 'https://github.com/djberg96/ptools'
+  version "1.5.0-#{CREW_RUBY_VER}"
+  license 'Apache-2.0'
+  compatibility 'all'
+  source_url 'SKIP'
+
+  conflicts_ok
+  no_compile_needed
+end

--- a/packages/ruby_rbs.rb
+++ b/packages/ruby_rbs.rb
@@ -17,6 +17,7 @@ class Ruby_rbs < RUBY
   })
 
   depends_on 'ruby_abbrev' # R
+  depends_on 'ruby_logger' # R
 
   conflicts_ok
   gem_compile_needed


### PR DESCRIPTION
- Also adds a `ruby_ptools` package.

Tested & Working properly:
- [ ] `x86_64`
- [ ] `i686`
- [ ] `armv7l` <!-- (reasons why it doesn't) -->
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=fix crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
