### PR TITLE
Tuptime 5.2.3 => 5.2.4

### DIFF
--- a/packages/tuptime.rb
+++ b/packages/tuptime.rb
@@ -3,7 +3,7 @@ require 'package'
 class Tuptime < Package
   description 'Report historical and statistical real time of the system, keeping it between restarts.'
   homepage 'https://github.com/rfmoz/tuptime'
-  version '5.2.3'
+  version '5.2.4'
   license 'GPL-2.0'
   compatibility 'all'
   source_url 'https://github.com/rfmoz/tuptime.git'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` 
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-tuptime crew update \
&& yes | crew upgrade
```