### PR TITLE
Difftastic 0.60.0 => 0.62.0

### DIFF
--- a/packages/difftastic.rb
+++ b/packages/difftastic.rb
@@ -3,7 +3,7 @@ require 'package'
 class Difftastic < Package
   description 'Difftastic is a structural diff tool that compares files based on their syntax.'
   homepage 'https://github.com/Wilfred/difftastic'
-  version '0.60.0'
+  version '0.62.0'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/Wilfred/difftastic.git'
@@ -11,10 +11,10 @@ class Difftastic < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'a76daf14ae3e2b82c635da690b27d9dfc3e83b22a856d8a1ef0c9ad5e1dfcea7',
-     armv7l: 'a76daf14ae3e2b82c635da690b27d9dfc3e83b22a856d8a1ef0c9ad5e1dfcea7',
-       i686: 'b766154522964c4b421f9afba18885d87b96a07df295329bf85a5704546ec6d5',
-     x86_64: '649c57d13b0a9d234e23b62c5c34b0025859687abb393f2c543c69f804d88b61'
+    aarch64: '67cd66a4e4c1e96f16819b75b20ffabd43f0586fe3057b2a99a1df59df63e1a0',
+     armv7l: '67cd66a4e4c1e96f16819b75b20ffabd43f0586fe3057b2a99a1df59df63e1a0',
+       i686: '0202aa02d6bc115f10480901bdc53cf7dfec9130f6873859b035bcb2feae2481',
+     x86_64: 'f2706ced7fc57e3b311e449a2db4bfe86489b58d53071ea9e94d2436c9adf954'
   })
 
   depends_on 'rust' => :build


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` 
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-difftastic crew update \
&& yes | crew upgrade
```