### PR TITLE
Add pdfbox package

### DIFF
--- a/manifest/armv7l/p/pdfbox.filelist
+++ b/manifest/armv7l/p/pdfbox.filelist
@@ -1,0 +1,2 @@
+/usr/local/bin/pdfbox
+/usr/local/share/pdfbox/pdfbox-app.jar

--- a/manifest/x86_64/p/pdfbox.filelist
+++ b/manifest/x86_64/p/pdfbox.filelist
@@ -1,0 +1,2 @@
+/usr/local/bin/pdfbox
+/usr/local/share/pdfbox/pdfbox-app.jar

--- a/packages/pdfbox.rb
+++ b/packages/pdfbox.rb
@@ -1,0 +1,35 @@
+require 'package'
+
+class Pdfbox < Package
+  description 'The Apache PDFBox® library is an open source Java tool for working with PDF documents.'
+  homepage 'https://pdfbox.apache.org/'
+  version '3.0.5'
+  license 'Apache-2.0'
+  compatibility 'aarch64 armv7l x86_64'
+  source_url "https://dlcdn.apache.org/pdfbox/#{version}/pdfbox-app-#{version}.jar"
+  source_sha256 'd076467fd02214ebc7b5b9d5b3b9ac0891ef768168114ed8a4811b5d16606285'
+
+  depends_on 'openjdk17' unless File.exist?("#{CREW_PREFIX}/bin/java") # R
+  depends_on 'libx11' # R
+  depends_on 'libxext' # R
+  depends_on 'libxrender' # R
+  depends_on 'libxtst' # R
+
+  no_compile_needed
+
+  def self.build
+    File.write 'pdfbox.sh', <<~EOF
+      #!/bin/bash
+      java -jar #{CREW_PREFIX}/share/pdfbox/pdfbox-app.jar "$@"
+    EOF
+  end
+
+  def self.install
+    FileUtils.install "pdfbox-app-#{version}.jar", "#{CREW_DEST_PREFIX}/share/pdfbox/pdfbox-app.jar"
+    FileUtils.install 'pdfbox.sh', "#{CREW_DEST_PREFIX}/bin/pdfbox", mode: 0o755
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nType 'pdfbox help' to get started.\n"
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -6925,6 +6925,11 @@ url: https://salsa.debian.org/debian/pcsc-lite/-/tags
 activity: medium
 ---
 kind: url
+name: pdfbox
+url: https://pdfbox.apache.org/download.html
+activity: low
+---
+kind: url
 name: pdfchain
 url: https://downloads.sourceforge.net/project/pdfchain/files/
 activity: none


### PR DESCRIPTION
## Description
The Apache PDFBox® library is an open source Java tool for working with PDF documents. This project allows creation of new PDF documents, manipulation of existing documents and the ability to extract content from documents. Apache PDFBox also includes several command-line utilities. Apache PDFBox is published under the Apache License v2.0.  See https://pdfbox.apache.org/.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-pdfbox-package crew update \
&& yes | crew upgrade
```