### PR TITLE
Signal_desktop 7.61.0 => 7.62.0

### DIFF
--- a/packages/signal_desktop.rb
+++ b/packages/signal_desktop.rb
@@ -3,12 +3,12 @@ require 'package'
 class Signal_desktop < Package
   description 'Private Messenger for Windows, Mac, and Linux'
   homepage 'https://signal.org/'
-  version '7.61.0'
+  version '7.62.0'
   license 'AGPL-3.0'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_#{version}_amd64.deb"
-  source_sha256 '751f92490b75ad5679559c925f5a15a04f650076e38860c4e3c3a9c9eaf9c135'
+  source_sha256 '6c986a073600d737156b3af121d3e7d3162cd7d594beda251a6c74c441f8be04'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m137 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-signal_desktop crew update \
&& yes | crew upgrade
```