### PR TITLE
Vivaldi 7.2.3621.67-1 => 7.2.3621.71-1

### DIFF
--- a/manifest/armv7l/v/vivaldi.filelist
+++ b/manifest/armv7l/v/vivaldi.filelist
@@ -18,7 +18,6 @@
 /usr/local/share/vivaldi/MEIPreload/preloaded_data.pb
 /usr/local/share/vivaldi/PrivacySandboxAttestationsPreloaded/manifest.json
 /usr/local/share/vivaldi/PrivacySandboxAttestationsPreloaded/privacy-sandbox-attestations.dat
-/usr/local/share/vivaldi/WidevineCdm
 /usr/local/share/vivaldi/chrome_crashpad_handler
 /usr/local/share/vivaldi/cron/vivaldi
 /usr/local/share/vivaldi/icudtl.dat
@@ -209,7 +208,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/adblocker_resources/redirectable_resources.json
 /usr/local/share/vivaldi/resources/vivaldi/background-bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/background-common-bundle.js
-/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-d259e4fcd140b97505cab69ef6a84ab0.js
+/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-5e1343d0219b793fee10722a849b672e.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle-mailreader-worker.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/components/mail/mail.html

--- a/manifest/x86_64/v/vivaldi.filelist
+++ b/manifest/x86_64/v/vivaldi.filelist
@@ -18,7 +18,6 @@
 /usr/local/share/vivaldi/MEIPreload/preloaded_data.pb
 /usr/local/share/vivaldi/PrivacySandboxAttestationsPreloaded/manifest.json
 /usr/local/share/vivaldi/PrivacySandboxAttestationsPreloaded/privacy-sandbox-attestations.dat
-/usr/local/share/vivaldi/WidevineCdm
 /usr/local/share/vivaldi/chrome_crashpad_handler
 /usr/local/share/vivaldi/cron/vivaldi
 /usr/local/share/vivaldi/icudtl.dat
@@ -209,7 +208,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/adblocker_resources/redirectable_resources.json
 /usr/local/share/vivaldi/resources/vivaldi/background-bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/background-common-bundle.js
-/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-6ebe081e8ccf561e25eb2b2660c97011.js
+/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-9e38af95f25c60b88935c0351de91c70.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle-mailreader-worker.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/components/mail/mail.html

--- a/packages/vivaldi.rb
+++ b/packages/vivaldi.rb
@@ -4,7 +4,7 @@ require 'convenience_functions'
 class Vivaldi < Package
   description 'Vivaldi is a new browser that blocks unwanted ads, protects you from trackers, and puts you in control with unique built-in features.'
   homepage 'https://vivaldi.com/'
-  version '7.2.3621.67-1'
+  version '7.2.3621.71-1'
   license 'Vivaldi'
   compatibility 'aarch64 armv7l x86_64'
   min_glibc '2.37'
@@ -24,10 +24,10 @@ class Vivaldi < Package
   case ARCH
   when 'aarch64', 'armv7l'
     arch = 'armhf'
-    source_sha256 'b592bc63e2f832051bcb8b86343a7c3d3648c8ea8244fe8280a51a624b2b63da'
+    source_sha256 '1354bfc936f22fea79f383fc9b3a3546e3946241f8054bdf99f5229a717edc9d'
   when 'x86_64'
     arch = 'amd64'
-    source_sha256 '8031432dcf51348f4ab729bd271e97add9bd5ca2263b3f9b1d5e4969d09cd16a'
+    source_sha256 '177142f105d6957a1d3f094a8a17c1968a98fc2d89564f96607b0fa71820eb84'
   end
 
   source_url "https://downloads.vivaldi.com/stable/vivaldi-stable_#{version}_#{arch}.deb"


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable  to launch in hatch m133 container
- [x] `armv7l` Unable  to launch in strongbad m133 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-vivaldi crew update \
&& yes | crew upgrade
```