### PR TITLE
Terraform 1.11.2 => 1.11.3

### DIFF
--- a/packages/terraform.rb
+++ b/packages/terraform.rb
@@ -3,7 +3,7 @@ require 'package'
 class Terraform < Package
   description 'Terraform is a tool for building, changing, and combining infrastructure safely and efficiently.'
   homepage 'https://www.terraform.io/'
-  version '1.11.2'
+  version '1.11.3'
   license 'Apache-2.0, BSD-2, BSD-4, ECL-2.0, imagemagick, ISC, JSON, MIT, MIT-with-advertising, MPL-2.0 and unicode'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Terraform < Package
      x86_64: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_amd64.zip"
   })
   source_sha256({
-    aarch64: '576a77c919e0bd8fc224b1b9090e96b1975c7bf1cee096312f2b68a121f1477c',
-     armv7l: '576a77c919e0bd8fc224b1b9090e96b1975c7bf1cee096312f2b68a121f1477c',
-       i686: '5c6d482a1d95abfd01f6e8c0382f8424bbcd44b4a05b49beeb62aac5f402fdd6',
-     x86_64: 'b94f7c5080196081ea5180e8512edd3c2037f28445ce3562cfb0adfd0aab64ca'
+    aarch64: '9bf99463a9353a4242a5650fedc20833537db26c0aa7063ab673a179a5a7ba26',
+     armv7l: '9bf99463a9353a4242a5650fedc20833537db26c0aa7063ab673a179a5a7ba26',
+       i686: 'f5a4250f371df3b9b54b7f802495a9e341a8846e3536f673d1f8c1d28e8c0b85',
+     x86_64: '377c8c18e2beab24f721994859236e98383350bf767921436511370d1f7c472b'
   })
 
   def self.install


### PR DESCRIPTION
## Description

This commit updates the Terraform CLI from version 1.11.2 to version 1.11.3.

## Additional information

Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##