### PR TITLE
Fix using 'crew download' to get package binaries for no_source_build and gem_compile_needed packages.

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -471,7 +471,7 @@ def download
 
   if !url
     abort "No precompiled binary or source is available for #{@device[:architecture]}.".lightred
-  elsif url.casecmp?('SKIP') || (@pkg.no_source_build? || @pkg.gem_compile_needed?)
+  elsif url.casecmp?('SKIP') || ((@pkg.no_source_build? || @pkg.gem_compile_needed?) && caller.grep(/download_command/).empty?)
     puts 'Skipping source download...'
   elsif @pkg.build_from_source
     puts 'Downloading source...'
@@ -488,9 +488,10 @@ def download
     # We want to skip when no_source_build is true during the build,
     # but when we have built a binary we are in upgrade, and we need
     # download since we need to extract the just generated binary.
-    next if (@pkg.no_source_build? || @pkg.gem_compile_needed?) && !@pkg.in_upgrade && !@pkg.in_install
+    next if (@pkg.no_source_build? || @pkg.gem_compile_needed?) && !@pkg.in_upgrade && caller.grep(/download_command/).empty?
     case File.basename(filename)
-    # Sources that download with our internal downloader
+    # Sources that download with our internal downloader.
+    # This also covers all precompiled binaries.
     when /\.zip$/i, /\.(tar(\.(gz|bz2|xz|lzma|lz|zst))?|tgz|tbz|tpxz|txz)$/i, /\.deb$/i, /\.AppImage$/i, /\.gem$/i
       # Recall file from cache if requested
       if CREW_CACHE_ENABLED
@@ -514,6 +515,10 @@ def download
               puts 'Archive copied from cache'.green if CREW_VERBOSE
             end
             puts 'Archive found in cache'.lightgreen
+            unless caller.grep(/download_command/).empty?
+              puts 'Downloaded to: '.lightblue + File.join(CREW_BREW_DIR, filename).blue
+              FileUtils.rm_rf @extract_dir
+            end
             return { source:, filename: }
           else
             puts 'Cached archive checksum mismatch. 😔 Will download.'.lightred
@@ -540,6 +545,10 @@ def download
           FileUtils.cp filename, CREW_CACHE_DIR, verbose: @fileutils_verbose
           puts 'Archive copied to cache'.green if CREW_VERBOSE
         end
+      end
+      unless caller.grep(/download_command/).empty?
+        puts 'Downloaded to: '.lightblue + File.join(CREW_BREW_DIR, filename).blue
+        FileUtils.rm_rf @extract_dir
       end
       return { source:, filename: }
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.56.6' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.56.7' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]


### PR DESCRIPTION
- Note that `caller_locations(1,1)[0].label == 'download_command'` does not work for this...

Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=download_fix crew update \
&& yes | crew upgrade
```
