### PR TITLE
Refactor tests/commands/remove.rb

### DIFF
--- a/tests/commands/remove.rb
+++ b/tests/commands/remove.rb
@@ -1,7 +1,6 @@
 require 'minitest/autorun'
 require_relative '../../commands/remove'
 require_relative '../../lib/const'
-require_relative '../../lib/package_utils'
 
 # Add lib to LOAD_PATH
 $LOAD_PATH << File.join(CREW_LIB_PATH, 'lib')
@@ -10,68 +9,32 @@ $LOAD_PATH << File.join(CREW_LIB_PATH, 'lib')
 String.use_color = false
 
 class RemoveCommandTest < Minitest::Test
-  def setup
-    @random_essential_package_name = CREW_ESSENTIAL_PACKAGES.sample
-    puts <<~ESSENTIAL_PACKAGE_REMOVAL_TEST_EOF
-
-      Testing the removal of essential package #{@random_essential_package_name}, which was picked at random from one the essential packages: #{CREW_ESSENTIAL_PACKAGES.join(', ')}
-      (This should fail.)
-
-    ESSENTIAL_PACKAGE_REMOVAL_TEST_EOF
-    @random_essential_pkg = Package.load_package("#{@random_essential_package_name}.rb")
-
-    @package_with_essential_file = 'gcc_build'
-    @essential_file = File.join(CREW_LIB_PREFIX, 'libstdc++.so.6')
-    puts <<~PACKAGE_WITH_ESSENTIAL_FILE_REMOVAL_TEST_EOF
-
-      Testing the removal of package #{@package_with_essential_file}.
-      (This should succeed, but essential file #{@essential_file}
-      should not be removed.)
-
-    PACKAGE_WITH_ESSENTIAL_FILE_REMOVAL_TEST_EOF
-
-    @normal_package_name = 'xxd_standalone'
-    puts <<~NORMAL_PACKAGE_REMOVAL_TEST_EOF
-
-      Testing the removal of normal package #{@normal_package_name}.
-      (This should succeed.)
-
-    NORMAL_PACKAGE_REMOVAL_TEST_EOF
-    @normal_pkg = Package.load_package("#{@normal_package_name}.rb")
-  end
-
   def test_remove_essential_package
-    # expected_output = %(  #{@random_essential_package_name.capitalize} is considered an essential package needed for
-    # Chromebrew to function and thus cannot be removed.
-    # )
-    # assert_output(expected_output, nil) do
-    # Command.remove(@random_essential_pkg, true)
-    # end
+    random_essential_package = CREW_ESSENTIAL_PACKAGES.sample
+    puts "Testing the removal of essential package #{random_essential_package}, which was picked at random from one of the essential packages: #{CREW_ESSENTIAL_PACKAGES.join(', ')}. This should fail."
 
-    assert_raises(SystemExit) { Command.remove(@random_essential_pkg) }
-  end
-
-  def test_remove_package_with_essential_file
-    assert_output(true) do
-      until PackageUtils.installed?(@package_with_essential_file)
-        system "yes | crew install -d #{@package_with_essential_file}", %i[out err] => File::NULL
-        sleep 2
-      end
-      system "crew remove -d #{@package_with_essential_file}", %i[out err] => File::NULL
-      return File.file?(@essential_file)
+    assert_raises(SystemExit) do
+      # We don't want the output of this command, so we just capture it here and ignore it.
+      capture_io { Command.remove(Package.load_package("#{random_essential_package}.rb"), false) }
     end
   end
 
+  def test_remove_package_with_essential_file
+    essential_file = File.join(CREW_LIB_PREFIX, 'libstdc++.so.6')
+    puts "Testing the removal of package gcc_build. This should succeed, but essential file #{essential_file} should not be removed."
+
+    system 'crew install gcc_build', %i[out err] => File::NULL
+    capture_io { Command.remove(Package.load_package('gcc_build.rb'), false) }
+    assert File.file?(essential_file), nil
+  end
+
   def test_remove_normal_package
-    expected_output = <<~EOT
-      #{@normal_package_name} removed
-    EOT
-    assert_output(/^#{Regexp.escape(expected_output.chomp)}!/, nil) do
-      until PackageUtils.installed?(@normal_package_name)
-        system "yes | crew install -d #{@normal_package_name}", %i[out err] => File::NULL
-        sleep 2
-      end
-      Command.remove(@normal_pkg, true)
+    puts 'Testing the removal of normal package xxd_standalone. This should succeed.'
+
+    expected_output = "xxd_standalone removed!\n"
+    assert_output expected_output, nil do
+      system 'crew install xxd_standalone', %i[out err] => File::NULL
+      Command.remove(Package.load_package('xxd_standalone.rb'), false)
     end
   end
 end


### PR DESCRIPTION
## Description
Some general refactoring that I'm splitting out here rather than adding to #9707.

Changes:
- The puts statements for each test are now included in the test body itself, rather than all being run at the start and thus out of order with the actual running of the test itself.
- Use `Command.remove` instead of a system call, and use `capture_io` to ensure it remains silent.
- Eliminate unnecessary variables and move the remaining ones into their respective tests.
- Simplify assertions and use the correct methods for the correct purposes.

Note that you aren't really supposed to print at all in a minitest file, so there are still some minor visual issues when running the test:
![image](https://github.com/user-attachments/assets/d09f40e3-1a27-44ce-886d-5f443ce9aabf)

Personally, I'd rather remove the printing entirely, but that's a more opinionated change that I didn't want to hold up this refactoring with.
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=unearth crew update \
&& yes | crew upgrade
```