### PR TITLE
Split out definition of require_gem to standalone file

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1,26 +1,9 @@
 #!/usr/bin/env ruby
+# We require color here to get access to .lightred.
 require_relative '../lib/color'
-# Disallow sudo
+# Disallow sudo.
 abort 'Chromebrew should not be run as root.'.lightred if Process.uid.zero?
-def require_gem(gem_name_and_require = nil, require_override = nil)
-  # Allow only loading gems when needed.
-  return if gem_name_and_require.nil?
-
-  gem_name = gem_name_and_require.split('/')[0]
-  begin
-    gem gem_name
-  rescue LoadError
-    puts " -> install #{gem_name} gem".orange
-    Gem.install(gem_name)
-    gem gem_name
-  end
-  requires = if require_override.nil?
-               gem_name_and_require.split('/')[1].nil? ? gem_name_and_require.split('/')[0] : gem_name_and_require
-             else
-               require_override
-             end
-  require requires
-end
+require_relative '../lib/require_gem'
 require_gem('activesupport', 'active_support/core_ext/object/blank')
 require_gem('highline')
 # The json gem can break when upgrading from a much older version of ruby.

--- a/lib/buildsystems/ruby.rb
+++ b/lib/buildsystems/ruby.rb
@@ -2,26 +2,8 @@ require 'color'
 require 'gem_compact_index_client'
 require 'package'
 require 'package_utils'
+require 'require_gem'
 
-def require_gem(gem_name_and_require = nil, require_override = nil)
-  # Allow only loading gems when needed.
-  return if gem_name_and_require.nil?
-
-  gem_name = gem_name_and_require.split('/')[0]
-  begin
-    gem gem_name
-  rescue LoadError
-    puts " -> install #{gem_name} gem".orange
-    Gem.install(gem_name)
-    gem gem_name
-  end
-  requires = if require_override.nil?
-               gem_name_and_require.split('/')[1].nil? ? gem_name_and_require.split('/')[0] : gem_name_and_require
-             else
-               require_override
-             end
-  require requires
-end
 require_gem('activesupport', 'active_support/core_ext/object/blank')
 
 def check_gem_binary_build_needed(gem_name = nil, gem_version = nil)

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -4,26 +4,8 @@ require 'uri'
 require_relative 'const'
 require_relative 'color'
 require_relative 'progress_bar'
+require_relative 'require_gem'
 
-def require_gem(gem_name_and_require = nil, require_override = nil)
-  # Allow only loading gems when needed.
-  return if gem_name_and_require.nil?
-
-  gem_name = gem_name_and_require.split('/')[0]
-  begin
-    gem gem_name
-  rescue LoadError
-    puts " -> install #{gem_name} gem".orange
-    Gem.install(gem_name)
-    gem gem_name
-  end
-  requires = if require_override.nil?
-               gem_name_and_require.split('/')[1].nil? ? gem_name_and_require.split('/')[0] : gem_name_and_require
-             else
-               require_override
-             end
-  require requires
-end
 require_gem('activesupport', 'active_support/core_ext/object/blank')
 require_gem('ptools')
 

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -4,26 +4,8 @@ require 'etc'
 require 'json'
 require_relative 'color'
 require_relative 'package'
+require_relative 'require_gem'
 
-def require_gem(gem_name_and_require = nil, require_override = nil)
-  # Allow only loading gems when needed.
-  return if gem_name_and_require.nil?
-
-  gem_name = gem_name_and_require.split('/')[0]
-  begin
-    gem gem_name
-  rescue LoadError
-    puts " -> install #{gem_name} gem".orange
-    Gem.install(gem_name)
-    gem gem_name
-  end
-  requires = if require_override.nil?
-               gem_name_and_require.split('/')[1].nil? ? gem_name_and_require.split('/')[0] : gem_name_and_require
-             else
-               require_override
-             end
-  require requires
-end
 require_gem('highline')
 
 # All needed constants & variables should be defined here in case they

--- a/lib/misc_functions.rb
+++ b/lib/misc_functions.rb
@@ -1,27 +1,7 @@
 # lib/misc_functions.rb
 # Generic implementations of various functions/algorithms that are not crew-specific.
+require 'matrix'
 require_relative 'color'
-
-def require_gem(gem_name_and_require = nil, require_override = nil)
-  # Allow only loading gems when needed.
-  return if gem_name_and_require.nil?
-
-  gem_name = gem_name_and_require.split('/')[0]
-  begin
-    gem gem_name
-  rescue LoadError
-    puts " -> install #{gem_name} gem".orange
-    Gem.install(gem_name)
-    gem gem_name
-  end
-  requires = if require_override.nil?
-               gem_name_and_require.split('/')[1].nil? ? gem_name_and_require.split('/')[0] : gem_name_and_require
-             else
-               require_override
-             end
-  require requires
-end
-require_gem('matrix')
 
 class MiscFunctions
   def self.human_size(bytes)

