### PR TITLE
Micro 2.0.13 => 2.0.14

### DIFF
--- a/packages/micro.rb
+++ b/packages/micro.rb
@@ -3,24 +3,25 @@ require 'package'
 class Micro < Package
   description 'A modern and intuitive terminal-based text editor'
   homepage 'https://micro-editor.github.io/'
-  version '2.0.13'
+  version '2.0.14'
   license 'MIT'
   compatibility 'all'
   case ARCH
   when 'aarch64', 'armv7l'
-    source_url 'https://github.com/zyedidia/micro/releases/download/v2.0.13/micro-2.0.13-linux-arm.tar.gz'
-    source_sha256 'adb9cf644354a5c85819db40e1a427f0f4951b172597bbcd3ef94ecc4a8c4b75'
+    source_url "https://github.com/zyedidia/micro/releases/download/v#{version}/micro-#{version}-linux-arm.tar.gz"
+    source_sha256 '9f490d88bd30a548af99a905f50244dc6c80f3c7a3c6f98faeb5b0a7329f7dea'
   when 'i686'
-    source_url 'https://github.com/zyedidia/micro/releases/download/v2.0.13/micro-2.0.13-linux32.tar.gz'
-    source_sha256 'a711d7281152b2b578a7b91bca70fe6782ca3e317e99be640dbb6bb3eb5a2bcd'
+    source_url "https://github.com/zyedidia/micro/releases/download/v#{version}/micro-#{version}-linux32.tar.gz"
+    source_sha256 'cbb95a472be2c8de93f57e58dd540cfc799154be5c6031c7ca4b6b8872d13113'
   when 'x86_64'
-    source_url 'https://github.com/zyedidia/micro/releases/download/v2.0.13/micro-2.0.13-linux64.tar.gz'
-    source_sha256 'a50e405d3d09d58f6b2c182429c18537a05f317dc0c3c9cb834b3271362e4781'
+    source_url "https://github.com/zyedidia/micro/releases/download/v#{version}/micro-#{version}-linux64.tar.gz"
+    source_sha256 '704e96add9b44e0041179f7934338d330e85230af6869f70b88720830f554786'
   end
 
   no_compile_needed
+  no_shrink
 
   def self.install
-    system "install -Dm755 micro #{CREW_DEST_PREFIX}/bin/micro"
+    FileUtils.install 'micro', "#{CREW_DEST_PREFIX}/bin/micro", mode: 0o755
   end
 end


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` 
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-micro crew update \
&& yes | crew upgrade
```