### PR TITLE
Signal_desktop 7.37.0 => 7.38.0

### DIFF
--- a/manifest/x86_64/s/signal_desktop.filelist
+++ b/manifest/x86_64/s/signal_desktop.filelist
@@ -110,6 +110,8 @@
 /usr/local/share/Signal/resources/app.asar.unpacked/node_modules/@signalapp/libsignal-client/prebuilds/linux-x64/@signalapp+libsignal-client.node
 /usr/local/share/Signal/resources/app.asar.unpacked/node_modules/@signalapp/ringrtc/build/linux/libringrtc-x64.node
 /usr/local/share/Signal/resources/app.asar.unpacked/node_modules/fs-xattr/build/Release/xattr.node
+/usr/local/share/Signal/resources/app.asar.unpacked/node_modules/mac-screen-capture-permissions/build/Release/screencapturepermissions.node
+/usr/local/share/Signal/resources/apparmor-profile
 /usr/local/share/Signal/resources/package-type
 /usr/local/share/Signal/signal-desktop
 /usr/local/share/Signal/snapshot_blob.bin

--- a/packages/signal_desktop.rb
+++ b/packages/signal_desktop.rb
@@ -3,12 +3,12 @@ require 'package'
 class Signal_desktop < Package
   description 'Private Messenger for Windows, Mac, and Linux'
   homepage 'https://signal.org/'
-  version '7.37.0'
+  version '7.38.0'
   license 'AGPL-3.0'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_#{version}_amd64.deb"
-  source_sha256 '4ecd53483c48352b48b592fa04e27326d50e2eb20cb245d298b3033fef55bb44'
+  source_sha256 '3781f4870bef89e8e0a66414d645c3e64137e6176ed9ef2659fa7d8635515318'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m131 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-signal_desktop crew update \
&& yes | crew upgrade
```