### PR TITLE
Google_chrome 133.0.6943.141-1 => 134.0.6998.35-1

### DIFF
--- a/packages/google_chrome.rb
+++ b/packages/google_chrome.rb
@@ -5,12 +5,12 @@ class Google_chrome < Package
   description 'Google Chrome is a fast, easy to use, and secure web browser.'
   homepage 'https://www.google.com/chrome/'
   @update_channel = 'stable'
-  version '133.0.6943.141-1'
+  version '134.0.6998.35-1'
   license 'google-chrome'
   compatibility 'x86_64'
   min_glibc '2.28'
   source_url "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-#{@update_channel}/google-chrome-#{@update_channel}_#{@version}_amd64.deb"
-  source_sha256 '88c5bd5777404401bb909802096213d0e043b3162a0e7a7e0a9c20723013f332'
+  source_sha256 'f5bc9159c02a4a58204866084aa9e36bb6b7f2b677b8d482f47ad9998fb3ca30'
 
   depends_on 'nss'
   depends_on 'cairo'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m133 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-google_chrome crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
