### PR TITLE
Rustdesk 1.3.6 => 1.3.7

### DIFF
--- a/packages/rustdesk.rb
+++ b/packages/rustdesk.rb
@@ -3,7 +3,7 @@ require 'package'
 class Rustdesk < Package
   description 'An open-source remote desktop application designed for self-hosting, as an alternative to TeamViewer.'
   homepage 'https://rustdesk.com/'
-  version '1.3.6'
+  version '1.3.7'
   license 'AGPL-3.0'
   compatibility 'x86_64 aarch64 armv7l'
   min_glibc '2.37'
@@ -13,9 +13,9 @@ class Rustdesk < Package
      x86_64: "https://github.com/rustdesk/rustdesk/releases/download/#{version}/rustdesk-#{version}-x86_64.deb"
   })
   source_sha256({
-    aarch64: 'f1b27c08755b94c2636acf7069d4453fdfeca7f3ea7954b10dfc0266b45a6f00',
-     armv7l: 'f1b27c08755b94c2636acf7069d4453fdfeca7f3ea7954b10dfc0266b45a6f00',
-     x86_64: 'd4b9b47cbdf7786c3116bb278c6c5a8b8b058eecc23646e798b7f5961539c801'
+    aarch64: 'fc3b861468e12f572cdf327e6ecef219cc8a92af8caaaf8146d715064445d4a3',
+     armv7l: 'fc3b861468e12f572cdf327e6ecef219cc8a92af8caaaf8146d715064445d4a3',
+     x86_64: '2e5ac2a3d2d381fa5b835f516a8ba2289b9505bb4cb7fad68acf459d889390bf'
   })
 
   depends_on 'gtk3'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`  Unable to launch in strongbad m131 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-rustdesk crew update \
&& yes | crew upgrade
```