### PR TITLE
Opera 117.0.5408.53 => 117.0.5408.93

### DIFF
--- a/packages/opera.rb
+++ b/packages/opera.rb
@@ -4,7 +4,7 @@ require 'convenience_functions'
 class Opera < Package
   description 'Opera is a multi-platform web browser based on Chromium and developed by Opera Software.'
   homepage 'https://www.opera.com/'
-  version '117.0.5408.53'
+  version '117.0.5408.93'
   license 'OPERA-2018'
   compatibility 'x86_64'
   min_glibc '2.29'
@@ -12,7 +12,7 @@ class Opera < Package
   # faster apt mirror, but only works when downloading latest version of opera
   # source_url "https://deb.opera.com/opera/pool/non-free/o/opera-stable/opera-stable_#{version}_amd64.deb"
   source_url "https://deb.opera.com/opera-stable/pool/non-free/o/opera-stable/opera-stable_#{version}_amd64.deb"
-  source_sha256 '79bae2d5f293b40f117030e6c55347f7e5f36c51956b83795d4f78bde793ff4a'
+  source_sha256 'd508b54ae87980325714e9c8dec8e62c236b3450ea57d9f5b13877ac5ad106ba'
 
   depends_on 'gtk3'
   depends_on 'gsettings_desktop_schemas'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m133 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-opera crew update \
&& yes | crew upgrade
```