### PR TITLE
Add dependabot.yml to check for github action version updates, fixup reviewcop workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily" 
+  target-branch: "master" 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
@@ -6,7 +7,7 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "daily" 
-  target-branch: "master" 
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "master"

--- a/.github/workflows/Markdown-lint.yml
+++ b/.github/workflows/Markdown-lint.yml
@@ -12,7 +12,6 @@ jobs:
       - name: Markdown-lint
         uses: reviewdog/action-markdownlint@v0
         with:
-          fail_on_error: true
+          fail_level: any
           markdownlint_flags: '-s .mdl_style.rb'
           reporter: github-pr-check
-          reviewdog_flags: '-fail-level=any'

--- a/.github/workflows/Rubocop.yml
+++ b/.github/workflows/Rubocop.yml
@@ -15,8 +15,7 @@ jobs:
       - name: Rubocop
         uses: reviewdog/action-rubocop@v2
         with:
-          fail_on_error: true
+          fail_level: any
           filter_mode: nofilter
           only_changed: true
           reporter: github-pr-check
-          reviewdog_flags: '-fail-level=any'

--- a/.github/workflows/ShellCheck.yml
+++ b/.github/workflows/ShellCheck.yml
@@ -13,6 +13,5 @@ jobs:
         uses: reviewdog/action-shellcheck@v1
         with:
           exclude: './tools/*'
-          fail_on_error: true
+          fail_level: any
           reporter: github-pr-check
-          reviewdog_flags: '-fail-level=any'

--- a/.github/workflows/YAMLlint.yml
+++ b/.github/workflows/YAMLlint.yml
@@ -12,6 +12,5 @@ jobs:
       - name: YAMLLint
         uses: reviewdog/action-yamllint@v1
         with:
-          fail_on_error: true
+          fail_level: any
           reporter: github-pr-check
-          reviewdog_flags: '-fail-level=any'


### PR DESCRIPTION
- Dependabot config copied from https://github.com/actions/runner/blob/main/.github/dependabot.yml
- Reviewdog workflows updated to use the newer non-deprecated `fail_level: any` option.
