### PR TITLE
Add crew upstream command and missing -f|--force option on applicable commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Where available commands are:
 | update       | update crew itself |
 | upgrade      | update all or specific package(s) |
 | upload       | upload binaries for all or specific package(s) |
+| upstream     | check if an upstream version is available for package(s) |
 | whatprovides | regex search for package(s) that contains file(s) |
 
 Available packages are listed in the [packages directory](https://github.com/chromebrew/chromebrew/tree/master/packages).

--- a/bin/crew
+++ b/bin/crew
@@ -95,9 +95,8 @@ String.use_color = args['--color'] || !args['--no-color']
 @opt_version   = args['--version']
 
 # Verbose options
-@fileutils_verbose = CREW_VERBOSE
-@verbose           = CREW_VERBOSE ? 'v' : ''
-@short_verbose     = CREW_VERBOSE ? '-v' : ''
+@verbose       = CREW_VERBOSE ? 'v' : ''
+@short_verbose = CREW_VERBOSE ? '-v' : ''
 
 # Make sure crew work directories exist.
 FileUtils.mkdir_p CREW_BREW_DIR
@@ -464,11 +463,11 @@ def download
           if Digest::SHA256.hexdigest(File.read(cachefile)) == sha256sum || sha256sum =~ /^SKIP$/i || cachefile.include?(CREW_LOCAL_BUILD_DIR)
             begin
               # Hard link cached file if possible.
-              FileUtils.ln cachefile, CREW_BREW_DIR, force: true, verbose: @fileutils_verbose unless File.identical?(cachefile, "#{CREW_BREW_DIR}/#{filename}")
+              FileUtils.ln cachefile, CREW_BREW_DIR, force: true, verbose: CREW_VERBOSE unless File.identical?(cachefile, "#{CREW_BREW_DIR}/#{filename}")
               puts 'Archive hard linked from cache'.green if CREW_VERBOSE
             rescue StandardError
               # Copy cached file if hard link fails.
-              FileUtils.cp cachefile, CREW_BREW_DIR, verbose: @fileutils_verbose unless File.identical?(cachefile, "#{CREW_BREW_DIR}/#{filename}")
+              FileUtils.cp cachefile, CREW_BREW_DIR, verbose: CREW_VERBOSE unless File.identical?(cachefile, "#{CREW_BREW_DIR}/#{filename}")
               puts 'Archive copied from cache'.green if CREW_VERBOSE
             end
             puts 'Archive found in cache'.lightgreen
@@ -495,11 +494,11 @@ def download
       if CREW_CACHE_ENABLED && cachefile.to_s.empty? && File.writable?(CREW_CACHE_DIR)
         begin
           # Hard link to cache if possible.
-          FileUtils.ln filename, CREW_CACHE_DIR, verbose: @fileutils_verbose
+          FileUtils.ln filename, CREW_CACHE_DIR, verbose: CREW_VERBOSE
           puts 'Archive hard linked to cache'.green if CREW_VERBOSE
         rescue StandardError
           # Copy to cache if hard link fails.
-          FileUtils.cp filename, CREW_CACHE_DIR, verbose: @fileutils_verbose
+          FileUtils.cp filename, CREW_CACHE_DIR, verbose: CREW_VERBOSE
           puts 'Archive copied to cache'.green if CREW_VERBOSE
         end
       end
@@ -596,7 +595,7 @@ end
 def unpack(meta)
   target_dir = nil
   Dir.chdir CREW_BREW_DIR do
-    FileUtils.mkdir_p @extract_dir, verbose: @fileutils_verbose
+    FileUtils.mkdir_p @extract_dir, verbose: CREW_VERBOSE
 
     build_cachefile = File.join(CREW_CACHE_DIR, "#{@pkg.name}-#{@pkg.version}-build-#{@device[:architecture]}.tar.zst")
     if CREW_CACHE_BUILD && File.file?(build_cachefile) && File.file?("#{build_cachefile}.sha256") && (system "cd #{CREW_CACHE_DIR} && sha256sum -c #{build_cachefile}.sha256")
@@ -631,7 +630,7 @@ def unpack(meta)
         system 'tar', "-x#{@verbose}f", *Dir['data.*'], '-C', @extract_dir, exception: true
       when /\.AppImage$/i
         puts "Unpacking 'AppImage' archive, this may take a while..."
-        FileUtils.chmod 0o755, meta[:filename], verbose: @fileutils_verbose
+        FileUtils.chmod 0o755, meta[:filename], verbose: CREW_VERBOSE
         system "../#{meta[:filename]}", '--appimage-extract', chdir: @extract_dir, exception: true
       when /\.gem$/i
         puts "Moving #{@pkg.gem_name} binary gem for install..."
@@ -659,7 +658,7 @@ def unpack(meta)
       target_dir = @extract_dir
     end
     # Remove tarball to save space.
-    FileUtils.rm_f meta[:filename], verbose: @fileutils_verbose if File.file?(meta[:filename])
+    FileUtils.rm_f meta[:filename], verbose: CREW_VERBOSE if File.file?(meta[:filename])
   end
   return File.join(CREW_BREW_DIR, target_dir)
 end
@@ -694,7 +693,7 @@ def build_and_preconfigure(target_dir)
     end
     @pkg.in_build = false
     # wipe crew destdir
-    FileUtils.rm_rf Dir["#{CREW_DEST_DIR}/*"], verbose: @fileutils_verbose unless @pkg.superclass.to_s == 'RUBY'
+    FileUtils.rm_rf Dir["#{CREW_DEST_DIR}/*"], verbose: CREW_VERBOSE unless @pkg.superclass.to_s == 'RUBY'
     puts 'Preconfiguring package...'
     cache_build if CREW_CACHE_BUILD
     @pkg.install unless @pkg.superclass.to_s == 'RUBY'
@@ -1076,8 +1075,8 @@ def install_package(pkgdir)
     # install filelist, dlist and binary files
     puts 'Performing install...'
 
-    FileUtils.mv 'dlist', File.join(CREW_META_PATH, "#{@pkg.name}.directorylist"), verbose: @fileutils_verbose
-    FileUtils.mv 'filelist', File.join(CREW_META_PATH, "#{@pkg.name}.filelist"), verbose: @fileutils_verbose
+    FileUtils.mv 'dlist', File.join(CREW_META_PATH, "#{@pkg.name}.directorylist"), verbose: CREW_VERBOSE
+    FileUtils.mv 'filelist', File.join(CREW_META_PATH, "#{@pkg.name}.filelist"), verbose: CREW_VERBOSE
 
     unless CREW_NOT_LINKS || @pkg.no_links?
       brokensymlinks = `find . -type l -exec test ! -e {} \\; -print`.chomp
@@ -1213,7 +1212,7 @@ def resolve_dependencies
   puts 'The following packages also need to be installed: '
 
   @dependencies.each do |dep|
-    FileUtils.cp "#{CREW_LOCAL_REPO_ROOT}/packages/#{dep}.rb", CREW_PACKAGES_PATH if !File.file?(File.join(CREW_PACKAGES_PATH, "#{dep}.rb")) && File.file?(File.join(CREW_LOCAL_REPO_ROOT, "packages/#{dep}.rb")) && Package.agree_default_yes("The package file for #{dep}, which is a required dependency to build #{@pkg.name} only exists in #{CREW_LOCAL_REPO_ROOT}/packages/ . Is it ok to copy it to #{CREW_PACKAGES_PATH} so that the build can continue?")
+    FileUtils.cp "#{CREW_LOCAL_REPO_ROOT}/packages/#{dep}.rb", CREW_PACKAGES_PATH if !File.file?(File.join(CREW_PACKAGES_PATH, "#{dep}.rb")) && File.file?(File.join(CREW_LOCAL_REPO_ROOT, "packages/#{dep}.rb")) && (@opt_force || Package.agree_default_yes("The package file for #{dep}, which is a required dependency to build #{@pkg.name} only exists in #{CREW_LOCAL_REPO_ROOT}/packages/ . Is it ok to copy it to #{CREW_PACKAGES_PATH} so that the build can continue?"))
     abort "Dependency #{dep} for #{@pkg.name} was not found.".lightred unless File.file?(File.join(CREW_PACKAGES_PATH, "#{dep}.rb"))
   end
 
@@ -1357,8 +1356,8 @@ def resolve_dependencies_and_build
   ensure
     # cleanup
     unless @opt_keep
-      FileUtils.rm_rf Dir["#{CREW_BREW_DIR}/*"], verbose: @fileutils_verbose
-      FileUtils.mkdir_p "#{CREW_BREW_DIR}/dest", verbose: @fileutils_verbose # this is a little ugly, feel free to find a better way
+      FileUtils.rm_rf Dir["#{CREW_BREW_DIR}/*"], verbose: CREW_VERBOSE
+      FileUtils.mkdir_p "#{CREW_BREW_DIR}/dest", verbose: CREW_VERBOSE # this is a little ugly, feel free to find a better way
     end
   end
   puts "#{@pkg.name.capitalize} is built!".lightgreen
@@ -1506,7 +1505,7 @@ def upload(pkg_name = nil, pkg_version = nil, gitlab_token = nil, gitlab_token_u
       puts "\e[1A\e[KChecking for existing upload ...\r".orange
       if `curl -fsI #{new_url}`.lines.first.split[1] == '200'
         puts "\n#{File.basename(new_tarfile)} has already been uploaded.\nPlease change the #{package} package version from #{new_version} and try again.\n".lightred
-        if Package.agree_default_no('Do you want to overwrite the existing upload instead')
+        if @opt_force || Package.agree_default_no('Do you want to overwrite the existing upload instead')
           puts "\e[1A\e[KOverwriting existing upload...\r".orange
           crewlog "#{arch} = #{new_sha256}"
           binary_sha256_hash[arch.to_sym] = new_sha256
@@ -1814,6 +1813,15 @@ def upload_command(args)
   args['<name>'].each do |name|
     search name
     upload(name, @pkg.version, gitlab_token, gitlab_token_username, @pkg.binary_compression)
+  end
+end
+
+def upstream_command(args)
+  args['<name>'].each do |name|
+    search name
+    Dir.chdir CREW_PACKAGES_PATH do
+      system "../tools/version.rb #{name} #{@short_verbose}"
+    end
   end
 end
 

--- a/commands/help.rb
+++ b/commands/help.rb
@@ -7,18 +7,18 @@ class Command
     when 'build'
       puts <<~EOT
         Build package(s).
-        Usage: crew build [-k|--keep] [-v|--verbose] <package1> [<package2> ...]
+        Usage: crew build [-f|--force] [-k|--keep] [-v|--verbose] <package1> [<package2> ...]
         Build package(s) from source and place the archive and checksum in the `CREW_LOCAL_BUILD_DIR/release/<arch>` directory.
         Build package(s) from source and place the archive and checksum in the current working directory.
+        If `-f` or `--force` is present, interactive prompts will be disabled.
         If `-k` or `--keep` is present, the `CREW_BREW_DIR` (#{CREW_BREW_DIR}) directory will remain.
         If `-v` or `--verbose` is present, extra information will be displayed.
       EOT
     when 'check'
       puts <<~EOT
-        Check package(s) for syntax errors, and copy local packages to the chromebrew directory.
+        Check package(s) for syntax errors.
         Usage: crew check [-f|--force] <package1> [<package2> ...]
-        Local packages will be copied to the chromebrew directory if they do not exist there, or if they are different to the chromebrew package files.
-        If `-f` or `--force` is present, packages will be copied without question.
+        If `-f` or `--force` is present, interactive prompts will be disabled.
       EOT
     when 'const'
       puts <<~EOT
@@ -30,7 +30,6 @@ class Command
       puts <<~EOT
         Display dependencies of package(s).
         Usage: crew deps [-t|--tree] [-b|--include-build-deps] [--exclude-buildessential] <package1> [<package2> ...]
-
         If `-t` or `--tree` specified, dependencies will be printed in a tree-structure format
         If `-b` or `--include-build-deps` specified, build dependencies will be included in output
         It `--exclude-buildessential` specified, `buildessential` and its dependencies will not be inserted automatically
@@ -52,8 +51,9 @@ class Command
     when 'install'
       puts <<~EOT
         Install package(s).
-        Usage: crew install [-k|--keep] [-s|--source] [-S|--recursive-build] [-v|--verbose] <package1> [<package2> ...]
+        Usage: crew install [-f|--force] [-k|--keep] [-s|--source] [-S|--recursive-build] [-v|--verbose] <package1> [<package2> ...]
         The package(s) must have a valid name.  Use `crew search <pattern>` to search for packages to install.
+        If `-f` or `--force` is present, interactive prompts will be disabled.
         If `-k` or `--keep` is present, the `CREW_BREW_DIR` (#{CREW_BREW_DIR}) directory will remain.
         If `-s` or `--source` is present, the package(s) will be compiled instead of installed via binary.
         If `-S` or `--recursive-build` is present, the package(s), including all dependencies, will be compiled instead of installed via binary.
@@ -84,7 +84,8 @@ class Command
     when 'reinstall'
       puts <<~EOT
         Remove and install package(s).
-        Usage: crew reinstall [-k|--keep] [-s|--source] [-S|--recursive-build] [-v|--verbose] <package1> [<package2> ...]
+        Usage: crew reinstall [-f|--force] [-k|--keep] [-s|--source] [-S|--recursive-build] [-v|--verbose] <package1> [<package2> ...]
+        If `-f` or `--force` is present, interactive prompts will be disabled.
         If `-k` or `--keep` is present, the `CREW_BREW_DIR` (#{CREW_BREW_DIR}) directory will remain.
         If `-s` or `--source` is present, the package(s) will be compiled instead of installed via binary.
         If `-S` or `--recursive-build` is present, the package(s), including all dependencies, will be compiled instead of installed via binary.
@@ -93,8 +94,9 @@ class Command
     when 'remove'
       puts <<~EOT
         Remove package(s).
-        Usage: crew remove [-v|--verbose] <package1> [<package2> ...]
+        Usage: crew remove [-f|--force] [-v|--verbose] <package1> [<package2> ...]
         The package(s) must be currently installed.
+        If `-f` or `--force` is present, interactive prompts will be disabled.
         If `-v` or `--verbose` is present, extra information will be displayed.
       EOT
     when 'search'
@@ -127,20 +129,28 @@ class Command
     when 'upgrade'
       puts <<~EOT
         Update package(s).
-        Usage: crew upgrade [-v|--verbose] [-s|--source] <package1> [<package2> ...]
+        Usage: crew upgrade [-f|--force] [-s|--source] [-v|--verbose] <package1> [<package2> ...]
         If package(s) are omitted, all packages will be updated.  Otherwise, specific package(s) will be updated.
         Use `crew update` to update crew itself.
+        If `-f` or `--force` is present, interactive prompts will be disabled.
         If `-s` or `--source` is present, the package(s) will be compiled instead of upgraded via binary.
         If `-v` or `--verbose` is present, extra information will be displayed.
       EOT
     when 'upload'
       puts <<~EOT
         Upload binaries.
-        Usage: crew upload [<package1> <package2> ...]
+        Usage: crew upload [-f|--force] [-v|--verbose] [<package1> <package2> ...]
         This will update the binary_sha256 hashes in each package and upload binaries to GitLab.
         The GITLAB_TOKEN environment variable must be set to access the upstream repository.
         If no package(s) are provided, all binaries in `#{CREW_LOCAL_REPO_ROOT}/release/<arch>` will be uploaded.
+        If `-f` or `--force` is present, interactive prompts will be disabled.
         If `-v` or `--verbose` is present, additional debug information will be displayed.
+      EOT
+    when 'upstream'
+      puts <<~EOT
+        Check if an upstream version is available for package(s).
+        Usage: crew upstream [-v|--verbose] [<package1> <package2> ...]
+        If `-v` or `--verbose` is present, extra information will be displayed.
       EOT
     when 'version'
       puts <<~EOT

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.57.3' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.57.4' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]
@@ -342,27 +342,28 @@ CREW_DOCOPT ||= <<~DOCOPT
     crew postinstall [options] [-v|--verbose] <name> ...
     crew prop [options] [<property>]
     crew reinstall [options] [-f|--force] [-k|--keep] [-s|--source] [-S|--recursive-build] [-v|--verbose] <name> ...
-    crew remove [options] [-v|--verbose] <name> ...
+    crew remove [options] [-f|--force] [-v|--verbose] <name> ...
     crew search [options] [-v|--verbose] <name> ...
     crew sysinfo [options] [-v|--verbose]
     crew update [options] [-v|--verbose]
-    crew upgrade [options] [-k|--keep] [-s|--source] [-v|--verbose] [<name> ...]
-    crew upload [options] [-v|--verbose] [<name> ...]
+    crew upgrade [options] [-f|--force] [-k|--keep] [-s|--source] [-v|--verbose] [<name> ...]
+    crew upload [options] [-f|--force] [-v|--verbose] [<name> ...]
+    crew upstream [options] [-v|--verbose] [<name> ...]
     crew whatprovides [options] <pattern> ...
 
     -b --include-build-deps  Include build dependencies in output.
-    -t --tree                Print dependencies in a tree-structure format.
     -c --color               Use colors even if standard out is not a tty.
     -d --no-color            Disable colors even if standard out is a tty.
+    -D --debug               Enable debugging.
     -f --force               Force where relevant.
+    -h --help                Show this screen.
     -k --keep                Keep the `CREW_BREW_DIR` (#{CREW_BREW_DIR}) directory.
     -L --license             Display the crew license.
     -s --source              Build or download from source even if pre-compiled binary exists.
     -S --recursive-build     Build from source, including all dependencies, even if pre-compiled binaries exist.
+    -t --tree                Print dependencies in a tree-structure format.
     -v --verbose             Show extra information.
     -V --version             Display the crew version.
-    -h --help                Show this screen.
-    -D --debug               Enable debugging.
 DOCOPT
 
 # All available crew commands.


### PR DESCRIPTION
Tested & working properly.
```
$ crew upstream cmake
Package                            Status              Current             Upstream
-------                            ------              -------             --------
cmake                              outdated            3.31.5              3.31.6
```
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-upstream-command crew update \
&& yes | crew upgrade
```