### PR TITLE
Vscodium 1.95.2.24313 => 1.95.3.24321

### DIFF
--- a/packages/vscodium.rb
+++ b/packages/vscodium.rb
@@ -3,17 +3,17 @@ require 'package'
 class Vscodium < Package
   description 'VSCodium is Open Source Software Binaries of VSCode with a community-driven default configuration.'
   homepage 'https://vscodium.com/'
-  version '1.95.2.24313'
+  version '1.95.3.24321'
   license 'MIT'
   compatibility 'aarch64 armv7l x86_64'
   case ARCH
   when 'aarch64', 'armv7l'
     source_url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium-linux-armhf-#{version}.tar.gz"
-    source_sha256 '211b93a60bda18f62cee5ec279f6179af9b94d827535cd89f6c1c832a3ae6dfa'
+    source_sha256 'ecfd344f16f53f7fd10e03f5e128bf541e9dbe854d0de31598d49376bc4e6e40'
     @arch = 'arm'
   when 'x86_64'
     source_url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium-linux-x64-#{version}.tar.gz"
-    source_sha256 'c3c97f536692f7d658ddd77dc809693d4cb48b720c9ab97d3931bec028633639'
+    source_sha256 'bee8ea5a5ccd38ce80ff152aa94a563ddc2696a199a9e4f64a406509ed928824'
     @arch = 'x64'
   end
 


### PR DESCRIPTION
Tested & (not) Working properly:
- [x] `x86_64`
- [x] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-vscodium crew update \
&& yes | crew upgrade
```