### PR TITLE
Opera 119.0.5497.110 => 119.0.5497.131

### DIFF
--- a/manifest/x86_64/o/opera.filelist
+++ b/manifest/x86_64/o/opera.filelist
@@ -173,6 +173,7 @@
 /usr/local/share/x86_64-linux-gnu/opera/resources/specific_keywords.json
 /usr/local/share/x86_64-linux-gnu/opera/resources/standard_themes/default_dark_theme.zip
 /usr/local/share/x86_64-linux-gnu/opera/resources/standard_themes/default_theme.zip
+/usr/local/share/x86_64-linux-gnu/opera/resources/travel_intent_keywords.json
 /usr/local/share/x86_64-linux-gnu/opera/resources/video_conference_popout.json
 /usr/local/share/x86_64-linux-gnu/opera/snapshot_blob.bin
 /usr/local/share/x86_64-linux-gnu/opera/v8_context_snapshot.bin

--- a/packages/opera.rb
+++ b/packages/opera.rb
@@ -4,7 +4,7 @@ require 'convenience_functions'
 class Opera < Package
   description 'Opera is a multi-platform web browser based on Chromium and developed by Opera Software.'
   homepage 'https://www.opera.com/'
-  version '119.0.5497.110'
+  version '119.0.5497.131'
   license 'OPERA-2018'
   compatibility 'x86_64'
   min_glibc '2.29'
@@ -12,7 +12,7 @@ class Opera < Package
   # faster apt mirror, but only works when downloading latest version of opera
   # source_url "https://deb.opera.com/opera/pool/non-free/o/opera-stable/opera-stable_#{version}_amd64.deb"
   source_url "https://deb.opera.com/opera-stable/pool/non-free/o/opera-stable/opera-stable_#{version}_amd64.deb"
-  source_sha256 '654e186a32af9256eaf5a4924d52f94c3a636eb2675d3918a027e941a9b89264'
+  source_sha256 'e6d4854fcc65b137a8f369824d6cfeb679357a68e8d2b987df4cca871c4c5b07'
 
   depends_on 'gtk3'
   depends_on 'gsettings_desktop_schemas'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m137 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-opera crew update \
&& yes | crew upgrade
```