### PR TITLE
Google_chrome 138.0.7204.157-1 => 138.0.7204.168-1

### DIFF
--- a/packages/google_chrome.rb
+++ b/packages/google_chrome.rb
@@ -5,12 +5,12 @@ class Google_chrome < Package
   description 'Google Chrome is a fast, easy to use, and secure web browser.'
   homepage 'https://www.google.com/chrome/'
   @update_channel = 'stable'
-  version '138.0.7204.157-1'
+  version '138.0.7204.168-1'
   license 'google-chrome'
   compatibility 'x86_64'
   min_glibc '2.28'
   source_url "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-#{@update_channel}/google-chrome-#{@update_channel}_#{@version}_amd64.deb"
-  source_sha256 '42659ebd4e1c62651cea551b146e1b43568a16e532214a2b26330c175e1bcd9e'
+  source_sha256 'bdf30440e87d559b0b12595df2a7de2d8f41e77cf502ac914d0ffba767311d88'
 
   depends_on 'nss'
   depends_on 'cairo'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m137 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-google_chrome crew update \
&& yes | crew upgrade
```