### PR TITLE
Add binary gem for ruby_resolv.

### DIFF
--- a/packages/ruby_resolv.rb
+++ b/packages/ruby_resolv.rb
@@ -3,13 +3,19 @@ require 'buildsystems/ruby'
 class Ruby_resolv < RUBY
   description 'Thread-aware dns resolver library in ruby.'
   homepage 'https://github.com/ruby/resolv'
-  version "0.4.0-#{CREW_RUBY_VER}"
+  version "0.5.0-#{CREW_RUBY_VER}"
   license 'BSD-2-Clause'
   compatibility 'all'
   source_url 'SKIP'
+  binary_compression 'gem'
 
-  depends_on 'ruby_resolv' # R
+  binary_sha256({
+    aarch64: 'c28efd69d8d6e2a04ede2b3d61f68427a8350678f01dcc3b27f2af267016c56c',
+     armv7l: 'c28efd69d8d6e2a04ede2b3d61f68427a8350678f01dcc3b27f2af267016c56c',
+       i686: 'aa700af01d3abca7808f2d9f77273bcbf552d92771982206ce6b57e38682adde',
+     x86_64: '3ac05f4dcd9478ceb1ed1268f00dda03b990423334867be9a4295814c4896fe7'
+  })
 
   conflicts_ok
-  no_compile_needed
+  gem_compile_needed
 end


### PR DESCRIPTION
- This gem now requires a build.
##
Builds:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=ruby_resolv crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
