### PR TITLE
fastfetch: 2.24.0 => 2.42.0

### DIFF
--- a/packages/fastfetch.rb
+++ b/packages/fastfetch.rb
@@ -6,7 +6,7 @@ require 'buildsystems/cmake'
 class Fastfetch < CMake
   description 'Like Neofetch, but much faster because written in C'
   homepage 'https://github.com/fastfetch-cli/fastfetch'
-  version '2.24.0'
+  version '2.42.0'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/fastfetch-cli/fastfetch.git'
@@ -26,13 +26,6 @@ class Fastfetch < CMake
   depends_on 'glibc' # R
   depends_on 'yyjson' # R
 
-  # The videodev linux header files are too old on the i686 kernel.
-  # See https://github.com/fastfetch-cli/fastfetch/issues/1265
-  cmake_options "-DENABLE_SQLITE3=ON \
-    -DENABLE_RPM=OFF \
-    -DENABLE_IMAGEMAGICK6=OFF \
-    -DENABLE_IMAGEMAGICK7=OFF \
-    -DENABLE_SYSTEM_YYJSON=ON \
-    -DINSTALL_LICENSE=OFF \
-    #{ARCH == 'i686' ? '-DHAVE_LINUX_VIDEODEV2=false' : ''}"
+  cmake_options "-DENABLE_SYSTEM_YYJSON=ON \
+    -DINSTALL_LICENSE=OFF"
 end


### PR DESCRIPTION
Removed unnecessary cmake options. They will be detected automatically