### PR TITLE
Rustdesk 1.3.8 => 1.3.9

### DIFF
--- a/manifest/x86_64/r/rustdesk.filelist
+++ b/manifest/x86_64/r/rustdesk.filelist
@@ -48,6 +48,7 @@
 /usr/local/share/rustdesk/data/flutter_assets/assets/linux.svg
 /usr/local/share/rustdesk/data/flutter_assets/assets/mac.svg
 /usr/local/share/rustdesk/data/flutter_assets/assets/message_24dp_5F6368.svg
+/usr/local/share/rustdesk/data/flutter_assets/assets/more.ttf
 /usr/local/share/rustdesk/data/flutter_assets/assets/peer_searchbar.ttf
 /usr/local/share/rustdesk/data/flutter_assets/assets/pinned.svg
 /usr/local/share/rustdesk/data/flutter_assets/assets/rec.svg

--- a/packages/rustdesk.rb
+++ b/packages/rustdesk.rb
@@ -3,7 +3,7 @@ require 'package'
 class Rustdesk < Package
   description 'An open-source remote desktop application designed for self-hosting, as an alternative to TeamViewer.'
   homepage 'https://rustdesk.com/'
-  version '1.3.8'
+  version '1.3.9'
   license 'AGPL-3.0'
   compatibility 'aarch64 armv7l x86_64'
   min_glibc '2.37'
@@ -13,9 +13,9 @@ class Rustdesk < Package
      x86_64: "https://github.com/rustdesk/rustdesk/releases/download/#{version}/rustdesk-#{version}-x86_64.deb"
   })
   source_sha256({
-    aarch64: '869a63858aa5f234880d6f87e89e17e1f4fa6cd855a8d0175dae2d47c2786386',
-     armv7l: '869a63858aa5f234880d6f87e89e17e1f4fa6cd855a8d0175dae2d47c2786386',
-     x86_64: '01d86146a4971a10263a1923e0620ed34f339ef7092051c28044305f376cd374'
+    aarch64: 'fbd398186abb4714d232d85579e693c78b23bf80b7741d0ba8c677db760bc290',
+     armv7l: 'fbd398186abb4714d232d85579e693c78b23bf80b7741d0ba8c677db760bc290',
+     x86_64: '449af5ef83b70e87a1f84a4c24dbe2205f6f5ac462eb057c65adf6cd67edeb43'
   })
 
   depends_on 'gtk3'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m134 container
- [x] `armv7l` Unable to launch in strongbad m134 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-rustdesk crew update \
&& yes | crew upgrade
```