### PR TITLE
Adjust cmake buildsystem to run verbose tests when run_tests is enabled.

### DIFF
--- a/lib/buildsystems/cmake.rb
+++ b/lib/buildsystems/cmake.rb
@@ -24,6 +24,6 @@ class CMake < Package
 
   def self.check
     puts "Testing with #{CREW_NINJA} test.".orange if @run_tests
-    system "#{CREW_NINJA} -C #{@cmake_build_relative_dir}/builddir test" if @run_tests
+    system "ctest --test-dir #{@cmake_build_relative_dir}/builddir --rerun-failed --output-on-failure" if @run_tests
   end
 end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.55.6' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.55.7' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]

--- a/packages/libmaxminddb.rb
+++ b/packages/libmaxminddb.rb
@@ -3,7 +3,7 @@ require 'buildsystems/cmake'
 class Libmaxminddb < CMake
   description 'C library for the MaxMind DB file format.'
   homepage 'https://maxmind.github.io/libmaxminddb/'
-  version '1.10.0'
+  version '1.11.0'
   license 'Apache-2.0'
   compatibility 'all'
   source_url 'https://github.com/maxmind/libmaxminddb.git'
@@ -11,13 +11,15 @@ class Libmaxminddb < CMake
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'b7a5d8d87fb90b9ad90f653afc25e0cf22e39ee68165315035273def178002e3',
-     armv7l: 'b7a5d8d87fb90b9ad90f653afc25e0cf22e39ee68165315035273def178002e3',
-       i686: '45cf1073e286d4c5ba40b1fd20fd861827fde48e8826df06bb6cf6f22a0385eb',
-     x86_64: '14fd9c46f2a7b1b299d03b156cacad5efd47bca6683f5488a93353fa544b4189'
+    aarch64: '9317f59be14aa2d07e3d02ff2e00bdbd48fa47c5f93d6a0264730dd194cefec7',
+     armv7l: '9317f59be14aa2d07e3d02ff2e00bdbd48fa47c5f93d6a0264730dd194cefec7',
+       i686: '0fc6795d757ee451a0a16f5c4254d2de282bdde92818fb1ab98fd21867a577c1',
+     x86_64: 'f35e028343a26c60c3a93a6938925d8549e7614f13166795566196e8ef3745e8'
   })
 
-  cmake_options '-DBUILD_SHARED_LIBS=ON'
+  depends_on 'glibc' # R
 
   run_tests
+
+  cmake_options '-DBUILD_SHARED_LIBS=ON'
 end


### PR DESCRIPTION
- Also updates `libmaxminddb` to make sure that this doesn't break tests.

Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=ctest crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
