### PR TITLE
Use source_url for peazip

### DIFF
--- a/packages/peazip.rb
+++ b/packages/peazip.rb
@@ -3,18 +3,19 @@ require 'package'
 class Peazip < Package
   description 'Free file archiver utility to open and extract RAR, TAR and ZIP archives'
   homepage 'https://peazip.github.io/'
+  version ARCH.eql?('x86_64') ? '10.1.0' : '5.2.0'
   license 'LGPL-3'
   compatibility 'x86_64 aarch64 armv7l'
-  case ARCH
-  when 'aarch64', 'armv7l'
-    version '5.2.0'
-    source_url 'https://downloads.sourceforge.net/project/peazip/5.2.0/pea-gtk2-arm.tar.gz'
-    source_sha256 '6724a5c4e273f086680ac30440a2014b647322d25ed9bba574b7b8edba61abcc'
-  when 'x86_64'
-    version '10.1.0'
-    source_url "https://github.com/peazip/PeaZip/releases/download/#{version}/peazip_portable-#{version}.LINUX.GTK2.x86_64.tar.gz"
-    source_sha256 'ba456a771184e9720d158b6740ac9d6e40e7a68720f36125f354368b239386ea'
-  end
+  source_url({
+    aarch64: 'https://downloads.sourceforge.net/project/peazip/5.2.0/pea-gtk2-arm.tar.gz',
+     armv7l: 'https://downloads.sourceforge.net/project/peazip/5.2.0/pea-gtk2-arm.tar.gz',
+     x86_64: "https://github.com/peazip/PeaZip/releases/download/#{version}/peazip_portable-#{version}.LINUX.GTK2.x86_64.tar.gz"
+  })
+  source_sha256({
+    aarch64: '6724a5c4e273f086680ac30440a2014b647322d25ed9bba574b7b8edba61abcc',
+     armv7l: '6724a5c4e273f086680ac30440a2014b647322d25ed9bba574b7b8edba61abcc',
+     x86_64: 'ba456a771184e9720d158b6740ac9d6e40e7a68720f36125f354368b239386ea'
+  })
 
   depends_on 'gtk2'
   depends_on 'sommelier'


### PR DESCRIPTION
Fixes `/usr/local/lib/crew/lib/package_utils.rb:75:in `get_clean_version': undefined method `gsub!' for nil (NoMethodError)`.
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l` 
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-peazip crew update \
&& yes | crew upgrade
```