### PR TITLE
Github_cli 2.60.1 => 2.63.1

### DIFF
--- a/packages/github_cli.rb
+++ b/packages/github_cli.rb
@@ -3,7 +3,7 @@ require 'package'
 class Github_cli < Package
   description 'Official Github CLI tool'
   homepage 'https://cli.github.com/'
-  version '2.60.1'
+  version '2.63.1'
   license 'MIT'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Github_cli < Package
      x86_64: "https://github.com/cli/cli/releases/download/v#{version}/gh_#{version}_linux_amd64.tar.gz"
   })
   source_sha256({
-    aarch64: '9ca62426c20b6cdd5e32ffe5ae6fca75edea14645bc6de0e853025eadd3544a6',
-     armv7l: '9ca62426c20b6cdd5e32ffe5ae6fca75edea14645bc6de0e853025eadd3544a6',
-       i686: '9f83869ca7b11d014481c73afbebea6ea238c8585684cec7389eca03513636cb',
-     x86_64: 'dfcd9926de38a797e88e604c3111ecf9ddf13c524706712b2b0d2e2fc4a6ed7f'
+    aarch64: 'b0e74d2495c88293a85002466838efbb23dcc065295edf93040b37274d90681f',
+     armv7l: 'b0e74d2495c88293a85002466838efbb23dcc065295edf93040b37274d90681f',
+       i686: '17678eca9365795140173aac44877fd496bf947b295f2761860661b0b17dd277',
+     x86_64: '09678eb6e5d14f18de1ee09c37b76e60c0ac1b968f5728f70e1bcb5367af01cd'
   })
 
   no_compile_needed


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` 
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-github_cli crew update \
&& yes | crew upgrade
```