### PR TITLE
Brave 1.80.115 => 1.80.120

### DIFF
--- a/packages/brave.rb
+++ b/packages/brave.rb
@@ -4,12 +4,12 @@ require 'convenience_functions'
 class Brave < Package
   description 'Next generation Brave browser for macOS, Windows, Linux, Android.'
   homepage 'https://brave.com/'
-  version '1.80.115'
+  version '1.80.120'
   license 'MPL-2'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://github.com/brave/brave-browser/releases/download/v#{version}/brave-browser-#{version}-linux-amd64.zip"
-  source_sha256 '6d66cf5d2b4eda48d12e20b3f992e71fef11a9e8b6da86874f1405b49eb0e446'
+  source_sha256 'd33749d7eaef662408812943a3e34a47fb7319216b15a0072e79f8977cd9a476'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m137 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-brave crew update \
&& yes | crew upgrade
```