### PR TITLE
Google_chrome 129.0.6668.100-1 => 130.0.6723.58-1

### DIFF
--- a/packages/google_chrome.rb
+++ b/packages/google_chrome.rb
@@ -4,12 +4,12 @@ class Google_chrome < Package
   @update_channel = 'stable'
   description 'Google Chrome is a fast, easy to use, and secure web browser.'
   homepage 'https://www.google.com/chrome/'
-  version '129.0.6668.100-1'
+  version '130.0.6723.58-1'
   license 'google-chrome'
   compatibility 'x86_64'
   min_glibc '2.28'
   source_url "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-#{@update_channel}/google-chrome-#{@update_channel}_#{@version}_amd64.deb"
-  source_sha256 'e4d2133a70c455de4f7b2593f6b3d5805bf95b96cfda1f9b2ccdf48639a9833b'
+  source_sha256 '1d6142fbd3a9e236bf4b778fe7a37d8643a431b0ab6c5f8d1c473148b6fce478'
 
   depends_on 'nss'
   depends_on 'cairo'


### PR DESCRIPTION
Tested & (not) Working properly:
- [x] `x86_64` Unable to launch in hatch m129 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-google_chrome crew update \
&& yes | crew upgrade
```