### PR TITLE
Add wezterm package

### DIFF
--- a/manifest/x86_64/w/wezterm.filelist
+++ b/manifest/x86_64/w/wezterm.filelist
@@ -1,0 +1,13 @@
+/usr/local/bin/open-wezterm-here
+/usr/local/bin/strip-ansi-escapes
+/usr/local/bin/wezterm
+/usr/local/bin/wezterm-gui
+/usr/local/bin/wezterm-mux-server
+/usr/local/etc/bash.d/10-wezterm
+/usr/local/etc/bash.d/wezterm.sh
+/usr/local/share/applications/org.wezfurlong.wezterm.desktop
+/usr/local/share/bash-completion/completions/wezterm
+/usr/local/share/icons/hicolor/128x128/apps/org.wezfurlong.wezterm.png
+/usr/local/share/metainfo/org.wezfurlong.wezterm.appdata.xml
+/usr/local/share/nautilus-python/extensions/wezterm-nautilus.py
+/usr/local/share/zsh/functions/Completion/Unix/_wezterm

--- a/packages/wezterm.rb
+++ b/packages/wezterm.rb
@@ -1,0 +1,26 @@
+require 'package'
+
+class Wezterm < Package
+  description 'WezTerm is a powerful cross-platform terminal emulator and multiplexer'
+  homepage 'https://wezfurlong.org/wezterm/'
+  version '20240203-110809-5046fc22'
+  license 'MIT'
+  compatibility 'x86_64'
+  min_glibc '2.28'
+  source_url "https://github.com/wez/wezterm/releases/download/#{version}/wezterm-#{version}.Debian12.deb"
+  source_sha256 'd3a5c97093fbc0a87e8f9616e44efc4c9503cfc495fd1cfe4ffeff88578d15f8'
+
+  depends_on 'libxkbcommon'
+  depends_on 'xcb_util_image'
+
+  no_compile_needed
+  no_shrink
+  print_source_bashrc
+
+  def self.install
+    FileUtils.install 'etc/profile.d/wezterm.sh', "#{CREW_DEST_PREFIX}/etc/bash.d/wezterm.sh", mode: 0o644
+    FileUtils.install 'usr/share/bash-completion/completions/wezterm', "#{CREW_DEST_PREFIX}/etc/bash.d/10-wezterm", mode: 0o644
+    FileUtils.mv 'usr/bin', CREW_DEST_PREFIX
+    FileUtils.mv 'usr/share', CREW_DEST_PREFIX
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -9331,6 +9331,11 @@ url: https://github.com/wayland-project/weston/releases/
 activity: medium
 ---
 kind: url
+name: wezterm
+url: https://github.com/wez/wezterm/releases
+activity: low
+---
+kind: url
 name: wget2
 url: https://ftpmirror.gnu.org/wget/
 activity: low


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m129 container.  Works on x86_64 Chromebook with glibc 2.37.
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-wezterm-package crew update \
&& yes | crew upgrade
```