### PR TITLE
Libtorrent 2.0.9-1 => 2.0.10

### DIFF
--- a/manifest/armv7l/l/libtorrent.filelist
+++ b/manifest/armv7l/l/libtorrent.filelist
@@ -278,6 +278,6 @@
 /usr/local/lib/cmake/LibtorrentRasterbar/LibtorrentRasterbarTargets.cmake
 /usr/local/lib/libtorrent-rasterbar.so
 /usr/local/lib/libtorrent-rasterbar.so.2.0
-/usr/local/lib/libtorrent-rasterbar.so.2.0.9
+/usr/local/lib/libtorrent-rasterbar.so.2.0.10
 /usr/local/lib/pkgconfig/libtorrent-rasterbar.pc
 /usr/local/share/cmake/Modules/FindLibtorrentRasterbar.cmake

--- a/manifest/i686/l/libtorrent.filelist
+++ b/manifest/i686/l/libtorrent.filelist
@@ -278,6 +278,6 @@
 /usr/local/lib/cmake/LibtorrentRasterbar/LibtorrentRasterbarTargets.cmake
 /usr/local/lib/libtorrent-rasterbar.so
 /usr/local/lib/libtorrent-rasterbar.so.2.0
-/usr/local/lib/libtorrent-rasterbar.so.2.0.9
+/usr/local/lib/libtorrent-rasterbar.so.2.0.10
 /usr/local/lib/pkgconfig/libtorrent-rasterbar.pc
 /usr/local/share/cmake/Modules/FindLibtorrentRasterbar.cmake

--- a/manifest/x86_64/l/libtorrent.filelist
+++ b/manifest/x86_64/l/libtorrent.filelist
@@ -278,6 +278,6 @@
 /usr/local/lib64/cmake/LibtorrentRasterbar/LibtorrentRasterbarTargets.cmake
 /usr/local/lib64/libtorrent-rasterbar.so
 /usr/local/lib64/libtorrent-rasterbar.so.2.0
-/usr/local/lib64/libtorrent-rasterbar.so.2.0.9
+/usr/local/lib64/libtorrent-rasterbar.so.2.0.10
 /usr/local/lib64/pkgconfig/libtorrent-rasterbar.pc
 /usr/local/share/cmake/Modules/FindLibtorrentRasterbar.cmake

--- a/packages/libtorrent.rb
+++ b/packages/libtorrent.rb
@@ -3,18 +3,18 @@ require 'buildsystems/cmake'
 class Libtorrent < CMake
   description 'Feature complete C++ bittorrent implementation focusing on efficiency and scalability.'
   homepage 'https://www.libtorrent.org/'
-  version '2.0.9-1'
+  version '2.0.10'
   license 'Unknown, BSD-3-Clause'
   compatibility 'all'
-  source_url 'https://github.com/arvidn/libtorrent/releases/download/v2.0.9/libtorrent-rasterbar-2.0.9.tar.gz'
+  source_url "https://github.com/arvidn/libtorrent/releases/download/v#{version}/libtorrent-rasterbar-#{version}.tar.gz"
   source_sha256 '90cd92b6061c5b664840c3d5e151d43fedb24f5b2b24e14425ffbb884ef1798e'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '3cb2ebed40910fc51e140ba44958877ac14363fcbdc71ddaa97e15ee76b3128b',
-     armv7l: '3cb2ebed40910fc51e140ba44958877ac14363fcbdc71ddaa97e15ee76b3128b',
-       i686: '945b87b3f97f19da0a81a2562e96ea2fcf55eddaf53c3aa2ecddd4be12efbb99',
-     x86_64: 'ccde87bd39b059c4ed710a3a4e905ebf43419e097cd326356f4b8d386619eed6'
+    aarch64: 'cf3e30dd7fffa4a538d2d33ddc58fe939fb0bf09a483c0dbc1294f2c5aad49e3',
+     armv7l: 'cf3e30dd7fffa4a538d2d33ddc58fe939fb0bf09a483c0dbc1294f2c5aad49e3',
+       i686: '1c7df2be1186aa7d946fe462cebe6f1176ee15f907bd51ed681bfa95daf29546',
+     x86_64: '1b9aa2111346efb2f6fcdbcbecd5d1e01ede2c571c16cd4f36f72cb228099fe5'
   })
 
   depends_on 'boost'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` 
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-libtorrent crew update \
&& yes | crew upgrade
``