### PR TITLE
Vscodium 1.100.23258 => 1.101.03933

### DIFF
--- a/manifest/armv7l/v/vscodium.filelist
+++ b/manifest/armv7l/v/vscodium.filelist
@@ -5,8 +5,6 @@
 /usr/local/VSCodium-linux-arm/chrome_100_percent.pak
 /usr/local/VSCodium-linux-arm/chrome_200_percent.pak
 /usr/local/VSCodium-linux-arm/chrome_crashpad_handler
-/usr/local/VSCodium-linux-arm/clang_x86_v8_arm/icudtl.dat
-/usr/local/VSCodium-linux-arm/clang_x86_v8_arm/snapshot_blob.bin
 /usr/local/VSCodium-linux-arm/codium
 /usr/local/VSCodium-linux-arm/icudtl.dat
 /usr/local/VSCodium-linux-arm/libEGL.so
@@ -210,8 +208,12 @@
 /usr/local/VSCodium-linux-arm/resources/app/extensions/github-authentication/package.json
 /usr/local/VSCodium-linux-arm/resources/app/extensions/github-authentication/package.nls.json
 /usr/local/VSCodium-linux-arm/resources/app/extensions/github/README.md
+/usr/local/VSCodium-linux-arm/resources/app/extensions/github/dist/430.js
+/usr/local/VSCodium-linux-arm/resources/app/extensions/github/dist/555.js
+/usr/local/VSCodium-linux-arm/resources/app/extensions/github/dist/698.js
 /usr/local/VSCodium-linux-arm/resources/app/extensions/github/dist/extension.js
 /usr/local/VSCodium-linux-arm/resources/app/extensions/github/dist/extension.js.LICENSE.txt
+/usr/local/VSCodium-linux-arm/resources/app/extensions/github/extension.webpack.config.cjs
 /usr/local/VSCodium-linux-arm/resources/app/extensions/github/images/icon.png
 /usr/local/VSCodium-linux-arm/resources/app/extensions/github/markdown.css
 /usr/local/VSCodium-linux-arm/resources/app/extensions/github/package.json
@@ -682,6 +684,7 @@
 /usr/local/VSCodium-linux-arm/resources/app/extensions/prompt-basics/language-configuration.json
 /usr/local/VSCodium-linux-arm/resources/app/extensions/prompt-basics/package.json
 /usr/local/VSCodium-linux-arm/resources/app/extensions/prompt-basics/package.nls.json
+/usr/local/VSCodium-linux-arm/resources/app/extensions/prompt-basics/snippets/chatmode.code-snippets
 /usr/local/VSCodium-linux-arm/resources/app/extensions/prompt-basics/snippets/instructions.code-snippets
 /usr/local/VSCodium-linux-arm/resources/app/extensions/prompt-basics/snippets/prompt.code-snippets
 /usr/local/VSCodium-linux-arm/resources/app/extensions/prompt-basics/syntaxes/prompt.tmLanguage.json
@@ -1839,8 +1842,8 @@
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/undici/lib/dispatcher/dispatcher.js
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/undici/lib/dispatcher/env-http-proxy-agent.js
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/undici/lib/dispatcher/fixed-queue.js
+/usr/local/VSCodium-linux-arm/resources/app/node_modules/undici/lib/dispatcher/h2c-client.js
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/undici/lib/dispatcher/pool-base.js
-/usr/local/VSCodium-linux-arm/resources/app/node_modules/undici/lib/dispatcher/pool-stats.js
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/undici/lib/dispatcher/pool.js
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/undici/lib/dispatcher/proxy-agent.js
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/undici/lib/dispatcher/retry-agent.js
@@ -1863,6 +1866,7 @@
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/undici/lib/llhttp/llhttp_simd-wasm.js
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/undici/lib/llhttp/utils.js
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/undici/lib/mock/mock-agent.js
+/usr/local/VSCodium-linux-arm/resources/app/node_modules/undici/lib/mock/mock-call-history.js
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/undici/lib/mock/mock-client.js
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/undici/lib/mock/mock-errors.js
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/undici/lib/mock/mock-interceptor.js
@@ -1872,6 +1876,7 @@
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/undici/lib/mock/pending-interceptors-formatter.js
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/undici/lib/util/cache.js
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/undici/lib/util/date.js
+/usr/local/VSCodium-linux-arm/resources/app/node_modules/undici/lib/util/stats.js
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/undici/lib/util/timers.js
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/undici/lib/web/cache/cache.js
 /usr/local/VSCodium-linux-arm/resources/app/node_modules/undici/lib/web/cache/cachestorage.js
