### PR TITLE
crew: Remove `activesupport` gem, implement `.blank?` logic in `lib/convenience_functions`

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -4,7 +4,6 @@ require_relative '../lib/color'
 # Disallow sudo.
 abort 'Chromebrew should not be run as root.'.lightred if Process.uid.zero?
 require_relative '../lib/require_gem'
-require_gem('activesupport', 'active_support/core_ext/object/blank')
 require_gem('highline')
 # The json gem can break when upgrading from a much older version of ruby.
 require_gem('json')

--- a/lib/buildsystems/ruby.rb
+++ b/lib/buildsystems/ruby.rb
@@ -5,8 +5,6 @@ require_relative '../package_utils'
 require_relative '../report_buildsystem_methods'
 require_relative '../require_gem'
 
-require_gem('activesupport', 'active_support/core_ext/object/blank')
-
 def check_gem_binary_build_needed(ruby_gem_name = nil, ruby_gem_version = nil)
   puts "Checking to see if gem compile for #{ruby_gem_name} is needed..."
   @extract_dir = "#{ruby_gem_name}.#{Time.now.utc.strftime('%Y%m%d%H%M%S')}.dir"

--- a/lib/convenience_functions.rb
+++ b/lib/convenience_functions.rb
@@ -6,12 +6,12 @@ require_relative 'const'
 require_relative 'crewlog'
 require_relative 'downloader'
 
-class NilClass; def blank? = true; end
-class Numeric;  def blank? = false; end
-class Array;    def blank? = self.empty?; end
-class Hash;     def blank? = self.empty?; end
-class Symbol;   def blank? = self.empty?; end
-class String;   def blank? = self.strip.empty?; end
+class NilClass; def blank? = true        ; end
+class Numeric;  def blank? = false       ; end
+class Array;    def blank? = empty?      ; end
+class Hash;     def blank? = empty?      ; end
+class Symbol;   def blank? = empty?      ; end
+class String;   def blank? = strip.empty?; end
 
 class ConvenienceFunctions
   def self.determine_conflicts(pkg_name, filelist = File.join(CREW_META_PATH, "#{pkg_name}.filelist"), exclude_suffix = nil, verbose: false)

--- a/lib/convenience_functions.rb
+++ b/lib/convenience_functions.rb
@@ -6,11 +6,12 @@ require_relative 'const'
 require_relative 'crewlog'
 require_relative 'downloader'
 
-class NilClass; def blank? = true        ; end
-class Numeric;  def blank? = false       ; end
-class Array;    def blank? = empty?      ; end
-class Hash;     def blank? = empty?      ; end
-class Symbol;   def blank? = empty?      ; end
+# Reimplementation of .blank? method from ActiveSupport
+class NilClass; def blank? = true;         end
+class Numeric;  def blank? = false;        end
+class Array;    def blank? = empty?;       end
+class Hash;     def blank? = empty?;       end
+class Symbol;   def blank? = empty?;       end
 class String;   def blank? = strip.empty?; end
 
 class ConvenienceFunctions

--- a/lib/convenience_functions.rb
+++ b/lib/convenience_functions.rb
@@ -6,6 +6,13 @@ require_relative 'const'
 require_relative 'crewlog'
 require_relative 'downloader'
 
+class NilClass; def blank? = true; end
+class Numeric;  def blank? = false; end
+class Array;    def blank? = self.empty?; end
+class Hash;     def blank? = self.empty?; end
+class Symbol;   def blank? = self.empty?; end
+class String;   def blank? = self.strip.empty?; end
+
 class ConvenienceFunctions
   def self.determine_conflicts(pkg_name, filelist = File.join(CREW_META_PATH, "#{pkg_name}.filelist"), exclude_suffix = nil, verbose: false)
     conflicts       = {}

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -6,7 +6,6 @@ require_relative 'color'
 require_relative 'progress_bar'
 require_relative 'require_gem'
 
-require_gem('activesupport', 'active_support/core_ext/object/blank')
 require_gem('ptools')
 
 begin

--- a/lib/fixup.rb
+++ b/lib/fixup.rb
@@ -7,7 +7,6 @@ require_relative 'color'
 require_relative 'package'
 require_relative 'require_gem'
 
-require_gem('activesupport', 'active_support/core_ext/object/blank')
 require_gem('highline')
 
 # All needed constants & variables should be defined here in case they

--- a/packages/core.rb
+++ b/packages/core.rb
@@ -89,7 +89,6 @@ class Core < Package
   depends_on 'readline'
   depends_on 'rtmpdump'
   depends_on 'ruby'
-  depends_on 'ruby_activesupport'
   depends_on 'ruby_concurrent_ruby'
   # Allows for building binary gems if necessary.
   depends_on 'ruby_gem_compiler'

--- a/tools/core_packages.txt
+++ b/tools/core_packages.txt
@@ -145,7 +145,6 @@ readline
 rtmpdump
 ruby
 ruby_abbrev
-ruby_activesupport
 ruby_base64
 ruby_benchmark
 ruby_bigdecimal

--- a/tools/json.rb
+++ b/tools/json.rb
@@ -8,7 +8,6 @@ require_relative '../lib/package'
 require_relative '../lib/package_utils'
 require_relative '../lib/require_gem'
 
-require_gem('activesupport', 'active_support/core_ext/object/blank')
 require_gem('ptools')
 
 output = []

--- a/tools/update_ruby_gem_packages.rb
+++ b/tools/update_ruby_gem_packages.rb
@@ -10,7 +10,6 @@ require_relative '../lib/color'
 require_relative '../lib/const'
 require_relative '../lib/gem_compact_index_client'
 require_relative '../lib/require_gem'
-require_gem('activesupport', 'active_support/core_ext/object/blank')
 require_gem 'concurrent-ruby'
 
 def check_for_updated_ruby_packages


### PR DESCRIPTION
It makes no sense to load a ~1MB external gem library just for one single function, especially when it can be easily reimplemented within a few lines...

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/supechicken/chromebrew.git CREW_BRANCH=no_activesupport crew update \
&& yes | crew upgrade
```