### PR TITLE
Filezilla 3.68.1 => 3.69.0

### DIFF
--- a/manifest/armv7l/f/filezilla.filelist
+++ b/manifest/armv7l/f/filezilla.filelist
@@ -2,10 +2,10 @@
 /usr/local/bin/fzputtygen
 /usr/local/bin/fzsftp
 /usr/local/etc/env.d/10-filezilla
-/usr/local/lib/libfzclient-commonui-private-3.68.1.so
+/usr/local/lib/libfzclient-commonui-private-3.69.0.so
 /usr/local/lib/libfzclient-commonui-private.la
 /usr/local/lib/libfzclient-commonui-private.so
-/usr/local/lib/libfzclient-private-3.68.1.so
+/usr/local/lib/libfzclient-private-3.69.0.so
 /usr/local/lib/libfzclient-private.la
 /usr/local/lib/libfzclient-private.so
 /usr/local/share/appdata/filezilla.appdata.xml

--- a/manifest/armv7l/l/libfilezilla.filelist
+++ b/manifest/armv7l/l/libfilezilla.filelist
@@ -62,8 +62,8 @@
 /usr/local/include/libfilezilla/xml.hpp
 /usr/local/lib/libfilezilla.la
 /usr/local/lib/libfilezilla.so
-/usr/local/lib/libfilezilla.so.46
-/usr/local/lib/libfilezilla.so.46.0.0
+/usr/local/lib/libfilezilla.so.47
+/usr/local/lib/libfilezilla.so.47.0.0
 /usr/local/lib/pkgconfig/libfilezilla.pc
 /usr/local/share/locale/an/LC_MESSAGES/libfilezilla.mo
 /usr/local/share/locale/ar/LC_MESSAGES/libfilezilla.mo

--- a/manifest/x86_64/f/filezilla.filelist
+++ b/manifest/x86_64/f/filezilla.filelist
@@ -2,10 +2,10 @@
 /usr/local/bin/fzputtygen
 /usr/local/bin/fzsftp
 /usr/local/etc/env.d/10-filezilla
-/usr/local/lib64/libfzclient-commonui-private-3.68.1.so
+/usr/local/lib64/libfzclient-commonui-private-3.69.0.so
 /usr/local/lib64/libfzclient-commonui-private.la
 /usr/local/lib64/libfzclient-commonui-private.so
-/usr/local/lib64/libfzclient-private-3.68.1.so
+/usr/local/lib64/libfzclient-private-3.69.0.so
 /usr/local/lib64/libfzclient-private.la
 /usr/local/lib64/libfzclient-private.so
 /usr/local/share/appdata/filezilla.appdata.xml

--- a/manifest/x86_64/l/libfilezilla.filelist
+++ b/manifest/x86_64/l/libfilezilla.filelist
@@ -62,8 +62,8 @@
 /usr/local/include/libfilezilla/xml.hpp
 /usr/local/lib64/libfilezilla.la
 /usr/local/lib64/libfilezilla.so
-/usr/local/lib64/libfilezilla.so.46
-/usr/local/lib64/libfilezilla.so.46.0.0
+/usr/local/lib64/libfilezilla.so.47
+/usr/local/lib64/libfilezilla.so.47.0.0
 /usr/local/lib64/pkgconfig/libfilezilla.pc
 /usr/local/share/locale/an/LC_MESSAGES/libfilezilla.mo
 /usr/local/share/locale/ar/LC_MESSAGES/libfilezilla.mo

--- a/packages/filezilla.rb
+++ b/packages/filezilla.rb
@@ -3,19 +3,19 @@ require 'buildsystems/autotools'
 class Filezilla < Autotools
   description 'FileZilla Client is a free FTP solution.'
   homepage 'https://filezilla-project.org/'
-  version '3.68.1'
+  version '3.69.0'
   license 'GPL-2'
   compatibility 'aarch64 armv7l x86_64'
   # NOTE: This may generate a 403 forbidden error. To receive a new source url,
   # download from here: https://filezilla-project.org/download.php?show_all=1.
