### PR TITLE
Brave 1.76.73 => 1.76.74

### DIFF
--- a/packages/brave.rb
+++ b/packages/brave.rb
@@ -4,12 +4,12 @@ require 'convenience_functions'
 class Brave < Package
   description 'Next generation Brave browser for macOS, Windows, Linux, Android.'
   homepage 'https://brave.com/'
-  version '1.76.73'
+  version '1.76.74'
   license 'MPL-2'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://github.com/brave/brave-browser/releases/download/v#{version}/brave-browser-#{version}-linux-amd64.zip"
-  source_sha256 '58d3dbe518240f0e9d63c227afd9337875b7476f8b9c349e7b1caf208b54c4b5'
+  source_sha256 '5100231a735aec00bcb5c18c07200438b6cddaca902e44faae0a79cb9f36d5fa'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m133 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-brave crew update \
&& yes | crew upgrade
```