### PR TITLE
Refactor tools/update_python_pip_packages.rb to not be loaded and split into functions

### DIFF
--- a/tools/build_updated_packages.rb
+++ b/tools/build_updated_packages.rb
@@ -59,7 +59,7 @@ if SKIP_UPDATE_CHECKS
   puts 'Skipping pip and gem remote update checks.'.orange
 else
   puts 'Checking for pip package version updates...'.orange
-  load 'tools/update_python_pip_packages.rb'
+  Kernel.system 'tools/update_python_pip_packages.rb'
   puts 'Checking for ruby gem package version updates...'.orange
   load 'tools/update_ruby_gem_packages.rb'
 end

--- a/tools/update_python_pip_packages.rb
+++ b/tools/update_python_pip_packages.rb
@@ -9,56 +9,71 @@
 # Add >LOCAL< lib to LOAD_PATH
 $LOAD_PATH.unshift '../lib'
 require_relative '../lib/color'
+require_relative '../lib/const'
 require_relative '../lib/require_gem'
-
-CREW_GITLAB_PKG_REPO = 'https://gitlab.com/api/v4/projects/26210301/packages'
-CREW_NPROC = `nproc`.chomp
-
 require_gem('activesupport', 'active_support/core_ext/object/blank')
 require_gem 'concurrent-ruby'
 
-py3_files = Dir['packages/py3_*.rb']
-pip_files = `grep -l "^require 'buildsystems/pip'" packages/*.rb`.chomp.split
-relevant_pip_packages = (py3_files + pip_files).uniq!
+def check_for_updated_python_packages
+  # Get a list of all the python/pip packages to check for updates.
+  py3_files = Dir['packages/py3_*.rb']
+  pip_files = `grep -l "^require 'buildsystems/pip'" packages/*.rb`.chomp.split
+  relevant_pip_packages = (py3_files + pip_files).uniq!
 
-pip_config = `pip config list`.chomp
-system "pip config --user set global.index-url #{CREW_GITLAB_PKG_REPO}/pypi/simple", %i[err out] => File::NULL unless pip_config.include?("global.index-url='#{CREW_GITLAB_PKG_REPO}/pypi/simple'")
-system 'pip config --user set global.extra-index-url https://pypi.org/simple', %i[err out] => File::NULL unless pip_config.include?("global.extra-index-url='https://pypi.org/simple'")
-system 'pip config --user set global.trusted-host gitlab.com', %i[err out] => File::NULL unless pip_config.include?("global.trusted-host='gitlab.com'")
+  # Sets the correct pip configuration values if they are not already set.
+  pip_config = `pip config list`.chomp
+  system "pip config --user set global.index-url #{CREW_GITLAB_PKG_REPO}/pypi/simple", %i[err out] => File::NULL unless pip_config.include?("global.index-url='#{CREW_GITLAB_PKG_REPO}/pypi/simple'")
+  system 'pip config --user set global.extra-index-url https://pypi.org/simple', %i[err out] => File::NULL unless pip_config.include?("global.extra-index-url='https://pypi.org/simple'")
+  system 'pip config --user set global.trusted-host gitlab.com', %i[err out] => File::NULL unless pip_config.include?("global.trusted-host='gitlab.com'")
 
-pool = Concurrent::ThreadPoolExecutor.new(
-  min_threads: 1,
-  max_threads: CREW_NPROC.to_i + 1,
-  max_queue: 0, # unbounded work queue
-  fallback_policy: :caller_runs
-)
-total_files_to_check = relevant_pip_packages.length
-numlength = total_files_to_check.to_s.length
-relevant_pip_packages.each_with_index do |package, index|
-  pool.post do
-    pip_name = package.gsub('.rb', '').sub('py3_', '').gsub('_', '-').gsub('packages/', '')
-    prerelease = system("grep -q '^\ \ prerelease' #{package}") ? '--pre' : nil
-    puts "\e[1A\e[K[#{(index + 1).to_s.rjust(numlength)}/#{total_files_to_check}] Checking pypi for #{prerelease.blank? ? '' : 'prerelease '}updates to #{pip_name}...\r".orange
-    pip_version = `python3 -m pip index versions #{prerelease} #{pip_name} 2>/dev/null | head -n 1 | awk '{print $2}'`.chomp.delete('()')
-    next package if pip_version.blank?
+  pool = Concurrent::ThreadPoolExecutor.new(
+    min_threads: 1,
+    max_threads: CREW_NPROC.to_i + 1,
+    max_queue: 0, # unbounded work queue
+    fallback_policy: :caller_runs
+  )
+  total_files_to_check = relevant_pip_packages.length
+  numlength = total_files_to_check.to_s.length
+  updateable_packages = {}
+  relevant_pip_packages.each_with_index do |package, index|
+    pool.post do
+      pip_name = package.gsub('.rb', '').sub('py3_', '').gsub('_', '-').gsub('packages/', '')
+      prerelease = system("grep -q '^\ \ prerelease' #{package}") ? '--pre' : nil
+      # The \e[1A\e[K[] is to ensure the concurrency doesn't mess up the order of the printed status updates.
+      puts "\e[1A\e[K[#{(index + 1).to_s.rjust(numlength)}/#{total_files_to_check}] Checking pypi for #{prerelease.blank? ? '' : 'prerelease '}updates to #{pip_name}...\r".orange
+      pip_version = `python3 -m pip index versions #{prerelease} #{pip_name} 2>/dev/null | head -n 1 | awk '{print $2}'`.chomp.delete('()')
+      next package if pip_version.blank?
 
