### PR TITLE
Add byebug gem and fix regression in crew install of no_source_build packages

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -488,7 +488,7 @@ def download
     # We want to skip when no_source_build is true during the build,
     # but when we have built a binary we are in upgrade, and we need
     # download since we need to extract the just generated binary.
-    crewlog "(@pkg.no_source_build? || @pkg.gem_compile_needed?) && !@pkg.in_upgrade && !@pkg.in_install && caller.grep(/download_command/).empty?"
+    crewlog '(@pkg.no_source_build? || @pkg.gem_compile_needed?) && !@pkg.in_upgrade && !@pkg.in_install && caller.grep(/download_command/).empty?'
     crewlog "#{@pkg.no_source_build?} || #{@pkg.gem_compile_needed?} && #{!@pkg.in_upgrade} && #{!@pkg.in_install} && #{caller.grep(/download_command/).empty?}"
     next if (@pkg.no_source_build? || @pkg.gem_compile_needed?) && !@pkg.in_upgrade && !@pkg.in_install && caller.grep(/download_command/).empty?
     case File.basename(filename)

--- a/bin/crew
+++ b/bin/crew
@@ -471,7 +471,7 @@ def download
 
   if !url
     abort "No precompiled binary or source is available for #{@device[:architecture]}.".lightred
-  elsif url.casecmp?('SKIP') || ((@pkg.no_source_build? || @pkg.gem_compile_needed?) && caller.grep(/download_command/).empty?)
+  elsif url.casecmp?('SKIP') || (@pkg.no_source_build? || @pkg.gem_compile_needed?)
     puts 'Skipping source download...'
   elsif @pkg.build_from_source
     puts 'Downloading source...'
@@ -488,7 +488,9 @@ def download
     # We want to skip when no_source_build is true during the build,
     # but when we have built a binary we are in upgrade, and we need
     # download since we need to extract the just generated binary.
-    next if (@pkg.no_source_build? || @pkg.gem_compile_needed?) && !@pkg.in_upgrade && caller.grep(/download_command/).empty?
+    crewlog "(@pkg.no_source_build? || @pkg.gem_compile_needed?) && !@pkg.in_upgrade && !@pkg.in_install && caller.grep(/download_command/).empty?"
+    crewlog "#{@pkg.no_source_build?} || #{@pkg.gem_compile_needed?} && #{!@pkg.in_upgrade} && #{!@pkg.in_install} && #{caller.grep(/download_command/).empty?}"
+    next if (@pkg.no_source_build? || @pkg.gem_compile_needed?) && !@pkg.in_upgrade && !@pkg.in_install && caller.grep(/download_command/).empty?
     case File.basename(filename)
     # Sources that download with our internal downloader.
     # This also covers all precompiled binaries.

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.56.7' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.56.8' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]

--- a/packages/ruby_byebug.rb
+++ b/packages/ruby_byebug.rb
@@ -1,7 +1,7 @@
 require 'buildsystems/ruby'
 
 class Ruby_byebug < RUBY
-  description '|- Byebug is a Ruby debugger.'
+  description 'Byebug is a Ruby debugger.'
   homepage 'https://github.com/deivid-rodriguez/byebug'
   version "11.1.3-#{CREW_RUBY_VER}"
   license 'BSD-2-Clause'

--- a/packages/ruby_byebug.rb
+++ b/packages/ruby_byebug.rb
@@ -1,0 +1,21 @@
+require 'buildsystems/ruby'
+
+class Ruby_byebug < RUBY
+  description '|- Byebug is a Ruby debugger.'
+  homepage 'https://github.com/deivid-rodriguez/byebug'
+  version "11.1.3-#{CREW_RUBY_VER}"
+  license 'BSD-2-Clause'
+  compatibility 'all'
+  source_url 'SKIP'
+  binary_compression 'gem'
+
+  binary_sha256({
+    aarch64: 'a66196f0efe8c3d71684307b069a33483e56ec1d2217e4f33101fdbfef1f1f87',
+     armv7l: 'a66196f0efe8c3d71684307b069a33483e56ec1d2217e4f33101fdbfef1f1f87',
+       i686: '59217683304ae983a704955c2082222b5eeefc369b62804fc06cbc01d567cd39',
+     x86_64: 'c668fb6e1798a9ac0091fcaae08d47d09af02762204f839754619c385621b559'
+  })
+
+  conflicts_ok
+  gem_compile_needed
+end

--- a/packages/ruby_pry_byebug.rb
+++ b/packages/ruby_pry_byebug.rb
@@ -8,6 +8,7 @@ class Ruby_pry_byebug < RUBY
   compatibility 'all'
   source_url 'SKIP'
 
+  depends_on 'ruby_byebug' # L
   depends_on 'ruby_pry' # L
   conflicts_ok
   no_compile_needed

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -7950,6 +7950,11 @@ url: https://github.com/asciidoctor/asciidoctor/releases
 activity: medium
 ---
 kind: url
+name: ruby_byebug
+url: https://github.com/deivid-rodriguez/byebug/releases
+activity: low
+---
+kind: url
 name: ruby_concurrent_ruby
 url: https://github.com/ruby-concurrency/concurrent-ruby/releases
 activity: medium


### PR DESCRIPTION
- The regression was due to an inadvertent deletion of `&& !@pkg.in_install`