### PR TITLE
Add workaround for gh cli not being able to add reviewer teams to PRs.

### DIFF
--- a/.github/workflows/Updater.yml
+++ b/.github/workflows/Updater.yml
@@ -219,5 +219,11 @@ jobs:
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git fetch --depth=5
           mapfile -t updated_packages < <( git diff-tree --no-commit-id --name-only -r $(git log --oneline | grep $CREW_BRANCH | tail -n 1 | awk '{print $1}')..$(git rev-parse --verify HEAD) | grep -v manifest)
-          UPDATED_FILES="Updated packages:$(echo '';for file in "${updated_packages[@]}" ; do echo "- ${file}" ; done)"
-          gh pr create --title "Automatic PR to update packages for ${{ needs.update-check.outputs.output1 }}" --body "${UPDATED_FILES}" -r chromebrew/active
+          export UPDATED_FILES="Updated packages:$(echo '';for file in "${updated_packages[@]}" ; do echo "- ${file}" ; done)"
+          gh pr create --title "Automatic PR to update packages for ${{ needs.update-check.outputs.output1 }}" --body "${UPDATED_FILES}"
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ github.repository }}/pulls/$(gh pr list --search ${{ needs.update-check.outputs.output1 }} --json number | jq -r '.[].number')/requested_reviewers \
+            -f "team_reviewers[]=active"


### PR DESCRIPTION
- The `gh cli` pr creation option doesn't allow teams to be set as reviewers.