### PR TITLE
Opera 116.0.5366.51 => 116.0.5366.71

### DIFF
--- a/packages/opera.rb
+++ b/packages/opera.rb
@@ -4,7 +4,7 @@ require 'convenience_functions'
 class Opera < Package
   description 'Opera is a multi-platform web browser based on Chromium and developed by Opera Software.'
   homepage 'https://www.opera.com/'
-  version '116.0.5366.51'
+  version '116.0.5366.71'
   license 'OPERA-2018'
   compatibility 'x86_64'
   min_glibc '2.29'
@@ -12,7 +12,7 @@ class Opera < Package
   # faster apt mirror, but only works when downloading latest version of opera
   # source_url "https://deb.opera.com/opera/pool/non-free/o/opera-stable/opera-stable_#{version}_amd64.deb"
   source_url "https://deb.opera.com/opera-stable/pool/non-free/o/opera-stable/opera-stable_#{version}_amd64.deb"
-  source_sha256 '8967a78c7eb9e99c56c2798c79008368be14704c35a2e022ce832be65bd8c993'
+  source_sha256 '1201ebf185800025e24ff4becd38406d31a81556ce5d55dc27f30afff4d6ccbe'
 
   depends_on 'gtk3'
   depends_on 'gsettings_desktop_schemas'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m131 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-opera crew update \
&& yes | crew upgrade
```