### PR TITLE
tre 07e66d0 -> 0.9.0

### DIFF
--- a/packages/tre.rb
+++ b/packages/tre.rb
@@ -3,11 +3,11 @@ require 'buildsystems/autotools'
 class Tre < Autotools
   description 'The approximate regex matching library and agrep command line tool.'
   homepage 'https://github.com/laurikari/tre'
-  version '07e66d0'
+  version '0.9.0'
   license 'BSD-2'
   compatibility 'all'
   source_url 'https://github.com/laurikari/tre.git'
-  git_hashtag '07e66d07b44ae95a7a89f79c7ce1090f0f4d64db'
+  git_hashtag "v#{version}"
   binary_compression 'tar.zst'
 
   binary_sha256({


### PR DESCRIPTION
Working on removing all our nonstandard versions, so we can have a nice clean Repology report. This project just started tagging its release again after a while.

##
Builds:
- [ ] `x86_64`
- [ ] `i686`
- [ ] `armv7l`
##
Tested & Working properly:
- [ ] `x86_64`
- [ ] `i686`
- [ ] `armv7l` <!-- (reasons why it doesn't) -->
##
- [ ] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=progers crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
