### PR TITLE
Adjust crew to put out json when CREW_UNATTENDED=1 crew update is run.

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -346,7 +346,7 @@ def update
   end
 
   if CREW_UNATTENDED && can_be_updated.positive?
-    puts updatable_packages
+    puts updatable_packages.to_json
   elsif can_be_updated.positive?
     puts "\n#{can_be_updated} packages can be updated."
     puts 'Run `crew upgrade` to update all packages or `crew upgrade <package1> [<package2> ...]` to update specific packages.'

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.55.9' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.56.0' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]


### PR DESCRIPTION
- Change build_updated_packages accordingly.
- This fixes an issue of the `crew update` output containing other info that is difficult to parse, for instance from the llvm19_* packages when a version changes and there is an intentional human-readable output.
- Also adjusts `build_updated_packages` to check for new files in the last commit that should be checked to see if binaries have been uploaded.

##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=update_json crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
