### PR TITLE
Adjust version checking

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.56.3' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.56.4' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]
@@ -308,6 +308,7 @@ PY_SETUP_INSTALL_OPTIONS         ||= "#{PY_SETUP_INSTALL_OPTIONS_NO_SVEM} --sing
 PY3_BUILD_OPTIONS                ||= '--wheel --no-isolation'
 PY3_INSTALLER_OPTIONS            ||= "--destdir=#{CREW_DEST_DIR} --compile-bytecode 2 dist/*.whl"
 
+CREW_GCC_VER ||= Kernel.system('which gcc', %i[out err] => File::NULL) ? "gcc#{`gcc -dumpversion`.chomp}" : 'gcc14' unless defined?(CREW_GCC_VER)
 CREW_ICU_VER ||= Kernel.system('which uconv', %i[out err] => File::NULL) ? "icu#{`uconv --version`.chomp.split[3]}" : 'icu75.1' unless defined?(CREW_ICU_VER)
 CREW_PERL_VER ||= Kernel.system('which perl', %i[out err] => File::NULL) ? "perl#{`perl -MConfig -e "print \\\"\\\$Config{'PERL_API_REVISION'}.\\\$Config{'PERL_API_VERSION'}\\\";"`}" : 'perl5.40' unless defined?(CREW_PERL_VER)
 CREW_PY_VER ||= Kernel.system("#{CREW_PREFIX}/bin/python3 --version", %i[out err] => File::NULL) ? "py#{`python3 -c "print('.'.join(__import__('platform').python_version_tuple()[:2]))"`.chomp}" : 'py3.13' unless defined?(CREW_PY_VER)

--- a/lib/package_utils.rb
+++ b/lib/package_utils.rb
@@ -71,6 +71,8 @@ class PackageUtils
   end
 
   def self.get_clean_version(pkg_version)
+    # Delete -gcc14, futureproofed until gcc 100
+    pkg_version.gsub!(/-gcc\d{2}/, '')
     # Trim kde- suffixes in qt5 packages so nothing else gets confused.
     pkg_version.delete_prefix!('kde-')
     # Delete -py3.12, futureproofed until Python 4

--- a/packages/binutils.rb
+++ b/packages/binutils.rb
@@ -5,7 +5,7 @@ require 'package'
 class Binutils < Package
   description 'The GNU Binutils are a collection of binary tools.'
   homepage 'https://www.gnu.org/software/binutils/'
-  version '2.43.1-gcc14'
+  version "2.43.1-#{CREW_GCC_VER}"
   license 'GPL-3+'
   compatibility 'all'
   source_url "https://ftpmirror.gnu.org/binutils/binutils-#{version.split('-').first}.tar.bz2"

--- a/packages/gdb.rb
+++ b/packages/gdb.rb
@@ -6,7 +6,7 @@ require 'buildsystems/autotools'
 class Gdb < Autotools
   description 'The GNU Debugger'
   homepage 'https://www.gnu.org/software/gdb/'
-  version "15.1-gcc14-#{CREW_PY_VER}"
+  version "15.1-#{CREW_GCC_VER}-#{CREW_PY_VER}"
   license 'GPL3'
   compatibility 'all'
   source_url "https://ftpmirror.gnu.org/gnu/gdb/gdb-#{version.split('-').first}.tar.xz"

--- a/tools/version.rb
+++ b/tools/version.rb
@@ -117,6 +117,12 @@ if filelist.length.positive?
       next
     end
 
+    # Skip ruby and pip buildsystem packages.
+    if pkg.superclass.to_s == 'RUBY' || pkg.superclass.to_s == 'Pip'
+      puts pkg.name.ljust(35) + 'skipped'.lightred if verbose
+      next
+    end
+
     # Get the upstream version.
     upstream_version = get_version(pkg.name.tr('_', '-'), pkg.homepage)
     # Some packages don't work with this yet, so gracefully exit now rather than throwing false positives.


### PR DESCRIPTION
- Add `CREW_GCC_VER` constant and account for it in the version cleaning algorithm, and adjust the few packages that use `-gcc14` in their versions accordingly.
- Have `version.rb` skip packages with a RUBY or Pip superclass indicating those buildsystems are being used, and thus they have their own update checker. (This handles packages like `awscli` that use the pip buildsystem but are not named with a `py3_` prefix.)


- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
