### PR TITLE
Google_chrome 131.0.6778.264-1 => 132.0.6834.83-1

### DIFF
--- a/packages/google_chrome.rb
+++ b/packages/google_chrome.rb
@@ -4,12 +4,12 @@ class Google_chrome < Package
   @update_channel = 'stable'
   description 'Google Chrome is a fast, easy to use, and secure web browser.'
   homepage 'https://www.google.com/chrome/'
-  version '131.0.6778.264-1'
+  version '132.0.6834.83-1'
   license 'google-chrome'
   compatibility 'x86_64'
   min_glibc '2.28'
   source_url "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-#{@update_channel}/google-chrome-#{@update_channel}_#{@version}_amd64.deb"
-  source_sha256 'cdf3d791f8e7bd518ed3d5f87aa4e28bbacfc2278c12c40ccbda7db576f97c35'
+  source_sha256 'aae7efee6ee243cc97e9678d6a34db3c42c299186be061816bc5b3cbe88c1618'
 
   depends_on 'nss'
   depends_on 'cairo'
@@ -30,6 +30,25 @@ class Google_chrome < Package
   end
 
   def self.postinstall
+    print "\nSet Chrome as your default browser? [Y/n]: "
+    case $stdin.gets.chomp.downcase
+    when '', 'y', 'yes'
+      Dir.chdir("#{CREW_PREFIX}/bin") do
+        FileUtils.ln_sf 'google-chrome', 'x-www-browser'
+      end
+      puts 'Chrome is now your default browser.'.lightgreen
+    else
+      puts 'No change has been made.'.orange
+    end
     ExitMessage.add "\nType 'google-chrome' to get started.\n"
+  end
+
+  def self.preremove
+    Dir.chdir("#{CREW_PREFIX}/bin") do
+      if File.exist?('x-www-browser') && File.symlink?('x-www-browser') && \
+         File.realpath('x-www-browser') == "#{CREW_PREFIX}/share/chrome/google-chrome"
+        FileUtils.rm "#{CREW_PREFIX}/bin/x-www-browser"
+      end
+    end
   end
 end


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m131 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-google_chrome crew update \
&& yes | crew upgrade
```