### PR TITLE
Adjust crew update command.

### DIFF
--- a/bin/crew
+++ b/bin/crew
@@ -246,13 +246,11 @@ def update
       GIT_REPAIR_COMMANDS
     end
 
-    system(<<~GIT_UPDATE_COMMANDS, chdir: CREW_LIB_PATH, exception: true)
-      ## Update crew from git.
-      # Set sparse-checkout folders.
-      git sparse-checkout set packages manifest/#{ARCH} lib commands bin crew tests tools
-      git sparse-checkout reapply
-      git fetch #{CREW_REPO} #{CREW_BRANCH}
-    GIT_UPDATE_COMMANDS
+    ## Update crew from git.
+    # Set sparse-checkout folders.
+    system "git sparse-checkout set packages manifest/#{ARCH} lib commands bin crew tests tools", chdir: CREW_LIB_PATH, exception: true
+    system 'git sparse-checkout reapply', chdir: CREW_LIB_PATH, exception: true
+    system "git fetch #{CREW_REPO} #{CREW_BRANCH}", chdir: CREW_LIB_PATH, exception: true
     # Now that we've fetched all the new changes, see if lib/const.rb was changed.
     # We do this before resetting to FETCH_HEAD because we lose the original HEAD when doing so.
     to_update = `cd #{CREW_LIB_PATH} && git show --name-only HEAD..FETCH_HEAD`.include?('lib/const.rb')

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -4,7 +4,7 @@ require 'etc'
 require 'open3'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.62.2' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.62.3' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]


### PR DESCRIPTION
- This is meant to avoid the out of memory errors when using ruby threading to start patchelf processes to patch binaries during crew update, which has out of memory errors on recent milestones on the ARM containers.

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=glibc crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
