### PR TITLE
Monero and monero_gui 0.18.3.4 => 0.18.4.0

### DIFF
--- a/packages/monero.rb
+++ b/packages/monero.rb
@@ -3,7 +3,7 @@ require 'package'
 class Monero < Package
   description 'Private, decentralized cryptocurrency that keeps your finances confidential and secure.'
   homepage 'https://www.getmonero.org/'
-  version '0.18.3.4'
+  version '0.18.4.0'
   license 'The Cryptonote developers,The Boolberry developers,MIT'
   compatibility 'aarch64 armv7l x86_64'
   min_glibc '2.27'
@@ -14,9 +14,9 @@ class Monero < Package
      x86_64: "https://downloads.getmonero.org/cli/monero-linux-x64-v#{version}.tar.bz2"
   })
   source_sha256({
-    aarch64: '354603c56446fb0551cdd6933bce5a13590b7881e05979b7ec25d89e7e59a0e2',
-     armv7l: '354603c56446fb0551cdd6933bce5a13590b7881e05979b7ec25d89e7e59a0e2',
-     x86_64: '51ba03928d189c1c11b5379cab17dd9ae8d2230056dc05c872d0f8dba4a87f1d'
+    aarch64: 'b35b5e8d27d799cea6cf3ff539a672125292784739db41181b92a9c73e1c325b',
+     armv7l: 'b35b5e8d27d799cea6cf3ff539a672125292784739db41181b92a9c73e1c325b',
+     x86_64: '16cb74c899922887827845a41d37c7f3121462792a540843f2fcabcc1603993f'
   })
 
   no_compile_needed

--- a/packages/monero_gui.rb
+++ b/packages/monero_gui.rb
@@ -1,13 +1,14 @@
 require 'package'
+require 'misc_functions'
 
 class Monero_gui < Package
   description 'Private, decentralized cryptocurrency that keeps your finances confidential and secure.'
   homepage 'https://www.getmonero.org/'
-  version '0.18.3.4'
+  version '0.18.4.0'
   license 'The Cryptonote developers,The Boolberry developers,MIT'
   compatibility 'x86_64'
   source_url "https://downloads.getmonero.org/gui/monero-gui-linux-x64-v#{version}.tar.bz2"
-  source_sha256 '2866f3a2be30e4c4113e6274cad1d6698f81c37ceebc6e8f084c57230a0f70a6'
+  source_sha256 'e276f9e67396515f671a08c5438fb1db4358c9d8946ec7ef79b9dda552092ad7'
 
   depends_on 'monero'
   depends_on 'xcb_util_image'
@@ -18,6 +19,10 @@ class Monero_gui < Package
 
   no_compile_needed
   no_shrink
+
+  def self.preflight
+    MiscFunctions.check_free_disk_space(425302426)
+  end
 
   def self.build
     File.write 'monero.sh', <<~EOF
@@ -41,5 +46,9 @@ class Monero_gui < Package
       To view the user guide, execute the following:
       crew install zathura && zathura #{CREW_PREFIX}/share/monero/monero-gui-wallet-guide.pdf
     EOF
+  end
+
+  def self.postremove
+    Package.agree_to_remove("#{HOME}/.bitmonero")
   end
 end


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l` Monero only
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-monero-packages crew update \
&& yes | crew upgrade
```