### PR TITLE
Add speakify package

### DIFF
--- a/manifest/i686/s/speakify.filelist
+++ b/manifest/i686/s/speakify.filelist
@@ -1,0 +1,13 @@
+/usr/local/bin/speakify
+/usr/local/share/speakify/Dockerfile
+/usr/local/share/speakify/__pycache__/main.cpython-311.pyc
+/usr/local/share/speakify/main.py
+/usr/local/share/speakify/readme.md
+/usr/local/share/speakify/requirements.txt
+/usr/local/share/speakify/speakify.sh
+/usr/local/share/speakify/static/SPEAKIFY.svg
+/usr/local/share/speakify/static/SPEAKIFYW.svg
+/usr/local/share/speakify/static/favicon.ico
+/usr/local/share/speakify/templates/index.html
+/usr/local/share/speakify/vercel.json
+/usr/local/share/speakify/voices.json

--- a/manifest/x86_64/s/speakify.filelist
+++ b/manifest/x86_64/s/speakify.filelist
@@ -1,0 +1,13 @@
+/usr/local/bin/speakify
+/usr/local/share/speakify/Dockerfile
+/usr/local/share/speakify/__pycache__/main.cpython-311.pyc
+/usr/local/share/speakify/main.py
+/usr/local/share/speakify/readme.md
+/usr/local/share/speakify/requirements.txt
+/usr/local/share/speakify/speakify.sh
+/usr/local/share/speakify/static/SPEAKIFY.svg
+/usr/local/share/speakify/static/SPEAKIFYW.svg
+/usr/local/share/speakify/static/favicon.ico
+/usr/local/share/speakify/templates/index.html
+/usr/local/share/speakify/vercel.json
+/usr/local/share/speakify/voices.json

--- a/packages/speakify.rb
+++ b/packages/speakify.rb
@@ -1,0 +1,35 @@
+require 'package'
+
+class Speakify < Package
+  description 'Speakify is a web application that uses Edge TTS to convert text to speech using a variety of voices.'
+  homepage 'https://github.com/habitual69/speakify'
+  version '07f685a07b0ee3c89c3c4d19a1a22ec84a57cd4f-py3.13'
+  license 'MIT'
+  compatibility 'i686 x86_64'
+  source_url 'https://github.com/habitual69/speakify.git'
+  git_hashtag version.split('-').first
+
+  depends_on 'python3' # R
+
+  no_compile_needed
+
+  def self.build
+    File.write 'speakify.sh', <<~EOF
+      #!/bin/bash
+      cd #{CREW_PREFIX}/share/speakify
+      python3 main.py
+    EOF
+  end
+
+  def self.install
+    FileUtils.rm_rf Dir['.git*']
+    system 'pip install -r requirements.txt'
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/share/speakify"
+    FileUtils.cp_r Dir['.'], "#{CREW_DEST_PREFIX}/share/speakify"
+    FileUtils.install 'speakify.sh', "#{CREW_DEST_PREFIX}/bin/speakify", mode: 0o755
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nType 'speakify' to get started."
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -8685,6 +8685,11 @@ url: https://github.com/holman/spark/releases
 activity: none
 ---
 kind: url
+name: speakify
+url: https://github.com/habitual69/speakify
+activity: low
+---
+kind: url
 name: speedometer
 url: https://httpredir.debian.org/debian/pool/main/s/speedometer/
 activity: none


### PR DESCRIPTION
## Description
Speakify is a web application that uses Edge TTS to convert text to speech using a variety of voices.  See https://speakify-two.vercel.app/.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` May need rust to compile
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-speakify-package crew update \
&& yes | crew upgrade
```