### PR TITLE
Bitcoin Core 28.1 => 29.0

### DIFF
--- a/manifest/armv7l/b/bitcoin_core.filelist
+++ b/manifest/armv7l/b/bitcoin_core.filelist
@@ -6,10 +6,6 @@
 /usr/local/bin/bitcoind
 /usr/local/bin/test_bitcoin
 /usr/local/etc/bitcoin.conf
-/usr/local/include/bitcoinconsensus.h
-/usr/local/lib/libbitcoinconsensus.so
-/usr/local/lib/libbitcoinconsensus.so.0
-/usr/local/lib/libbitcoinconsensus.so.0.0.0
 /usr/local/share/man/man1/bitcoin-cli.1.zst
 /usr/local/share/man/man1/bitcoin-qt.1.zst
 /usr/local/share/man/man1/bitcoin-tx.1.zst

--- a/manifest/x86_64/b/bitcoin_core.filelist
+++ b/manifest/x86_64/b/bitcoin_core.filelist
@@ -6,10 +6,6 @@
 /usr/local/bin/bitcoind
 /usr/local/bin/test_bitcoin
 /usr/local/etc/bitcoin.conf
-/usr/local/include/bitcoinconsensus.h
-/usr/local/lib64/libbitcoinconsensus.so
-/usr/local/lib64/libbitcoinconsensus.so.0
-/usr/local/lib64/libbitcoinconsensus.so.0.0.0
 /usr/local/share/man/man1/bitcoin-cli.1.zst
 /usr/local/share/man/man1/bitcoin-qt.1.zst
 /usr/local/share/man/man1/bitcoin-tx.1.zst

--- a/packages/bitcoin_core.rb
+++ b/packages/bitcoin_core.rb
@@ -3,18 +3,18 @@ require 'package'
 class Bitcoin_core < Package
   description 'Bitcoin Core is a full Bitcoin client and builds the backbone of the network.'
   homepage 'https://bitcoincore.org/'
-  version '28.1'
+  version '29.0'
   license 'MIT'
   compatibility 'aarch64 armv7l x86_64'
   source_url({
-    aarch64: 'https://bitcoincore.org/bin/bitcoin-core-28.1/bitcoin-28.1-arm-linux-gnueabihf.tar.gz',
-     armv7l: 'https://bitcoincore.org/bin/bitcoin-core-28.1/bitcoin-28.1-arm-linux-gnueabihf.tar.gz',
-     x86_64: 'https://bitcoincore.org/bin/bitcoin-core-28.1/bitcoin-28.1-x86_64-linux-gnu.tar.gz'
+    aarch64: "https://bitcoincore.org/bin/bitcoin-core-#{version}/bitcoin-#{version}-arm-linux-gnueabihf.tar.gz",
+     armv7l: "https://bitcoincore.org/bin/bitcoin-core-#{version}/bitcoin-#{version}-arm-linux-gnueabihf.tar.gz",
+     x86_64: "https://bitcoincore.org/bin/bitcoin-core-#{version}/bitcoin-#{version}-x86_64-linux-gnu.tar.gz"
   })
   source_sha256({
-    aarch64: '6448274420ac632c528bbd4da7198692232cef7bd16d101febc5d05f7d4af1d2',
-     armv7l: '6448274420ac632c528bbd4da7198692232cef7bd16d101febc5d05f7d4af1d2',
-     x86_64: '07f77afd326639145b9ba9562912b2ad2ccec47b8a305bd075b4f4cb127b7ed7'
+    aarch64: 'ea8ca24ab56d486a55289c43cb4256f9f0e66224899cc43482c9498a3f2614d1',
+     armv7l: 'ea8ca24ab56d486a55289c43cb4256f9f0e66224899cc43482c9498a3f2614d1',
+     x86_64: 'a681e4f6ce524c338a105f214613605bac6c33d58c31dc5135bbc02bc458bb6c'
   })
 
   no_compile_needed


### PR DESCRIPTION
Removes libbitcoinconsensus, as that is no-longer shipped.

##
Builds:
- [ ] `x86_64`
- [ ] `i686`
- [ ] `armv7l`
##
Tested & Working properly:
- [ ] `x86_64`
- [ ] `i686`
- [ ] `armv7l` <!-- (reasons why it doesn't) -->
##
- [ ] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
