### PR TITLE
crew upload: mkdir before binary download.

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -1578,6 +1578,7 @@ def upload(pkg_name = nil, pkg_version = nil, gitlab_token = nil, gitlab_token_u
         next arch unless remote_binary
         # 3e. If a local binary doesn't exist, but a remote binary exists,
         #     download it.
+        FileUtils.mkdir_p release_dir
         system "curl -Ls #{new_url} > #{local_tarfile}"
       else
         local_binary = true

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -3,7 +3,7 @@
 require 'etc'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.59.0' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.59.1' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]


### PR DESCRIPTION
Should fix the build for https://github.com/chromebrew/chromebrew/pull/11823