### PR TITLE
Btop 1.4.2 => 1.4.4

### DIFF
--- a/packages/btop.rb
+++ b/packages/btop.rb
@@ -3,7 +3,7 @@ require 'package'
 class Btop < Package
   description 'Resource monitor that shows usage and stats for processor, memory, disks, network and processes.'
   homepage 'https://github.com/aristocratos/btop'
-  version '1.4.2'
+  version '1.4.4'
   license 'Apache-2.0'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Btop < Package
      x86_64: "https://github.com/aristocratos/btop/releases/download/v#{version}/btop-x86_64-linux-musl.tbz"
   })
   source_sha256({
-    aarch64: '25df48ee78f1c70d47dc30df7dd92fc431770a3fc60864d003553bc9e7cc1f6b',
-     armv7l: '25df48ee78f1c70d47dc30df7dd92fc431770a3fc60864d003553bc9e7cc1f6b',
-       i686: '366b1c7300b4ff37fe632566523e2331f54b52beedb2e5152a0f9bf65598d7bb',
-     x86_64: '03869e0007874bfca7d995501568b68c0d2e2be770f2268859f876dc3edff657'
+    aarch64: '3ec9228ee74334eaea1601e5813afbca936323665b323fefba1393022518e3d6',
+     armv7l: '3ec9228ee74334eaea1601e5813afbca936323665b323fefba1393022518e3d6',
+       i686: '9c73269c11b04692c724d3364c1dd9c6a41a4f678165a433de23a4cd8d04ea72',
+     x86_64: 'fec7d1b59c671290a0f80d5a32617ea6d60412485fc04318fd194b9550ff6b49'
   })
 
   no_compile_needed


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-btop crew update \
&& yes | crew upgrade
```