### PR TITLE
Add tauri_cli package

### DIFF
--- a/manifest/x86_64/t/tauri_cli.filelist
+++ b/manifest/x86_64/t/tauri_cli.filelist
@@ -1,0 +1,1 @@
+/usr/local/bin/tauri

--- a/packages/tauri_cli.rb
+++ b/packages/tauri_cli.rb
@@ -1,0 +1,22 @@
+require 'package'
+
+class Tauri_cli < Package
+  description 'Build smaller, faster, and more secure desktop and mobile applications with a web frontend.'
+  homepage 'https://tauri.app/'
+  version '2.1.0'
+  license 'Apache-2.0, MIT'
+  compatibility 'x86_64'
+  min_glibc '2.29'
+  source_url "https://github.com/tauri-apps/tauri/releases/download/tauri-cli-v#{version}/cargo-tauri-x86_64-unknown-linux-gnu.tgz"
+  source_sha256 'c8cd0f2610253007f1370e11a5ba38107e91c6d6a2cc4c238b31e0a3a40195de'
+
+  no_compile_needed
+
+  def self.install
+    FileUtils.install 'cargo-tauri', "#{CREW_DEST_PREFIX}/bin/tauri", mode: 0o755
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nType 'tauri' to get started.\n"
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -8635,6 +8635,11 @@ url: https://github.com/GothenburgBitFactory/taskwarrior/releases
 activity: medium
 ---
 kind: url
+name: tauri_cli
+url: https://github.com/tauri-apps/tauri/releases
+activity: high
+---
+kind: url
 name: tbb
 url: https://github.com/oneapi-src/oneTBB/releases
 activity: medium


### PR DESCRIPTION
## Description
Build smaller, faster, and more secure desktop and mobile applications with a web frontend.

## Additional information
See https://tauri.app/.

Tested & Working properly:
- [x] `x86_64` Works in hatch m130 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-tauri_cli-package crew update \
&& yes | crew upgrade
```