### PR TITLE
Ruby gem version checks should exclude versions with 'rc' in them.

### DIFF
--- a/packages/ruby_activesupport.rb
+++ b/packages/ruby_activesupport.rb
@@ -3,7 +3,7 @@ require 'buildsystems/ruby'
 class Ruby_activesupport < RUBY
   description 'A toolkit of support libraries and Ruby core extensions extracted from the Rails framework.'
   homepage 'https://rubyonrails.org/'
-  version "8.0.0.rc2-#{CREW_RUBY_VER}"
+  version "8.0.0-#{CREW_RUBY_VER}"
   license 'MIT'
   compatibility 'all'
   source_url 'SKIP'

--- a/tools/update_ruby_gem_packages.rb
+++ b/tools/update_ruby_gem_packages.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# update_ruby_gem_packages version 1.7 (for Chromebrew)
+# update_ruby_gem_packages version 1.8 (for Chromebrew)
 # Author: Satadru Pramanik (satmandu) satadru at gmail dot com
 # Usage in root of cloned chromebrew repo:
 # tools/update_ruby_gem_packages.rb
@@ -55,6 +55,7 @@ relevant_gem_packages.each_with_index do |package, index|
     gem_test_versions.delete_if { |i| i.include?('beta') }
     gem_test_versions.delete_if { |i| i.include?('java') }
     gem_test_versions.delete_if { |i| i.include?('pre') }
+    gem_test_versions.delete_if { |i| i.include?('rc') }
     gem_test_version = gem_test_versions.max
     puts "#{untested_package_name} is #{gem_test_name} version #{gem_test_version}".lightpurple if CREW_VERBOSE
     gem_name = gem_test_name.blank? ? Gem::SpecFetcher.fetcher.suggest_gems_from_name(untested_package_name).first : gem_test_name


### PR DESCRIPTION
- Also updates `ruby_activesupport` to  non-rc version.
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_