### PR TITLE
Vivaldi 7.4.3684.38-1 => 7.4.3684.43-1

### DIFF
--- a/manifest/armv7l/v/vivaldi.filelist
+++ b/manifest/armv7l/v/vivaldi.filelist
@@ -128,6 +128,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/_locales/de_CH/messages.json
 /usr/local/share/vivaldi/resources/vivaldi/_locales/el/messages.json
 /usr/local/share/vivaldi/resources/vivaldi/_locales/en/messages.json
+/usr/local/share/vivaldi/resources/vivaldi/_locales/en_CA/messages.json
 /usr/local/share/vivaldi/resources/vivaldi/_locales/en_GB/messages.json
 /usr/local/share/vivaldi/resources/vivaldi/_locales/en_US/messages.json
 /usr/local/share/vivaldi/resources/vivaldi/_locales/eo/messages.json
@@ -208,7 +209,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/adblocker_resources/redirectable_resources.json
 /usr/local/share/vivaldi/resources/vivaldi/background-bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/background-common-bundle.js
-/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-ead28c391d70d60db40632132d1231f9.js
+/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-a6cfe56a8b3c238091d6ec07d19b56fc.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle-mailreader-worker.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/components/mail/mail.html

--- a/manifest/x86_64/v/vivaldi.filelist
+++ b/manifest/x86_64/v/vivaldi.filelist
@@ -128,6 +128,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/_locales/de_CH/messages.json
 /usr/local/share/vivaldi/resources/vivaldi/_locales/el/messages.json
 /usr/local/share/vivaldi/resources/vivaldi/_locales/en/messages.json
+/usr/local/share/vivaldi/resources/vivaldi/_locales/en_CA/messages.json
 /usr/local/share/vivaldi/resources/vivaldi/_locales/en_GB/messages.json
 /usr/local/share/vivaldi/resources/vivaldi/_locales/en_US/messages.json
 /usr/local/share/vivaldi/resources/vivaldi/_locales/eo/messages.json
@@ -208,7 +209,7 @@
 /usr/local/share/vivaldi/resources/vivaldi/adblocker_resources/redirectable_resources.json
 /usr/local/share/vivaldi/resources/vivaldi/background-bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/background-common-bundle.js
-/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-b4143090609a5ec17eaa4473aa5a59b9.js
+/usr/local/share/vivaldi/resources/vivaldi/background-service-worker-ba4a06803101048f66ecd7a6865460a5.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle-mailreader-worker.js
 /usr/local/share/vivaldi/resources/vivaldi/bundle.js
 /usr/local/share/vivaldi/resources/vivaldi/components/mail/mail.html

--- a/packages/vivaldi.rb
+++ b/packages/vivaldi.rb
@@ -4,7 +4,7 @@ require 'convenience_functions'
 class Vivaldi < Package
   description 'Vivaldi is a new browser that blocks unwanted ads, protects you from trackers, and puts you in control with unique built-in features.'
   homepage 'https://vivaldi.com/'
-  version '7.4.3684.38-1'
+  version '7.4.3684.43-1'
   license 'Vivaldi'
   compatibility 'aarch64 armv7l x86_64'
   min_glibc '2.37'
@@ -24,10 +24,10 @@ class Vivaldi < Package
   case ARCH
   when 'aarch64', 'armv7l'
     arch = 'armhf'
-    source_sha256 '9231dc725eb94645dc34e06b7c4fb9a40035958cf59d79049cbc1d1597a5b587'
+    source_sha256 '99905f3a17a2e0e80ae1a9efc47b5f878258818a05d329e6105e909106f68447'
   when 'x86_64'
     arch = 'amd64'
-    source_sha256 '87f65c26ae7582c6f4dd5e4a1653ce13d1f43689d8c4935e59583650240404fb'
+    source_sha256 'b431a87b0e6310eaa81c81d2be83ac05cb84ceaf35ed84f4a4548edcb8b8f0e5'
   end
 
   source_url "https://downloads.vivaldi.com/stable/vivaldi-stable_#{version}_#{arch}.deb"


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in nocturne m90 container
- [x] `armv7l` Unable to launch in fievel m91 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-vivaldi crew update \
&& yes | crew upgrade
```