### PR TITLE
Phive 0.15.3 => 0.16.0

### DIFF
--- a/manifest/armv7l/p/phive.filelist
+++ b/manifest/armv7l/p/phive.filelist
@@ -1,0 +1,1 @@
+/usr/local/bin/phive

--- a/packages/phive.rb
+++ b/packages/phive.rb
@@ -3,11 +3,11 @@ require 'package'
 class Phive < Package
   description 'The PHAR Installation and Verification Environment (PHIVE)'
   homepage 'https://phar.io/'
-  version '0.15.3'
+  version '0.16.0'
   license 'BSD'
   compatibility 'aarch64 armv7l x86_64'
   source_url "https://github.com/phar-io/phive/releases/download/#{version}/phive-#{version}.phar"
-  source_sha256 '3f4ab8130e83bb62c2a51359e7004df95b60ad07bbd319f4b39d35a48a051e27'
+  source_sha256 '1525f25afec4bcdc0aa8db7bb4b0063851332e916698daf90c747461642a42ed'
 
   depends_on 'php83' unless File.exist? "#{CREW_PREFIX}/bin/php"
 


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-phive crew update \
&& yes | crew upgrade
```