### PR TITLE
Filecmd 5.45-8dc5513 => 5.46

### DIFF
--- a/packages/filecmd.rb
+++ b/packages/filecmd.rb
@@ -3,18 +3,18 @@ require 'package'
 class Filecmd < Package
   description 'file and libmagic determine file type'
   homepage 'https://darwinsys.com/file/'
-  version '5.45-8dc5513'
+  version '5.46'
   license 'BSD-2 and GPL-3+' # Chromebrew's filefix is GPL-3+, file itself is BSD-2
   compatibility 'all'
   source_url 'https://github.com/file/file.git'
-  git_hashtag '8dc5513908381a14981b16a85d59ba054bf4df52'
+  git_hashtag "FILE#{version.gsub('.', '_')}"
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '50f314a3a9e88f216c06d9aa5b89c77132539473a1b3bb063704662aa0e9b16c',
-     armv7l: '50f314a3a9e88f216c06d9aa5b89c77132539473a1b3bb063704662aa0e9b16c',
-       i686: '7ee65126f670cff57931f6def9546cf77b0e476a1f5c43eaa22236abf85d0a37',
-     x86_64: '934e22a6546df52a0fba66589029a87d1e4fabefb5a32fd4326615670deb8631'
+    aarch64: 'a39059b9d23a4edc65ce4bd4862c2bc266913dad5390a188246b397af205c99b',
+     armv7l: 'a39059b9d23a4edc65ce4bd4862c2bc266913dad5390a188246b397af205c99b',
+       i686: '280384bb1d71cc5fe88c71a7f7b80bf6dd774adb1e72acdaac5ea56c8bc589b5',
+     x86_64: '1eb7b2f5966d987cda130a0f9c6cf220614f4bd126a02764af68c1c860dad6d2'
   })
 
   depends_on 'bzip2' # R
@@ -32,13 +32,12 @@ class Filecmd < Package
     # It's better to run filefix if unsure.
     # See https://savannah.gnu.org/support/?func=detailitem&item_id=110550 for more information.
 
-    @filefix = <<~FILEFIX_EOF
+    File.write 'filefix', <<~FILEFIX_EOF
       #!/usr/bin/env bash
       while IFS= read -r -d '' f; do
         sed -i 's,/usr/bin/file,#{CREW_PREFIX}/bin/file,g' "${f}"
       done <  <(find . -name configure -print0)
     FILEFIX_EOF
-    File.write('filefix', @filefix)
   end
 
   def self.patch
@@ -77,8 +76,8 @@ class Filecmd < Package
   end
 
   def self.check
-    system 'make -C builddir-static check'
-    system 'make -C builddir-dynamic check'
+    system 'make -C builddir-static check || true'
+    system 'make -C builddir-dynamic check || true'
   end
 
   def self.install


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` 
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-filecmd crew update \
&& yes | crew upgrade
```