### PR TITLE
Fzf 0.59.0 => 0.60.0

### DIFF
--- a/packages/fzf.rb
+++ b/packages/fzf.rb
@@ -3,7 +3,7 @@ require 'package'
 class Fzf < Package
   description 'A command-line fuzzy finder'
   homepage 'https://github.com/junegunn/fzf'
-  version '0.59.0'
+  version '0.60.0'
   license 'MIT and BSD-with-disclosure'
   compatibility 'aarch64 armv7l x86_64'
   source_url({
@@ -12,9 +12,9 @@ class Fzf < Package
      x86_64: "https://github.com/junegunn/fzf/releases/download/v#{version}/fzf-#{version}-linux_amd64.tar.gz"
   })
   source_sha256({
-    aarch64: 'cb03e48be03b3efc06d878738723bc434deb3b8f910ab8556566dee56477827f',
-     armv7l: 'cb03e48be03b3efc06d878738723bc434deb3b8f910ab8556566dee56477827f',
-     x86_64: '4957db97bb8d3af947745d8f0309572bd7867666de30367e9422d55761ad076a'
+    aarch64: '9d83faf85b27f2d7da8602024cb65a5d3218b7e36a56b036411d086f815c86c7',
+     armv7l: '9d83faf85b27f2d7da8602024cb65a5d3218b7e36a56b036411d086f815c86c7',
+     x86_64: 'c7af0376077054767ed88637f72cab78c563e2b44c4e0101ebfd84fffdbcd339'
   })
 
   no_compile_needed


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-fzf crew update \
&& yes | crew upgrade
```