### PR TITLE
Update browsers

### DIFF
--- a/manifest/armv7l/v/vivaldi.filelist
+++ b/manifest/armv7l/v/vivaldi.filelist
@@ -208,7 +208,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/adblocker_resources/redirectable_resources.json
 /usr/local/share/vivaldi/resources/vivaldi/background-bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/background-common-bundle.js
-/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-9847929878667978db793b3b0949573d.js
+/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-5556f69292d4fc2d8081892492877d34.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle-mailreader-worker.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/components/mail/mail.html

--- a/manifest/x86_64/f/firefox.filelist
+++ b/manifest/x86_64/f/firefox.filelist
@@ -28,7 +28,6 @@
 /usr/local/firefox/icons/updater.png
 /usr/local/firefox/libfreeblpriv3.so
 /usr/local/firefox/libgkcodecs.so
-/usr/local/firefox/libipcclientcerts.so
 /usr/local/firefox/liblgpllibs.so
 /usr/local/firefox/libmozavcodec.so
 /usr/local/firefox/libmozavutil.so
@@ -38,7 +37,6 @@
 /usr/local/firefox/libmozwayland.so
 /usr/local/firefox/libnspr4.so
 /usr/local/firefox/libnss3.so
-/usr/local/firefox/libnssckbi.so
 /usr/local/firefox/libnssutil3.so
 /usr/local/firefox/libplc4.so
 /usr/local/firefox/libplds4.so

--- a/manifest/x86_64/v/vivaldi.filelist
+++ b/manifest/x86_64/v/vivaldi.filelist
@@ -208,7 +208,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/adblocker_resources/redirectable_resources.json
 /usr/local/share/vivaldi/resources/vivaldi/background-bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/background-common-bundle.js
-/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-021ba78064aba728f180415ff80a8546.js
+/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-ffff9b88816c35dfb5e49d0cd127b372.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle-mailreader-worker.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/components/mail/mail.html

--- a/packages/brave.rb
+++ b/packages/brave.rb
@@ -4,12 +4,12 @@ require 'convenience_functions'
 class Brave < Package
   description 'Next generation Brave browser for macOS, Windows, Linux, Android.'
   homepage 'https://brave.com/'
-  version '1.76.82'
+  version '1.77.95'
   license 'MPL-2'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://github.com/brave/brave-browser/releases/download/v#{version}/brave-browser-#{version}-linux-amd64.zip"
-  source_sha256 'bd111feb69ace09152d1f771e50562607b2f827de9a2edcc1037138156c71963'
+  source_sha256 '0d54e7e97afdf920055116c0ffafbca69f55235ed4d9d57b01d0261369c5878c'
 
   no_compile_needed
   no_shrink

--- a/packages/firefox.rb
+++ b/packages/firefox.rb
@@ -3,12 +3,12 @@ require 'package'
 class Firefox < Package
   description 'Mozilla Firefox (or simply Firefox) is a free and open-source web browser'
   homepage 'https://www.mozilla.org/en-US/firefox/'
-  version '136.0.4'
+  version '137.0'
   license 'MPL-2.0, GPL-2 and LGPL-2.1'
   compatibility 'x86_64'
   min_glibc '2.35'
   source_url "https://download-installer.cdn.mozilla.net/pub/firefox/releases/#{version}/linux-x86_64/en-US/firefox-#{version}.tar.xz"
-  source_sha256 'ffebf056b2d6cb477ed5768b899d84b6ba553787ca9465cd5783f5e3ebbe75d7'
+  source_sha256 '4d2d0a64a11f8aab7a1be583e1e4cddfaf2671967212b369a87489f3c11c3ac9'
 
   depends_on 'at_spi2_core'
   depends_on 'cairo'

--- a/packages/mullvad.rb
+++ b/packages/mullvad.rb
@@ -4,11 +4,11 @@ require 'convenience_functions'
 class Mullvad < Package
   description 'Privacy-focused browser'
   homepage 'https://mullvad.net/browser'
