### PR TITLE
Mullvad 14.0.5 => 14.0.7

### DIFF
--- a/manifest/x86_64/m/mullvad.filelist
+++ b/manifest/x86_64/m/mullvad.filelist
@@ -189,8 +189,6 @@
 /usr/local/share/mullvad/libsoftokn3.so
 /usr/local/share/mullvad/libssl3.so
 /usr/local/share/mullvad/libstdc++/libstdc++.so.6
-/usr/local/share/mullvad/libstdc++/libstdc++.so.6.0.28
-/usr/local/share/mullvad/libstdc++/libstdc++.so.6.0.28-gdb.py
 /usr/local/share/mullvad/libxul.so
 /usr/local/share/mullvad/mullvadbrowser
 /usr/local/share/mullvad/mullvadbrowser.real

--- a/packages/mullvad.rb
+++ b/packages/mullvad.rb
@@ -4,11 +4,11 @@ require 'convenience_functions'
 class Mullvad < Package
   description 'Privacy-focused browser'
   homepage 'https://mullvad.net/browser'
-  version '14.0.5'
+  version '14.0.7'
   license 'Mozilla Public License V2'
   compatibility 'x86_64'
   source_url "https://github.com/mullvad/mullvad-browser/releases/download/#{version}/mullvad-browser-linux-x86_64-#{version}.tar.xz"
-  source_sha256 'cbdf08cc29e88db0430e3e8f71bc6d4cfc1f1c0e30669c3a835aad992824a450'
+  source_sha256 '3e0359474061e65df2e95c1df013eecfd0e6d0c4a9e93da2a386239b2fdc3c7d'
 
   depends_on 'gtk3'
   depends_on 'gdk_base'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m133 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-mullvad crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
