### PR TITLE
Add a command not found handler for Chromebrew

### DIFF
--- a/manifest/armv7l/c/command_not_found.filelist
+++ b/manifest/armv7l/c/command_not_found.filelist
@@ -1,0 +1,2 @@
+/usr/local/bin/command-not-found-handler
+/usr/local/etc/bash.d/03-command-not-found

--- a/manifest/i686/c/command_not_found.filelist
+++ b/manifest/i686/c/command_not_found.filelist
@@ -1,0 +1,2 @@
+/usr/local/bin/command-not-found-handler
+/usr/local/etc/bash.d/03-command-not-found

--- a/manifest/x86_64/c/command_not_found.filelist
+++ b/manifest/x86_64/c/command_not_found.filelist
@@ -1,0 +1,2 @@
+/usr/local/bin/command-not-found-handler
+/usr/local/etc/bash.d/03-command-not-found

--- a/packages/command_not_found.rb
+++ b/packages/command_not_found.rb
@@ -11,8 +11,8 @@ class Command_not_found < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '123',
-     armv7l: '123',
+    aarch64: '7f8de55deb147596cac8c0fd518de614fb509ce0e7492e7592f13b69ce94e6a3',
+     armv7l: '7f8de55deb147596cac8c0fd518de614fb509ce0e7492e7592f13b69ce94e6a3',
        i686: '775b86ef37ac0e7f541af095d939063c4dcd2512e330a88aab7846a9f6e80c47',
      x86_64: '4e1bc306c0e7995946c5f0d219a35a2e4115bee31914a242cff479a4cc5360d4'
   })

--- a/packages/command_not_found.rb
+++ b/packages/command_not_found.rb
@@ -24,8 +24,8 @@ class Command_not_found < Package
   end
 
   def self.install
-    FileUtils.mkdir_p %W[#{CREW_PREFIX}/bin #{CREW_PREFIX}/etc/bash.d]
-    FileUtils.install 'command-not-found-handler', "#{CREW_PREFIX}/bin/command-not-found-handler", mode: 0o755
-    FileUtils.install 'command-not-found.sh', "#{CREW_PREFIX}/etc/bash.d/03-command-not-found", mode: 0o644
+    FileUtils.mkdir_p %W[#{CREW_DEST_PREFIX}/bin #{CREW_DEST_PREFIX}/etc/bash.d]
+    FileUtils.install 'command-not-found-handler', "#{CREW_DEST_PREFIX}/bin/command-not-found-handler", mode: 0o755
+    FileUtils.install 'command-not-found.sh', "#{CREW_DEST_PREFIX}/etc/bash.d/03-command-not-found", mode: 0o644
   end
 end

--- a/packages/command_not_found.rb
+++ b/packages/command_not_found.rb
@@ -10,6 +10,13 @@ class Command_not_found < Package
   git_hashtag version
   binary_compression 'tar.zst'
 
+  binary_sha256({
+    aarch64: '123',
+     armv7l: '123',
+       i686: '123',
+     x86_64: '123'
+  })
+
   print_source_bashrc
 
   def self.build

--- a/packages/command_not_found.rb
+++ b/packages/command_not_found.rb
@@ -14,7 +14,7 @@ class Command_not_found < Package
     aarch64: '123',
      armv7l: '123',
        i686: '775b86ef37ac0e7f541af095d939063c4dcd2512e330a88aab7846a9f6e80c47',
-     x86_64: '123'
+     x86_64: '4e1bc306c0e7995946c5f0d219a35a2e4115bee31914a242cff479a4cc5360d4'
   })
 
   depends_on 'glibc' # R

--- a/packages/command_not_found.rb
+++ b/packages/command_not_found.rb
@@ -13,9 +13,11 @@ class Command_not_found < Package
   binary_sha256({
     aarch64: '123',
      armv7l: '123',
-       i686: '123',
+       i686: '775b86ef37ac0e7f541af095d939063c4dcd2512e330a88aab7846a9f6e80c47',
      x86_64: '123'
   })
+
+  depends_on 'glibc' # R
 
   print_source_bashrc
 

--- a/packages/command_not_found.rb
+++ b/packages/command_not_found.rb
@@ -2,11 +2,11 @@ require 'package'
 
 class Command_not_found < Package
   description 'Show suggestions for non-installed commands'
-  homepage 'https://github.com/chromebrew/command-not-found'
+  homepage 'https://github.com/chromebrew/command-not-found-handler'
   version '0.1'
   license 'GPL-3'
   compatibility 'all'
