### PR TITLE
Fix issue with overmatching gem names.

### DIFF
--- a/.github/workflows/Rubocop.yml
+++ b/.github/workflows/Rubocop.yml
@@ -1,6 +1,9 @@
 ---
 name: Rubocop
 on: workflow_call
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   rubocop:
     runs-on: ubuntu-latest

--- a/install.sh
+++ b/install.sh
@@ -337,12 +337,14 @@ gem update --no-update-sources -N --system
 gem cleanup
 
 # Mark packages as installed for pre-installed gems.
-mapfile -t installed_gems < <(gem list | awk -F ' \(' '{print $1, $2}' | sed -e 's/default://' -e 's/)//' -e 's/,//' -e 's/-/_/' | awk '{print $1, $2}')
-for i in ${!installed_gems[@]}
+mapfile -t installed_gems < <(gem list | awk -F ' \(' '{print $1, $2}' | sed -e 's/default://' -e 's/)//' -e 's/,//' | awk '{print $1, $2}')
+for i in "${!installed_gems[@]}"
   do
    j="${installed_gems[$i]}"
    gem_package="${j% *}"
+   crew_gem_package="ruby_${gem_package//-/_}"
    gem_version="${j#* }"
+   gem contents "${gem_package}" > "${CREW_META_PATH}/${crew_gem_package}.filelist"
    update_device_json "ruby_${gem_package//-/_}" "${gem_version}" ""
 done
 

--- a/install.sh
+++ b/install.sh
@@ -168,8 +168,6 @@ echo_out 'Set up the local package repo...'
 
 # Download the chromebrew repository.
 curl -L --progress-bar https://github.com/"${OWNER}"/"${REPO}"/tarball/"${BRANCH}" | tar -xz --strip-components=1 -C "${CREW_LIB_PATH}"
-# Disable ruby updates until late in the install.
-sed -i -e "s/depends_on 'default_gems'/# depends_on 'default_gems'/" -e "s/depends_on 'bundled_gems'/# depends_on 'bundled_gems'/" -e "s/^  version.*$/  version '1.0'/" "${CREW_LIB_PATH}/packages/core.rb"
 
 BOOTSTRAP_PACKAGES='lz4 zlib xzutils zstd crew_mvdir ruby git ca_certificates libyaml openssl'
 
