### PR TITLE
Zed 0.172.11 => 0.173.10

### DIFF
--- a/packages/zed.rb
+++ b/packages/zed.rb
@@ -3,12 +3,12 @@ require 'package'
 class Zed < Package
   description 'Zed is a high-performance, multiplayer code editor'
   homepage 'https://zed.dev/'
-  version '0.172.11'
+  version '0.173.10'
   license 'GPL-3, AGPL-3, Apache-2.0'
   compatibility 'x86_64'
   min_glibc '2.28'
   source_url "https://github.com/zed-industries/zed/releases/download/v#{version}/zed-linux-x86_64.tar.gz"
-  source_sha256 'b2243efa1f66ddeada6c28255cd9cfb6e9122c9ba2b70d307d05ed17ce77e0d8'
+  source_sha256 '1e367e1d8598950f54de80188f7dcdfe8c8b2823c2402e47228442b5ecc9125f'
 
   depends_on 'alsa_lib'
   depends_on 'libbsd'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m132 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-zed crew update \
&& yes | crew upgrade
```