### PR TITLE
Go 1.23.0 => 1.23.2

### DIFF
--- a/manifest/armv7l/g/go.filelist
+++ b/manifest/armv7l/g/go.filelist
@@ -6729,6 +6729,8 @@
 /usr/local/share/go/src/internal/types/testdata/check/go1_19_20.go
 /usr/local/share/go/src/internal/types/testdata/check/go1_20_19.go
 /usr/local/share/go/src/internal/types/testdata/check/go1_21_19.go
+/usr/local/share/go/src/internal/types/testdata/check/go1_21_22.go
+/usr/local/share/go/src/internal/types/testdata/check/go1_22_21.go
 /usr/local/share/go/src/internal/types/testdata/check/go1_8.go
 /usr/local/share/go/src/internal/types/testdata/check/go1_xx_19.go
 /usr/local/share/go/src/internal/types/testdata/check/gotos.go
@@ -7005,6 +7007,8 @@
 /usr/local/share/go/src/internal/types/testdata/fixedbugs/issue67683.go
 /usr/local/share/go/src/internal/types/testdata/fixedbugs/issue67872.go
 /usr/local/share/go/src/internal/types/testdata/fixedbugs/issue67962.go
+/usr/local/share/go/src/internal/types/testdata/fixedbugs/issue68903.go
+/usr/local/share/go/src/internal/types/testdata/fixedbugs/issue68935.go
 /usr/local/share/go/src/internal/types/testdata/fixedbugs/issue6977.go
 /usr/local/share/go/src/internal/types/testdata/spec/assignability.go
 /usr/local/share/go/src/internal/types/testdata/spec/comparable.go
@@ -12317,6 +12321,9 @@
 /usr/local/share/go/test/fixedbugs/issue6899.go
 /usr/local/share/go/test/fixedbugs/issue6899.out
 /usr/local/share/go/test/fixedbugs/issue6902.go
+/usr/local/share/go/test/fixedbugs/issue69110.go
+/usr/local/share/go/test/fixedbugs/issue69434.go
+/usr/local/share/go/test/fixedbugs/issue69507.go
 /usr/local/share/go/test/fixedbugs/issue6964.go
 /usr/local/share/go/test/fixedbugs/issue6977.go
 /usr/local/share/go/test/fixedbugs/issue7023.dir/a.go

--- a/manifest/i686/g/go.filelist
+++ b/manifest/i686/g/go.filelist
@@ -6729,6 +6729,8 @@
 /usr/local/share/go/src/internal/types/testdata/check/go1_19_20.go
 /usr/local/share/go/src/internal/types/testdata/check/go1_20_19.go
 /usr/local/share/go/src/internal/types/testdata/check/go1_21_19.go
+/usr/local/share/go/src/internal/types/testdata/check/go1_21_22.go
+/usr/local/share/go/src/internal/types/testdata/check/go1_22_21.go
 /usr/local/share/go/src/internal/types/testdata/check/go1_8.go
 /usr/local/share/go/src/internal/types/testdata/check/go1_xx_19.go
 /usr/local/share/go/src/internal/types/testdata/check/gotos.go
@@ -7005,6 +7007,8 @@
 /usr/local/share/go/src/internal/types/testdata/fixedbugs/issue67683.go
 /usr/local/share/go/src/internal/types/testdata/fixedbugs/issue67872.go
 /usr/local/share/go/src/internal/types/testdata/fixedbugs/issue67962.go
+/usr/local/share/go/src/internal/types/testdata/fixedbugs/issue68903.go
+/usr/local/share/go/src/internal/types/testdata/fixedbugs/issue68935.go
 /usr/local/share/go/src/internal/types/testdata/fixedbugs/issue6977.go
 /usr/local/share/go/src/internal/types/testdata/spec/assignability.go
 /usr/local/share/go/src/internal/types/testdata/spec/comparable.go
@@ -12317,6 +12321,9 @@
 /usr/local/share/go/test/fixedbugs/issue6899.go
 /usr/local/share/go/test/fixedbugs/issue6899.out
 /usr/local/share/go/test/fixedbugs/issue6902.go
