### PR TITLE
Xfsprogs 6.11.0-icu75.1 => 6.12.0-icu75.1

### DIFF
--- a/manifest/armv7l/x/xfsprogs.filelist
+++ b/manifest/armv7l/x/xfsprogs.filelist
@@ -64,6 +64,7 @@
 /usr/local/share/man/man2/ioctl_xfs_scrub_metadata.2.zst
 /usr/local/share/man/man2/ioctl_xfs_scrubv_metadata.2.zst
 /usr/local/share/man/man2/ioctl_xfs_setresblks.2.zst
+/usr/local/share/man/man2/ioctl_xfs_start_commit.2.zst
 /usr/local/share/man/man3/attr_list_by_handle.3.zst
 /usr/local/share/man/man3/attr_multi_by_handle.3.zst
 /usr/local/share/man/man3/fd_to_handle.3.zst
@@ -110,5 +111,6 @@
 /usr/local/share/xfsprogs/mkfs/lts_5.15.conf
 /usr/local/share/xfsprogs/mkfs/lts_5.4.conf
 /usr/local/share/xfsprogs/mkfs/lts_6.1.conf
+/usr/local/share/xfsprogs/mkfs/lts_6.12.conf
 /usr/local/share/xfsprogs/mkfs/lts_6.6.conf
 /usr/local/share/xfsprogs/xfs_scrub_all.cron

--- a/manifest/x86_64/x/xfsprogs.filelist
+++ b/manifest/x86_64/x/xfsprogs.filelist
@@ -65,6 +65,7 @@
 /usr/local/share/man/man2/ioctl_xfs_scrub_metadata.2.zst
 /usr/local/share/man/man2/ioctl_xfs_scrubv_metadata.2.zst
 /usr/local/share/man/man2/ioctl_xfs_setresblks.2.zst
+/usr/local/share/man/man2/ioctl_xfs_start_commit.2.zst
 /usr/local/share/man/man3/attr_list_by_handle.3.zst
 /usr/local/share/man/man3/attr_multi_by_handle.3.zst
 /usr/local/share/man/man3/fd_to_handle.3.zst
@@ -111,5 +112,6 @@
 /usr/local/share/xfsprogs/mkfs/lts_5.15.conf
 /usr/local/share/xfsprogs/mkfs/lts_5.4.conf
 /usr/local/share/xfsprogs/mkfs/lts_6.1.conf
+/usr/local/share/xfsprogs/mkfs/lts_6.12.conf
 /usr/local/share/xfsprogs/mkfs/lts_6.6.conf
 /usr/local/share/xfsprogs/xfs_scrub_all.cron

--- a/packages/xfsprogs.rb
+++ b/packages/xfsprogs.rb
@@ -3,7 +3,7 @@ require 'package'
 class Xfsprogs < Package
   description 'XFS filesystem utilities'
   homepage 'https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/'
-  version "6.11.0-#{CREW_ICU_VER}"
+  version "6.12.0-#{CREW_ICU_VER}"
   license 'LGPL-2.1'
   compatibility 'x86_64 aarch64 armv7l'
   source_url 'https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git'
@@ -11,9 +11,9 @@ class Xfsprogs < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'ec6b21bb4fc6d89796cd0473528f9d263ea0ff0dcea5b9f58fba3bdab9a97fc5',
-     armv7l: 'ec6b21bb4fc6d89796cd0473528f9d263ea0ff0dcea5b9f58fba3bdab9a97fc5',
-     x86_64: '60fe2d2aee8bdc9166ab6d296fe13acff482ae5168d2ab1f178e562df744ae98'
+    aarch64: 'cece01bad384d71762c2941bab3ec26eb61dced7f308c578d2669c9dcebbae19',
+     armv7l: 'cece01bad384d71762c2941bab3ec26eb61dced7f308c578d2669c9dcebbae19',
+     x86_64: '1cb8708d6c9bd0664500acc609d3fb5e7315c1b95802e7adb7d5262fe8c972f6'
   })
 
   depends_on 'gcc_lib' # R


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l` 
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-xfsprogs crew update \
&& yes | crew upgrade
```
```
$ for b in $(crew files xfsprogs|grep /usr/local/sbin); do $b -V; done
/usr/local/sbin/fsck.xfs: -V does not exist
mkfs.xfs version 6.12.0
xfs_admin version 6.12.0
xfs_bmap version 6.12.0
xfs_copy version 6.12.0
xfs_db version 6.12.0
xfs_estimate version 6.12.0
xfs_freeze version 6.12.0
xfs_fsr version 6.12.0
xfs_growfs version 6.12.0
xfs_info version 6.12.0
xfs_io version 6.12.0
xfs_logprint version 6.12.0
xfs_mdrestore version 6.12.0
xfs_metadump version 6.12.0
xfs_mkfile version 6.12.0
xfs_ncheck version 6.12.0
xfs_info version 6.12.0
xfs_quota version 6.12.0
xfs_repair version 6.12.0
xfs_rtcp version 6.12.0
EXPERIMENTAL xfs_scrub program in use! Use at your own risk!
xfs_scrub version 6.12.0
bash: /usr/local/sbin/xfs_scrub_all: cannot execute: required file not found
xfs_spaceman version 6.12.0
```