### PR TITLE
Signal_desktop 7.48.0 => 7.49.0

### DIFF
--- a/manifest/x86_64/s/signal_desktop.filelist
+++ b/manifest/x86_64/s/signal_desktop.filelist
@@ -106,9 +106,9 @@
 /usr/local/share/Signal/resources.pak
 /usr/local/share/Signal/resources/app-update.yml
 /usr/local/share/Signal/resources/app.asar
-/usr/local/share/Signal/resources/app.asar.unpacked/node_modules/@signalapp/better-sqlite3/build/Release/better_sqlite3.node
 /usr/local/share/Signal/resources/app.asar.unpacked/node_modules/@signalapp/libsignal-client/prebuilds/linux-x64/@signalapp+libsignal-client.node
 /usr/local/share/Signal/resources/app.asar.unpacked/node_modules/@signalapp/ringrtc/build/linux/libringrtc-x64.node
+/usr/local/share/Signal/resources/app.asar.unpacked/node_modules/@signalapp/sqlcipher/prebuilds/linux-x64/@signalapp+sqlcipher.node
 /usr/local/share/Signal/resources/app.asar.unpacked/node_modules/fs-xattr/build/Release/xattr.node
 /usr/local/share/Signal/resources/apparmor-profile
 /usr/local/share/Signal/resources/package-type

--- a/packages/signal_desktop.rb
+++ b/packages/signal_desktop.rb
@@ -3,12 +3,12 @@ require 'package'
 class Signal_desktop < Package
   description 'Private Messenger for Windows, Mac, and Linux'
   homepage 'https://signal.org/'
-  version '7.48.0'
+  version '7.49.0'
   license 'AGPL-3.0'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_#{version}_amd64.deb"
-  source_sha256 'd7ca49ef681153954edc17defbde1066cf51af0c07a9e04d98def3ced768c624'
+  source_sha256 '7a35008a28db70af282b3cb7f8e8e3a471022568d21a99fa7ae9b483e311eba1'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m134 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-signal_desktop crew update \
&& yes | crew upgrade
```