### PR TITLE
Add debugging to build workflow.

### DIFF
--- a/tools/github_actions_update_builder.sh
+++ b/tools/github_actions_update_builder.sh
@@ -4,4 +4,6 @@
 cd /output/ || exit 1
 git config --global --add safe.directory /output
 export CREW_AGREE_TIMEOUT_SECONDS=1
+set -x
 tools/build_updated_packages.rb --skip
+echo "Exit code of build run was: $?"


### PR DESCRIPTION
- Just trying to figure out how to keep build checks from triggering workflow cancellation when nothing needed to be built for a particular architecture.