### PR TITLE
Signal_desktop 7.58.0 => 7.59.0

### DIFF
--- a/manifest/x86_64/s/signal_desktop.filelist
+++ b/manifest/x86_64/s/signal_desktop.filelist
@@ -111,6 +111,8 @@
 /usr/local/share/Signal/resources/app.asar.unpacked/node_modules/@signalapp/sqlcipher/prebuilds/linux-x64/@signalapp+sqlcipher.node
 /usr/local/share/Signal/resources/app.asar.unpacked/node_modules/fs-xattr/build/Release/xattr.node
 /usr/local/share/Signal/resources/apparmor-profile
+/usr/local/share/Signal/resources/org.signalapp.enable-backups.policy
+/usr/local/share/Signal/resources/org.signalapp.view-aep.policy
 /usr/local/share/Signal/resources/package-type
 /usr/local/share/Signal/signal-desktop
 /usr/local/share/Signal/snapshot_blob.bin

--- a/packages/signal_desktop.rb
+++ b/packages/signal_desktop.rb
@@ -3,12 +3,12 @@ require 'package'
 class Signal_desktop < Package
   description 'Private Messenger for Windows, Mac, and Linux'
   homepage 'https://signal.org/'
-  version '7.58.0'
+  version '7.59.0'
   license 'AGPL-3.0'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_#{version}_amd64.deb"
-  source_sha256 '55e125fb782262fc77f3d1c2582a37a39735ed2dc9687709feb45356cf4f10ae'
+  source_sha256 'b7abdf91cef5c86081abd9f808bcc807e27c807a5d115741a8e074d0d0debe18'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable  to launch in hatch m137 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-signal_desktop crew update \
&& yes | crew upgrade
```