### PR TITLE
Audacity 3.7.0 => 3.7.1

### DIFF
--- a/manifest/x86_64/a/audacity.filelist
+++ b/manifest/x86_64/a/audacity.filelist
@@ -9,6 +9,7 @@
 /usr/local/share/audacity/apprun-hooks/linuxdeploy-plugin-gtk.sh
 /usr/local/share/audacity/audacity-url-handler.desktop
 /usr/local/share/audacity/audacity.desktop
+/usr/local/share/audacity/audacity.png
 /usr/local/share/audacity/audacity.sh
 /usr/local/share/audacity/audacity.svg
 /usr/local/share/audacity/bin/audacity

--- a/packages/audacity.rb
+++ b/packages/audacity.rb
@@ -3,12 +3,12 @@ require 'package'
 class Audacity < Package
   description "Audacity is the world's most popular audio editing and recording app"
   homepage 'https://www.audacityteam.org/'
-  version '3.7.0'
+  version '3.7.1'
   license 'GPL-3'
   compatibility 'x86_64'
   min_glibc '2.30'
   source_url "https://github.com/audacity/audacity/releases/download/Audacity-#{version}/audacity-linux-#{version}-x64-22.04.AppImage"
-  source_sha256 '8c92601a46456b2cfc942a3effd5588dd69f8b79f7aaa735e88f447be5efbe41'
+  source_sha256 '3bdb2620518fbcfd59d5a532eb783c50d08f19fd8d10e6a54ca1a67620869686'
 
   depends_on 'gtk3'
   depends_on 'libthai'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m130 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-audacity crew update \
&& yes | crew upgrade
```