### PR TITLE
Zed 0.163.3 => 0.165.4

### DIFF
--- a/packages/zed.rb
+++ b/packages/zed.rb
@@ -3,12 +3,12 @@ require 'package'
 class Zed < Package
   description 'Zed is a high-performance, multiplayer code editor'
   homepage 'https://zed.dev/'
-  version '0.163.3'
+  version '0.165.4'
   license 'GPL-3, AGPL-3, Apache-2.0'
   compatibility 'x86_64'
   min_glibc '2.28'
   source_url "https://github.com/zed-industries/zed/releases/download/v#{version}/zed-linux-x86_64.tar.gz"
-  source_sha256 '7b4fa77e8aa767114a1344cccab0a42340aeaca8d7ba27d656d68fb6497668f4'
+  source_sha256 '006a3cf587da3056f49e146525af9606ca75558326961364f950f5a6f080b1eb'
 
   depends_on 'alsa_lib'
   depends_on 'libbsd'


### PR DESCRIPTION
Tested & (not) Working properly:
- [x] `x86_64` Unable to launch in hatch m130 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-zed crew update \
&& yes | crew upgrade
```