@@ -270,7 +268,7 @@ function extract_install () {
 
 function update_device_json () {
   cd "${CREW_CONFIG_PATH}"
-  echo_intra "Adding new information on ${1} to device.json..."
+  echo_intra "Adding new information on ${1} ${2} to device.json..."
   new_info=$(jq --arg name "$1" --arg version "$2" --arg sha256 "$3" '.installed_packages |= . + [{"name": $name, "version": $version, "sha256": $sha256}]' device.json)
   cat <<< "${new_info}" > device.json
 }
@@ -338,6 +336,16 @@ gem sources -u
 gem update --no-update-sources -N --system
 gem cleanup
 
+# Mark packages as installed for pre-installed gems.
+mapfile -t installed_gems < <(gem list | awk -F ' \(' '{print $1, $2}' | sed -e 's/default://' -e 's/)//' -e 's/,//' -e 's/-/_/' | awk '{print $1, $2}')
+for i in ${!installed_gems[@]}
+  do
+   j="${installed_gems[$i]}"
+   gem_package="${j% *}"
+   gem_version="${j#* }"
+   update_device_json "ruby_${gem_package//-/_}" "${gem_version}" ""
+done
+
 echo_info "Installing essential ruby gems...\n"
 BOOTSTRAP_GEMS='activesupport concurrent-ruby highline ptools'
 # shellcheck disable=SC2086
@@ -394,9 +402,7 @@ else
   # Set mtimes of files to when the file was committed.
   git-restore-mtime -sq 2>/dev/null
 
-  # Try to efficiently update installed gems before installing the
-  # Chromebrew gem package updates.
-  crew update && yes | crew upgrade
+  OWNER=${OWNER} REPO=${REPO} crew update
 fi
 echo -e "${RESET}"
 

--- a/lib/buildsystems/ruby.rb
+++ b/lib/buildsystems/ruby.rb
@@ -63,7 +63,7 @@ def set_vars(passed_name = nil, passed_version = nil)
   gem_test_name = gem_test.split.first
   gem_test_versions = gem_test.split[1].split(',')
   gem_test_versions.delete_if { |i| i.include?('beta') }
-  gem_test_version = gem_test_versions.last
+  gem_test_version = gem_test_versions.max
   @gem_name = gem_test_name.blank? ? Gem::SpecFetcher.fetcher.suggest_gems_from_name(passed_name.gsub(/^ruby_/, '')).first : gem_test_name
   @remote_gem_ver = gem_test_name.blank? ? Gem.latest_version_for(@gem_name).to_s : gem_test_version
   @gem_ver = passed_version.split('-').first.to_s
@@ -82,14 +82,8 @@ class RUBY < Package
     set_vars(name, version)
     puts "Examining #{@gem_name} gem...".orange
     @gem_filelist_path = File.join(CREW_META_PATH, "#{name}.filelist")
-    puts "gem search  --no-update-sources -l -i \"^#{@gem_name}\$\" -v #{@gem_ver}"
     @gem_latest_version_installed = Kernel.system "gem search  --no-update-sources -l -i \"^#{@gem_name}\$\" -v #{@gem_ver}", %i[out err] => File::NULL
-    puts @gem_latest_version_installed
-    gem_anyversion_installed = Kernel.system "gem search --no-update-sources -l -i \"^#{@gem_name}\$\"", %i[out err] => File::NULL
-    puts "gem search --no-update-sources -l -i \"^#{@gem_name}\$\""
-    puts gem_anyversion_installed
-    puts "preflight: @gem_name: #{@gem_name}, @gem_ver: #{@gem_ver}, @gem_latest_version_installed: #{@gem_latest_version_installed} && @remote_gem_ver.to_s: #{Gem::Version.new(@remote_gem_ver.to_s)} == Gem::Version.new(@gem_ver): #{Gem::Version.new(@gem_ver)} && File.file?(@gem_filelist_path): #{File.file?(@gem_filelist_path)}"
-    Kernel.system ""
+    crewlog "preflight: @gem_name: #{@gem_name}, @gem_ver: #{@gem_ver}, @gem_latest_version_installed: #{@gem_latest_version_installed} && @remote_gem_ver.to_s: #{Gem::Version.new(@remote_gem_ver.to_s)} == Gem::Version.new(@gem_ver): #{Gem::Version.new(@gem_ver)} && File.file?(@gem_filelist_path): #{File.file?(@gem_filelist_path)}"
     # Create a filelist from the gem if the latest gem version is
     # installed but the filelist doesn't exist.
     Kernel.system "gem contents #{@gem_name}", %i[out] => [@gem_filelist_path, 'w'] if @gem_latest_version_installed && !File.file?(@gem_filelist_path)
@@ -120,11 +114,9 @@ class RUBY < Package
   end
 
   def self.install
-    puts "gem search  --no-update-sources -l -i \"^#{@gem_name}\$\" -v #{@gem_ver}"
     @gem_latest_version_installed = Kernel.system "gem search  --no-update-sources -l -i \"^#{@gem_name}\$\" -v #{@gem_ver}", %i[out err] => File::NULL
-    puts @gem_latest_version_installed
     gem_anyversion_installed = Kernel.system "gem search --no-update-sources -l -i \"^#{@gem_name}\$\"", %i[out err] => File::NULL
-    puts "install: @gem_name: #{@gem_name}, @gem_ver: #{@gem_ver}, !@gem_latest_version_installed && gem_anyversion_installed: #{!@gem_latest_version_installed && gem_anyversion_installed}, @gem_latest_version_installed: #{@gem_latest_version_installed} && @remote_gem_ver.to_s: #{Gem::Version.new(@remote_gem_ver.to_s)} == Gem::Version.new(@gem_ver): #{Gem::Version.new(@gem_ver)} && File.file?(@gem_filelist_path): #{File.file?(@gem_filelist_path)}"
+    crewlog "install: @gem_name: #{@gem_name}, @gem_ver: #{@gem_ver}, !@gem_latest_version_installed && gem_anyversion_installed: #{!@gem_latest_version_installed && gem_anyversion_installed}, @gem_latest_version_installed: #{@gem_latest_version_installed} && @remote_gem_ver.to_s: #{Gem::Version.new(@remote_gem_ver.to_s)} == Gem::Version.new(@gem_ver): #{Gem::Version.new(@gem_ver)} && File.file?(@gem_filelist_path): #{File.file?(@gem_filelist_path)}"
     crewlog "no_compile_needed?: #{no_compile_needed?} @gem_binary_build_needed.blank?: #{@gem_binary_build_needed.blank?}, gem_compile_needed?: #{gem_compile_needed?}"
     unless @install_gem
       puts "#{@gem_name} #{@gem_ver} is already installed.".lightgreen

--- a/lib/buildsystems/ruby.rb
+++ b/lib/buildsystems/ruby.rb
@@ -53,9 +53,11 @@ def set_vars(passed_name = nil, passed_version = nil)
       end
     end)
   end
