### PR TITLE
Fix path for files passed to patchelf to set our glibc interpreter.

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -916,7 +916,6 @@ def expand_binaries_and_fix_interpreter_path(dir)
       next unless File.file?(execfiletopatch)
 
       pool.post do
-
         # Decompress the binary if compressed.
         system "upx -qq -d #{execfiletopatch}", %i[err] => File::NULL, exception: false
 

--- a/bin/crew
+++ b/bin/crew
@@ -916,8 +916,6 @@ def expand_binaries_and_fix_interpreter_path(dir)
       next unless File.file?(execfiletopatch)
 
       pool.post do
-        execfile.slice! '.'
-        File.join(dir, execfiletopatch)
 
         # Decompress the binary if compressed.
         system "upx -qq -d #{execfiletopatch}", %i[err] => File::NULL, exception: false

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -4,7 +4,7 @@ require 'etc'
 require 'open3'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.61.8' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.61.9' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]


### PR DESCRIPTION
- The path being used was wrong, since this code is using `Find.find` instead of \``find`\`.