### PR TITLE
Opera 114.0.5282.142 => 114.0.5282.154

### DIFF
--- a/manifest/x86_64/o/opera.filelist
+++ b/manifest/x86_64/o/opera.filelist
@@ -130,7 +130,6 @@
 /usr/local/share/x86_64-linux-gnu/opera/resources/opera_intro_extension/427fc33b09a5b15cc69c.png
 /usr/local/share/x86_64-linux-gnu/opera/resources/opera_intro_extension/42ff001a8c225fc1a354.png
 /usr/local/share/x86_64-linux-gnu/opera/resources/opera_intro_extension/439f3447a96cad7c116c.jpg
-/usr/local/share/x86_64-linux-gnu/opera/resources/opera_intro_extension/44d85d37ca16b0b3a224.ttf
 /usr/local/share/x86_64-linux-gnu/opera/resources/opera_intro_extension/45763c696a4442585bb4.svg
 /usr/local/share/x86_64-linux-gnu/opera/resources/opera_intro_extension/5481ba37652e144d94d4.png
 /usr/local/share/x86_64-linux-gnu/opera/resources/opera_intro_extension/587706f4d9807ac4bdf4.png

--- a/packages/opera.rb
+++ b/packages/opera.rb
@@ -3,7 +3,7 @@ require 'package'
 class Opera < Package
   description 'Opera is a multi-platform web browser based on Chromium and developed by Opera Software.'
   homepage 'https://www.opera.com/'
-  version '114.0.5282.142'
+  version '114.0.5282.154'
   license 'OPERA-2018'
   compatibility 'x86_64'
   min_glibc '2.29'
@@ -11,7 +11,7 @@ class Opera < Package
   # faster apt mirror, but only works when downloading latest version of opera
   # source_url "https://deb.opera.com/opera/pool/non-free/o/opera-stable/opera-stable_#{version}_amd64.deb"
   source_url "https://deb.opera.com/opera-stable/pool/non-free/o/opera-stable/opera-stable_#{version}_amd64.deb"
-  source_sha256 '258e41a50f036d4aabe79be9afd955e41fa2734514e053816cde340b236dca66'
+  source_sha256 'b0cf6d7f9ca7bd1acd2ff4bf3f248f38eff1412bd82ee05df0445686b74bddc1'
 
   depends_on 'gtk3'
   depends_on 'gsettings_desktop_schemas'


### PR DESCRIPTION
Tested & (not) Working properly:
- [x] `x86_64` Unable to launch in hatch m129 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-opera crew update \
&& yes | crew upgrade
```