### PR TITLE
Show installed gem version during gem update, add CREW_RUBY_VER to gem json entry in install.sh .

### DIFF
--- a/lib/buildsystems/ruby.rb
+++ b/lib/buildsystems/ruby.rb
@@ -63,6 +63,7 @@ def set_vars(passed_name = nil, passed_version = nil)
   gem_test_name = gem_test.split.first
   gem_test_versions = gem_test.split[1].split(',')
   gem_test_versions.delete_if { |i| i.include?('beta') }
+  gem_test_versions.delete_if { |i| i.include?('pre') }
   gem_test_version = gem_test_versions.max
   @gem_name = gem_test_name.blank? ? Gem::SpecFetcher.fetcher.suggest_gems_from_name(passed_name.gsub(/^ruby_/, '')).first : gem_test_name
   @remote_gem_ver = gem_test_name.blank? ? Gem.latest_version_for(@gem_name).to_s : gem_test_version
@@ -133,7 +134,9 @@ class RUBY < Package
         Kernel.system "gem install --no-update-sources -N --local #{CREW_DEST_DIR}/#{@gem_name}-#{@gem_ver}-#{GEM_ARCH}.gem --conservative"
       end
     elsif gem_anyversion_installed
-      puts "Updating #{@gem_name} gem to #{@gem_ver}...".orange
+      installed_gem_info = [`gem list -l -e #{@gem_name}`.chomp.to_s].grep(/#{@gem_name}/)[0].delete('()').gsub('default:', '').split
+      @gem_installed_version = installed_gem_info[1]
+      puts "Updating #{@gem_name} gem to #{@gem_ver} from #{@gem_installed_version}...".orange
       Kernel.system "gem update --no-update-sources -N #{@gem_name} --conservative"
     else
       puts "Installing #{@gem_name} gem #{@gem_ver}...".orange

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.54.6' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.54.7' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]

--- a/tools/update_ruby_gem_packages.rb
+++ b/tools/update_ruby_gem_packages.rb
@@ -47,6 +47,7 @@ relevant_gem_packages.each_with_index do |package, index|
     puts "#{untested_package_name} versions for #{gem_test_name} are #{gem_test.split[1].split(',')}" if CREW_VERBOSE
     gem_test_versions = gem_test.split[1].split(',')
     gem_test_versions.delete_if { |i| i.include?('beta') }
+    gem_test_versions.delete_if { |i| i.include?('pre') }
     gem_test_version = gem_test_versions.max
     puts "#{untested_package_name} is #{gem_test_name} version #{gem_test_version}".lightpurple if CREW_VERBOSE
     gem_name = gem_test_name.blank? ? Gem::SpecFetcher.fetcher.suggest_gems_from_name(untested_package_name).first : gem_test_name


### PR DESCRIPTION

- Also remove gem versions with "pre" in the version from being used for installs.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=ruby crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
