### PR TITLE
Adjust ruby buildsystem to use Gem::Version.new to sanitize gem version numbers, adjust activesupport package dependencies.

### DIFF
--- a/.github/workflows/Markdown-lint.yml
+++ b/.github/workflows/Markdown-lint.yml
@@ -4,11 +4,14 @@ on: workflow_call
 jobs:
   markdown-lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Markdown-lint
         uses: reviewdog/action-markdownlint@v0
         with:
-          reporter: github-pr-review
+          reporter: github-pr-check
           fail_on_error: true
           markdownlint_flags: '-s .mdl_style.rb'

--- a/.github/workflows/Markdown-lint.yml
+++ b/.github/workflows/Markdown-lint.yml
@@ -12,6 +12,7 @@ jobs:
       - name: Markdown-lint
         uses: reviewdog/action-markdownlint@v0
         with:
-          reporter: github-pr-check
           fail_on_error: true
           markdownlint_flags: '-s .mdl_style.rb'
+          reporter: github-pr-check
+          reviewdog_flags: '-fail-level=any'

--- a/.github/workflows/Rubocop.yml
+++ b/.github/workflows/Rubocop.yml
@@ -15,7 +15,8 @@ jobs:
       - name: Rubocop
         uses: reviewdog/action-rubocop@v2
         with:
-          reporter: github-pr-check
           fail_on_error: true
           filter_mode: nofilter
+          only_changed: true
+          reporter: github-pr-check
           reviewdog_flags: '-fail-level=any'

--- a/.github/workflows/Rubocop.yml
+++ b/.github/workflows/Rubocop.yml
@@ -1,12 +1,12 @@
 ---
 name: Rubocop
 on: workflow_call
-permissions:
-  contents: read
-  pull-requests: write
 jobs:
   rubocop:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
@@ -15,6 +15,7 @@ jobs:
       - name: Rubocop
         uses: reviewdog/action-rubocop@v2
         with:
-          reporter: github-pr-review
+          reporter: github-pr-check
           fail_on_error: true
           filter_mode: nofilter
+          reviewdog_flags: '-fail-level=any'

--- a/.github/workflows/ShellCheck.yml
+++ b/.github/workflows/ShellCheck.yml
@@ -4,11 +4,14 @@ on: workflow_call
 jobs:
   shellcheck:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: ShellCheck
         uses: reviewdog/action-shellcheck@v1
         with:
-          reporter: github-pr-review
+          reporter: github-pr-check
           fail_on_error: true
           exclude: './tools/*'

--- a/.github/workflows/ShellCheck.yml
+++ b/.github/workflows/ShellCheck.yml
@@ -12,6 +12,7 @@ jobs:
       - name: ShellCheck
         uses: reviewdog/action-shellcheck@v1
         with:
-          reporter: github-pr-check
-          fail_on_error: true
           exclude: './tools/*'
+          fail_on_error: true
+          reporter: github-pr-check
+          reviewdog_flags: '-fail-level=any'

--- a/.github/workflows/YAMLlint.yml
+++ b/.github/workflows/YAMLlint.yml
@@ -12,5 +12,6 @@ jobs:
       - name: YAMLLint
         uses: reviewdog/action-yamllint@v1
         with:
-          reporter: github-pr-check
           fail_on_error: true
+          reporter: github-pr-check
+          reviewdog_flags: '-fail-level=any'

--- a/.github/workflows/YAMLlint.yml
+++ b/.github/workflows/YAMLlint.yml
@@ -4,10 +4,13 @@ on: workflow_call
 jobs:
   yamllint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: YAMLLint
         uses: reviewdog/action-yamllint@v1
         with:
-          reporter: github-pr-review
+          reporter: github-pr-check
           fail_on_error: true

--- a/lib/buildsystems/ruby.rb
+++ b/lib/buildsystems/ruby.rb
@@ -65,7 +65,7 @@ def set_vars(passed_name = nil, passed_version = nil)
   # Any version with a letter is considered a prerelease as per
   # https://github.com/rubygems/rubygems/blob/b5798efd348935634d4e0e2b846d4f455582db48/lib/rubygems/version.rb#L305
   gem_test_versions.delete_if { |i| i.match?(/[a-zA-Z]/) }
-  gem_test_version = gem_test_versions.map {|v| Gem::Version.new(v)}.max.to_s
+  gem_test_version = gem_test_versions.map { |v| Gem::Version.new(v) }.max.to_s
   @gem_name = gem_test_name.blank? ? Gem::SpecFetcher.fetcher.suggest_gems_from_name(passed_name.gsub(/^ruby_/, '')).first : gem_test_name
   @remote_gem_ver = gem_test_name.blank? ? Gem.latest_version_for(@gem_name).to_s : gem_test_version
   @gem_ver = passed_version.split('-').first.to_s

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.54.8' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.54.9' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]

--- a/packages/ruby_activesupport.rb
+++ b/packages/ruby_activesupport.rb
@@ -8,7 +8,17 @@ class Ruby_activesupport < RUBY
   compatibility 'all'
   source_url 'SKIP'
 
-  depends_on 'ruby_concurrent_ruby' # L
+  depends_on 'ruby_base64'
+  depends_on 'ruby_bigdecimal'
+  depends_on 'ruby_concurrent_ruby'
+  depends_on 'ruby_connection_pool'
+  depends_on 'ruby_drb'
+  depends_on 'ruby_i18n'
+  depends_on 'ruby_logger'
+  depends_on 'ruby_minitest'
+  depends_on 'ruby_securerandom'
+  depends_on 'ruby_tzinfo'
+
   conflicts_ok
   no_compile_needed
 end


### PR DESCRIPTION
- Also fixes linting unit tests so that they fail when they are tripped.

Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=install crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
