### PR TITLE
Mediainfo 24.04 => 25.04

### DIFF
--- a/packages/libmediainfo.rb
+++ b/packages/libmediainfo.rb
@@ -3,18 +3,18 @@ require 'package'
 class Libmediainfo < Package
   description 'MediaInfo is a convenient unified display of the most relevant technical and tag data for video and audio files.'
   homepage 'https://mediaarea.net/en/MediaInfo'
-  version '24.04'
+  version '25.04'
   license 'BSD-2'
   compatibility 'all'
-  source_url 'https://mediaarea.net/download/binary/libmediainfo0/24.04/MediaInfo_DLL_24.04_GNU_FromSource.tar.xz'
-  source_sha256 'ad93d20aa87f5e45415a2e1b70725006d97d9ca560b84175056809be73a4469d'
+  source_url "https://mediaarea.net/download/binary/libmediainfo0/#{version}/MediaInfo_DLL_#{version}_GNU_FromSource.tar.xz"
+  source_sha256 '958530caacf1a897d48587d59177dc7d4d54cfd0cc4ccb922432d907c94af1d4'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'b4465fc64fa432ffdd890dd8b4ebd048d84e806c75f30e215d3bd08aa045aaa2',
-     armv7l: 'b4465fc64fa432ffdd890dd8b4ebd048d84e806c75f30e215d3bd08aa045aaa2',
-       i686: '4e95604cafcdd336dbd11ec5e07c31661f55e1e2197331261f211cbb9b87046d',
-     x86_64: 'b2daaf6c3077d6a3686ad912182174bc31f8eaec18cde8e6e9bf4453fadf49c5'
+    aarch64: '028a158e4ec285018b9e7e285ef4f4e67273890edb3455fa9c8f06b0c82a284b',
+     armv7l: '028a158e4ec285018b9e7e285ef4f4e67273890edb3455fa9c8f06b0c82a284b',
+       i686: '42dfcbdba287f36429d57fe344bf0c9bb5f2b71bc14a097b9d8a8723f2992229',
+     x86_64: '20b41b5118591f29f0567b1d9bdacfc7cd87f5c634e243fcd73183dd7e09ee51'
   })
 
   depends_on 'gcc_lib' # R

--- a/packages/mediainfo.rb
+++ b/packages/mediainfo.rb
@@ -3,19 +3,23 @@ require 'package'
 class Mediainfo < Package
   description 'MediaInfo is a convenient unified display of the most relevant technical and tag data for video and audio files.'
   homepage 'https://mediaarea.net/en/MediaInfo'
-  version '24.04'
+  version '25.04'
   license 'BSD-2'
   compatibility 'all'
-  source_url 'https://mediaarea.net/download/binary/mediainfo/24.04/MediaInfo_CLI_24.04_GNU_FromSource.tar.xz'
-  source_sha256 'bb5bae69a9067f76250976cd1a6fadde110cf9bfb4dea7e18070f0f08cf23eb8'
+  source_url "https://mediaarea.net/download/binary/mediainfo/#{version}/MediaInfo_CLI_#{version}_GNU_FromSource.tar.xz"
+  source_sha256 'ecd286de77cb13ea4b6ce0ebdbbff3f3da89c67ec2d5c330d47f385a4329c5d2'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'a3fa699cb3ef87f24fcd94401b4811d52a176c8abd721be5ac4432e40efa32f4',
-     armv7l: 'a3fa699cb3ef87f24fcd94401b4811d52a176c8abd721be5ac4432e40efa32f4',
-       i686: '48a637c6095d6fb5843078e4c7da412e855c517965753e3f77a68763ed9c8f9d',
-     x86_64: '9a761f66c3e2f8f7f8728cf2adba442b6ee62182c3037b49abbd4af489855bec'
+    aarch64: 'de0646614be731fa8011661ac2a7277136c4c57508220ba2ebd76d4bad2920e2',
+     armv7l: 'de0646614be731fa8011661ac2a7277136c4c57508220ba2ebd76d4bad2920e2',
+       i686: '2ed96d3e74442d3445a8c46d0223cdb5bac87fe55f54be5be65fef0157345df4',
+     x86_64: '43fd82dc685e1a5955f1302029be5af6eaf5060f1b4ba3caa3d6f276629bedbd'
   })
+
+  depends_on 'gcc_lib' # R
+  depends_on 'glibc' # R
+  depends_on 'zlib' # R
 
   def self.patch
     # Fix /usr/bin/file: No such file or directory

--- a/packages/mediainfo_gui.rb
+++ b/packages/mediainfo_gui.rb
@@ -3,21 +3,37 @@ require 'package'
 class Mediainfo_gui < Package
   description 'MediaInfo is a convenient unified display of the most relevant technical and tag data for video and audio files.'
   homepage 'https://mediaarea.net/en/MediaInfo'
-  version '24.04'
+  version '25.04'
   license 'BSD-2'
   compatibility 'aarch64 armv7l x86_64'
-  source_url 'https://mediaarea.net/download/binary/mediainfo-gui/24.04/MediaInfo_GUI_24.04_GNU_FromSource.tar.xz'
+  source_url "https://mediaarea.net/download/binary/mediainfo-gui/#{version}/MediaInfo_GUI_#{version}_GNU_FromSource.tar.xz"
   source_sha256 '6a24f6529ab802e594ce89cc2e7816a2b0ffe06130545c3593ab334f2ceb9cd1'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'bd1f7b1babcbd5822228a30cd8d7ec00226cc5c9f98b57807eee75e06c4742f8',
-     armv7l: 'bd1f7b1babcbd5822228a30cd8d7ec00226cc5c9f98b57807eee75e06c4742f8',
-     x86_64: '89c9cd970e7b46c8ed7dc19bf0df1ba9f7fe8ce1658cc9145475d4c12b78a822'
+    aarch64: '22dc67babe776a8e731bbd3c9d8203506935f8b475f9c4f175e647be99be147f',
+     armv7l: '22dc67babe776a8e731bbd3c9d8203506935f8b475f9c4f175e647be99be147f',
+     x86_64: 'cadcc0059ce6d49c71e155bcc0965447c3c0bb143296d8379928d117f160fcaf'
   })
 
-  depends_on 'libmediainfo'
-  depends_on 'gtk3'
+  depends_on 'at_spi2_core' # R
+  depends_on 'cairo' # R
+  depends_on 'gcc_lib' # R
+  depends_on 'gdk_pixbuf' # R
+  depends_on 'glib' # R
+  depends_on 'glibc' # R
+  depends_on 'gtk3' # R
+  depends_on 'harfbuzz' # R
+  depends_on 'libjpeg_turbo' # R
+  depends_on 'libmediainfo' # R
+  depends_on 'libsm' # R
+  depends_on 'libtiff' # R
+  depends_on 'libx11' # R
+  depends_on 'libxxf86vm' # R
+  depends_on 'pango' # R
+  depends_on 'zlib' # R
+
+  gnome
 
   def self.patch
     # Fix /usr/bin/file: No such file or directory
@@ -32,5 +48,9 @@ class Mediainfo_gui < Package
     Dir.chdir 'MediaInfo/Project/GNU/GUI' do
       system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
     end
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nType 'mediainfo-gui' to get started.\n"
   end
 end


### PR DESCRIPTION
- Libmediainfo 24.04 => 25.04
- Mediainfo_gui 24.04 => 25.04
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686` libmediainfo only
- [x] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-mediainfo-packages crew update \
&& yes | crew upgrade
```