### PR TITLE
gcc: Disable upx

### DIFF
--- a/packages/gcc_build.rb
+++ b/packages/gcc_build.rb
@@ -49,6 +49,7 @@ class Gcc_build < Package
   depends_on 'zlib' # R
   depends_on 'zstd' # R
 
+  no_shrink
   no_env_options
 
   @gcc_version = version.split('-')[0].partition('.')[0]


### PR DESCRIPTION
Disabling `upx` makes a huge difference in compiling speed:
```
$ time gcc /tmp/test.c

real    0m1.032s
user    0m0.998s
sys     0m0.032s

$ cat /usr/local/etc/crew/meta/gcc_build.filelist | xargs upx -d &> /dev/null
$ time gcc /tmp/test.c

real    0m0.135s
user    0m0.120s
sys     0m0.015s
```

Do we need new binaries for this?