-  version '14.0.7'
+  version '14.0.9'
   license 'Mozilla Public License V2'
   compatibility 'x86_64'
   source_url "https://github.com/mullvad/mullvad-browser/releases/download/#{version}/mullvad-browser-linux-x86_64-#{version}.tar.xz"
-  source_sha256 '3e0359474061e65df2e95c1df013eecfd0e6d0c4a9e93da2a386239b2fdc3c7d'
+  source_sha256 'e665699524ea5d54cbf9048983486d84a50bfc98b05f70370c2f3af4747343b3'
 
   depends_on 'gtk3'
   depends_on 'gdk_base'

--- a/packages/opera.rb
+++ b/packages/opera.rb
@@ -4,7 +4,7 @@ require 'convenience_functions'
 class Opera < Package
   description 'Opera is a multi-platform web browser based on Chromium and developed by Opera Software.'
   homepage 'https://www.opera.com/'
-  version '117.0.5408.163'
+  version '117.0.5408.197'
   license 'OPERA-2018'
   compatibility 'x86_64'
   min_glibc '2.29'
@@ -12,7 +12,7 @@ class Opera < Package
   # faster apt mirror, but only works when downloading latest version of opera
   # source_url "https://deb.opera.com/opera/pool/non-free/o/opera-stable/opera-stable_#{version}_amd64.deb"
   source_url "https://deb.opera.com/opera-stable/pool/non-free/o/opera-stable/opera-stable_#{version}_amd64.deb"
-  source_sha256 '882ac3faf12b0cccc3e21159d5380a3629df4fe44ece3f6c46367193455ec733'
+  source_sha256 '65361d9a9f1f49c066e52175731d8bc21315eba3244a112dc30ed50c94c30139'
 
   depends_on 'gtk3'
   depends_on 'gsettings_desktop_schemas'

--- a/packages/vivaldi.rb
+++ b/packages/vivaldi.rb
@@ -4,7 +4,7 @@ require 'convenience_functions'
 class Vivaldi < Package
   description 'Vivaldi is a new browser that blocks unwanted ads, protects you from trackers, and puts you in control with unique built-in features.'
   homepage 'https://vivaldi.com/'
-  version '7.3.3635.4-1'
+  version '7.3.3635.7-1'
   license 'Vivaldi'
   compatibility 'aarch64 armv7l x86_64'
   min_glibc '2.37'
@@ -24,10 +24,10 @@ class Vivaldi < Package
   case ARCH
   when 'aarch64', 'armv7l'
     arch = 'armhf'
-    source_sha256 'e91ed7a1a7bc6b39c1839109d8f55861ccb1532e276a8c6ad9112995a39117da'
+    source_sha256 '1eb120280a3f6405eb9863cc907ba59c4b151750f3ed07152c997f39460db850'
   when 'x86_64'
     arch = 'amd64'
-    source_sha256 'b180b7760c05852dfd78e48089f5a084255c9b41e588f688d17bdfe22dca2cf6'
+    source_sha256 'f09cbb2f9052599548162cd6d75a4e7d7860793f6b3f56764f4683982efd7db4'
   end
 
   source_url "https://downloads.vivaldi.com/stable/vivaldi-stable_#{version}_#{arch}.deb"


### PR DESCRIPTION
- Brave 1.76.82 => 1.77.95
- Firefox 136.0.4 => 137.0
- Mullvad 14.0.7 => 14.0.9
- Opera 117.0.5408.163 => 117.0.5408.197
- Vivaldi 7.3.3635.4-1 => 7.3.3635.7-1
##
Tested & Working properly:
- [x] `x86_64` Only firefox was successfully launched in hatch m134 container
- [x] `armv7l` Only vivalidi and unable to launch in strongbad m134 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-browsers crew update \
&& yes | crew upgrade
```