### PR TITLE
Terraform 1.9.8 => 1.10.0

### DIFF
--- a/packages/terraform.rb
+++ b/packages/terraform.rb
@@ -3,7 +3,7 @@ require 'package'
 class Terraform < Package
   description 'Terraform is a tool for building, changing, and combining infrastructure safely and efficiently.'
   homepage 'https://www.terraform.io/'
-  version '1.9.8'
+  version '1.10.0'
   license 'Apache-2.0, BSD-2, BSD-4, ECL-2.0, imagemagick, ISC, JSON, MIT, MIT-with-advertising, MPL-2.0 and unicode'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Terraform < Package
      x86_64: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_amd64.zip"
   })
   source_sha256({
-    aarch64: 'cb6db8471e361bb9ad6bbd43d9c780d37208e6dbe416900fdc8999af9e459b77',
-     armv7l: 'cb6db8471e361bb9ad6bbd43d9c780d37208e6dbe416900fdc8999af9e459b77',
-       i686: 'aa85bb2e0c68f2ee148d1ea854ee0aa78086017cbda9058371be8be2f4c18d10',
-     x86_64: '186e0145f5e5f2eb97cbd785bc78f21bae4ef15119349f6ad4fa535b83b10df8'
+    aarch64: '8209739371bad76287e04aedd2a3b1b6bcf5c16ae9ba8adbb93dc3d7346df9f1',
+     armv7l: '8209739371bad76287e04aedd2a3b1b6bcf5c16ae9ba8adbb93dc3d7346df9f1',
+       i686: '8af8eb3315ecade87ec6cb04dd16a5b6ebefd7bf7058b8e8db7422c1c9500108',
+     x86_64: '4b05f4848d365597cf7ac5b59334c62a16b3bb7b524586578ee45ba823b6758b'
   })
 
   def self.install


### PR DESCRIPTION
## Description

This commit updates the Terraform CLI from version 1.9.8 to 1.10.0.

## Additional information

Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_