### PR TITLE
Edge 136.0.3240.76-1 => 136.0.3240.92-1

### DIFF
--- a/packages/edge.rb
+++ b/packages/edge.rb
@@ -4,12 +4,12 @@ require 'convenience_functions'
 class Edge < Package
   description 'Microsoft Edge is the fast and secure browser'
   homepage 'https://www.microsoft.com/en-us/edge'
-  version '136.0.3240.76-1'
+  version '136.0.3240.92-1'
   license 'MIT'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_#{version}_amd64.deb"
-  source_sha256 '6e234cd5ec49ff151c9a16631fb65c145f5c615aac3dabdb6edb099d1565c85a'
+  source_sha256 '04b4287e74be559c365f36beb38fa8233de24ed8c8a17d95d9ce83547951d8c3'
 
   depends_on 'at_spi2_core'
   depends_on 'libcom_err'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable  to launch in nocturne m90 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-edge crew update \
&& yes | crew upgrade
```