### PR TITLE
Termius 9.25.1 => 9.27.2

### DIFF
--- a/packages/termius.rb
+++ b/packages/termius.rb
@@ -3,12 +3,12 @@ require 'package'
 class Termius < Package
   description 'Modern SSH Client'
   homepage 'https://termius.com/'
-  version '9.25.1'
+  version '9.27.2'
   license 'Apache-2.0, LGPL-2.1, MIT'
   compatibility 'x86_64'
   min_glibc '2.33'
   source_url 'https://www.termius.com/download/linux/Termius.deb'
-  source_sha256 '8278abfc37764808c743f48a5caf2c0ab6eb175708d694bc05ae2c5e7dc1208b'
+  source_sha256 '5a1086cad7e2335db505a62126fb583b2cb3f5ca8ffc74296b936a8f42812a0a'
 
   depends_on 'sommelier'
 


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m137 container
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-termius crew update \
&& yes | crew upgrade
```