### PR TITLE
Add etcd package

### DIFF
--- a/manifest/x86_64/e/etcd.filelist
+++ b/manifest/x86_64/e/etcd.filelist
@@ -1,0 +1,3 @@
+/usr/local/bin/etcd
+/usr/local/bin/etcdctl
+/usr/local/bin/etcdutl

--- a/packages/etcd.rb
+++ b/packages/etcd.rb
@@ -1,0 +1,23 @@
+require 'package'
+
+class Etcd < Package
+  description 'Distributed reliable key-value store for the most critical data of a distributed system'
+  homepage 'https://etcd.io/'
+  version '3.5.21'
+  license 'Apache-2.0'
+  compatibility 'x86_64'
+  source_url "https://github.com/etcd-io/etcd/releases/download/v#{version}/etcd-v#{version}-linux-amd64.tar.gz"
+  source_sha256 'adddda4b06718e68671ffabff2f8cee48488ba61ad82900e639d108f2148501c'
+
+  no_compile_needed
+  no_shrink
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    FileUtils.install %w[etcd etcdctl etcdutl], "#{CREW_DEST_PREFIX}/bin", mode: 0o755
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nSee documentation: https://etcd.io/docs/latest.\n"
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -1730,6 +1730,11 @@ url: http://erlang.org/download
 activity: high
 ---
 kind: url
+name: etcd
+url: https://github.com/etcd-io/etcd/releases
+activity: high
+---
+kind: url
 name: ethtool
 url: https://mirrors.edge.kernel.org/pub/software/network/ethtool/
 activity: medium


### PR DESCRIPTION
## Description
etcd is a strongly consistent, distributed key-value store that provides a reliable way to store data that needs to be accessed by a distributed system or cluster of machines. It gracefully handles leader elections during network partitions and can tolerate machine failure, even in the leader node.  See https://etcd.io/.
##
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-etcd-package crew update \
&& yes | crew upgrade
```