### PR TITLE
Switch java packages without new versions to openjdk8

### DIFF
--- a/packages/rsu_client.rb
+++ b/packages/rsu_client.rb
@@ -16,7 +16,7 @@ class Rsu_client < Package
      x86_64: '535a8a5339b57fe5929b6b1ff4fc40c8c93039ecf43006c2323c0d65502ed899'
   })
 
-  depends_on 'jdk8'
+  depends_on 'openjdk8'
   depends_on 'p7zip'
   depends_on 'wxwidgets'
   depends_on 'xdg_utils'

--- a/packages/upm.rb
+++ b/packages/upm.rb
@@ -9,7 +9,7 @@ class Upm < Package
   source_url 'https://downloads.sourceforge.net/project/upm/upm-1.15.1/upm-1.15.1.tar.gz'
   source_sha256 'c8ade41ec0fe6f387f6e44b941ce5f17a3c2e2d096b4be766bed29ee606ac078'
 
-  depends_on 'jdk8'
+  depends_on 'openjdk8'
   depends_on 'sommelier'
 
   def self.build

--- a/packages/vuze.rb
+++ b/packages/vuze.rb
@@ -14,7 +14,7 @@ class Vuze < Package
      x86_64: '062957f74835d906c6788056224dda734b92e64473a4ac330afbd29041d71c74'
   })
 
-  depends_on 'jdk8' unless CREW_IN_CONTAINER
+  depends_on 'openjdk8'
   depends_on 'gtk3'
 
   def self.patch


### PR DESCRIPTION
## Description
Working on #7476. I've switched all the packages that haven't had new releases and so don't need to be updated to openjdk8. Admittedly some of these packages may need additional inspection (vuze was forked and upstream development has stopped, rsu_client was archived upstream due to no longer working with rs3) but I've confirmed to the best of my ability that the switch to openjdk8 has not broken these packages any more than they already are.

##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=sofar crew update \
&& yes | crew upgrade
```
