### PR TITLE
Firefox 138.0 => 138.0.1

### DIFF
--- a/packages/firefox.rb
+++ b/packages/firefox.rb
@@ -3,12 +3,12 @@ require 'package'
 class Firefox < Package
   description 'Mozilla Firefox (or simply Firefox) is a free and open-source web browser'
   homepage 'https://www.mozilla.org/en-US/firefox/'
-  version '138.0'
+  version '138.0.1'
   license 'MPL-2.0, GPL-2 and LGPL-2.1'
   compatibility 'x86_64'
   min_glibc '2.35'
   source_url "https://download-installer.cdn.mozilla.net/pub/firefox/releases/#{version}/linux-x86_64/en-US/firefox-#{version}.tar.xz"
-  source_sha256 'a9b83684f6fa9eecf29c79119bab9239c4255ac53ce12126ced524cc8c7da758'
+  source_sha256 '943abbbae0df188771bb58125a8aaada68bac5a37641629b305619abc4bd9756'
 
   depends_on 'at_spi2_core'
   depends_on 'cairo'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m134 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-firefox crew update \
&& yes | crew upgrade
```