### PR TITLE
Run rubocop on tree to catch all of the offenses being missed previously by the rubocop-chromebrew issue

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1845,11 +1845,9 @@ end
 
 @last_update_check = Dir["#{CREW_LIB_PATH}/{.git/FETCH_HEAD,lib/const.rb}"].compact.map { |i| File.mtime(i).utc.to_i }.max
 crewlog("The last update was #{MiscFunctions.time_difference(@last_update_check, Time.now.to_i)} ago.")
-unless ARGV[0] == 'update'
-  if Time.now.to_i - @last_update_check > (CREW_UPDATE_CHECK_INTERVAL * 3600 * 24)
-    plural = CREW_UPDATE_CHECK_INTERVAL < 2 ? '' : 's'
-    puts "It has been more than #{CREW_UPDATE_CHECK_INTERVAL} day#{plural} since crew was last updated. Please run 'crew update'.".lightpurple
-  end
+if ARGV[0] != 'update' && Time.now.to_i - @last_update_check > ((CREW_UPDATE_CHECK_INTERVAL * 3600 * 24))
+  plural = CREW_UPDATE_CHECK_INTERVAL < 2 ? '' : 's'
+  puts "It has been more than #{CREW_UPDATE_CHECK_INTERVAL} day#{plural} since crew was last updated. Please run 'crew update'.".lightpurple
 end
 command_name = args.select { |k, v| v && command?(k) }.keys[0]
 send("#{command_name}_command", args)

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -71,7 +71,7 @@ end
 @fixup_json = JSON.load_file(File.join(CREW_CONFIG_PATH, 'device.json'))
 def keep_keys(arr, keeper_keys)
   keepers = keeper_keys.to_set
-  arr.map { |h| h.select { |k, _| keepers.include?(k) } }
+  arr.map { |h| h.slice(*keepers) }
 end
 # Use @installed_packages.include?(pkg_name) to determine if a package is
 # installed.

--- a/lib/require_gem.rb
+++ b/lib/require_gem.rb
@@ -13,9 +13,9 @@ def require_gem(gem_name_and_require = nil, require_override = nil)
     gem gem_name
   end
   requires = if require_override.nil?
-              gem_name_and_require.split('/')[1].nil? ? gem_name_and_require.split('/')[0] : gem_name_and_require
-            else
-              require_override
-            end
+               gem_name_and_require.split('/')[1].nil? ? gem_name_and_require.split('/')[0] : gem_name_and_require
+             else
+               require_override
+             end
   require requires
 end

--- a/packages/a2png.rb
+++ b/packages/a2png.rb
@@ -27,12 +27,12 @@ class A2png < Autotools
       patches = [
         # FreeBSD patch to avoid -Wimplicit-function-declaration errors.
         ['https://raw.githubusercontent.com/freebsd/freebsd-ports/06dfcbd2cbebaf3b3b81744ed8adaa903f1b24b7/graphics/a2png/files/patch-src_image.h',
-        '86d2cb207854649c486485d215ffc6758a4af6ab9b1acd5f6b266dd793f5c80e'],
+         '86d2cb207854649c486485d215ffc6758a4af6ab9b1acd5f6b266dd793f5c80e'],
         # FreeBSD patch to avoid C99 inline semantics.
         ['https://raw.githubusercontent.com/freebsd/freebsd-ports/06dfcbd2cbebaf3b3b81744ed8adaa903f1b24b7/graphics/a2png/files/patch-src_image.c',
-        'fece9703dbc73447135bbb9bc2fd4d3af6052f8025e516fff0592257aa1377e0'],
+         'fece9703dbc73447135bbb9bc2fd4d3af6052f8025e516fff0592257aa1377e0'],
         ['https://raw.githubusercontent.com/freebsd/freebsd-ports/06dfcbd2cbebaf3b3b81744ed8adaa903f1b24b7/graphics/a2png/files/patch-src_parse.c',
-        '65d0bf84b659381b18536498bf82d83386fc347ac80b374f1393eaf1dc5d80b2']
+         '65d0bf84b659381b18536498bf82d83386fc347ac80b374f1393eaf1dc5d80b2']
       ]
       ConvenienceFunctions.patch(patches)
     end

