### PR TITLE
Add fdupes package

### DIFF
--- a/manifest/armv7l/f/fdupes.filelist
+++ b/manifest/armv7l/f/fdupes.filelist
@@ -1,0 +1,3 @@
+/usr/local/bin/fdupes
+/usr/local/share/man/man1/fdupes.1.zst
+/usr/local/share/man/man7/fdupes-help.7.zst

--- a/manifest/i686/f/fdupes.filelist
+++ b/manifest/i686/f/fdupes.filelist
@@ -1,0 +1,3 @@
+/usr/local/bin/fdupes
+/usr/local/share/man/man1/fdupes.1.zst
+/usr/local/share/man/man7/fdupes-help.7.zst

--- a/manifest/x86_64/f/fdupes.filelist
+++ b/manifest/x86_64/f/fdupes.filelist
@@ -1,0 +1,3 @@
+/usr/local/bin/fdupes
+/usr/local/share/man/man1/fdupes.1.zst
+/usr/local/share/man/man7/fdupes-help.7.zst

--- a/packages/fdupes.rb
+++ b/packages/fdupes.rb
@@ -1,0 +1,26 @@
+require 'buildsystems/autotools'
+
+class Fdupes < Autotools
+  description 'Program for identifying or deleting duplicate files residing within specified directories.'
+  homepage 'https://github.com/adrianlopezroche/fdupes'
+  version '2.3.2'
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://github.com/adrianlopezroche/fdupes.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+    aarch64: '380ae7833a60f5c8a3b5d6775e28247cfad53936b86d7d94c4cf62a12a71d0ff',
+     armv7l: '380ae7833a60f5c8a3b5d6775e28247cfad53936b86d7d94c4cf62a12a71d0ff',
+       i686: 'c1723549021cfecdf9cf087a81e5c5c1a3e307754d781932411d504422625409',
+     x86_64: '73038847795557bb79c7ce94a38246816a7619d19e130ea3854151479a4923d6'
+  })
+
+  depends_on 'glibc' # R
+  depends_on 'ncurses' # R
+  depends_on 'pcre2' # R
+  depends_on 'sqlite' # R
+
+  run_tests
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -1875,6 +1875,11 @@ url: https://github.com/sharkdp/fd/releases/
 activity: low
 ---
 kind: url
+name: fdupes
+url: https://github.com/adrianlopezroche/fdupes
+activity: low
+---
+kind: url
 name: feh
 url: https://feh.finalrewind.org/
 activity: medium


### PR DESCRIPTION
## Description
FDUPES is a program for identifying duplicate files residing within specified directories.  See https://github.com/adrianlopezroche/fdupes.  All tests passed.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-fdupes-package crew update \
&& yes | crew upgrade
```