### PR TITLE
Add vitetris package

### DIFF
--- a/manifest/armv7l/v/vitetris.filelist
+++ b/manifest/armv7l/v/vitetris.filelist
@@ -1,0 +1,5 @@
+/usr/local/bin/tetris
+/usr/local/share/applications/vitetris.desktop
+/usr/local/share/doc/vitetris/README
+/usr/local/share/doc/vitetris/licence.txt
+/usr/local/share/pixmaps/vitetris.xpm

--- a/manifest/i686/v/vitetris.filelist
+++ b/manifest/i686/v/vitetris.filelist
@@ -1,0 +1,5 @@
+/usr/local/bin/tetris
+/usr/local/share/applications/vitetris.desktop
+/usr/local/share/doc/vitetris/README
+/usr/local/share/doc/vitetris/licence.txt
+/usr/local/share/pixmaps/vitetris.xpm

--- a/manifest/x86_64/v/vitetris.filelist
+++ b/manifest/x86_64/v/vitetris.filelist
@@ -1,0 +1,5 @@
+/usr/local/bin/tetris
+/usr/local/share/applications/vitetris.desktop
+/usr/local/share/doc/vitetris/README
+/usr/local/share/doc/vitetris/licence.txt
+/usr/local/share/pixmaps/vitetris.xpm

--- a/packages/vitetris.rb
+++ b/packages/vitetris.rb
@@ -1,0 +1,37 @@
+require 'package'
+
+class Vitetris < Package
+  description 'Classic multiplayer tetris for the terminal'
+  homepage 'https://www.victornils.net/tetris/'
+  version '0.59.1'
+  license 'BSD-2-Clause'
+  compatibility 'all'
+  source_url 'https://github.com/vicgeralds/vitetris.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+    aarch64: '69b94bfbcf0fd6ab0744745f0f9512aa2de9eab0dd7ec97cd9603d085173c8cf',
+     armv7l: '69b94bfbcf0fd6ab0744745f0f9512aa2de9eab0dd7ec97cd9603d085173c8cf',
+       i686: '0cdc60d994383f1182c61e9a07baa1686c9ad2f83d658f320223fba7e522adae',
+     x86_64: 'c5c834cd261fa11aa24d69f076dc6af1608a743bf0d3740d0d15f65a00ef7dd6'
+  })
+
+  depends_on 'curl' => :build
+  depends_on 'llvm' => :build
+  depends_on 'buildessential' => :build
+  depends_on 'glibc' # R
+
+  def self.build
+    system "./configure --prefix=#{CREW_PREFIX}"
+    system 'make CFLAGS="-O3 -pipe -Wno-error=implicit-int -Wno-error=implicit-function-declaration"'
+  end
+
+  def self.install
+    system "make DESTDIR=#{CREW_DEST_DIR} install"
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nUse command 'tetris' to launch Vitetris.\n"
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -9255,6 +9255,11 @@ url: https://gitlab.freedesktop.org/virgl/virglrenderer/-/tags
 activity: low
 ---
 kind: url
+name: vitetris
+url: https://github.com/vicgeralds/vitetris/releases
+activity: none
+---
+kind: url
 name: vivaldi
 url: https://vivaldi.com/download/
 activity: medium


### PR DESCRIPTION
Contribution credit goes to @FinnBaltazar1111.

## Description
Classic multiplayer tetris for the terminal.  See http://victornils.net/tetris/.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` 
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-vitetris-package crew update \
&& yes | crew upgrade
```