### PR TITLE
Vivaldi 7.0.3495.18-1 => 7.0.3495.20-1

### DIFF
--- a/manifest/armv7l/v/vivaldi.filelist
+++ b/manifest/armv7l/v/vivaldi.filelist
@@ -207,7 +207,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/adblocker_resources/redirectable_resources.json
 /usr/local/share/vivaldi/resources/vivaldi/background-bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/background-common-bundle.js
-/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-bb07611a4e53473c5fa4e913a0d297c7.js
+/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-9c66f3756073e47836b8f0eba5fed6fb.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle-mailreader-worker.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/components/mail/mail.html

--- a/manifest/x86_64/v/vivaldi.filelist
+++ b/manifest/x86_64/v/vivaldi.filelist
@@ -207,7 +207,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/adblocker_resources/redirectable_resources.json
 /usr/local/share/vivaldi/resources/vivaldi/background-bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/background-common-bundle.js
-/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-711592bee27ca0c9366337a219fbf304.js
+/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-9a12f87e8be1ac10ea3804893482980c.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle-mailreader-worker.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/components/mail/mail.html

--- a/packages/vivaldi.rb
+++ b/packages/vivaldi.rb
@@ -3,7 +3,7 @@ require 'package'
 class Vivaldi < Package
   description 'Vivaldi is a new browser that blocks unwanted ads, protects you from trackers, and puts you in control with unique built-in features.'
   homepage 'https://vivaldi.com/'
-  version '7.0.3495.18-1'
+  version '7.0.3495.20-1'
   license 'Vivaldi'
   compatibility 'x86_64 aarch64 armv7l'
   min_glibc '2.29'
@@ -23,10 +23,10 @@ class Vivaldi < Package
   case ARCH
   when 'aarch64', 'armv7l'
     arch = 'armhf'
-    source_sha256 'aa384004a6967379afdcf84cee3eabe63d42ee46f0e0b8a0568cd94ef0ab7a73'
+    source_sha256 '0cae9119ae288fa26352adf94c2f38abc4dba9b9c6b76304fa240a30a4b0d9ee'
   when 'x86_64'
     arch = 'amd64'
-    source_sha256 '2c52adb88a2b6f6d7f53acac1eae86468d053f60e00fbc8ce83c2e225a6e4f95'
+    source_sha256 '64ccacf417a2531c14fed5e0528cdd7270fc52db7df62d0ea761e7e75748a07d'
   end
 
   source_url "https://downloads.vivaldi.com/stable/vivaldi-stable_#{version}_#{arch}.deb"


### PR DESCRIPTION
Tested & (not) Working properly:
- [x] `x86_64` Unable to launch in hatch m130 container
- [x] `armv7l`  Unable to launch in strongbad m130 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-vivaldi crew update \
&& yes | crew upgrade
```