--- a/lib/package.rb
+++ b/lib/package.rb
@@ -3,27 +3,9 @@ require 'json'
 require_relative 'const'
 require_relative 'color'
 require_relative 'package_helpers'
+require_relative 'require_gem'
 require_relative 'selector'
 
-def require_gem(gem_name_and_require = nil, require_override = nil)
-  # Allow only loading gems when needed.
-  return if gem_name_and_require.nil?
-
-  gem_name = gem_name_and_require.split('/')[0]
-  begin
-    gem gem_name
-  rescue LoadError
-    puts " -> install #{gem_name} gem".orange
-    Gem.install(gem_name)
-    gem gem_name
-  end
-  requires = if require_override.nil?
-               gem_name_and_require.split('/')[1].nil? ? gem_name_and_require.split('/')[0] : gem_name_and_require
-             else
-               require_override
-             end
-  require requires
-end
 require_gem 'highline'
 require_gem 'timeout'
 

--- a/lib/require_gem.rb
+++ b/lib/require_gem.rb
@@ -1,0 +1,21 @@
+require_relative 'color'
+
+def require_gem(gem_name_and_require = nil, require_override = nil)
+  # Allow only loading gems when needed.
+  return if gem_name_and_require.nil?
+
+  gem_name = gem_name_and_require.split('/')[0]
+  begin
+    gem gem_name
+  rescue LoadError
+    puts " -> install #{gem_name} gem".orange
+    Gem.install(gem_name)
+    gem gem_name
+  end
+  requires = if require_override.nil?
+              gem_name_and_require.split('/')[1].nil? ? gem_name_and_require.split('/')[0] : gem_name_and_require
+            else
+              require_override
+            end
+  require requires
+end

--- a/tools/build_updated_packages.rb
+++ b/tools/build_updated_packages.rb
@@ -17,6 +17,7 @@ require 'English'
 require_relative '../lib/color'
 require_relative '../lib/const'
 require_relative '../lib/package'
+require_relative '../lib/require_gem'
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
 abort "\nGITLAB_TOKEN environment variable not set.\n".lightred if ENV['GITLAB_TOKEN'].nil?
@@ -26,25 +27,6 @@ puts "Setting the CREW_AGREE_TIMEOUT_SECONDS environment variable to less than t
 SKIP_UPDATE_CHECKS = ARGV.include?('--skip')
 CHECK_ALL_PYTHON = ARGV.include?('--check-all-python')
 CHECK_ALL_RUBY = ARGV.include?('--check-all-ruby')
-def require_gem(gem_name_and_require = nil, require_override = nil)
-  # Allow only loading gems when needed.
-  return if gem_name_and_require.nil?
-
-  gem_name = gem_name_and_require.split('/')[0]
-  begin
-    gem gem_name
-  rescue LoadError
-    puts " -> install #{gem_name} gem".orange
-    Gem.install(gem_name)
-    gem gem_name
-  end
-  requires = if require_override.nil?
-               gem_name_and_require.split('/')[1].nil? ? gem_name_and_require.split('/')[0] : gem_name_and_require
-             else
-               require_override
-             end
-  require requires
-end
 require_gem 'highline'
 require_gem 'timeout'
 

--- a/tools/create_default_gems_packages.rb
+++ b/tools/create_default_gems_packages.rb
@@ -14,25 +14,8 @@ require 'fileutils'
 require 'json'
 require_relative '../lib/color'
 require_relative '../lib/const'
-def require_gem(gem_name_and_require = nil, require_override = nil)
-  # Allow only loading gems when needed.
-  return if gem_name_and_require.nil?
+require_relative '../lib/require_gem'
 
-  gem_name = gem_name_and_require.split('/')[0]
-  begin
-    gem gem_name
-  rescue LoadError
-    puts " -> install #{gem_name} gem".orange
-    Gem.install(gem_name)
-    gem gem_name
-  end
-  requires = if require_override.nil?
-               gem_name_and_require.split('/')[1].nil? ? gem_name_and_require.split('/')[0] : gem_name_and_require
-             else
-               require_override
-             end
-  require requires
-end
 require_gem('httpparty')
 
 def create_default_gems_package

--- a/tools/create_gem_packages.rb
+++ b/tools/create_gem_packages.rb
@@ -13,26 +13,8 @@ require 'fileutils'
 require 'json'
 require_relative '../lib/color'
 require_relative '../lib/const'
