### PR TITLE
Allow wildcard (*) parameters in crew upstream

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1817,10 +1817,13 @@ def upload_command(args)
 end
 
 def upstream_command(args)
+  puts "#{'Package'.ljust(35)}#{'Status'.ljust(20)}#{'Current'.ljust(20)}Upstream"
+  puts "#{'-------'.ljust(35)}#{'------'.ljust(20)}#{'-------'.ljust(20)}--------"
   args['<name>'].each do |name|
+    name.gsub!('.rb', '')
     search name
     Dir.chdir CREW_PACKAGES_PATH do
-      system "../tools/version.rb #{name} #{@short_verbose}"
+      system "../tools/version.rb #{name} #{@short_verbose} -n"
     end
   end
 end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.57.4' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.57.5' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]

--- a/tools/version.rb
+++ b/tools/version.rb
@@ -2,7 +2,7 @@
 
 if ARGV.include?('-h') || ARGV.include?('--help')
   abort <<~EOM
-    Usage: ./version.rb [<package>] [-h, --help, -v, --verbose]
+    Usage: ./version.rb [<package>] [-h, --help, -n, --no-header, -v, --verbose]
     Example: ./version.rb abcde -v
     The <package> can contain '*': ./version.rb xorg_*
     If <package> is omitted, all packages will be checked.
@@ -104,8 +104,10 @@ else
 end
 
 if filelist.length.positive?
-  puts "#{'Package'.ljust(35)}#{'Status'.ljust(20)}#{'Current'.ljust(20)}Upstream"
-  puts "#{'-------'.ljust(35)}#{'------'.ljust(20)}#{'-------'.ljust(20)}--------"
+  unless ARGV.include?('-n') || ARGV.include?('--no-header')
+    puts "#{'Package'.ljust(35)}#{'Status'.ljust(20)}#{'Current'.ljust(20)}Upstream"
+    puts "#{'-------'.ljust(35)}#{'------'.ljust(20)}#{'-------'.ljust(20)}--------"
+  end
   filelist.each do |filename|
     pkg = Package.load_package(filename)
     # Instead of typing out the name of every python package, we just use a regex here.


### PR DESCRIPTION
Tested & working properly:
```
$ crew upstream z*
Package                            Status              Current             Upstream
-------                            ------              -------             --------
zathura                            outdated            0.5.2               0.5.11
zed                                outdated            0.175.6             0.176.1
zenity                             outdated            4.0.1               4.1.90
zile                               outdated            2.4.14              2.6.2
zimg                               outdated            3.0.1               3.0.5
zvbi                               outdated            0.2.42              0.2.43
zziplib                            outdated            0.13.72             0.13.78
```
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-upstream-command crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
