### PR TITLE
Joplin 3.2.12 => 3.3.1

### DIFF
--- a/packages/joplin.rb
+++ b/packages/joplin.rb
@@ -3,11 +3,12 @@ require 'package'
 class Joplin < Package
   description 'Open source note-taking app'
   homepage 'https://joplinapp.org/'
-  version '3.2.12'
+  version '3.3.1'
   license 'AGPL-3.0'
   compatibility 'x86_64'
+  min_glibc '2.28'
   source_url "https://objects.joplinusercontent.com/v#{version}/Joplin-#{version}.AppImage"
-  source_sha256 'fb614540b353eb5866c8e91f2ca33c5423013632264c731edc3355991e9972f7'
+  source_sha256 '73e00977f165269e5138ab1f1bb8a085947edb4b077209759ee62591ac9723f4'
 
   depends_on 'gtk3'
   depends_on 'gdk_base'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable  to launch in hatch m132 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-joplin crew update \
&& yes | crew upgrade
```