### PR TITLE
Add tests for force and verbose arguments to Command.remove

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1297,7 +1297,7 @@ def install
   # remove it just before the file copy
   if @pkg.in_upgrade
     puts 'Attempting removal since this is an upgrade or reinstall...'
-    Command.remove(@pkg)
+    Command.remove(@pkg, verbose: CREW_VERBOSE, force: @opt_force)
   end
 
   if @pkg.is_fake?
@@ -1844,7 +1844,7 @@ end
 def remove_command(args)
   args['<name>'].each do |name|
     search name
-    Command.remove(@pkg)
+    Command.remove(@pkg, verbose: CREW_VERBOSE, force: @opt_force)
   end
 end
 

--- a/commands/remove.rb
+++ b/commands/remove.rb
@@ -6,7 +6,7 @@ require_relative '../lib/package'
 require_relative '../lib/package_utils'
 
 class Command
-  def self.remove(pkg, verbose = CREW_VERBOSE)
+  def self.remove(pkg, verbose: false, force: false)
     device_json = JSON.load_file(File.join(CREW_CONFIG_PATH, 'device.json'))
 
     # Make sure the package is actually installed before we attempt to remove it.
@@ -16,7 +16,7 @@ class Command
     end
 
     # Do not remove any packages in CREW_ESSENTIAL_PACKAGES, as those are needed for ruby and thus crew to run.
-    if CREW_ESSENTIAL_PACKAGES.include?(pkg.name) && !CREW_FORCE
+    if CREW_ESSENTIAL_PACKAGES.include?(pkg.name) && !force
       return if pkg.in_upgrade
 
       puts <<~ESSENTIAL_PACKAGE_WARNING_EOF.gsub(/^(?=\w)/, '  ').lightred
@@ -60,7 +60,7 @@ class Command
 
           # When searching for files to delete we exclude the files from CREW_ESSENTIAL_PACKAGES.
           essential_packages_exclude_froms = ''
-          unless CREW_FORCE
+          unless force
             essential_packages_exclude_froms = CREW_ESSENTIAL_PACKAGES.map { |i| File.file?("#{File.join(CREW_META_PATH, i.to_s)}.filelist") ? "--exclude-from=#{File.join(CREW_META_PATH, i.to_s)}.filelist" : '' }.join(' ')
           end
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.57.1' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.57.2' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]


### PR DESCRIPTION
## Description
As discussed in https://github.com/chromebrew/chromebrew/pull/11365#discussion_r1961111269. 

I also added a test for verbose behavior.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=lightlegs crew update \
&& yes | crew upgrade
```