@@ -2028,6 +2033,8 @@
 /usr/local/VSCodium-linux-arm/resources/app/out/main.js
 /usr/local/VSCodium-linux-arm/resources/app/out/media/code-icon.svg
 /usr/local/VSCodium-linux-arm/resources/app/out/media/codicon.ttf
+/usr/local/VSCodium-linux-arm/resources/app/out/media/github.svg
+/usr/local/VSCodium-linux-arm/resources/app/out/media/google.svg
 /usr/local/VSCodium-linux-arm/resources/app/out/media/letterpress-dark.svg
 /usr/local/VSCodium-linux-arm/resources/app/out/media/letterpress-hcDark.svg
 /usr/local/VSCodium-linux-arm/resources/app/out/media/letterpress-hcLight.svg
@@ -2043,10 +2050,6 @@
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/base/node/terminateProcess.sh
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/base/parts/sandbox/electron-sandbox/preload-aux.js
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/base/parts/sandbox/electron-sandbox/preload.js
-/usr/local/VSCodium-linux-arm/resources/app/out/vs/code/electron-sandbox/processExplorer/processExplorer.html
-/usr/local/VSCodium-linux-arm/resources/app/out/vs/code/electron-sandbox/processExplorer/processExplorer.js
-/usr/local/VSCodium-linux-arm/resources/app/out/vs/code/electron-sandbox/processExplorer/processExplorerMain.css
-/usr/local/VSCodium-linux-arm/resources/app/out/vs/code/electron-sandbox/processExplorer/processExplorerMain.js
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/code/electron-sandbox/workbench/workbench.js
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/code/electron-utility/sharedProcess/sharedProcessMain.js
@@ -2059,7 +2062,10 @@
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/editor/common/services/editorWebWorkerMain.js
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/platform/accessibilitySignal/browser/media/break.mp3
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/platform/accessibilitySignal/browser/media/chatEditModifiedFile.mp3
+/usr/local/VSCodium-linux-arm/resources/app/out/vs/platform/accessibilitySignal/browser/media/chatUserActionRequired.mp3
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/platform/accessibilitySignal/browser/media/clear.mp3
+/usr/local/VSCodium-linux-arm/resources/app/out/vs/platform/accessibilitySignal/browser/media/codeActionApplied.mp3
+/usr/local/VSCodium-linux-arm/resources/app/out/vs/platform/accessibilitySignal/browser/media/codeActionTriggered.mp3
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/platform/accessibilitySignal/browser/media/diffLineDeleted.mp3
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/platform/accessibilitySignal/browser/media/diffLineInserted.mp3
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/platform/accessibilitySignal/browser/media/diffLineModified.mp3
@@ -2115,11 +2121,11 @@
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/workbench/contrib/terminal/common/scripts/shellIntegration.fish
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/workbench/contrib/webview/browser/pre/fake.html
-/usr/local/VSCodium-linux-arm/resources/app/out/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/workbench/contrib/webview/browser/pre/index.html
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/workbench/contrib/webview/browser/pre/service-worker.js
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/workbench/contrib/welcomeGettingStarted/common/media/ai-powered-suggestions.svg
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/workbench/contrib/welcomeGettingStarted/common/media/commandPalette.svg
+/usr/local/VSCodium-linux-arm/resources/app/out/vs/workbench/contrib/welcomeGettingStarted/common/media/customize-ai.svg
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/workbench/contrib/welcomeGettingStarted/common/media/dark-hc.png
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/workbench/contrib/welcomeGettingStarted/common/media/dark.png
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/workbench/contrib/welcomeGettingStarted/common/media/debug.svg
@@ -2144,7 +2150,6 @@
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/workbench/contrib/welcomeGettingStarted/common/media/shortcuts.svg
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/workbench/contrib/welcomeGettingStarted/common/media/terminal.svg
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/workbench/contrib/welcomeGettingStarted/common/media/workspaceTrust.svg
-/usr/local/VSCodium-linux-arm/resources/app/out/vs/workbench/services/extensionManagement/common/media/defaultIcon.png
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/workbench/services/languageDetection/browser/languageDetectionWebWorkerMain.js
 /usr/local/VSCodium-linux-arm/resources/app/out/vs/workbench/services/search/worker/localFileSearchMain.js

--- a/manifest/x86_64/v/vscodium.filelist
+++ b/manifest/x86_64/v/vscodium.filelist
@@ -208,8 +208,12 @@
 /usr/local/VSCodium-linux-x64/resources/app/extensions/github-authentication/package.json
 /usr/local/VSCodium-linux-x64/resources/app/extensions/github-authentication/package.nls.json
 /usr/local/VSCodium-linux-x64/resources/app/extensions/github/README.md
