### PR TITLE
Firefox 138.0.4 => 139.0

### DIFF
--- a/manifest/x86_64/f/firefox.filelist
+++ b/manifest/x86_64/f/firefox.filelist
@@ -6,6 +6,7 @@
 /usr/local/firefox/browser/chrome/icons/default/default48.png
 /usr/local/firefox/browser/chrome/icons/default/default64.png
 /usr/local/firefox/browser/omni.ja
+/usr/local/firefox/crashhelper
 /usr/local/firefox/crashreporter
 /usr/local/firefox/defaults/pref/channel-prefs.js
 /usr/local/firefox/dependentlibs.list

--- a/packages/firefox.rb
+++ b/packages/firefox.rb
@@ -3,12 +3,12 @@ require 'package'
 class Firefox < Package
   description 'Mozilla Firefox (or simply Firefox) is a free and open-source web browser'
   homepage 'https://www.mozilla.org/en-US/firefox/'
-  version '138.0.4'
+  version '139.0'
   license 'MPL-2.0, GPL-2 and LGPL-2.1'
   compatibility 'x86_64'
   min_glibc '2.35'
   source_url "https://download-installer.cdn.mozilla.net/pub/firefox/releases/#{version}/linux-x86_64/en-US/firefox-#{version}.tar.xz"
-  source_sha256 'c27d5bf7483eda49aae544d9f8b4f064dbc7341b27d7098378108e52071bf947'
+  source_sha256 '1e3eab20cb84af1510b22e663438bd31ee1473652e10eb48661dcc6f1c0bbbe8'
 
   depends_on 'at_spi2_core'
   depends_on 'cairo'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in nocturne m90 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-firefox crew update \
&& yes | crew upgrade
```