### PR TITLE
Add flareget package

### DIFF
--- a/manifest/x86_64/f/flareget.filelist
+++ b/manifest/x86_64/f/flareget.filelist
@@ -1,0 +1,16 @@
+/usr/local/bin/flareget
+/usr/local/bin/flareget-chrome-host
+/usr/local/etc/chromium/native-messaging-hosts/com.flareget.flareget.json
+/usr/local/etc/opt/chrome/native-messaging-hosts/com.flareget.flareget.json
+/usr/local/lib/mozilla/native-messaging-hosts/com.flareget.flareget.json
+/usr/local/share/applications/flareget.desktop
+/usr/local/share/doc/flareget/changelog.Debian.gz
+/usr/local/share/doc/flareget/copyright
+/usr/local/share/doc/flareget/dhelper.dat
+/usr/local/share/icons/hicolor/128x128/apps/flareget.png
+/usr/local/share/icons/hicolor/16x16/apps/flareget.png
+/usr/local/share/icons/hicolor/32x32/apps/flareget.png
+/usr/local/share/icons/hicolor/64x64/apps/flareget.png
+/usr/local/share/lintian/overrides/flareget
+/usr/local/share/man/man1/flareget-chrome-host.1.zst
+/usr/local/share/man/man1/flareget.1.zst

--- a/packages/flareget.rb
+++ b/packages/flareget.rb
@@ -1,0 +1,21 @@
+require 'package'
+
+class Flareget < Package
+  description 'Full featured, multi-threaded download manager and accelerator'
+  homepage 'https://flareget.com/'
+  version '5.0.1'
+  license 'Copyright (C) 2012-2014 FlareGet.com'
+  compatibility 'x86_64'
+  source_url 'https://dl.flareget.com/downloads/files/flareget/debs/amd64/flareget_5.0-1_amd64.deb'
+  source_sha256 'b7793ce3a90faf29e6190440a5df75080877098c130b33331b7f096789354e06'
+
+  depends_on 'qt5_base' # R
+
+  no_compile_needed
+
+  def self.install
+    FileUtils.mkdir_p CREW_DEST_PREFIX
+    FileUtils.mv 'etc', CREW_DEST_PREFIX
+    FileUtils.mv Dir['usr/*'], CREW_DEST_PREFIX
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -1985,6 +1985,11 @@ url: https://ftp.osuosl.org/pub/xiph/releases/flac/
 activity: none
 ---
 kind: url
+name: flareget
+url: https://flareget.com/download
+activity: medium
+---
+kind: url
 name: flatpak
 url: https://github.com/flatpak/flatpak/releases/
 activity: medium


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m135 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-flareget-package crew update \
&& yes | crew upgrade
```