### PR TITLE
Edge 129.0.2792.89-1 => 130.0.2849.46-1

### DIFF
--- a/manifest/x86_64/e/edge.filelist
+++ b/manifest/x86_64/e/edge.filelist
@@ -12,10 +12,10 @@
 /usr/local/share/man/man1/microsoft-edge.1.zst
 /usr/local/share/man/man1/msedge.1.zst
 /usr/local/share/menu/microsoft-edge.menu
+/usr/local/share/msedge/AdSelectionAttestationsPreloaded/ad-selection-attestations.dat
+/usr/local/share/msedge/AdSelectionAttestationsPreloaded/manifest.json
 /usr/local/share/msedge/MEIPreload/manifest.json
 /usr/local/share/msedge/MEIPreload/preloaded_data.pb
-/usr/local/share/msedge/PrivacySandboxAttestationsPreloaded/manifest.json
-/usr/local/share/msedge/PrivacySandboxAttestationsPreloaded/privacy-sandbox-attestations.dat
 /usr/local/share/msedge/WidevineCdm/_platform_specific/linux_x64/libwidevinecdm.so
 /usr/local/share/msedge/WidevineCdm/manifest.json
 /usr/local/share/msedge/cron/microsoft-edge

--- a/packages/edge.rb
+++ b/packages/edge.rb
@@ -3,12 +3,12 @@ require 'package'
 class Edge < Package
   description 'Microsoft Edge is the fast and secure browser'
   homepage 'https://www.microsoft.com/en-us/edge'
-  version '129.0.2792.89-1'
+  version '130.0.2849.46-1'
   license 'MIT'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_#{version}_amd64.deb"
-  source_sha256 '09bb96c2632b6d0cea6de6eea6fa792a4c783c7fc9ce58608acb73acf4e72643'
+  source_sha256 '42c721707483a186a48dfe2861721ce344b29e20ae7cd9a31c93eebd16b3752c'
 
   depends_on 'at_spi2_core'
   depends_on 'libcom_err'


### PR DESCRIPTION
Tested & (not) Working properly:
- [x] `x86_64` Unable to launch in hatch m129 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-edge crew update \
&& yes | crew upgrade
```