### PR TITLE
Bail out of crew upload if the built package has no files

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1473,6 +1473,10 @@ def upload(pkg_name = nil, pkg_version = nil, gitlab_token = nil, gitlab_token_u
         puts "#{release_dir}/#{package}-#{pkg_version}-chromeos-#{arch}.#{binary_compression.nil? ? '(tar.xz|tar.zst)' : binary_compression} not found.\n".lightred
         next arch
       end
+
+      # If the filelist exists and is empty, the build was probably supposed to have files.
+      abort "#{package} has an empty manifest. Something probably went wrong with the build.".lightred if File.empty?("#{CREW_LOCAL_REPO_ROOT}/manifest/#{arch}/#{@pkg.name.chr}/#{@pkg.name}.filelist")
+
       if binary_compression_not_in_file
         ext = File.extname(new_tarfile)
         binary_compression = @pkg.superclass.to_s == 'RUBY' ? 'gem' : "tar#{ext}"

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.58.0' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.58.1' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]


### PR DESCRIPTION
## Description
This sanity check would have saved me quite a bit of time in the past, but better late than never.

Tested and working on `x86_64`.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=atleast crew update \
&& yes | crew upgrade
```
