### PR TITLE
Add sshpass package

### DIFF
--- a/manifest/armv7l/s/sshpass.filelist
+++ b/manifest/armv7l/s/sshpass.filelist
@@ -1,0 +1,2 @@
+/usr/local/bin/sshpass
+/usr/local/share/man/man1/sshpass.1.zst

--- a/manifest/i686/s/sshpass.filelist
+++ b/manifest/i686/s/sshpass.filelist
@@ -1,0 +1,2 @@
+/usr/local/bin/sshpass
+/usr/local/share/man/man1/sshpass.1.zst

--- a/manifest/x86_64/s/sshpass.filelist
+++ b/manifest/x86_64/s/sshpass.filelist
@@ -1,0 +1,2 @@
+/usr/local/bin/sshpass
+/usr/local/share/man/man1/sshpass.1.zst

--- a/packages/sshpass.rb
+++ b/packages/sshpass.rb
@@ -1,0 +1,21 @@
+require 'buildsystems/autotools'
+
+class Sshpass < Autotools
+  description 'Tool for non-interactivly performing password authentication'
+  homepage 'https://sourceforge.net/projects/sshpass/'
+  version '1.10'
+  license 'GPL-2'
+  compatibility 'all'
+  source_url "https://downloads.sourceforge.net/project/sshpass/sshpass/#{version}/sshpass-#{version}.tar.gz"
+  source_sha256 'ad1106c203cbb56185ca3bad8c6ccafca3b4064696194da879f81c8d7bdfeeda'
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+    aarch64: '9f2431ab17af5f0a13187fa6d6d568cbee45bab6fafd239642ddadedf1e1c9ec',
+     armv7l: '9f2431ab17af5f0a13187fa6d6d568cbee45bab6fafd239642ddadedf1e1c9ec',
+       i686: 'a3b6bd7ad0e863608e781b8734c326406eeb46048e2e23c7603fcd295ab92f64',
+     x86_64: '7ac826922ae01f0a82082e545bc30e306b1e4b146f9839a235ec025f5e903fce'
+  })
+
+  depends_on 'glibc' # R
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -8495,6 +8495,11 @@ url: https://github.com/libfuse/sshfs/releases
 activity: low
 ---
 kind: url
+name: sshpass
+url: https://sourceforge.net/projects/sshpass/files/sshpass/
+activity: none
+---
+kind: url
 name: sshrc
 url: https://github.com/Russell91/sshrc/releases
 activity: medium


### PR DESCRIPTION
## Description
Sshpass is a tool for non-interactivly performing password authentication with SSH's so called "interactive keyboard password authentication".  See https://sourceforge.net/projects/sshpass/.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` 
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-sshpass-package crew update \
&& yes | crew upgrade
```