### PR TITLE
Apktool 2.11.1 => 2.12.0

### DIFF
--- a/packages/apktool.rb
+++ b/packages/apktool.rb
@@ -3,7 +3,7 @@ require 'package'
 class Apktool < Package
   description 'A tool for reverse engineering Android apk files'
   homepage 'https://apktool.org/'
-  version '2.11.1'
+  version '2.12.0'
   license 'Apache-2.0'
   compatibility 'all'
   source_url "https://raw.githubusercontent.com/iBotPeaches/Apktool/v#{version}/scripts/linux/apktool"
@@ -15,7 +15,7 @@ class Apktool < Package
 
   def self.install
     downloader "https://github.com/iBotPeaches/Apktool/releases/download/v#{version}/apktool_#{version}.jar",
-               '56d59c524fc764263ba8d345754d8daf55b1887818b15cd3b594f555d249e2db', 'apktool.jar'
+               'effb69dab2f93806cafc0d232f6be32c2551b8d51c67650f575e46c016908fdd', 'apktool.jar'
     FileUtils.install 'apktool.jar', "#{CREW_DEST_PREFIX}/bin/apktool.jar", mode: 0o644
     FileUtils.install 'apktool', "#{CREW_DEST_PREFIX}/bin/apktool", mode: 0o755
   end


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-apktool crew update \
&& yes | crew upgrade
```