### PR TITLE
Wp_cli 2.11.0 => 2.12.0

### DIFF
--- a/packages/wp_cli.rb
+++ b/packages/wp_cli.rb
@@ -3,11 +3,11 @@ require 'package'
 class Wp_cli < Package
   description 'The command line interface for WordPress'
   homepage 'https://wp-cli.org/'
-  version '2.11.0'
+  version '2.12.0'
   license 'LGPL-3'
   compatibility 'aarch64 armv7l x86_64'
   source_url "https://github.com/wp-cli/wp-cli/releases/download/v#{version}/wp-cli-#{version}.phar"
-  source_sha256 'a39021ac809530ea607580dbf93afbc46ba02f86b6cffd03de4b126ca53079f6'
+  source_sha256 'ce34ddd838f7351d6759068d09793f26755463b4a4610a5a5c0a97b68220d85c'
 
   depends_on 'php83' unless File.exist? "#{CREW_PREFIX}/bin/php"
 


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-wp_cli crew update \
&& yes | crew upgrade
```