### PR TITLE
Glab 1.48.0 => 1.50.0

### DIFF
--- a/packages/glab.rb
+++ b/packages/glab.rb
@@ -3,7 +3,7 @@ require 'package'
 class Glab < Package
   description 'A GitLab CLI tool bringing GitLab to your command line'
   homepage 'https://gitlab.com/gitlab-org/cli'
-  version '1.48.0'
+  version '1.50.0'
   license 'MIT'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Glab < Package
      x86_64: "https://gitlab.com/gitlab-org/cli/-/releases/v#{version}/downloads/glab_#{version}_linux_amd64.tar.gz"
   })
   source_sha256({
-    aarch64: '56e4a264915ed13292eff1c6fe033f1415f7b886c0375c2101ca6edaceca86e3',
-     armv7l: '56e4a264915ed13292eff1c6fe033f1415f7b886c0375c2101ca6edaceca86e3',
-       i686: '7b1c881695b5dfdb2b32f072fa24c313fe02e10c74d161e74544c61d86bc098e',
-     x86_64: 'fd2799d7a17132f807ab1eecb329bf62b988b4ac1b4efd8eac8f6be4fa4153e0'
+    aarch64: 'b75fab6dd1d03894823a69dfb8ee17b68de1adf817a63d11158c63a121fdaa3c',
+     armv7l: 'b75fab6dd1d03894823a69dfb8ee17b68de1adf817a63d11158c63a121fdaa3c',
+       i686: '49c999c9d5793ffd4a71172e1eb02cedcfe006fb13191edf1c7a77b9e01769de',
+     x86_64: '9b623bec9c23ea869a6d8abd20451d623b9428c6cbac3cbd7f9fba0dc1a26448'
   })
 
   no_compile_needed


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` 
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-glab crew update \
&& yes | crew upgrade
```