### PR TITLE
Termius 9.19.2 => 9.21.2

### DIFF
--- a/packages/termius.rb
+++ b/packages/termius.rb
@@ -3,11 +3,11 @@ require 'package'
 class Termius < Package
   description 'Modern SSH Client'
   homepage 'https://termius.com/'
-  version '9.19.2'
+  version '9.21.2'
   license 'Apache-2.0, LGPL-2.1, MIT'
   compatibility 'x86_64'
   source_url 'https://www.termius.com/download/linux/Termius.deb'
-  source_sha256 '74939b08a86ed34c8354d034e6c91f6b07a94fe2f91dcb0bd844f394afbaa7e6'
+  source_sha256 '6423dc0fba556ad376f8a56f75babbf2533f58f93db89ae1b9ba70076a0a6fd2'
 
   depends_on 'sommelier'
 


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m136 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-termius crew update \
&& yes | crew upgrade
```