### PR TITLE
Only have tools/version.rb report stable version updates when using 'crew check -V <package>'.

### DIFF
--- a/tools/version.rb
+++ b/tools/version.rb
@@ -22,9 +22,9 @@ def get_version(name, homepage)
   anitya_id = get_anitya_id(name, homepage)
   # If we weren't able to get an Anitya ID, return early here to save time and headaches
   return nil if anitya_id.nil?
-  # Get the latest version of the package
+  # Get the latest stable version of the package
   json = JSON.parse(Net::HTTP.get(URI("https://release-monitoring.org/api/v2/versions/?project_id=#{anitya_id}")))
-  return json['latest_version']
+  return json['stable_versions'][0]
 end
 
 def get_anitya_id(name, homepage)


### PR DESCRIPTION

```bash
for pkg in $(grep -l no_compile_needed *) ; do echo ${pkg%.rb} ; crew check -V ${pkg%.rb} | grep outdated ; done
abcl
acquia_cli
act
act                                outdated            0.2.34              0.2.70
angle_grinder
apktool
atom
audacity
autojump
aws2
balena_etcher
bash_snippets
bat
bazel
```
...