### PR TITLE
Update ninja to 1.13.0 and enable new jobserver functionality when using ninja.

### DIFF
--- a/lib/buildsystems/cmake.rb
+++ b/lib/buildsystems/cmake.rb
@@ -13,7 +13,7 @@ class CMake < Package
     print_buildsystem_methods
 
     system "#{@pre_cmake_options} cmake -S #{@cmake_build_relative_dir} -B #{@cmake_build_relative_dir}/builddir -G Ninja #{@crew_cmake_options} #{@cmake_options}"
-    system "#{CREW_NINJA} -C #{@cmake_build_relative_dir}/builddir"
+    system "#{CREW_PREFIX}/bin/jobserver_pool.py -j #{CREW_NPROC} #{CREW_NINJA} -C #{@cmake_build_relative_dir}/builddir"
     @cmake_build_extras&.call
   end
 
@@ -24,6 +24,6 @@ class CMake < Package
 
   def self.check
     puts "Testing with #{CREW_NINJA} test.".orange if @run_tests
-    system "ctest -j --progress --test-dir #{@cmake_build_relative_dir}/builddir --rerun-failed --output-on-failure" if @run_tests
+    system "#{CREW_PREFIX}/bin/jobserver_pool.py -j #{CREW_NPROC} ctest -j --progress --test-dir #{@cmake_build_relative_dir}/builddir --rerun-failed --output-on-failure" if @run_tests
   end
 end

--- a/lib/buildsystems/meson.rb
+++ b/lib/buildsystems/meson.rb
@@ -14,7 +14,7 @@ class Meson < Package
 
     system "#{@pre_meson_options} meson setup #{@crew_meson_options} #{@meson_options} #{@meson_build_relative_dir}/builddir #{@meson_build_relative_dir}"
     system "meson configure --no-pager #{@meson_build_relative_dir}/builddir"
-    system "#{CREW_NINJA} -C #{@meson_build_relative_dir}/builddir"
+    system "#{CREW_PREFIX}/bin/jobserver_pool.py -j #{CREW_NPROC} #{CREW_NINJA} -C #{@meson_build_relative_dir}/builddir"
     @meson_build_extras&.call
   end
 

--- a/manifest/armv7l/n/ninja.filelist
+++ b/manifest/armv7l/n/ninja.filelist
@@ -1,1 +1,2 @@
+/usr/local/bin/jobserver_pool.py
 /usr/local/bin/ninja

--- a/manifest/i686/n/ninja.filelist
+++ b/manifest/i686/n/ninja.filelist
@@ -1,1 +1,2 @@
+/usr/local/bin/jobserver_pool.py
 /usr/local/bin/ninja

--- a/manifest/x86_64/n/ninja.filelist
+++ b/manifest/x86_64/n/ninja.filelist
@@ -1,1 +1,2 @@
+/usr/local/bin/jobserver_pool.py
 /usr/local/bin/ninja

--- a/packages/ninja.rb
+++ b/packages/ninja.rb
@@ -3,7 +3,7 @@ require 'buildsystems/cmake'
 class Ninja < CMake
   description 'a small build system with a focus on speed'
   homepage 'https://ninja-build.org'
-  version '1.12.1'
+  version '1.13.0'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://github.com/ninja-build/ninja.git'
@@ -11,10 +11,10 @@ class Ninja < CMake
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '9a6273179b9c9242db8c19708498d3de8a9bcc98292615cfbf44364cb4db4536',
-     armv7l: '9a6273179b9c9242db8c19708498d3de8a9bcc98292615cfbf44364cb4db4536',
-       i686: '98466d2c4986666d124e9cdac21a7e129ce86741a5823975410c0830cc49acf6',
-     x86_64: '0216d7f30e7aeb8febfc94c7c985e109de83d3e836dc4c9d41164017113cc4b4'
+    aarch64: 'cd86c68d1a9fe2aa7db45e788e67261e2eb9d32c1bf70d95aa9b874c5180bd77',
+     armv7l: 'cd86c68d1a9fe2aa7db45e788e67261e2eb9d32c1bf70d95aa9b874c5180bd77',
+       i686: 'd3b37e4bc424829e7729fbe4443810ae7cb681b81545c81a254a39d2310ffbe4',
+     x86_64: '48c4285b8d85f09b65980b3d5d1641298220d48be6f5106fc9ebc174d5c5ae0d'
   })
 
   depends_on 'gcc_lib' # R
@@ -23,10 +23,11 @@ class Ninja < CMake
 
   cmake_options '-DBUILD_TESTING=OFF'
 
-  def self.patch
-    puts 'Patching to update status on edge finish.'.orange
-    downloader 'https://patch-diff.githubusercontent.com/raw/ninja-build/ninja/pull/2312.patch',
-               '09608df70838e8af1a4dab69f735da071699cb10af2336dfe22f92451edbe886'
-    system 'patch -F 3 -p1 -i 2312.patch'
+  cmake_build_extras do
+    system "sed -i 's,/usr/bin/env ,#{CREW_PREFIX}/bin/,' misc/jobserver_pool.py"
+  end
+
+  cmake_install_extras do
+    FileUtils.install 'misc/jobserver_pool.py', "#{CREW_DEST_PREFIX}/bin/jobserver_pool.py", mode: 0o755
   end
 end


### PR DESCRIPTION
- See also https://thebrokenrail.com/2025/06/30/ninja-jobserver.html


Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l` <!-- (reasons why it doesn't) -->
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=ninja crew update \
&& yes | crew upgrade
```

<!--
## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
-->
