### PR TITLE
Google_chrome 134.0.6998.117-1 => 135.0.7049.84-1

### DIFF
--- a/packages/google_chrome.rb
+++ b/packages/google_chrome.rb
@@ -5,12 +5,12 @@ class Google_chrome < Package
   description 'Google Chrome is a fast, easy to use, and secure web browser.'
   homepage 'https://www.google.com/chrome/'
   @update_channel = 'stable'
-  version '134.0.6998.117-1'
+  version '135.0.7049.84-1'
   license 'google-chrome'
   compatibility 'x86_64'
   min_glibc '2.28'
   source_url "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-#{@update_channel}/google-chrome-#{@update_channel}_#{@version}_amd64.deb"
-  source_sha256 '1c9da23c2d348c4a9ed41f4fa42bb3793299a6068d667b1e32e12a42935e591b'
+  source_sha256 '67280cd98b8c2f6dca3c943c2a5e5fd98a88fb4bdb5e70b77d893c97c47f9d79'
 
   depends_on 'nss'
   depends_on 'cairo'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m134 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-google_chrome crew update \
&& yes | crew upgrade
```