+/usr/local/VSCodium-linux-x64/resources/app/extensions/github/dist/430.js
+/usr/local/VSCodium-linux-x64/resources/app/extensions/github/dist/555.js
+/usr/local/VSCodium-linux-x64/resources/app/extensions/github/dist/698.js
 /usr/local/VSCodium-linux-x64/resources/app/extensions/github/dist/extension.js
 /usr/local/VSCodium-linux-x64/resources/app/extensions/github/dist/extension.js.LICENSE.txt
+/usr/local/VSCodium-linux-x64/resources/app/extensions/github/extension.webpack.config.cjs
 /usr/local/VSCodium-linux-x64/resources/app/extensions/github/images/icon.png
 /usr/local/VSCodium-linux-x64/resources/app/extensions/github/markdown.css
 /usr/local/VSCodium-linux-x64/resources/app/extensions/github/package.json
@@ -680,6 +684,7 @@
 /usr/local/VSCodium-linux-x64/resources/app/extensions/prompt-basics/language-configuration.json
 /usr/local/VSCodium-linux-x64/resources/app/extensions/prompt-basics/package.json
 /usr/local/VSCodium-linux-x64/resources/app/extensions/prompt-basics/package.nls.json
+/usr/local/VSCodium-linux-x64/resources/app/extensions/prompt-basics/snippets/chatmode.code-snippets
 /usr/local/VSCodium-linux-x64/resources/app/extensions/prompt-basics/snippets/instructions.code-snippets
 /usr/local/VSCodium-linux-x64/resources/app/extensions/prompt-basics/snippets/prompt.code-snippets
 /usr/local/VSCodium-linux-x64/resources/app/extensions/prompt-basics/syntaxes/prompt.tmLanguage.json
@@ -1837,8 +1842,8 @@
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/undici/lib/dispatcher/dispatcher.js
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/undici/lib/dispatcher/env-http-proxy-agent.js
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/undici/lib/dispatcher/fixed-queue.js
+/usr/local/VSCodium-linux-x64/resources/app/node_modules/undici/lib/dispatcher/h2c-client.js
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/undici/lib/dispatcher/pool-base.js
-/usr/local/VSCodium-linux-x64/resources/app/node_modules/undici/lib/dispatcher/pool-stats.js
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/undici/lib/dispatcher/pool.js
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/undici/lib/dispatcher/proxy-agent.js
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/undici/lib/dispatcher/retry-agent.js
@@ -1861,6 +1866,7 @@
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/undici/lib/llhttp/llhttp_simd-wasm.js
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/undici/lib/llhttp/utils.js
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/undici/lib/mock/mock-agent.js
+/usr/local/VSCodium-linux-x64/resources/app/node_modules/undici/lib/mock/mock-call-history.js
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/undici/lib/mock/mock-client.js
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/undici/lib/mock/mock-errors.js
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/undici/lib/mock/mock-interceptor.js
@@ -1870,6 +1876,7 @@
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/undici/lib/mock/pending-interceptors-formatter.js
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/undici/lib/util/cache.js
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/undici/lib/util/date.js
+/usr/local/VSCodium-linux-x64/resources/app/node_modules/undici/lib/util/stats.js
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/undici/lib/util/timers.js
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/undici/lib/web/cache/cache.js
 /usr/local/VSCodium-linux-x64/resources/app/node_modules/undici/lib/web/cache/cachestorage.js
@@ -2026,6 +2033,8 @@
 /usr/local/VSCodium-linux-x64/resources/app/out/main.js
 /usr/local/VSCodium-linux-x64/resources/app/out/media/code-icon.svg
 /usr/local/VSCodium-linux-x64/resources/app/out/media/codicon.ttf
+/usr/local/VSCodium-linux-x64/resources/app/out/media/github.svg
+/usr/local/VSCodium-linux-x64/resources/app/out/media/google.svg
 /usr/local/VSCodium-linux-x64/resources/app/out/media/letterpress-dark.svg
 /usr/local/VSCodium-linux-x64/resources/app/out/media/letterpress-hcDark.svg
 /usr/local/VSCodium-linux-x64/resources/app/out/media/letterpress-hcLight.svg
