### PR TITLE
Remove newline after agree prompts

### DIFF
--- a/lib/package.rb
+++ b/lib/package.rb
@@ -53,7 +53,7 @@ class Package
   def self.agree_default_no(message = nil)
     # This defaults to false.
     Timeout.timeout(CREW_AGREE_TIMEOUT_SECONDS) do
-      return agree_with_default("#{message} (yes/NO)?", true, default: 'n')
+      return agree_with_default("#{message} (yes/NO)? ", true, default: 'n')
     end
   rescue Timeout::Error
     return false
@@ -62,7 +62,7 @@ class Package
   def self.agree_default_yes(message = nil)
     # This defaults to true.
     Timeout.timeout(CREW_AGREE_TIMEOUT_SECONDS) do
-      return agree_with_default("#{message} (YES/no)?", true, default: 'y')
+      return agree_with_default("#{message} (YES/no)? ", true, default: 'y')
     end
   rescue Timeout::Error
     return true
@@ -77,7 +77,7 @@ class Package
       puts "Cannot identify #{config_object}.".lightred
       return
     end
-    if agree_default_no("Would you like to remove the config #{identifier}: #{config_object}")
+    if agree_default_no("Would you like to remove the config #{identifier}: #{config_object} ")
       FileUtils.rm_rf config_object
       puts "#{config_object} removed.".lightgreen
     else


### PR DESCRIPTION
Yes, it really is this simple.

Before:
```
$ crew remove dbeaver
Would you like to remove the config directory: /home/chronos/user/.local/share/DBeaverData (yes/NO)?
y
/home/chronos/user/.local/share/DBeaverData removed.
dbeaver removed!
```
After:
```
$ crew remove dbeaver
Would you like to remove the config directory: /home/chronos/user/.local/share/DBeaverData  (yes/NO)? n
/home/chronos/user/.local/share/DBeaverData saved.
dbeaver removed!
```
##
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-package.rb crew update \
&& yes | crew upgrade
```