### PR TITLE
Joplin 3.2.6 => 3.2.10

### DIFF
--- a/packages/joplin.rb
+++ b/packages/joplin.rb
@@ -3,11 +3,11 @@ require 'package'
 class Joplin < Package
   description 'Open source note-taking app'
   homepage 'https://joplinapp.org/'
-  version '3.2.6'
+  version '3.2.10'
   license 'AGPL-3.0'
   compatibility 'x86_64'
   source_url "https://objects.joplinusercontent.com/v#{version}/Joplin-#{version}.AppImage"
-  source_sha256 '37a7eb2158dc49498c89cfbf349ba4d677f46ee93762092447280fafdc2301d2'
+  source_sha256 '6661ddf04a84a915c85154f973f0bc9d015d24c5ea88a7817d9995927cd954ba'
 
   depends_on 'gtk3'
   depends_on 'gdk_base'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in nocturne m90 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-joplin crew update \
&& yes | crew upgrade
```