### PR TITLE
Add basic CI testing for lib/fixup.rb

### DIFF
--- a/.github/workflows/Unit-Test.yml
+++ b/.github/workflows/Unit-Test.yml
@@ -69,7 +69,7 @@ jobs:
             manifest/**
             packages/*.rb
             tools/packages.yaml
-            tools/*.json
+            tools/repology.json
       - name: Get all changed package files
         id: changed-ruby-files
         uses: tj-actions/changed-files@v45
@@ -198,6 +198,7 @@ jobs:
                 --privileged \
                 -u chronos \
                 -e CHANGED_PACKAGES="${CHANGED_PACKAGES}" \
+                -e NON_PKG_CHANGED_FILES="${NON_PKG_CHANGED_FILES}" \
                 -e LD_LIBRARY_PATH="/usr/local/lib${LIB_SUFFIX}" \
                 -e GCONV_PATH="/usr/local/lib${LIB_SUFFIX}/gconv" \
                 -e CREW_REPO="${CREW_REPO}" \

--- a/tests/unit_test_stub.sh
+++ b/tests/unit_test_stub.sh
@@ -7,6 +7,7 @@ last_update=$(stat -c %y /usr/local/lib/crew/tests/unit_test_stub.sh)
 echo "Last Updated: ${last_update}"
 stub_mtime=$(stat -c %Y /usr/local/lib/crew/tests/unit_test_stub.sh)
 echo "CHANGED_PACKAGES: ${CHANGED_PACKAGES}"
+echo "NON_PKG_CHANGED_FILES: ${NON_PKG_CHANGED_FILES}"
 cd /usr/local/lib/crew/packages/
 yes | crew update
 yes | crew upgrade


### PR DESCRIPTION
## Description
As discussed in #11456. This isn't perfect, as there's plenty of different old versions to test upgrading from, but this tests basic functionality as well as deprecating/renaming packages.

I gated running this behind non-package files being changed, and moved the command + library tests behind it as well-- this means CI is faster for PRs that only change packages, and they won't get blocked by new CI failures as a result of a changing environment, but it also means we won't find out about those failures until a PR with non-package updates is submitted. This is consistent with the way we conditionally run tests/lints across the repo, though.

##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=herald crew update \
&& yes | crew upgrade
```