### PR TITLE
Edge 135.0.3179.98-1 => 136.0.3240.64-1

### DIFF
--- a/manifest/x86_64/e/edge.filelist
+++ b/manifest/x86_64/e/edge.filelist
@@ -3,6 +3,7 @@
 /usr/local/bin/microsoft-edge-stable
 /usr/local/bin/msedge
 /usr/local/share/appdata/microsoft-edge.appdata.xml
+/usr/local/share/applications/com.microsoft.Edge.desktop
 /usr/local/share/applications/microsoft-edge.desktop
 /usr/local/share/doc/microsoft-edge-stable/changelog.gz
 /usr/local/share/gnome-control-center/default-apps/microsoft-edge.xml

--- a/packages/edge.rb
+++ b/packages/edge.rb
@@ -4,12 +4,12 @@ require 'convenience_functions'
 class Edge < Package
   description 'Microsoft Edge is the fast and secure browser'
   homepage 'https://www.microsoft.com/en-us/edge'
-  version '135.0.3179.98-1'
+  version '136.0.3240.64-1'
   license 'MIT'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_#{version}_amd64.deb"
-  source_sha256 '0291339ce51e66b2987f6e5fc76c310b9a5c54c0d05c3f70b3cdda2743f6774e'
+  source_sha256 'cf2a2ea4d76d5cae66bc8e68ca9f40255ad6c1894c28e55a6813a70ce8c73b4a'
 
   depends_on 'at_spi2_core'
   depends_on 'libcom_err'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable  to launch in hatch m135 container
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-edge crew update \
&& yes | crew upgrade
```