### PR TITLE
Refactor tools/update_ruby_gem_packages.rb to not be loaded and split into functions.

### DIFF
--- a/tools/build_updated_packages.rb
+++ b/tools/build_updated_packages.rb
@@ -61,7 +61,7 @@ else
   puts 'Checking for pip package version updates...'.orange
   Kernel.system 'tools/update_python_pip_packages.rb'
   puts 'Checking for ruby gem package version updates...'.orange
-  load 'tools/update_ruby_gem_packages.rb'
+  Kernel.system 'tools/update_ruby_gem_packages.rb'
 end
 changed_files = `git diff HEAD --name-only`.chomp.split
 changed_files_previous_commit = `git diff-tree --no-commit-id --name-only -r $(git rev-parse origin/master)..$(git rev-parse --verify HEAD)`.chomp.split

--- a/tools/update_ruby_gem_packages.rb
+++ b/tools/update_ruby_gem_packages.rb
@@ -7,55 +7,67 @@
 # Add >LOCAL< lib to LOAD_PATH
 $LOAD_PATH.unshift '../lib'
 require_relative '../lib/color'
+require_relative '../lib/const'
 require_relative '../lib/gem_compact_index_client'
 require_relative '../lib/require_gem'
-CREW_NPROC = `nproc`.chomp
-CREW_RUBY_VER = "ruby#{RUBY_VERSION.slice(/(?:.*(?=\.))/)}"
-CREW_VERBOSE = false
-
 require_gem('activesupport', 'active_support/core_ext/object/blank')
 require_gem 'concurrent-ruby'
 
-gems ||= BasicCompactIndexClient.new.gems
+def check_for_updated_ruby_packages
+  gems = BasicCompactIndexClient.new.gems
 
