### PR TITLE
crew: Rubyize file conflict algorithm

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -766,29 +766,6 @@ def compress_doc(dir)
   end
 end
 
-def determine_conflicts(dir, pkg)
-  conflicts = []
-  if File.file?("#{dir}/filelist")
-    if File.file?(File.join(CREW_META_PATH, "#{pkg}.filelist"))
-      puts 'Checking for conflicts with files from installed packages...'.orange
-      conflictscmd = `grep --exclude=#{File.join(CREW_META_PATH, "#{pkg}.filelist")} --exclude=#{CREW_META_PATH}/\\\*_build.filelist -Fxf #{dir}/filelist #{CREW_META_PATH}/*.filelist`
-      conflicts = conflictscmd.gsub(/(\.filelist|#{CREW_META_PATH})/, '').split("\n")
-      conflicts.reject!(&:empty?)
-    end
-  elsif File.file?(File.join(CREW_META_PATH, "#{pkg}.filelist"))
-    puts "Checking for conflicts of #{pkg} with files from installed packages...".orange
-    conflictscmd = `grep --exclude=#{File.join(CREW_META_PATH, "#{pkg}.filelist")} --exclude=#{CREW_META_PATH}/\\\*_build.filelist -Fxf #{File.join(CREW_META_PATH, "#{pkg}.filelist")} #{CREW_META_PATH}/*.filelist`
-    conflicts = conflictscmd.gsub(/(\.filelist|#{CREW_META_PATH})/, '').split("\n")
-    conflicts.reject!(&:empty?)
-  end
-  if conflicts.any?
-    puts 'There is a conflict with the same file in another package:'.orange
-    puts conflicts.to_s.orange
-  end
-  conflicts.map! { |x| x.to_s.partition(':').last }
-  return conflicts
-end
-
 def prepare_package(destdir)
   # Create the destdir if it does not exist to avoid having to have
   # this single line in no_compile_needed packages.
@@ -858,15 +835,24 @@ def prepare_package(destdir)
     end
 
     # check for conflicts with other installed files
-    conflicts = determine_conflicts(Dir.pwd, @pkg.name)
+    conflicts = ConvenienceFunctions.determine_conflicts(@pkg.name, File.join(Dir.pwd, 'filelist'), '_build')
+
     if conflicts.any?
       if CREW_CONFLICTS_ONLY_ADVISORY || @pkg.conflicts_ok?
-        puts 'Warning: There is a conflict with the same file in another package.'.orange
+        puts "Warning: There is a conflict with the same file in another package:\n".orange
       else
-        puts 'Error: There is a conflict with the same file in another package.'.lightred
+        puts "Error: There is a conflict with the same file in another package:\n".lightred
         errors = true
       end
-      puts conflicts
+
+      conflicts.each_pair do |pkgName, conflictFiles|
+        if errors
+          conflictFiles.each {|file| puts "#{pkgName}: #{file}".lightred }
+        else
+          conflictFiles.each {|file| puts "#{pkgName}: #{file}".orange }
+        end
+        puts
+      end
     end
 
     # abort if errors encountered

--- a/bin/crew
+++ b/bin/crew
@@ -835,7 +835,7 @@ def prepare_package(destdir)
     end
 
     # check for conflicts with other installed files
-    conflicts = ConvenienceFunctions.determine_conflicts(@pkg.name, File.join(Dir.pwd, 'filelist'), '_build')
+    conflicts = ConvenienceFunctions.determine_conflicts(@pkg.name, File.join(Dir.pwd, 'filelist'), '_build', verbose: CREW_VERBOSE)
 
     if conflicts.any?
       if CREW_CONFLICTS_ONLY_ADVISORY || @pkg.conflicts_ok?

--- a/commands/remove.rb
+++ b/commands/remove.rb
@@ -58,14 +58,14 @@ class Command
         if File.file?(filelist_path)
           filelist                = File.readlines(filelist_path, chomp: true)
           overlap_files           = ConvenienceFunctions.determine_conflicts(pkg.name, filelist_path, verbose: verbose)
-          essential_files         = Dir[File.join(CREW_META_PATH, '*.filelist')].flatten_map {|f| File.readlines(f, chomp: true)}
+          essential_files         = CREW_ESSENTIAL_PACKAGES.flat_map {|f| File.readlines(File.join(CREW_META_PATH, "#{f}.filelist"), chomp: true)}
           overlap_essential_files = filelist & essential_files
           files_to_remove         = filelist - overlap_files.values.flatten - overlap_essential_files
 
           if overlap_essential_files.any?
             warn "The following file(s) will not be deleted as they are required for Chromebrew to work properly:\n".orange
-            warn overlap_essential_files.join("\n")
-            warn
+            warn overlap_essential_files.join("\n").orange
+            warn "\n\n"
           end
 
           if overlap_files.any?

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.58.2' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.58.3' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]

--- a/lib/convenience_functions.rb
+++ b/lib/convenience_functions.rb
@@ -7,11 +7,11 @@ require_relative 'crewlog'
 require_relative 'downloader'
 
 class ConvenienceFunctions
-  def self.determine_conflicts(pkgName, filelist = File.join(CREW_META_PATH, "#{pkgName}.filelist"), excludeSuffix = nil)
+  def self.determine_conflicts(pkgName, filelist = File.join(CREW_META_PATH, "#{pkgName}.filelist"), excludeSuffix = nil, verbose: false)
     conflicts       = {}
     target_filelist = File.readlines(filelist, chomp: true)
 
-    puts 'Checking for conflicts with files from installed packages...'.orange
+    puts 'Checking for conflicts with files from installed packages...'.orange if verbose
 
     Dir[File.join(CREW_META_PATH, "*.filelist")].each do |filelist|
       filelist_name = File.basename(filelist, ".filelist")

--- a/lib/convenience_functions.rb
+++ b/lib/convenience_functions.rb
@@ -8,9 +8,7 @@ require_relative 'downloader'
 
 class ConvenienceFunctions
   def self.determine_conflicts(pkgName, filelist = File.join(CREW_META_PATH, "#{pkgName}.filelist"), excludeSuffix = nil)
-    conflicts = {}
-
-    # use the newly generated filelist during package install/build/upgrade
+    conflicts       = {}
     target_filelist = File.readlines(filelist, chomp: true)
 
     puts 'Checking for conflicts with files from installed packages...'.orange
@@ -18,8 +16,10 @@ class ConvenienceFunctions
     Dir[File.join(CREW_META_PATH, "*.filelist")].each do |filelist|
       filelist_name = File.basename(filelist, ".filelist")
 
+      # skip filelist belongs to the same package/explicitly indicated
       next if pkgName == filelist_name || (excludeSuffix && filelist_name.end_with?(excludeSuffix))
 
+      # find out identical file paths with intersection
       conflict = (target_filelist & File.readlines(filelist, chomp: true)).reject(&:empty?)
       conflicts[filelist_name] = conflict if conflict.any?
     end

--- a/lib/convenience_functions.rb
+++ b/lib/convenience_functions.rb
@@ -16,7 +16,7 @@ class ConvenienceFunctions
     Dir[File.join(CREW_META_PATH, "*.filelist")].each do |filelist|
       filelist_name = File.basename(filelist, ".filelist")
 
-      # skip filelist belongs to the same package/explicitly indicated
+      # skip filelist belongs to the same package/explicitly excluded
       next if pkgName == filelist_name || (excludeSuffix && filelist_name.end_with?(excludeSuffix))
 
       # find out identical file paths with intersection

--- a/lib/convenience_functions.rb
+++ b/lib/convenience_functions.rb
@@ -7,6 +7,26 @@ require_relative 'crewlog'
 require_relative 'downloader'
 
 class ConvenienceFunctions
+  def self.determine_conflicts(pkgName, filelist = File.join(CREW_META_PATH, "#{pkgName}.filelist"), excludeSuffix = nil)
+    conflicts = {}
+
+    # use the newly generated filelist during package install/build/upgrade
+    target_filelist = File.readlines(filelist, chomp: true)
+
+    puts 'Checking for conflicts with files from installed packages...'.orange
+
+    Dir[File.join(CREW_META_PATH, "*.filelist")].each do |filelist|
+      filelist_name = File.basename(filelist, ".filelist")
+
+      next if pkgName == filelist_name || (excludeSuffix && filelist_name.end_with?(excludeSuffix))
+
+      conflict = (target_filelist & File.readlines(filelist, chomp: true)).reject(&:empty?)
+      conflicts[filelist_name] = conflict if conflict.any?
+    end
+
+    return conflicts
+  end
+
   def self.load_symbolized_json
     return JSON.load_file(File.join(CREW_CONFIG_PATH, 'device.json'), symbolize_names: true).transform_values! { |val| val.is_a?(String) ? val.to_sym : val }
   end

--- a/tests/commands/remove.rb
+++ b/tests/commands/remove.rb
@@ -55,6 +55,7 @@ class RemoveCommandTest < Minitest::Test
     puts 'Testing the verbose removal of normal package xxd_standalone. This should succeed.'
 
     expected_output = <<~EOT
+      Checking for conflicts with files from installed packages...
       Removing file #{CREW_PREFIX}/bin/xxd
       Removing file #{CREW_PREFIX}/share/man/man1/xxd.1.zst
       Removing package xxd_standalone from device.json


### PR DESCRIPTION
This PR is a re-attempt to rubyize the file conflict algorithm after #5588

Compared with the old algorithm in #5588, the new one is much faster (still 0.02s slower than the current `grep` algorithm😅)

Here is a quick benchmark on it:
```
Checking for conflicts with files from installed packages...
old implementation in #5588:

acl
/usr/local/bin/opera
  3.506093   0.296185   3.802278 (  4.074560)

new implementation:

{"acl" => [["/usr/local/bin/opera\n"]]}
  0.032415   0.000927   0.033342 (  0.033387)

grep:

/acl:/usr/local/bin/opera
  0.000166   0.000023   0.015999 (  0.015967)

There is a conflict with the same file in another package:
["/acl:/usr/local/bin/opera"]
Error: There is a conflict with the same file in another package.
```


### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/supechicken/chromebrew.git CREW_BRANCH=rubyize_conflict_algorithm crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
