### PR TITLE
Move i686 builds up in build workflows.

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -168,7 +168,7 @@ jobs:
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git fetch --depth=5
+          git fetch --shallow-since="1 week"
           mapfile -t updated_package_array < <( git diff-tree --no-commit-id --name-only -r $(git rev-parse origin/master)..$(git rev-parse --verify HEAD) | grep -v manifest | grep "^packages" | sed -e 's,packages/,,' -e 's,.rb,,')
           echo -e "Updated packages:" > /tmp/pr.txt
           for file in "${updated_package_array[@]}"

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        arch: [x86_64, armv7l, i686]
+        arch: [i686, x86_64, armv7l]
         runner:
           - [self-hosted, X64]
           - [self-hosted, ARM]

--- a/.github/workflows/Updater.yml
+++ b/.github/workflows/Updater.yml
@@ -103,7 +103,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        arch: [x86_64, armv7l, i686]
+        arch: [i686, x86_64, armv7l]
         runner:
           - [self-hosted, X64]
           - [self-hosted, ARM]

--- a/.github/workflows/Updater.yml
+++ b/.github/workflows/Updater.yml
@@ -223,7 +223,7 @@ jobs:
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git fetch --shallow-since="1 week"
           git diff-tree --no-commit-id --name-only -r $(git rev-parse origin/master)..$(git rev-parse --verify HEAD)
-          mapfile -t updated_package_array < <( git diff-tree --no-commit-id --name-only -r $(git diff-tree --no-commit-id --name-only -r $(git rev-parse origin/master)..$(git rev-parse --verify HEAD)) | grep -v manifest | grep "^packages" | sed -e 's,packages/,,' -e 's,.rb,,')
+          mapfile -t updated_package_array < <( git diff-tree --no-commit-id --name-only -r $(git rev-parse origin/master)..$(git rev-parse --verify HEAD) | grep -v manifest | grep "^packages" | sed -e 's,packages/,,' -e 's,.rb,,')
           echo -e "Updated packages:" > /tmp/pr.txt
           for file in "${updated_package_array[@]}"
             do


### PR DESCRIPTION
- Earlier builds with X11 deps may add such deps to the package files after a build, which may cause the i686 build to fail.
- Also synchronize `git fetch` options between updater and build workflows.
- Fix code duplication in Updater workflow.