### PR TITLE
Adjust Updater workflow to not hit master directly.

### DIFF
--- a/.github/workflows/Updater.yml
+++ b/.github/workflows/Updater.yml
@@ -22,9 +22,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: true
+          ref: 'pre_glibc_standalone'
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.4.3'
+          ruby-version: '3.4.4'
       - name: Install Python pip
         run: sudo apt install -y python3-pip
       - name: Install ruby-libversion  # Hopefully this will get added as an Ubuntu/Debian package so we don't have to do this manually.


### PR DESCRIPTION
This is the first step towards building just the core/buildessential packages on older glibc to maintain compatibility wth older systems without requiring a newer glibc.

For more complex packages we of course want to build on the newer  glibc...

This still requires syncing updated packages up to master... but that can be done with a different PR.

This just makes sure that the automatic package updater doesn't build python and gem binaries that don't have maximum compability.