-  source_url 'https://github.com/supechicken/crew-command-not-found.git'
+  source_url 'https://github.com/supechicken/command-not-found-handler.git'
   git_hashtag version
   binary_compression 'tar.zst'
 

--- a/packages/command_not_found.rb
+++ b/packages/command_not_found.rb
@@ -7,7 +7,10 @@ class Command_not_found < Package
   license 'GPL-3'
   compatibility 'all'
   source_url 'https://github.com/supechicken/crew-command-not-found.git'
-  git_hashtag @version
+  git_hashtag version
+  binary_compression 'tar.zst'
+
+  print_source_bashrc
 
   def self.build
     system "mold -run cc #{CREW_COMMON_FLAGS} command-not-found-handler.c -o command-not-found-handler"

--- a/packages/command_not_found.rb
+++ b/packages/command_not_found.rb
@@ -2,7 +2,7 @@ require 'package'
 
 class Command_not_found < Package
   description 'Show suggestions for non-installed commands'
-  homepage 'https://github.com/chromebrew/crew-command-not-found'
+  homepage 'https://github.com/chromebrew/command-not-found'
   version '0.1'
   license 'GPL-3'
   compatibility 'all'

--- a/packages/command_not_found.rb
+++ b/packages/command_not_found.rb
@@ -1,0 +1,21 @@
+require 'package'
+
+class Command_not_found < Package
+  description 'Show suggestions for non-installed commands'
+  homepage 'https://github.com/chromebrew/crew-command-not-found'
+  version '0.1'
+  license 'GPL-3'
+  compatibility 'all'
+  source_url 'https://github.com/supechicken/crew-command-not-found.git'
+  git_hashtag @version
+
+  def self.build
+    system "mold -run cc #{CREW_COMMON_FLAGS} command-not-found-handler.c -o command-not-found-handler"
+  end
+
+  def self.install
+    FileUtils.mkdir_p %W[#{CREW_PREFIX}/bin #{CREW_PREFIX}/etc/bash.d]
+    FileUtils.install 'command-not-found-handler', "#{CREW_PREFIX}/bin/command-not-found-handler", mode: 0o755
+    FileUtils.install 'command-not-found.sh', "#{CREW_PREFIX}/etc/bash.d/03-command-not-found", mode: 0o644
+  end
+end

--- a/packages/core.rb
+++ b/packages/core.rb
@@ -3,7 +3,7 @@ require 'package'
 class Core < Package
   description 'Core Chromebrew Packages.'
   homepage 'https://github.com/chromebrew/chromebrew'
-  version '3.5'
+  version '3.6'
   license 'GPL-3+'
   compatibility 'all'
 

--- a/packages/core.rb
+++ b/packages/core.rb
@@ -15,6 +15,7 @@ class Core < Package
   depends_on 'bzip2'
   depends_on 'c_ares'
   depends_on 'ca_certificates'
+  depends_on 'command_not_found'
   depends_on 'crew_mvdir'
   depends_on 'crew_profile_base'
   depends_on 'crew_sudo' if CHROMEOS_RELEASE.to_i > 116

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -1121,7 +1121,7 @@ activity: low
 ---
 kind: url
 name: command_not_found
-url: https://github.com/chromebrew/command-not-found
+url: https://github.com/chromebrew/command-not-found-handler
 activity: medium
 ---
 kind: url

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -1120,6 +1120,11 @@ url: https://github.com/shyiko/commacd/releases
 activity: low
 ---
 kind: url
+name: command_not_found
+url: https://github.com/chromebrew/command-not-found
+activity: medium
+---
+kind: url
 name: composer
 url: https://github.com/composer/composer/releases
 activity: medium


### PR DESCRIPTION
**The [repo of this utility](https://github.com/supechicken/crew-command-not-found) will be transferred to Chromebrew org when this PR is ready**

### Description

Most mainstream Linux distros have their own `command-not-found` handler that shows the corresponding package when the user executes a non-installed command, which is kinda useful and we should also have one :)

This PR includes a `command-not-found` handler written in C, which will search for identical/similar commands and show their corresponding package by making use of the filelists in this repository

Here are some examples:
- For commands that are not installed:
```shell
$ PATH='' ls
The command 'ls' is not currently installed

However, the following Chromebrew package(s) provide it:

  uutils_coreutils
  coreutils

Install one of them with 'crew install <package>'
```
- For commands that are mistyped:
```shell
$ ngiix
No command 'ngiix' found. Did you mean:

  Command 'nginx' from package nginx

Install one of them with 'crew install <package>'
```

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/supechicken/chromebrew.git CREW_BRANCH=add_cmd_not_found_package crew update \
&& yes | crew upgrade
```

