### PR TITLE
Allow force removal of essential packages

### DIFF
--- a/commands/remove.rb
+++ b/commands/remove.rb
@@ -19,8 +19,11 @@ class Command
     # their dependencies, as those are needed for ruby and crew to run,
     # and thus should not be removed.
     # essential_deps = recursive_deps(CREW_ESSENTIAL_PACKAGES)
-    essential_deps = device_json['essential_deps']
-    crewlog "Essential Deps are #{essential_deps}."
+    essential_deps = []
+    unless CREW_FORCE
+      essential_deps = device_json['essential_deps']
+      crewlog "Essential Deps are #{essential_deps}."
+    end
     if essential_deps.include?(pkg.name)
       return if pkg.in_upgrade
 
@@ -66,7 +69,10 @@ class Command
         if File.file?(flist)
           # When searching for files to delete we exclude the files from
           # all packages and dependent packages of CREW_ESSENTIAL_PACKAGES.
-          essential_deps_exclude_froms = essential_deps.map { |i| File.file?("#{File.join(CREW_META_PATH, i.to_s)}.filelist") ? "--exclude-from=#{File.join(CREW_META_PATH, i.to_s)}.filelist" : '' }.join(' ')
+          essential_deps_exclude_froms = ''
+          unless CREW_FORCE
+            essential_deps_exclude_froms = essential_deps.map { |i| File.file?("#{File.join(CREW_META_PATH, i.to_s)}.filelist") ? "--exclude-from=#{File.join(CREW_META_PATH, i.to_s)}.filelist" : '' }.join(' ')
+          end
 
           package_files = `grep -h #{essential_deps_exclude_froms} \"^#{CREW_PREFIX}\\|^#{HOME}\" #{flist}`.split("\n").uniq.sort
           all_other_files = `grep -h --exclude #{pkg.name}.filelist \"^#{CREW_PREFIX}\\|^#{HOME}\" #{CREW_META_PATH}/*.filelist 2>/dev/null`.split("\n").uniq.sort

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.56.1' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.56.2' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]


### PR DESCRIPTION
This is dangerous but in certain use cases it makes sense.  For example, if you want to return to the ChromeOS binaries included in util_linux.  Also you may want to reinstall in certain situations.  Tested and working.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=allow-force-removal-essential-packages crew update \
&& yes | crew upgrade
```