-    relevant_pip_packages.delete(package)
-    # rubocop:disable Lint/InterpolationCheck
-    pkg_version = `sed -n -e 's/^\ \ version //p' #{package}`.chomp.delete("'").delete('"').gsub('-#{CREW_ICU_VER}', '').gsub('-#{CREW_PY_VER}', '')
-    # rubocop:enable Lint/InterpolationCheck
-    next package unless Gem::Version.new(pip_version) > Gem::Version.new(pkg_version)
+      relevant_pip_packages.delete(package)
+      pkg_version = `sed -n -e 's/^\ \ version //p' #{package}`.chomp.delete("'").delete('"').gsub('-#{CREW_ICU_VER}', '').gsub('-#{CREW_PY_VER}', '') # rubocop:disable Lint/InterpolationCheck
+      next package unless Gem::Version.new(pip_version) > Gem::Version.new(pkg_version)
 
-    puts "\e[1B\e[KUpdating #{pip_name} from #{pkg_version} to #{pip_version}\e[1A".lightblue
-    if pip_name == 'pyicu'
-      system "sed -i \"s,^\ \ version\ .*,\ \ version \\\"#{pip_version}-\#{CREW_ICU_VER}-\#{CREW_PY_VER}\\\",\" #{package}"
+      updateable_packages[package] = pip_version
+    end
+  end
+  pool.shutdown
+  pool.wait_for_termination
+
+  puts "Done checking pypi for updates to #{total_files_to_check} python packages.".orange
+  puts "Updated version#{relevant_pip_packages.length > 1 ? 's were' : ' was'} not listed in pypi for: #{relevant_pip_packages.map { |i| i.gsub('.rb', '').sub('ruby_', '').gsub('_', '-').gsub('packages/', '') }.join(' ')}".orange
+
+  return updateable_packages
+end
+
+def update_package_files(updateable_packages)
+  return if updateable_packages.empty?
+
+  updateable_packages.each_pair do |package, new_version|
+    package_name = package.gsub('.rb', '').sub('py3_', '').gsub('_', '-').gsub('packages/', '')
+    old_version = `sed -n -e 's/^\ \ version //p' #{package}`.chomp.delete("'").delete('"').gsub('-#{CREW_ICU_VER}', '').gsub('-#{CREW_PY_VER}', '') # rubocop:disable Lint/InterpolationCheck
+    puts "Updating #{package_name} from #{old_version} to #{new_version}".lightblue
+    if package_name == 'pyicu'
+      system "sed -i \"s,^\ \ version\ .*,\ \ version \\\"#{new_version}-\#{CREW_ICU_VER}-\#{CREW_PY_VER}\\\",\" #{package}"
     else
-      system "sed -i \"s,^\ \ version\ .*,\ \ version \\\"#{pip_version}-\#{CREW_PY_VER}\\\",\" #{package}"
+      system "sed -i \"s,^\ \ version\ .*,\ \ version \\\"#{new_version}-\#{CREW_PY_VER}\\\",\" #{package}"
     end
   end
 end
-pool.shutdown
-pool.wait_for_termination
-puts "Done checking pypi for updates to #{total_files_to_check} python packages.".orange
-return if relevant_pip_packages.blank?
 
-puts "Updated version#{relevant_pip_packages.length > 1 ? 's were' : ' was'} not listed in pypi for: #{relevant_pip_packages.map { |i| i.gsub('.rb', '').sub('ruby_', '').gsub('_', '-').gsub('packages/', '') }.join(' ')}".orange
+# If being run standalone, also update the package files with the new versions.
+update_package_files(check_for_updated_python_packages)


### PR DESCRIPTION
## Description
Running this via `system()` instead of `load()` lets us simplify some of the logic, as well as cleaning up shared state for a larger simplification later. Additionally, the splitting into functions here is a step towards implementing automatic updates for generic packages.

The git diff looks a little aggressive (at least when viewing whitespace) due to the functions, but I've only really changed about 10 lines or so.

Tested and working by going to an older container where the python/pip packages are not up to date and running it, both standalone and via `tools/build_updated_packages.rb`.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=pool crew update \
&& yes | crew upgrade
```