### PR TITLE
Termius 9.19.0 => 9.19.1

### DIFF
--- a/packages/termius.rb
+++ b/packages/termius.rb
@@ -3,11 +3,11 @@ require 'package'
 class Termius < Package
   description 'Modern SSH Client'
   homepage 'https://termius.com/'
-  version '9.19.0'
+  version '9.19.1'
   license 'Apache-2.0, LGPL-2.1, MIT'
   compatibility 'x86_64'
   source_url 'https://www.termius.com/download/linux/Termius.deb'
-  source_sha256 '371b0e3b58adc4d474ed498907b021ddbcef75843a528d62af59e86ca94b92da'
+  source_sha256 'adfd2a6539c546fab951983f6a2086a22bb5aeb9214637b8b721fb19fd0b0345'
 
   depends_on 'sommelier'
 


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m134 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-termius crew update \
&& yes | crew upgrade
```