--- a/packages/extremetuxracer.rb
+++ b/packages/extremetuxracer.rb
@@ -3,31 +3,30 @@ require 'package'
 class Extremetuxracer < Package
   description 'High speed arctic racing game based on Tux Racer'
   homepage 'https://sourceforge.net/projects/extremetuxracer/'
-  version "0.8.4-1"
+  version '0.8.4-1'
   compatibility 'aarch64 armv7l x86_64'
   license 'GPLv2'
-  source_url ({
-    "aarch64": "https://github.com/FinnBaltazar1111/extremetuxracer/releases/download/0.8.4/extremetuxracer_#{version}_armhf.deb",
-    "armv7l": "https://github.com/FinnBaltazar1111/extremetuxracer/releases/download/0.8.4/extremetuxracer_#{version}_armhf.deb",
-    "x86_64": "https://github.com/FinnBaltazar1111/extremetuxracer/releases/download/0.8.4/extremetuxracer_#{version}_amd64.deb"
+  source_url({
+    aarch64: "https://github.com/FinnBaltazar1111/extremetuxracer/releases/download/0.8.4/extremetuxracer_#{version}_armhf.deb",
+    armv7l: "https://github.com/FinnBaltazar1111/extremetuxracer/releases/download/0.8.4/extremetuxracer_#{version}_armhf.deb",
+    x86_64: "https://github.com/FinnBaltazar1111/extremetuxracer/releases/download/0.8.4/extremetuxracer_#{version}_amd64.deb"
   })
-  source_sha256 ({
-    "aarch64": "47e14334f142d6adc2094d5b9304b0c9129c2fa94e25765ad2c53523ac635202",
-    "armv7l": "47e14334f142d6adc2094d5b9304b0c9129c2fa94e25765ad2c53523ac635202",
-    "x86_64": "d081c1b4fcc8f4586f734c9c9f4c23a5f00909eda2596729d141328a637b99ea"
+  source_sha256({
+    aarch64: '94c7f0c9b13604ca9f6b314d5e3df54516346a7c0768d171f6350efeca19d913',
+     armv7l: '94c7f0c9b13604ca9f6b314d5e3df54516346a7c0768d171f6350efeca19d913',
+     x86_64: 'd081c1b4fcc8f4586f734c9c9f4c23a5f00909eda2596729d141328a637b99ea'
   })
-  
+
   depends_on 'libsdl2'
   depends_on 'mesa'
   depends_on 'mesa_utils'
   depends_on 'tcl'
 
   no_compile_needed
-  
 
   def self.install
     FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/"
-    FileUtils.cp_r ".", "#{CREW_DEST_PREFIX}"
+    FileUtils.cp_r '.', CREW_DEST_PREFIX.to_s
   end
 
   def self.postinstall

--- a/packages/filezilla.rb
+++ b/packages/filezilla.rb
@@ -8,7 +8,7 @@ class Filezilla < Autotools
   compatibility 'aarch64 armv7l x86_64'
   # NOTE: This may generate a 403 forbidden error. To receive a new source url,
   # download from here: https://filezilla-project.org/download.php?show_all=1.
-  source_url "https://dl2.cdn.filezilla-project.org/client/FileZilla_3.68.1_src.tar.xz?h=skd4cOQdsN3A5aBPQdOKWg&x=1740339243"
+  source_url 'https://dl2.cdn.filezilla-project.org/client/FileZilla_3.68.1_src.tar.xz?h=skd4cOQdsN3A5aBPQdOKWg&x=1740339243'
   source_sha256 '10468e6ef623ad9789996df61f588ca7417d39353678313611d54f2d8131a1db'
   binary_compression 'tar.zst'
 

--- a/packages/ghostty.rb
+++ b/packages/ghostty.rb
@@ -31,11 +31,11 @@ class Ghostty < Package
   depends_on 'zig' => :build
 
   def self.patch
-   system "sed -i 's/linkSystemLibrary2(\"bzip2\", dynamic_link_opts)/linkSystemLibrary2(\"bz2\", dynamic_link_opts)/' src/build/SharedDeps.zig"
+    system "sed -i 's/linkSystemLibrary2(\"bzip2\", dynamic_link_opts)/linkSystemLibrary2(\"bz2\", dynamic_link_opts)/' src/build/SharedDeps.zig"
   end
 
   def self.build
-    @zig_global_cache_dir = `pwd`.chomp + '/zig_cache'
+    @zig_global_cache_dir = "#{`pwd`.chomp}/zig_cache"
     FileUtils.mkdir_p @zig_global_cache_dir
     system "ZIG_GLOBAL_CACHE_DIR=#{@zig_global_cache_dir} ./nix/build-support/fetch-zig-cache.sh"
     system "DESTDIR=build zig build \

--- a/packages/oniguruma.rb
+++ b/packages/oniguruma.rb
@@ -18,5 +18,4 @@ class Oniguruma < Autotools
   })
 
   depends_on 'glibc' # R
-
 end

--- a/packages/ruby_ast.rb
+++ b/packages/ruby_ast.rb
@@ -1,7 +1,7 @@
 require 'buildsystems/ruby'
 
 class Ruby_ast < RUBY
-  description "A library for working with Abstract Syntax Trees."
+  description 'A library for working with Abstract Syntax Trees.'
   homepage 'https://whitequark.github.io/ast/'
   version "2.4.2-#{CREW_RUBY_VER}"
   license 'MIT'

--- a/packages/ruby_language_server_protocol.rb
+++ b/packages/ruby_language_server_protocol.rb
@@ -1,7 +1,7 @@
 require 'buildsystems/ruby'
 
 class Ruby_language_server_protocol < RUBY
-  description "A Language Server Protocol SDK."
+  description 'A Language Server Protocol SDK.'
   homepage 'https://github.com/mtsmfm/language_server-protocol-ruby'
   version "3.17.0.4-#{CREW_RUBY_VER}"
   license 'MIT'

--- a/packages/ruby_parser.rb
+++ b/packages/ruby_parser.rb
@@ -1,7 +1,7 @@
 require 'buildsystems/ruby'
 
 class Ruby_parser < RUBY
-  description "A Ruby parser written in pure Ruby."
+  description 'A Ruby parser written in pure Ruby.'
   homepage 'https://github.com/whitequark/parser'
   version "3.3.7.1-#{CREW_RUBY_VER}"
   license 'MIT'

--- a/packages/ruby_rainbow.rb
+++ b/packages/ruby_rainbow.rb
@@ -1,7 +1,7 @@
 require 'buildsystems/ruby'
 
 class Ruby_rainbow < RUBY
-  description "Colorize printed text on ANSI terminals."
+  description 'Colorize printed text on ANSI terminals.'
   homepage 'https://github.com/sickill/rainbow'
   version "3.1.1-#{CREW_RUBY_VER}"
   license 'MIT'

--- a/packages/ruby_regexp_parser.rb
+++ b/packages/ruby_regexp_parser.rb
@@ -1,7 +1,7 @@
 require 'buildsystems/ruby'
 
 class Ruby_regexp_parser < RUBY
-  description "A library for tokenizing, lexing, and parsing Ruby regular expressions."
+  description 'A library for tokenizing, lexing, and parsing Ruby regular expressions.'
   homepage 'https://github.com/ammar/regexp_parser'
   version "2.10.0-#{CREW_RUBY_VER}"
   license 'MIT'

--- a/packages/ruby_ruby_progressbar.rb
+++ b/packages/ruby_ruby_progressbar.rb
@@ -1,7 +1,7 @@
 require 'buildsystems/ruby'
 
 class Ruby_ruby_progressbar < RUBY
-  description "Ruby/ProgressBar is an extremely flexible text progress bar library for Ruby."
+  description 'Ruby/ProgressBar is an extremely flexible text progress bar library for Ruby.'
   homepage 'https://github.com/jfelchner/ruby-progressbar'
   version "1.13.0-#{CREW_RUBY_VER}"
   license 'MIT'

--- a/packages/ruby_unicode_emoji.rb
+++ b/packages/ruby_unicode_emoji.rb
@@ -1,7 +1,7 @@
 require 'buildsystems/ruby'
 
 class Ruby_unicode_emoji < RUBY
-  description "Provides various sophisticated regular expressions to work with Emoji in strings, incorporating the latest Unicode / Emoji standards."
+  description 'Provides various sophisticated regular expressions to work with Emoji in strings, incorporating the latest Unicode / Emoji standards.'
   homepage 'https://github.com/janlelis/unicode-emoji'
   version "4.0.4-#{CREW_RUBY_VER}"
   license 'MIT'

--- a/packages/spirv_llvm_translator.rb
+++ b/packages/spirv_llvm_translator.rb
@@ -22,5 +22,5 @@ class Spirv_llvm_translator < CMake
   depends_on 'llvm20_dev' => :build
   depends_on 'llvm20_lib' # R
 
-  cmake_options "-DBUILD_SHARED_LIBS=ON"
+  cmake_options '-DBUILD_SHARED_LIBS=ON'
 end

--- a/packages/zstd.rb
+++ b/packages/zstd.rb
@@ -1,7 +1,6 @@
 require 'buildsystems/cmake'
 
 class Zstd < CMake
-
   description 'Zstandard - Fast real-time compression algorithm'
   homepage 'https://facebook.github.io/zstd/'
   version '1.5.7' # Do not use @_ver here, it will break the installer.

--- a/tests/commands/list.rb
+++ b/tests/commands/list.rb
@@ -9,7 +9,7 @@ String.use_color = false
 
 class ListCommandTest < Minitest::Test
   def test_list_essential_packages
-    expected_output = CREW_ESSENTIAL_PACKAGES.join("\n") + "\n".to_s
+    expected_output = "#{CREW_ESSENTIAL_PACKAGES.join("\n")}\n"
     assert_output(expected_output, nil) do
       # Command.list(args['available'], args['compatible'], args['incompatible'], args['essential'], args['installed'], CREW_VERBOSE)
       Command.list(false, false, false, true, false, false)

--- a/tools/update_no_compile_packages.rb
+++ b/tools/update_no_compile_packages.rb
@@ -12,9 +12,7 @@ require_relative '../lib/const'
 require_relative '../lib/package'
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
-unless Dir.exist?('packages')
-  abort 'Unable to locate packages. Please run from the repository root directory.'.lightred
-end
+abort 'Unable to locate packages. Please run from the repository root directory.'.lightred unless Dir.exist?('packages')
 
 puts "Setting the CREW_AGREE_TIMEOUT_SECONDS environment variable to less than the default of #{CREW_AGREE_TIMEOUT_SECONDS} may speed this up...".orange if ENV['CREW_AGREE_TIMEOUT_SECONDS'].nil?
 
@@ -45,10 +43,10 @@ end
 abort 'No packages need to be updated.'.orange if updated_packages.empty?
 
 updated_packages.uniq!
-updated_packages.each { |p| puts p.sub('packages/', '').sub('.rb', '').to_s.lightblue }
 
 updated_packages.each do |pkg|
   name = pkg.sub('packages/', '').sub('.rb', '')
+  puts name.to_s.lightblue
 
   puts "Evaluating #{name} package...".orange
   @pkg_obj = Package.load_package(pkg)

--- a/tools/version.rb
+++ b/tools/version.rb
@@ -42,7 +42,7 @@ def get_anitya_id(name, homepage)
   elsif number_of_packages.zero? # Anitya either doesn't have this package, or has it under a different name.
     # If it has it under a different name, check if it has the name used by Chromebrew.
     json2 = JSON.parse(Net::HTTP.get(URI("https://release-monitoring.org/api/v2/packages/?name=#{name.tr('-', '_')}")))
-    return if (json2['total_items']).zero?
+    return if json2['total_items'].zero?
 
     (0..json2['total_items'] - 1).each do |i|
       next unless json2['items'][i]['distribution'] == 'Chromebrew'


### PR DESCRIPTION
## Description
See https://github.com/chromebrew/rubocop-chromebrew/issues/3 for more details.

Now that rubocop is working again, its noticed a couple of issues, so fix those now so we don't have a CI disaster.

Almost all of these were just `rubocop -A`, except `tools/update_no_compile_packages.rb` which required manual correction due to a `Style/CombinableLoops` offense.

Also, I've pushed a fix and released version 0.0.4 which incorporates this, which should get picked up by the next round of auto-updates. 

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=preempt crew update \
&& yes | crew upgrade
```
