### PR TITLE
Cabal 3.12.1.0 => 3.14.1.0

### DIFF
--- a/packages/cabal.rb
+++ b/packages/cabal.rb
@@ -3,7 +3,7 @@ require 'package'
 class Cabal < Package
   description 'Common Architecture for Building Applications and Libraries'
   homepage 'https://www.haskell.org/cabal/'
-  version '3.12.1.0'
+  version '3.14.1.0'
   license 'BSD'
   compatibility 'x86_64 i686'
   source_url({
@@ -11,8 +11,8 @@ class Cabal < Package
       i686: "https://downloads.haskell.org/~cabal/cabal-install-#{version}/cabal-install-#{version}-i386-linux-alpine3_12.tar.xz"
   })
   source_sha256({
-    x86_64: '6fa71b75c87cd57700348fc9c089703201aac5fd248a92e6bc7346fd2e007da7',
-      i686: '7890041cba03195bac2835eecaec349c39aad2ec0b729bd0c92f6f7f7ea240bf'
+    x86_64: 'b314d017d7525b662d9571b0de15870882862e32948d4c5d78e209641b474279',
+      i686: 'aeff8b622c18a8dc2cb6adc5b7e90fd807a92b51a9f689fc5804c2b91675b1b8'
   })
 
   no_compile_needed


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-cabal crew update \
&& yes | crew upgrade
```