### PR TITLE
Fix Ruby Gem Upgrades and detect missing rubocop.

### DIFF
--- a/commands/check.rb
+++ b/commands/check.rb
@@ -16,12 +16,12 @@ class Command
     end
 
     # Use rubocop to sanitize package file, and let errors get flagged.
-    if PackageUtils.installed?('ruby_rubocop')
+    if Kernel.system('rubocop --version', %i[out err] => File::NULL)
       puts "Using rubocop to sanitize #{local_package}".orange
       system "rubocop -c #{File.join(CREW_LOCAL_REPO_ROOT, '.rubocop.yml')} -A #{local_package}", exception: true
     else
       puts "Rubocop is not installed, and thus will not be used to sanitize #{local_package}".lightred
-      puts 'To install Rubocop, run the following command: '.lightred + 'crew install ruby_rubocop'.lightblue
+      puts 'To install Rubocop, run the following command: '.lightred + "crew #{PackageUtils.installed?('ruby_rubocop') ? 're' : ''}install ruby_rubocop".lightblue
     end
 
     to_copy = force

--- a/lib/buildsystems/ruby.rb
+++ b/lib/buildsystems/ruby.rb
@@ -111,6 +111,8 @@ class RUBY < Package
   end
 
   def self.install
+    # @install_gem will always be true during upgrades since we remove
+    # the old gem during the upgrade.
     unless @install_gem
       puts "#{@gem_name} #{@gem_installed_version} is properly installed.".lightgreen
       return
@@ -122,6 +124,12 @@ class RUBY < Package
       @gem_outdated = (Gem::Version.new(@gem_version) > Gem::Version.new(@gem_installed_version))
       @gem_latest_version_installed = Gem::Version.new(@gem_version) <= Gem::Version.new(@gem_installed_version)
       crewlog "@gem_version: #{@gem_version} @gem_installed_version: #{@gem_installed_version} @gem_outdated: #{@gem_outdated} @gem_latest_version_installed: #{@gem_latest_version_installed}"
+    else
+      # If the current gem being installed is not installed this should
+      # be false. This will also handle cases of the current installed
+      # gem as per 'gem list' being the same version as the version
+      # being upgraded to.
+      @gem_latest_version_installed = false
     end
 
     crewlog "no_compile_needed?: #{no_compile_needed?} @gem_binary_build_needed.blank?: #{@gem_binary_build_needed.blank?}, gem_compile_needed?: #{gem_compile_needed?}"


### PR DESCRIPTION
Fixes: #11473

- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Tested with:
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=rubocop crew update \
&& yes | crew upgrade ; which rubocop 
```
and
```bash
crew upgrade ; CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=rubocop crew update \
&& crew reinstall ruby_rubocop ; which rubocop
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
