### PR TITLE
Fzf 0.56.1 => 0.56.3

### DIFF
--- a/packages/fzf.rb
+++ b/packages/fzf.rb
@@ -3,7 +3,7 @@ require 'package'
 class Fzf < Package
   description 'A command-line fuzzy finder'
   homepage 'https://github.com/junegunn/fzf'
-  version '0.56.1'
+  version '0.56.3'
   license 'MIT and BSD-with-disclosure'
   compatibility 'x86_64 aarch64 armv7l'
   source_url({
@@ -12,9 +12,9 @@ class Fzf < Package
      x86_64: "https://github.com/junegunn/fzf/releases/download/v#{version}/fzf-#{version}-linux_amd64.tar.gz"
   })
   source_sha256({
-    aarch64: '9fa89b553df6b176ef89d2bec0c499fd230bbc97d1e034464bf7908b3ab6d9a7',
-     armv7l: '9fa89b553df6b176ef89d2bec0c499fd230bbc97d1e034464bf7908b3ab6d9a7',
-     x86_64: '738d892d011839e7347827ededc41b7cb15ce7687f07eaf489ed8eac13872183'
+    aarch64: '26408ce7ec311518dba6d8dd326bcf099bf8d97d21d40138cf303dab9c6f4f3f',
+     armv7l: '26408ce7ec311518dba6d8dd326bcf099bf8d97d21d40138cf303dab9c6f4f3f',
+     x86_64: '78e96a88cecfbdb3ff65df89cc47c02573407aee0edd08c87e18a8033d498fef'
   })
 
   no_compile_needed


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l` 
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-fzf crew update \
&& yes | crew upgrade
```