### PR TITLE
Refactor tools/update_ruby_gem_packages.rb to use package objects, the rubygems.org api, and more rubification

### DIFF
--- a/.github/workflows/Updater.yml
+++ b/.github/workflows/Updater.yml
@@ -79,7 +79,7 @@ jobs:
         env:
           UPDATE_BRANCH_NAME: ${{ steps.set-variables.outputs.UPDATE_BRANCH_NAME }}
         run: |
-          ruby tools/update_ruby_gem_packages.rb
+          LD_LIBRARY_PATH=/usr/local/lib ruby tools/update_ruby_gem_packages.rb
           # Create a new branch with the updated package files only
           # if there are updated packages. Otherwise exit early.
           if [ -n "$(git status --porcelain)" ]; then

--- a/lib/package_utils.rb
+++ b/lib/package_utils.rb
@@ -81,6 +81,8 @@ class PackageUtils
     pkg_version.delete_prefix!('kde-')
     # Delete -py3.12, futureproofed until Python 4
     pkg_version.gsub!(/-py3\.\d{2}/, '')
+    # Delete -ruby3.4, futureproofed until Ruby 4 or Ruby 3.10
+    pkg_version.gsub!(/-ruby3\.\d{1}/, '')
     # Delete -perl 5.40, futureproofed until Perl 5.100
     pkg_version.gsub!(/-perl5\.\d{2}/, '')
     # Delete -llvm18, futureproofed until llvm 100

--- a/tests/lib/package_utils.rb
+++ b/tests/lib/package_utils.rb
@@ -148,6 +148,10 @@ class PackageUtilsTest < Minitest::Test
     assert_equal('1.2.3', PackageUtils.get_clean_version('1.2.3-py3.12'))
   end
 
+  def test_get_clean_ruby_version
+    assert_equal('99.95', PackageUtils.get_clean_version('99.95-ruby3.4'))
+  end
+
   def test_get_clean_perl_version
     assert_equal('0.004.2', PackageUtils.get_clean_version('0.004.2-perl5.40'))
   end


### PR DESCRIPTION
## Description
Pretty similar to last time, but I swapped to directly querying the rubygems API, which lets us simplify a lot of things, lets us check the versions of all ruby packages (i.e. we can check rubocop-chromebrew now), and might be a little bit faster.

Also, I added support for stripping ruby versions in `PackageUtils.get_clean_version` so we can use that here, and it will also stop all of our ruby packages being marked as out of date in Repology (thats an additional ~130 packages marked as up to date now).

Tested and working in container and in codespace.
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=portrait crew update \
&& yes | crew upgrade
```