### PR TITLE
Use more gem caching to speed up gem installs.

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -57,6 +57,7 @@ require_relative '../lib/crewlog'
 require_relative '../lib/deb_utils'
 require_relative '../lib/docopt'
 require_relative '../lib/downloader'
+require_relative '../lib/gem_compact_index_client'
 require_relative '../lib/gnome'
 require_relative '../lib/misc_functions'
 require_relative '../lib/package'
@@ -741,6 +742,21 @@ end
 def pre_flight
   puts "Performing pre-flight checks for #{@pkg.name}...".lightblue
   abort PackageUtils.incompatible_reason(@pkg).join("\n").to_s.lightred unless PackageUtils.compatible?(@pkg)
+  if @pkg.superclass.to_s == 'RUBY'
+    puts 'Populating gem information using compact index client...'.lightgreen
+    $gems ||= BasicCompactIndexClient.new.gems
+    puts 'Done populating gem information.'.lightgreen
+    # Update gem sources if updated more than 1 day previously.
+    gem_spec_cache_dir = File.join(Gem.default_spec_cache_dir, 'rubygems.org%443')
+    FileUtils.mkdir_p gem_spec_cache_dir
+    gem_spec_cache_dir_age = (Time.now.to_i - File.mtime(gem_spec_cache_dir).utc.to_i)
+    puts "Gem source cache age: #{gem_spec_cache_dir_age}".lightgreen if CREW_VERBOSE
+    if gem_spec_cache_dir_age > (3600 * 24)
+      puts 'Updating gem source cache.'.lightgreen if CREW_VERBOSE
+      Kernel.system('gem sources -u')
+      puts 'Done updating gem source cache.'.lightgreen if CREW_VERBOSE
+    end
+  end
   @pkg.preflight
 end
 

--- a/lib/buildsystems/ruby.rb
+++ b/lib/buildsystems/ruby.rb
@@ -42,11 +42,6 @@ def set_vars(passed_name = nil, passed_version = nil)
   # version is in the form '(gem version)-ruby-(ruby version)'.
   # For example, name 'Ruby_awesome' and version '1.0.0-ruby-3.3'.
 
-  # Update gem sources if updated more than 1 hour previously.
-  ruby_gems_spec_cache_dir = File.join(Gem.default_spec_cache_dir, 'rubygems.org%443')
-  FileUtils.mkdir_p ruby_gems_spec_cache_dir
-  Kernel.system('gem sources -u') if (Time.now.to_i - File.mtime(ruby_gems_spec_cache_dir).utc.to_i) > (3600)
-
   # Just use the fetcher.suggest_gems_from_name function to figure out
   # proper gem name with the appropriate dashes and underscores.
   if CREW_VERBOSE
@@ -58,8 +53,11 @@ def set_vars(passed_name = nil, passed_version = nil)
       end
     end)
   end
-  @gem_name = Gem::SpecFetcher.fetcher.suggest_gems_from_name(passed_name.gsub(/^ruby_/, '')).first
-  @remote_gem_ver = Gem.latest_version_for(@gem_name).to_s
+  gem_test = $gems.grep(/#{name.gsub(/^ruby_/, '')}/).first
+  gem_test_name = gem_test.split.first
+  gem_test_version = gem_test.split[1].split(',').last
+  @gem_name = gem_test_name.blank? ? Gem::SpecFetcher.fetcher.suggest_gems_from_name(passed_name.gsub(/^ruby_/, '')).first : gem_test_name
+  @remote_gem_ver = gem_test_name.blank? ? Gem.latest_version_for(@gem_name).to_s : gem_test_version
   @gem_ver = passed_version.split('-').first.to_s
   @gem_package_ver = @gem_ver.dup
   # Use latest gem version.

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.54.4' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.54.5' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]

--- a/lib/gem_compact_index_client.rb
+++ b/lib/gem_compact_index_client.rb
@@ -1,0 +1,36 @@
+require 'uri'
+require 'net/http'
+
+# Adapted from https://github.com/rubygems/rubygems/issues/8012#issuecomment-2375499571
+# by @duckinator (Ellen Marie Dash)
+# A very bare-bones client for the Compact Index API
+# https://guides.rubygems.org/rubygems-org-compact-index-api/
+
+class BasicCompactIndexClient
+  def initialize(gem_server = 'https://rubygems.org/')
+    @gem_server = gem_server
+  end
+
+  # Returns a list of all gems on the specified gem server.
+  def gems
+    lines(request('/versions'))
+  end
+
+  private
+
+  def request(endpoint)
+    uri = URI.join(@gem_server, endpoint)
+    response = Net::HTTP.get_response(uri)
+
+    raise "got HTTP code #{response.code}, expected 200" unless response.is_a?(Net::HTTPOK)
+
+    response.body
+  end
+
+  def lines(data)
+    return [] if data.nil? || data.empty?
+    lines = data.split("\n")
+    header = lines.index('---')
+    header ? lines[header + 1..] : lines
+  end
+end


### PR DESCRIPTION
- Try to do more caching of gem information, and try to avoid reloading gem information for every gem install.
- I'm storing the gem cache in a global variable `$gems` but I'm open to suggestions on how to avoid that if there is a more elegant way to do this.

##
Builds:
- [ ] `x86_64`
- [ ] `i686`
- [ ] `armv7l`
##
Tested & Working properly:
- [ ] `x86_64`
- [ ] `i686`
- [ ] `armv7l` <!-- (reasons why it doesn't) -->
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=ruby crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
