### PR TITLE
Vivaldi 7.1.3570.50-1 => 7.1.3570.54-1

### DIFF
--- a/manifest/armv7l/v/vivaldi.filelist
+++ b/manifest/armv7l/v/vivaldi.filelist
@@ -209,7 +209,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/adblocker_resources/redirectable_resources.json
 /usr/local/share/vivaldi/resources/vivaldi/background-bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/background-common-bundle.js
-/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-3bf58a5f1e5518b62317a87746efd922.js
+/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-7d541c376a25b066b54e2b339469dad2.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle-mailreader-worker.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/components/mail/mail.html

--- a/manifest/x86_64/v/vivaldi.filelist
+++ b/manifest/x86_64/v/vivaldi.filelist
@@ -209,7 +209,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/adblocker_resources/redirectable_resources.json
 /usr/local/share/vivaldi/resources/vivaldi/background-bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/background-common-bundle.js
-/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-2b80674b6bb382b8a0f576fc1311d857.js
+/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-3ee68a12199ea1a66c1ca873d5424428.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle-mailreader-worker.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/components/mail/mail.html

--- a/packages/vivaldi.rb
+++ b/packages/vivaldi.rb
@@ -4,7 +4,7 @@ require 'convenience_functions'
 class Vivaldi < Package
   description 'Vivaldi is a new browser that blocks unwanted ads, protects you from trackers, and puts you in control with unique built-in features.'
   homepage 'https://vivaldi.com/'
-  version '7.1.3570.50-1'
+  version '7.1.3570.54-1'
   license 'Vivaldi'
   compatibility 'aarch64 armv7l x86_64'
   min_glibc '2.37'
@@ -24,10 +24,10 @@ class Vivaldi < Package
   case ARCH
   when 'aarch64', 'armv7l'
     arch = 'armhf'
-    source_sha256 '838a334dae96b527cbe1cd7f50124cdf2e0e5538c056b40218583df97150e17c'
+    source_sha256 '59050d4da607922107e8ef02e75b11143660741f2f5aeee03c4fd811624192a1'
   when 'x86_64'
     arch = 'amd64'
-    source_sha256 '7a0c23f65f9a8c41296ab0c84f4e07212f32b75942381069ef19d00cc59b04fa'
+    source_sha256 '706eaf2290bf645aae48d7931cca77e4ac79318eb267da09b3bca39d27d354cb'
   end
 
   source_url "https://downloads.vivaldi.com/stable/vivaldi-stable_#{version}_#{arch}.deb"


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m132 container
- [x] `armv7l` Unable to launch in strongbad m132 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-vivaldi crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
