### PR TITLE
Opera 119.0.5497.70 => 119.0.5497.88

### DIFF
--- a/packages/opera.rb
+++ b/packages/opera.rb
@@ -4,7 +4,7 @@ require 'convenience_functions'
 class Opera < Package
   description 'Opera is a multi-platform web browser based on Chromium and developed by Opera Software.'
   homepage 'https://www.opera.com/'
-  version '119.0.5497.70'
+  version '119.0.5497.88'
   license 'OPERA-2018'
   compatibility 'x86_64'
   min_glibc '2.29'
@@ -12,7 +12,7 @@ class Opera < Package
   # faster apt mirror, but only works when downloading latest version of opera
   # source_url "https://deb.opera.com/opera/pool/non-free/o/opera-stable/opera-stable_#{version}_amd64.deb"
   source_url "https://deb.opera.com/opera-stable/pool/non-free/o/opera-stable/opera-stable_#{version}_amd64.deb"
-  source_sha256 '3a7f13dc2609cf5ee7b8bc3983fc9b2231f7098ce6b97a3bfb28a10f446715b7'
+  source_sha256 '946e5439bdf5d40589183fecb40592c8c3c6a89bb4fc4244ab8d7177fda9cd8e'
 
   depends_on 'gtk3'
   depends_on 'gsettings_desktop_schemas'
@@ -24,16 +24,25 @@ class Opera < Package
   no_compile_needed
   no_shrink
 
+  def self.build
+    File.write 'opera.sh', <<~EOF
+      #!/bin/bash
+      LD_LIBRARY_PATH=/usr/local/share/x86_64-linux-gnu/opera:$LD_LIBRARY
+      #{CREW_PREFIX}/share/x86_64-linux-gnu/opera/opera "$@"
+    EOF
+  end
+
   def self.install
     # Since opera puts the executable in a location that is not in the path,
     # we need to link it to bin directory.
-    FileUtils.ln_sf "#{CREW_PREFIX}/share/x86_64-linux-gnu/opera/opera", 'bin/opera'
+    # FileUtils.ln_sf "#{CREW_PREFIX}/share/x86_64-linux-gnu/opera/opera", 'bin/opera'
 
     # Move lib subfolder to the share directory.
     FileUtils.mv 'lib/x86_64-linux-gnu/', 'share/'
-    FileUtils.rm_rf 'lib/'
+    FileUtils.rm_rf %w[bin/ lib/]
+    FileUtils.install 'opera.sh', "#{CREW_DEST_PREFIX}/bin/opera", mode: 0o755
+    FileUtils.rm_f 'opera.sh'
 
-    FileUtils.mkdir_p CREW_DEST_PREFIX
     FileUtils.mv Dir['*'], CREW_DEST_PREFIX
   end
 


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m136 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-opera crew update \
&& yes | crew upgrade
```