-  source_url 'https://dl2.cdn.filezilla-project.org/client/FileZilla_3.68.1_src.tar.xz?h=skd4cOQdsN3A5aBPQdOKWg&x=1740339243'
+  source_url 'https://dl2.cdn.filezilla-project.org/client/FileZilla_3.69.0_src.tar.xz?h=891QO2mtPR32shccVOpwcg&x=1744782753'
   source_sha256 '10468e6ef623ad9789996df61f588ca7417d39353678313611d54f2d8131a1db'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'f4a5a3ea8abade4a1331971fd638e4673a815753b4ff909109872ee6b923bfe3',
-     armv7l: 'f4a5a3ea8abade4a1331971fd638e4673a815753b4ff909109872ee6b923bfe3',
-     x86_64: '009b3c733ca4f8f38beceb7fd018623e109e1f582829a17e4eb99beb830c9ef2'
+    aarch64: '5f710527da92002fbd7be4a398cd7e1360cc1260cf5ba3944368559c81edc0e5',
+     armv7l: '5f710527da92002fbd7be4a398cd7e1360cc1260cf5ba3944368559c81edc0e5',
+     x86_64: 'dc6dbba44b07fd6f3c4e49fe8c4864f7d0d77af83b3c8287d525967ac8014a6f'
   })
 
   depends_on 'at_spi2_core' # R
@@ -36,14 +36,12 @@ class Filezilla < Autotools
   depends_on 'mesa' => :build
   depends_on 'nettle' # R
   depends_on 'pango' # R
-  depends_on 'sqlite' => :build
   depends_on 'sqlite' # R
   depends_on 'wayland_protocols' => :build
   depends_on 'wxwidgets' # R
   depends_on 'xcb_util' => :build
   depends_on 'xdg_utils' => :build
   depends_on 'zlib' # R
-  depends_on 'sqlite' # R
 
   print_source_bashrc
 

--- a/packages/libfilezilla.rb
+++ b/packages/libfilezilla.rb
@@ -3,19 +3,19 @@ require 'buildsystems/autotools'
 class Libfilezilla < Autotools
   description 'libfilezilla is a small and modern C++ library, offering some basic functionality to build high-performing, platform-independent programs.'
   homepage 'https://lib.filezilla-project.org/'
-  version '0.49.0'
+  version '0.50.0'
   license 'GPL-2+'
   compatibility 'aarch64 armv7l x86_64'
   # NOTE: This may generate a 403 forbidden error. To receive a new source url,
   # download from here: https://lib.filezilla-project.org/download.php?show_all=1.
-  source_url 'https://dl3.cdn.filezilla-project.org/libfilezilla/libfilezilla-0.49.0.tar.xz?h=G3r8CiGNYTY6d1KKq3SVOg&x=1740339657'
-  source_sha256 '4eea8abd456096625893b707e8db6c949e6f0466136c51c0b8ce58b5f8ef1e43'
+  source_url 'https://dl4.cdn.filezilla-project.org/libfilezilla/libfilezilla-0.50.0.tar.xz?h=d6jb0-dbxaplBx1p29Mg3A&x=1744782812'
+  source_sha256 '6d99be1b5a47fbc68aaab83bcc483d84ad170a672eb648a226bf792356455177'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'b7d0bfbe700515e0ffa62766800881d34fc1fa61bf71845f2a1435e6b23a4cd7',
-     armv7l: 'b7d0bfbe700515e0ffa62766800881d34fc1fa61bf71845f2a1435e6b23a4cd7',
-     x86_64: 'b7a1b3760a331fc3254c5378727f112ce0f943987ed3f41932d2d527aaefbbba'
+    aarch64: 'ec3d8ff0fc83851567cb3d62bfbb818e75d7ad24fa07b77384bdae481fa13bba',
+     armv7l: 'ec3d8ff0fc83851567cb3d62bfbb818e75d7ad24fa07b77384bdae481fa13bba',
+     x86_64: '876843dbc83386089025347d8a65437c796eb04d7fafc83064c2d8cd0683126f'
   })
 
   depends_on 'gcc_lib' # R


### PR DESCRIPTION
-  Libfilezilla 0.49.0 => 0.50.0
##
Tested & Working properly:
- [x] `x86_64` Unable to launch in nocturne m90 container
- [x] `armv7l` Unable to launch in fievel m91 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-filezilla crew update \
&& yes | crew upgrade
```