### PR TITLE
Composer 2.8.8 => 2.8.10

### DIFF
--- a/packages/composer.rb
+++ b/packages/composer.rb
@@ -3,11 +3,11 @@ require 'package'
 class Composer < Package
   description 'Dependency Manager for PHP'
   homepage 'https://getcomposer.org/'
-  version '2.8.8'
+  version '2.8.10'
   license 'MIT'
   compatibility 'aarch64 armv7l x86_64'
   source_url "https://github.com/composer/composer/releases/download/#{version}/composer.phar"
-  source_sha256 '957263e284b9f7a13d7f475dc65f3614d151b0c4dcc7e8761f7e7f749447fb68'
+  source_sha256 '28dbb6bd8bef31479c7985b774c130a8bda37dbe63c35b56f6cb6bc377427573'
 
   depends_on 'php83' unless File.exist? "#{CREW_PREFIX}/bin/php"
   depends_on 'xdg_base'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-composer crew update \
&& yes | crew upgrade
```