+require_relative '../lib/require_gem'
 
-def require_gem(gem_name_and_require = nil, require_override = nil)
-  # Allow only loading gems when needed.
-  return if gem_name_and_require.nil?
-
-  gem_name = gem_name_and_require.split('/')[0]
-  begin
-    gem gem_name
-  rescue LoadError
-    puts " -> install #{gem_name} gem".orange
-    Gem.install(gem_name)
-    gem gem_name
-  end
-  requires = if require_override.nil?
-               gem_name_and_require.split('/')[1].nil? ? gem_name_and_require.split('/')[0] : gem_name_and_require
-             else
-               require_override
-             end
-  require requires
-end
 require_gem('httpparty')
 
 def check_gem_binary_build_needed(gem_name = nil, gem_version = nil)

--- a/tools/json.rb
+++ b/tools/json.rb
@@ -6,26 +6,8 @@ $LOAD_PATH.unshift '../lib'
 require_relative '../lib/const'
 require_relative '../lib/package'
 require_relative '../lib/package_utils'
+require_relative '../lib/require_gem'
 
-def require_gem(gem_name_and_require = nil, require_override = nil)
-  # Allow only loading gems when needed.
-  return if gem_name_and_require.nil?
-
-  gem_name = gem_name_and_require.split('/')[0]
-  begin
-    gem gem_name
-  rescue LoadError
-    puts " -> install #{gem_name} gem".orange
-    Gem.install(gem_name)
-    gem gem_name
-  end
-  requires = if require_override.nil?
-               gem_name_and_require.split('/')[1].nil? ? gem_name_and_require.split('/')[0] : gem_name_and_require
-             else
-               require_override
-             end
-  require requires
-end
 require_gem('activesupport', 'active_support/core_ext/object/blank')
 require_gem('ptools')
 

--- a/tools/update_python_pip_packages.rb
+++ b/tools/update_python_pip_packages.rb
@@ -9,29 +9,11 @@
 # Add >LOCAL< lib to LOAD_PATH
 $LOAD_PATH.unshift '../lib'
 require_relative '../lib/color'
+require_relative '../lib/require_gem'
 
 CREW_GITLAB_PKG_REPO = 'https://gitlab.com/api/v4/projects/26210301/packages'
 CREW_NPROC = `nproc`.chomp
 
-def require_gem(gem_name_and_require = nil, require_override = nil)
-  # Allow only loading gems when needed.
-  return if gem_name_and_require.nil?
-
-  gem_name = gem_name_and_require.split('/')[0]
-  begin
-    gem gem_name
-  rescue LoadError
-    puts " -> install #{gem_name} gem".orange
-    Gem.install(gem_name)
-    gem gem_name
-  end
-  requires = if require_override.nil?
-               gem_name_and_require.split('/')[1].nil? ? gem_name_and_require.split('/')[0] : gem_name_and_require
-             else
-               require_override
-             end
-  require requires
-end
 require_gem('activesupport', 'active_support/core_ext/object/blank')
 require_gem 'concurrent-ruby'
 

--- a/tools/update_ruby_gem_packages.rb
+++ b/tools/update_ruby_gem_packages.rb
@@ -8,29 +8,11 @@
 $LOAD_PATH.unshift '../lib'
 require_relative '../lib/color'
 require_relative '../lib/gem_compact_index_client'
+require_relative '../lib/require_gem'
 CREW_NPROC = `nproc`.chomp
 CREW_RUBY_VER = "ruby#{RUBY_VERSION.slice(/(?:.*(?=\.))/)}"
 CREW_VERBOSE = false
 
-def require_gem(gem_name_and_require = nil, require_override = nil)
-  # Allow only loading gems when needed.
-  return if gem_name_and_require.nil?
-
-  gem_name = gem_name_and_require.split('/')[0]
-  begin
-    gem gem_name
-  rescue LoadError
-    puts " -> install #{gem_name} gem".orange
-    Gem.install(gem_name)
-    gem gem_name
-  end
-  requires = if require_override.nil?
-               gem_name_and_require.split('/')[1].nil? ? gem_name_and_require.split('/')[0] : gem_name_and_require
-             else
-               require_override
-             end
-  require requires
-end
 require_gem('activesupport', 'active_support/core_ext/object/blank')
 require_gem 'concurrent-ruby'
 


### PR DESCRIPTION
## Description
Not sure why we have this defined identically in so many places, but now we don't.

I tried using ConvenienceFunctions, but that led to circular requires and other issues, so its a standalone file. I am trying to avoid increasing the number of files in `lib`, but there are a couple suited for merging so this hopefully won't be too big of an issue.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=lowfru crew update \
&& yes | crew upgrade
```