@@ -2041,10 +2050,6 @@
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/base/node/terminateProcess.sh
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/base/parts/sandbox/electron-sandbox/preload-aux.js
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/base/parts/sandbox/electron-sandbox/preload.js
-/usr/local/VSCodium-linux-x64/resources/app/out/vs/code/electron-sandbox/processExplorer/processExplorer.html
-/usr/local/VSCodium-linux-x64/resources/app/out/vs/code/electron-sandbox/processExplorer/processExplorer.js
-/usr/local/VSCodium-linux-x64/resources/app/out/vs/code/electron-sandbox/processExplorer/processExplorerMain.css
-/usr/local/VSCodium-linux-x64/resources/app/out/vs/code/electron-sandbox/processExplorer/processExplorerMain.js
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/code/electron-sandbox/workbench/workbench.js
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/code/electron-utility/sharedProcess/sharedProcessMain.js
@@ -2057,7 +2062,10 @@
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/editor/common/services/editorWebWorkerMain.js
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/platform/accessibilitySignal/browser/media/break.mp3
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/platform/accessibilitySignal/browser/media/chatEditModifiedFile.mp3
+/usr/local/VSCodium-linux-x64/resources/app/out/vs/platform/accessibilitySignal/browser/media/chatUserActionRequired.mp3
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/platform/accessibilitySignal/browser/media/clear.mp3
+/usr/local/VSCodium-linux-x64/resources/app/out/vs/platform/accessibilitySignal/browser/media/codeActionApplied.mp3
+/usr/local/VSCodium-linux-x64/resources/app/out/vs/platform/accessibilitySignal/browser/media/codeActionTriggered.mp3
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/platform/accessibilitySignal/browser/media/diffLineDeleted.mp3
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/platform/accessibilitySignal/browser/media/diffLineInserted.mp3
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/platform/accessibilitySignal/browser/media/diffLineModified.mp3
@@ -2113,11 +2121,11 @@
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/workbench/contrib/terminal/common/scripts/shellIntegration.fish
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/workbench/contrib/webview/browser/pre/fake.html
-/usr/local/VSCodium-linux-x64/resources/app/out/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/workbench/contrib/webview/browser/pre/index.html
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/workbench/contrib/webview/browser/pre/service-worker.js
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/workbench/contrib/welcomeGettingStarted/common/media/ai-powered-suggestions.svg
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/workbench/contrib/welcomeGettingStarted/common/media/commandPalette.svg
+/usr/local/VSCodium-linux-x64/resources/app/out/vs/workbench/contrib/welcomeGettingStarted/common/media/customize-ai.svg
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/workbench/contrib/welcomeGettingStarted/common/media/dark-hc.png
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/workbench/contrib/welcomeGettingStarted/common/media/dark.png
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/workbench/contrib/welcomeGettingStarted/common/media/debug.svg
@@ -2142,7 +2150,6 @@
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/workbench/contrib/welcomeGettingStarted/common/media/shortcuts.svg
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/workbench/contrib/welcomeGettingStarted/common/media/terminal.svg
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/workbench/contrib/welcomeGettingStarted/common/media/workspaceTrust.svg
-/usr/local/VSCodium-linux-x64/resources/app/out/vs/workbench/services/extensionManagement/common/media/defaultIcon.png
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/workbench/services/extensions/worker/webWorkerExtensionHostIframe.html
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/workbench/services/languageDetection/browser/languageDetectionWebWorkerMain.js
 /usr/local/VSCodium-linux-x64/resources/app/out/vs/workbench/services/search/worker/localFileSearchMain.js

--- a/packages/vscodium.rb
+++ b/packages/vscodium.rb
@@ -3,18 +3,18 @@ require 'package'
 class Vscodium < Package
   description 'VSCodium is Open Source Software Binaries of VSCode with a community-driven default configuration.'
   homepage 'https://vscodium.com/'
-  version '1.100.23258'
+  version '1.101.03933'
   license 'MIT'
   compatibility 'aarch64 armv7l x86_64'
   min_glibc '2.28'
   case ARCH
   when 'aarch64', 'armv7l'
     source_url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium-linux-armhf-#{version}.tar.gz"
-    source_sha256 'a1bd97960bec93a285a3db2d966b864cf3d1c97429054002baae6ae3c85a1b1b'
+    source_sha256 'f35166fbd881722ed426ea73786ec558c088b1e5465924ac83232d39c7b57c4e'
     @arch = 'arm'
   when 'x86_64'
     source_url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium-linux-x64-#{version}.tar.gz"
-    source_sha256 'ebf1028106e5eebe0a23ae810293a28c874924fe27943120444d4910c25c4839'
+    source_sha256 '73fd3eebb9e8b0e0c6bcd15abfd240b1994e38be00aa57119ccd4abdc7d35e89'
     @arch = 'x64'
   end
 


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m136 container
- [x] `armv7l` Unable to launch in strongbad m136 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-vscodium crew update \
&& yes | crew upgrade
```