### PR TITLE
Vivaldi 7.3.3635.11-1 => 7.3.3635.12-1

### DIFF
--- a/manifest/armv7l/v/vivaldi.filelist
+++ b/manifest/armv7l/v/vivaldi.filelist
@@ -208,7 +208,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/adblocker_resources/redirectable_resources.json
 /usr/local/share/vivaldi/resources/vivaldi/background-bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/background-common-bundle.js
-/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-3189d819bc3b62cc1039b4349e755806.js
+/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-5c794d75bfc3b317bbc99900aaa00766.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle-mailreader-worker.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/components/mail/mail.html

--- a/manifest/x86_64/v/vivaldi.filelist
+++ b/manifest/x86_64/v/vivaldi.filelist
@@ -208,7 +208,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/adblocker_resources/redirectable_resources.json
 /usr/local/share/vivaldi/resources/vivaldi/background-bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/background-common-bundle.js
-/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-4cf2e9551d5910e646ff3c15b235ce0b.js
+/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-47f8f5172dc698dc8cf1a4bddb200700.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle-mailreader-worker.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/components/mail/mail.html

--- a/packages/vivaldi.rb
+++ b/packages/vivaldi.rb
@@ -4,7 +4,7 @@ require 'convenience_functions'
 class Vivaldi < Package
   description 'Vivaldi is a new browser that blocks unwanted ads, protects you from trackers, and puts you in control with unique built-in features.'
   homepage 'https://vivaldi.com/'
-  version '7.3.3635.11-1'
+  version '7.3.3635.12-1'
   license 'Vivaldi'
   compatibility 'aarch64 armv7l x86_64'
   min_glibc '2.37'
@@ -24,10 +24,10 @@ class Vivaldi < Package
   case ARCH
   when 'aarch64', 'armv7l'
     arch = 'armhf'
-    source_sha256 '898d88fd7cddc6dd6076604d01f1ced24d4622790fba0768faa5908593b958a1'
+    source_sha256 'beefdee19a0e82f3c5ac0344da9e3466ac99e8243add2535096fd964d634ce4d'
   when 'x86_64'
     arch = 'amd64'
-    source_sha256 '9093453d78997a48e87c6b4a15b19cf3973cc90ca6867b64081ba1ca5c100691'
+    source_sha256 'a9c5789fdfe701b6f41b0f1ace8ac34a3a63cb87177b65e547de16c2ec141327'
   end
 
   source_url "https://downloads.vivaldi.com/stable/vivaldi-stable_#{version}_#{arch}.deb"


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable  to launch in hatch m135 container
- [x] `armv7l` Unable  to launch in strongbad m135 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-vivaldi crew update \
&& yes | crew upgrade
```