+/usr/local/share/go/test/fixedbugs/issue69110.go
+/usr/local/share/go/test/fixedbugs/issue69434.go
+/usr/local/share/go/test/fixedbugs/issue69507.go
 /usr/local/share/go/test/fixedbugs/issue6964.go
 /usr/local/share/go/test/fixedbugs/issue6977.go
 /usr/local/share/go/test/fixedbugs/issue7023.dir/a.go

--- a/manifest/x86_64/g/go.filelist
+++ b/manifest/x86_64/g/go.filelist
@@ -6729,6 +6729,8 @@
 /usr/local/share/go/src/internal/types/testdata/check/go1_19_20.go
 /usr/local/share/go/src/internal/types/testdata/check/go1_20_19.go
 /usr/local/share/go/src/internal/types/testdata/check/go1_21_19.go
+/usr/local/share/go/src/internal/types/testdata/check/go1_21_22.go
+/usr/local/share/go/src/internal/types/testdata/check/go1_22_21.go
 /usr/local/share/go/src/internal/types/testdata/check/go1_8.go
 /usr/local/share/go/src/internal/types/testdata/check/go1_xx_19.go
 /usr/local/share/go/src/internal/types/testdata/check/gotos.go
@@ -7005,6 +7007,8 @@
 /usr/local/share/go/src/internal/types/testdata/fixedbugs/issue67683.go
 /usr/local/share/go/src/internal/types/testdata/fixedbugs/issue67872.go
 /usr/local/share/go/src/internal/types/testdata/fixedbugs/issue67962.go
+/usr/local/share/go/src/internal/types/testdata/fixedbugs/issue68903.go
+/usr/local/share/go/src/internal/types/testdata/fixedbugs/issue68935.go
 /usr/local/share/go/src/internal/types/testdata/fixedbugs/issue6977.go
 /usr/local/share/go/src/internal/types/testdata/spec/assignability.go
 /usr/local/share/go/src/internal/types/testdata/spec/comparable.go
@@ -12317,6 +12321,9 @@
 /usr/local/share/go/test/fixedbugs/issue6899.go
 /usr/local/share/go/test/fixedbugs/issue6899.out
 /usr/local/share/go/test/fixedbugs/issue6902.go
+/usr/local/share/go/test/fixedbugs/issue69110.go
+/usr/local/share/go/test/fixedbugs/issue69434.go
+/usr/local/share/go/test/fixedbugs/issue69507.go
 /usr/local/share/go/test/fixedbugs/issue6964.go
 /usr/local/share/go/test/fixedbugs/issue6977.go
 /usr/local/share/go/test/fixedbugs/issue7023.dir/a.go

--- a/packages/go.rb
+++ b/packages/go.rb
@@ -3,7 +3,7 @@ require 'package'
 class Go < Package
   description 'Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.'
   homepage 'https://go.dev'
-  version '1.23.0'
+  version '1.23.2'
   license 'BSD'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Go < Package
      x86_64: "https://go.dev/dl/go#{version}.linux-amd64.tar.gz"
   })
   source_sha256({
-    aarch64: '0efa1338e644d7f74064fa7f1016b5da7872b2df0070ea3b56e4fef63192e35b',
-     armv7l: '0efa1338e644d7f74064fa7f1016b5da7872b2df0070ea3b56e4fef63192e35b',
-       i686: '0e8a7340c2632e6fb5088d60f95b52be1f8303143e04cd34e9b2314fafc24edd',
-     x86_64: '905a297f19ead44780548933e0ff1a1b86e8327bb459e92f9c0012569f76f5e3'
+    aarch64: 'e3286bdde186077e65e961cbe18874d42a461e5b9c472c26572b8d4a98d15c40',
+     armv7l: 'e3286bdde186077e65e961cbe18874d42a461e5b9c472c26572b8d4a98d15c40',
+       i686: 'cb1ed4410f68d8be1156cee0a74fcfbdcd9bca377c83db3a9e1b07eebc6d71ef',
+     x86_64: '542d3c1705f1c6a1c5a80d5dc62e2e45171af291e755d591c5e6531ef63b454e'
   })
 
   no_compile_needed


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` 
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-go crew update \
&& yes | crew upgrade
```