### PR TITLE
Adjust libc version detection.

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -36,12 +36,12 @@ CREW_GLIBC_INTERPRETER ||= File.symlink?("#{CREW_PREFIX}/bin/ld.so") ? File.real
 
 # Glibc version can be found from the output of libc.so.6
 # LIBC_VERSION ||= ENV.fetch('LIBC_VERSION', Etc.confstr(Etc::CS_GNU_LIBC_VERSION).split.last) unless defined?(LIBC_VERSION)
-if File.file?("#{CREW_GLIBC_PREFIX}/libc.so.6")
-  @libcvertokens=  %x[/#{CREW_GLIBC_PREFIX}/libc.so.6].lines.first.chomp.split(/[\s]/)
-else
-  @libcvertokens=  %x[/#{ARCH_LIB}/libc.so.6].lines.first.chomp.split(/[\s]/)
-end
-LIBC_VERSION = @libcvertokens[@libcvertokens.find_index("version") + 1].sub!(/[[:punct:]]?$/,'')
+@libcvertokens = if File.file?("#{CREW_GLIBC_PREFIX}/libc.so.6")
+                   `/#{CREW_GLIBC_PREFIX}/libc.so.6`.lines.first.chomp.split(/[\s]/)
+                 else
+                   `/#{ARCH_LIB}/libc.so.6`.lines.first.chomp.split(/[\s]/)
+                 end
+LIBC_VERSION = @libcvertokens[@libcvertokens.find_index('version') + 1].sub!(/[[:punct:]]?$/, '')
 
 if CREW_PREFIX == '/usr/local'
   CREW_BUILD_FROM_SOURCE ||= ENV.fetch('CREW_BUILD_FROM_SOURCE', false) unless defined?(CREW_BUILD_FROM_SOURCE)

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -1,10 +1,4 @@
 require 'package'
-Package.load_package("#{__dir__}/glibc_build223.rb")
-Package.load_package("#{__dir__}/glibc_build227.rb")
-Package.load_package("#{__dir__}/glibc_build232.rb")
-Package.load_package("#{__dir__}/glibc_build233.rb")
-Package.load_package("#{__dir__}/glibc_build235.rb")
-Package.load_package("#{__dir__}/glibc_build237.rb")
 Package.load_package("#{__dir__}/glibc_standalone.rb")
 
 class Glibc < Package
@@ -14,32 +8,14 @@ class Glibc < Package
 
   is_fake
 
-  case
-  when LIBC_VERSION == '2.23'
-    version Glibc_build223.version
-    compatibility Glibc_build223.compatibility
-    depends_on 'glibc_build223'
-  when LIBC_VERSION == '2.27'
-    version Glibc_build227.version
-    compatibility Glibc_build227.compatibility
-    depends_on 'glibc_build227'
-  when LIBC_VERSION == '2.32'
-    version Glibc_build232.version
-    compatibility Glibc_build232.compatibility
-    depends_on 'glibc_build232'
-  when LIBC_VERSION == '2.33'
-    version Glibc_build233.version
-    compatibility Glibc_build233.compatibility
-    depends_on 'glibc_build233'
-  when LIBC_VERSION == '2.35'
-    version Glibc_build235.version
-    compatibility Glibc_build235.compatibility
-    depends_on 'glibc_lib235'
-  when LIBC_VERSION == '2.37'
-    version Glibc_build237.version
-    compatibility Glibc_build237.compatibility
-    depends_on 'glibc_lib237'
-  when LIBC_VERSION >= '2.41'
+  if LIBC_VERSION < '2.39' && LIBC_VERSION >= '2.23'
+    glibc_ver = LIBC_VERSION.sub('.', '').to_s
+    glibc_pkg = "glibc_build#{glibc_ver}"
+    glibc_obj = Package.load_package("#{__dir__}/#{glibc_pkg}")
+    version glibc_obj.version
+    compatibility glib_obj.compatibility
+    depends_on glibc_pkg
+  elsif LIBC_VERSION >= '2.41'
     version Glibc_standalone.version
     compatibility Glibc_standalone.compatibility
     depends_on 'glibc_standalone'

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -5,11 +5,12 @@ Package.load_package("#{__dir__}/glibc_build232.rb")
 Package.load_package("#{__dir__}/glibc_build233.rb")
 Package.load_package("#{__dir__}/glibc_build235.rb")
 Package.load_package("#{__dir__}/glibc_build237.rb")
+Package.load_package("#{__dir__}/glibc_standalone.rb")
 
 class Glibc < Package
   description 'The GNU C Library project provides the core libraries for GNU/Linux systems.'
-  homepage Glibc_build237.homepage
-  license Glibc_build237.license
+  homepage Glibc_standalone.homepage
+  license Glibc_standalone.license
 
   is_fake
 
@@ -38,6 +39,10 @@ class Glibc < Package
     version Glibc_build237.version
     compatibility Glibc_build237.compatibility
     depends_on 'glibc_lib237'
+  when '2.41'
+    version Glibc_standalone.version
+    compatibility Glibc_standalone.compatibility
+    depends_on 'glibc_standalone'
   else
     version LIBC_VERSION
     compatibility 'aarch64 armv7l x86_64'

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -8,14 +8,7 @@ class Glibc < Package
 
   is_fake
 
-  if LIBC_VERSION < '2.39' && LIBC_VERSION >= '2.23'
-    glibc_ver = LIBC_VERSION.sub('.', '').to_s
-    glibc_pkg = "glibc_build#{glibc_ver}"
-    glibc_obj = Package.load_package("#{__dir__}/#{glibc_pkg}")
-    version glibc_obj.version
-    compatibility glib_obj.compatibility
-    depends_on glibc_pkg
-  elsif LIBC_VERSION >= '2.41'
+  if LIBC_VERSION <= '2.41'
     version Glibc_standalone.version
     compatibility Glibc_standalone.compatibility
     depends_on 'glibc_standalone'

--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -14,32 +14,32 @@ class Glibc < Package
 
   is_fake
 
-  case LIBC_VERSION
-  when '2.23'
+  case
+  when LIBC_VERSION == '2.23'
     version Glibc_build223.version
     compatibility Glibc_build223.compatibility
     depends_on 'glibc_build223'
-  when '2.27'
+  when LIBC_VERSION == '2.27'
     version Glibc_build227.version
     compatibility Glibc_build227.compatibility
     depends_on 'glibc_build227'
-  when '2.32'
+  when LIBC_VERSION == '2.32'
     version Glibc_build232.version
     compatibility Glibc_build232.compatibility
     depends_on 'glibc_build232'
-  when '2.33'
+  when LIBC_VERSION == '2.33'
     version Glibc_build233.version
     compatibility Glibc_build233.compatibility
     depends_on 'glibc_build233'
-  when '2.35'
+  when LIBC_VERSION == '2.35'
     version Glibc_build235.version
     compatibility Glibc_build235.compatibility
     depends_on 'glibc_lib235'
-  when '2.37'
+  when LIBC_VERSION == '2.37'
     version Glibc_build237.version
     compatibility Glibc_build237.compatibility
     depends_on 'glibc_lib237'
-  when '2.41'
+  when LIBC_VERSION >= '2.41'
     version Glibc_standalone.version
     compatibility Glibc_standalone.compatibility
     depends_on 'glibc_standalone'


### PR DESCRIPTION
- Need to adjust LIBC version detection during install, otherwise older glibc overwrites glibc_standalone, and that wreaks havoc.
- This uses a variant of the older LIBC detection code we used to use.
- Bypassing container checks until this is merged and new containers get built...

##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/satmandu/chromebrew.git CREW_BRANCH=master crew update \
&& yes | crew upgrade
```