-  gem_test = $gems.grep(/#{name.gsub(/^ruby_/, '')}/).first
+  gem_test = $gems.grep(/#{"^#{passed_name.gsub(/^ruby_/, '')}\\s.*$"}/).first.blank? ? $gems.grep(/#{"^#{passed_name.gsub(/^ruby_/, '').gsub('_', '-')}\\s.*$"}/).first : $gems.grep(/#{"^#{passed_name.gsub(/^ruby_/, '')}\\s.*$"}/).first
   gem_test_name = gem_test.split.first
-  gem_test_version = gem_test.split[1].split(',').last
+  gem_test_versions = gem_test.split[1].split(',')
+  gem_test_versions.delete_if { |i| i.include?('beta') }
+  gem_test_version = gem_test_versions.last
   @gem_name = gem_test_name.blank? ? Gem::SpecFetcher.fetcher.suggest_gems_from_name(passed_name.gsub(/^ruby_/, '')).first : gem_test_name
   @remote_gem_ver = gem_test_name.blank? ? Gem.latest_version_for(@gem_name).to_s : gem_test_version
   @gem_ver = passed_version.split('-').first.to_s

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.54.5' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.54.6' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]

--- a/tools/update_ruby_gem_packages.rb
+++ b/tools/update_ruby_gem_packages.rb
@@ -47,7 +47,7 @@ relevant_gem_packages.each_with_index do |package, index|
     puts "#{untested_package_name} versions for #{gem_test_name} are #{gem_test.split[1].split(',')}" if CREW_VERBOSE
     gem_test_versions = gem_test.split[1].split(',')
     gem_test_versions.delete_if { |i| i.include?('beta') }
-    gem_test_version = gem_test_versions.last
+    gem_test_version = gem_test_versions.max
     puts "#{untested_package_name} is #{gem_test_name} version #{gem_test_version}".lightpurple if CREW_VERBOSE
     gem_name = gem_test_name.blank? ? Gem::SpecFetcher.fetcher.suggest_gems_from_name(untested_package_name).first : gem_test_name
     gem_version = gem_test_name.blank? ? Gem.latest_version_for(untested_package_name).to_s : gem_test_version

--- a/tools/update_ruby_gem_packages.rb
+++ b/tools/update_ruby_gem_packages.rb
@@ -52,7 +52,7 @@ relevant_gem_packages.each_with_index do |package, index|
     gem_name = gem_test_name.blank? ? Gem::SpecFetcher.fetcher.suggest_gems_from_name(untested_package_name).first : gem_test_name
     gem_version = gem_test_name.blank? ? Gem.latest_version_for(untested_package_name).to_s : gem_test_version
 
-    puts "[#{(index + 1).to_s.rjust(numlength)}/#{total_files_to_check}] Checking rubygems for updates to #{gem_name}...".orange
+    puts "[#{(index + 1).to_s.rjust(numlength)}/#{total_files_to_check}] Checking rubygems for updates to #{gem_name} in #{package}...".orange
     pkg_version = `sed -n -e 's/^\ \ version //p' #{package}`.chomp.delete("'").delete('"').gsub(/-\#{CREW_RUBY_VER}/, '').split('-').first
     next package if gem_version.blank?
     if Gem::Version.new(gem_version) > Gem::Version.new(pkg_version)


### PR DESCRIPTION
- Use regex to only match the exact gem name.
- Also adjust underscores to dashes if the gem package name doesn't match a gem name.
- Remove beta versions from the versions found.
- Update installer to record pre-installed gems and remove slow install workaround.
- Handle gem version lists sometimes not being sorted.
- Installer tested!
- Updates the update_ruby_gem_packages script to confirm that matching is occurring properly.
![image](https://github.com/user-attachments/assets/5e02f460-e3d6-4bb6-968e-6f1e5dcb7a09)


Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=ruby crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
