### PR TITLE
Audacity 3.6.2 => 3.7.0

### DIFF
--- a/manifest/x86_64/a/audacity.filelist
+++ b/manifest/x86_64/a/audacity.filelist
@@ -1,12 +1,14 @@
 /usr/local/bin/audacity
+/usr/local/share/applications/audacity-url-handler.desktop
 /usr/local/share/applications/audacity.desktop
 /usr/local/share/audacity/AppRun
 /usr/local/share/audacity/AppRun.wrapped
 /usr/local/share/audacity/EffectsMenuDefaults.xml
 /usr/local/share/audacity/apprun-hooks/00-preserve-environment.sh
+/usr/local/share/audacity/apprun-hooks/install-url-handler.sh
 /usr/local/share/audacity/apprun-hooks/linuxdeploy-plugin-gtk.sh
+/usr/local/share/audacity/audacity-url-handler.desktop
 /usr/local/share/audacity/audacity.desktop
-/usr/local/share/audacity/audacity.png
 /usr/local/share/audacity/audacity.sh
 /usr/local/share/audacity/audacity.svg
 /usr/local/share/audacity/bin/audacity
@@ -92,10 +94,12 @@
 /usr/local/share/audacity/lib/girepository-1.0/xft-2.0.typelib
 /usr/local/share/audacity/lib/girepository-1.0/xlib-2.0.typelib
 /usr/local/share/audacity/lib/girepository-1.0/xrandr-1.3.typelib
+/usr/local/share/audacity/lib/lib-audacity-application-logic.so
 /usr/local/share/audacity/lib/lib-audio-devices.so
 /usr/local/share/audacity/lib/lib-audio-graph.so
 /usr/local/share/audacity/lib/lib-audio-io.so
 /usr/local/share/audacity/lib/lib-basic-ui.so
+/usr/local/share/audacity/lib/lib-builtin-effects.so
 /usr/local/share/audacity/lib/lib-channel.so
 /usr/local/share/audacity/lib/lib-cloud-audiocom.so
 /usr/local/share/audacity/lib/lib-command-parameters.so
@@ -114,6 +118,7 @@
 /usr/local/share/audacity/lib/lib-graphics.so
 /usr/local/share/audacity/lib/lib-import-export.so
 /usr/local/share/audacity/lib/lib-ipc.so
+/usr/local/share/audacity/lib/lib-label-track.so
 /usr/local/share/audacity/lib/lib-ladspa.so
 /usr/local/share/audacity/lib/lib-lv2.so
 /usr/local/share/audacity/lib/lib-math.so
@@ -124,6 +129,7 @@
 /usr/local/share/audacity/lib/lib-network-manager.so
 /usr/local/share/audacity/lib/lib-note-track.so
 /usr/local/share/audacity/lib/lib-numeric-formats.so
+/usr/local/share/audacity/lib/lib-nyquist-effects.so
 /usr/local/share/audacity/lib/lib-playable-track.so
 /usr/local/share/audacity/lib/lib-preference-pages.so
 /usr/local/share/audacity/lib/lib-preferences.so
@@ -157,7 +163,9 @@
 /usr/local/share/audacity/lib/lib-viewport.so
 /usr/local/share/audacity/lib/lib-vst.so
 /usr/local/share/audacity/lib/lib-vst3.so
+/usr/local/share/audacity/lib/lib-wave-track-fft.so
 /usr/local/share/audacity/lib/lib-wave-track-paint.so
+/usr/local/share/audacity/lib/lib-wave-track-settings.so
 /usr/local/share/audacity/lib/lib-wave-track.so
 /usr/local/share/audacity/lib/lib-wx-init.so
 /usr/local/share/audacity/lib/lib-wx-wrappers.so
@@ -207,7 +215,6 @@
 /usr/local/share/audacity/lib/libjbig.so.0
 /usr/local/share/audacity/lib/libjpeg.so.8
 /usr/local/share/audacity/lib/liblzma.so.5
-/usr/local/share/audacity/lib/libmount.so.1
 /usr/local/share/audacity/lib/libmpg123.so.0
 /usr/local/share/audacity/lib/libogg.so.0
 /usr/local/share/audacity/lib/libopus.so.0

--- a/packages/audacity.rb
+++ b/packages/audacity.rb
@@ -3,12 +3,12 @@ require 'package'
 class Audacity < Package
   description "Audacity is the world's most popular audio editing and recording app"
   homepage 'https://www.audacityteam.org/'
-  version '3.6.2'
+  version '3.7.0'
   license 'GPL-3'
   compatibility 'x86_64'
   min_glibc '2.30'
-  source_url "https://github.com/audacity/audacity/releases/download/Audacity-#{version}/audacity-linux-#{version}-x64.AppImage"
-  source_sha256 'b009504d0f74b7fca7092d3c0fdb866b8894ab66473b951c2b7ed7e454282058'
+  source_url "https://github.com/audacity/audacity/releases/download/Audacity-#{version}/audacity-linux-#{version}-x64-22.04.AppImage"
+  source_sha256 '8c92601a46456b2cfc942a3effd5588dd69f8b79f7aaa735e88f447be5efbe41'
 
   depends_on 'gtk3'
   depends_on 'libthai'


### PR DESCRIPTION
Tested & (not) Working properly:
- [x] `x86_64` Unable to launch in hatch m129 container.  Splash screen freezes on load.
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-audacity crew update \
&& yes | crew upgrade
```