### PR TITLE
Nushell 0.101.0 => 0.102.0

### DIFF
--- a/packages/nushell.rb
+++ b/packages/nushell.rb
@@ -3,7 +3,7 @@ require 'package'
 class Nushell < Package
   description 'A new type of shell'
   homepage 'https://www.nushell.sh/'
-  version '0.101.0'
+  version '0.102.0'
   license 'MIT'
   compatibility 'aarch64 armv7l x86_64'
   min_glibc '2.28'
@@ -13,9 +13,9 @@ class Nushell < Package
      x86_64: "https://github.com/nushell/nushell/releases/download/#{version}/nu-#{version}-x86_64-unknown-linux-gnu.tar.gz"
   })
   source_sha256({
-    aarch64: '016052987cbe7aea796b12390c70786ed000f75089b93819aaa1bd61f60fddae',
-     armv7l: '016052987cbe7aea796b12390c70786ed000f75089b93819aaa1bd61f60fddae',
-     x86_64: '7149728c779b5d7e7f86e34f36fd31332f7677df3e9a47b5744a1e1756d3ce76'
+    aarch64: '9acf79ef550b0a351013f5140c2790145952f75eef922c0872a59d0293b07f19',
+     armv7l: '9acf79ef550b0a351013f5140c2790145952f75eef922c0872a59d0293b07f19',
+     x86_64: '8facc8575dc5cc1406d5f00625faf40556da986f8932e90c8f891241df7275a3'
   })
 
   no_compile_needed


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`  Unable to launch in strongbad m132 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-nushell crew update \
&& yes | crew upgrade
```