-pool = Concurrent::ThreadPoolExecutor.new(
-  min_threads: 1,
-  max_threads: CREW_NPROC.to_i + 1,
-  max_queue: 0, # unbounded work queue
-  fallback_policy: :caller_runs
-)
-relevant_gem_packages = Dir['packages/ruby_*.rb']
-total_files_to_check = relevant_gem_packages.length
-numlength = total_files_to_check.to_s.length
-relevant_gem_packages.each_with_index do |package, index|
-  pool.post do
-    untested_package_name = package.gsub(%r{^packages/ruby_}, '').gsub(/.rb$/, '')
-    gem_test = gems.grep(/#{"^#{untested_package_name}\\s.*$"}/).last.blank? ? gems.grep(/#{"^\(#{passed_name.gsub(/^ruby_/, '').gsub('_', ')*.(')}\\s\).*$"}/).last : gems.grep(/#{"^#{untested_package_name}\\s.*$"}/).last
-    abort "Cannot find #{passed_name} gem to install.".lightred if gem_test.blank?
-    gem_test_name = gem_test.split.first
-    puts "#{untested_package_name} versions for #{gem_test_name} are #{gem_test.split[1].split(',')}" if CREW_VERBOSE
-    gem_test_versions = gem_test.split[1].split(',')
-    # Any version with a letter is considered a prerelease as per
-    # https://github.com/rubygems/rubygems/blob/b5798efd348935634d4e0e2b846d4f455582db48/lib/rubygems/version.rb#L305
-    gem_test_versions.delete_if { |i| i.match?(/[a-zA-Z]/) }
-    gem_test_version = gem_test_versions.max
-    puts "#{untested_package_name} is #{gem_test_name} version #{gem_test_version}".lightpurple if CREW_VERBOSE
-    gem_name = gem_test_name.blank? ? Gem::SpecFetcher.fetcher.suggest_gems_from_name(untested_package_name).first : gem_test_name
-    gem_version = gem_test_name.blank? ? Gem.latest_version_for(untested_package_name).to_s : gem_test_version
+  pool = Concurrent::ThreadPoolExecutor.new(
+    min_threads: 1,
+    max_threads: CREW_NPROC.to_i + 1,
+    max_queue: 0, # unbounded work queue
+    fallback_policy: :caller_runs
+  )
+  relevant_gem_packages = Dir['packages/ruby_*.rb']
+  total_files_to_check = relevant_gem_packages.length
+  numlength = total_files_to_check.to_s.length
+  updateable_packages = {}
+  relevant_gem_packages.each_with_index do |package, index|
+    pool.post do
+      untested_package_name = package.gsub(%r{^packages/ruby_}, '').gsub(/.rb$/, '')
+      gem_test = gems.grep(/#{"^#{untested_package_name}\\s.*$"}/).last.blank? ? gems.grep(/#{"^\(#{passed_name.gsub(/^ruby_/, '').gsub('_', ')*.(')}\\s\).*$"}/).last : gems.grep(/#{"^#{untested_package_name}\\s.*$"}/).last
+      abort "Cannot find #{passed_name} gem to install.".lightred if gem_test.blank?
+      gem_test_name = gem_test.split.first
+      gem_test_versions = gem_test.split[1].split(',')
+      # Any version with a letter is considered a prerelease as per
+      # https://github.com/rubygems/rubygems/blob/b5798efd348935634d4e0e2b846d4f455582db48/lib/rubygems/version.rb#L305
+      gem_test_versions.delete_if { |i| i.match?(/[a-zA-Z]/) }
+      gem_test_version = gem_test_versions.max
+      gem_name = gem_test_name.blank? ? Gem::SpecFetcher.fetcher.suggest_gems_from_name(untested_package_name).first : gem_test_name
+      gem_version = gem_test_name.blank? ? Gem.latest_version_for(untested_package_name).to_s : gem_test_version
+      next package if gem_version.blank?
 
-    puts "[#{(index + 1).to_s.rjust(numlength)}/#{total_files_to_check}] Checking rubygems for updates to #{gem_name} in #{package}...".orange
-    pkg_version = `sed -n -e 's/^\ \ version //p' #{package}`.chomp.delete("'").delete('"').gsub(/-\#{CREW_RUBY_VER}/, '').split('-').first
-    next package if gem_version.blank?
-    if Gem::Version.new(gem_version) > Gem::Version.new(pkg_version)
-      puts "Updating #{gem_name} from #{pkg_version} to #{gem_version}".lightblue
-      system "sed -i \"s,^\ \ version\ .*,\ \ version \\\"#{gem_version}-\#{CREW_RUBY_VER}\\\",\" #{package}"
+      relevant_gem_packages.delete(package)
+      puts "[#{(index + 1).to_s.rjust(numlength)}/#{total_files_to_check}] Checking rubygems for updates to #{gem_name} in #{package}...".orange
+      pkg_version = `sed -n -e 's/^\ \ version //p' #{package}`.chomp.delete("'").delete('"').gsub(/-\#{CREW_RUBY_VER}/, '').split('-').first
+      next package unless Gem::Version.new(gem_version) > Gem::Version.new(pkg_version)
+
+      updateable_packages[package] = gem_version
     end
-    relevant_gem_packages.delete(package)
+  end
+  pool.shutdown
+  pool.wait_for_termination
+
+  puts "Done checking for updates to #{total_files_to_check} ruby gems.\r".orange
+  puts "Updated version#{relevant_gem_packages.length > 1 ? 's were' : ' was'} could not be found for: #{relevant_gem_packages.map { |i| i.gsub('.rb', '').sub('ruby_', '').gsub('_', '-').gsub('packages/', '') }.join(' ')}".orange
+
+  return updateable_packages
+end
+
+def update_package_files(updateable_packages)
+  return if updateable_packages.empty?
+
+  updateable_packages.each_pair do |package, new_version|
+    package_name = package.gsub(%r{^packages/ruby_}, '').gsub(/.rb$/, '')
+    old_version = `sed -n -e 's/^\ \ version //p' #{package}`.chomp.delete("'").delete('"').gsub(/-\#{CREW_RUBY_VER}/, '').split('-').first
+    puts "Updating #{package_name} from #{old_version} to #{new_version}".lightblue
+    system "sed -i \"s,^\ \ version\ .*,\ \ version \\\"#{new_version}-\#{CREW_RUBY_VER}\\\",\" #{package}"
   end
 end
-pool.shutdown
-pool.wait_for_termination
-puts "Done checking for updates to #{total_files_to_check} ruby gems.\r".orange
-return if relevant_gem_packages.blank?
 
-puts "Updated version#{relevant_gem_packages.length > 1 ? 's were' : ' was'} could not be found for: #{relevant_gem_packages.map { |i| i.gsub('.rb', '').sub('ruby_', '').gsub('_', '-').gsub('packages/', '') }.join(' ')}".orange
+# If being run standalone, also update the package files with the new versions.
+update_package_files(check_for_updated_ruby_packages)


### PR DESCRIPTION
## Description
More of the same as #11588, with the same caveats regarding diffs, purpose, etc.

Tested and working properly, both standalone and as part of `tools/build_updated_packages.rb`.

I've removed the lines guarded by `CREW_VERBOSE` because the previous implementation just always set `CREW_VERBOSE` to false so these lines would never be printed, so I'm maintaining behavior.

The one thing I have a question about is this:
```ruby
puts "Updated version#{relevant_gem_packages.length > 1 ? 's were' : ' was'} could not be found for: #{relevant_gem_packages.map { |i| i.gsub('.rb', '').sub('ruby_', '').gsub('_', '-').gsub('packages/', '') }.join(' ')}".orange
```

This line ends up printing something like `Updated versions were could not be found for: concurrent-ruby gem-compiler ...`, or presumably `Updated version was could not be found...`

@satmandu, what exactly is this supposed to convey?

I'm happy to sort out the proper grammar once I know the intended message, but at the moment I'm not quite sure what to remove.

I've left it the same for now, and I can always come back to it in a later pr.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=ph crew update \
&& yes | crew upgrade
```
