### PR TITLE
Lego 4.22.2 => 4.23.1

### DIFF
--- a/packages/lego.rb
+++ b/packages/lego.rb
@@ -3,7 +3,7 @@ require 'package'
 class Lego < Package
   description "Let's Encrypt/ACME client and library written in Go"
   homepage 'https://go-acme.github.io/lego/'
-  version '4.22.2'
+  version '4.23.1'
   license 'MIT'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Lego < Package
      x86_64: "https://github.com/go-acme/lego/releases/download/v#{version}/lego_v#{version}_linux_amd64.tar.gz"
   })
   source_sha256({
-    aarch64: 'c4b2852516cd66b29c83bdbe9647b5bee4ce90d74c3b472940f32a87b0cd5ddb',
-     armv7l: 'c4b2852516cd66b29c83bdbe9647b5bee4ce90d74c3b472940f32a87b0cd5ddb',
-       i686: '42e376f53cd817ff5bde48945feb22616301190e3862375614820ddb95affdb7',
-     x86_64: '04b20aeeb5f495ddf806219797adb8e99418a9bbb4440c67b426680f82b7bd1b'
+    aarch64: '56d3c2e3f85467203d359bbc0d15ff3431a205012bd827ace238e2b541311ed5',
+     armv7l: '56d3c2e3f85467203d359bbc0d15ff3431a205012bd827ace238e2b541311ed5',
+       i686: '6c99379a93008adc85c4531af84d43dc5fff2bc124cdbbaf21b805fb9e4ed0a3',
+     x86_64: '1fd60b1fd59c239bed22719a5de402cb745d1f933540cb1ec196e2c03e6e8882'
   })
 
   no_compile_needed


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-lego crew update \
&& yes | crew upgrade
```