### PR TITLE
Fix undefined method 'sub!' in tools/version.rb.

### DIFF
--- a/tools/version.rb
+++ b/tools/version.rb
@@ -23,7 +23,7 @@ require_relative '../lib/package_utils'
 
 def get_version(name, homepage, source)
   # Determine if the source is a GitHub repository.
-  unless source.nil?
+  unless source.nil? || source.is_a?(Hash)
     source.sub!('www.', '')
     url = URI.parse(source)
     if url.host == 'github.com'
@@ -57,7 +57,7 @@ def get_anitya_id(name, homepage)
     json2 = JSON.parse(Net::HTTP.get(URI("https://release-monitoring.org/api/v2/packages/?name=#{name.tr('-', '_')}")))
     return if json2['total_items'].zero?
 
-    (0..json2['total_items'] - 1).each do |i|
+    (0..(json2['total_items'] - 1)).each do |i|
       next unless json2['items'][i]['distribution'] == 'Chromebrew'
       return get_anitya_id(json2['items'][i]['project'], homepage) if json2['items'][i]['name'] == name.tr('-', '_')
     end
@@ -65,7 +65,7 @@ def get_anitya_id(name, homepage)
     candidates = []
     # First, we remove any candidates which are provided by language package managers, such as pip.
     # This is because Chromebrew does not repackage them (#7713), so they won't be what we're looking for.
-    (0..number_of_packages - 1).each do |i|
+    (0..(number_of_packages - 1)).each do |i|
       # If a package is not provided by a language package manager, the ecosystem will be set to the homepage.
       # https://release-monitoring.org/static/docs/api.html#get--api-v2-projects-
       candidates.append(i) if json['items'][i]['ecosystem'] == json['items'][i]['homepage']


### PR DESCRIPTION
Fixes the following:
```
../tools/version.rb:27:in 'Object#get_version': undefined method 'sub!' for an instance of Hash (NoMethodError)

    source.sub!('www.', '')
          ^^^^^
        from ../tools/version.rb:143:in 'block in <main>'
        from ../tools/version.rb:122:in 'Array#each'
        from ../tools/version.rb:122:in '<main>'
```