### PR TITLE
Revert "Add postinstall to glibc to add symlinks. (#12116)"

### DIFF
--- a/packages/glibc.rb
+++ b/packages/glibc.rb
@@ -7,7 +7,7 @@ unless CREW_PRE_GLIBC_STANDALONE
   class Glibc < Package
     description 'The GNU C Library project provides the core libraries for GNU/Linux systems.'
     homepage 'https://www.gnu.org/software/libc/'
-    version '2.41-6'
+    version '2.41-5'
     license 'LGPL-2.1+, BSD, HPND, ISC, inner-net, rc, and PCRE'
     compatibility 'all'
     source_url 'https://sourceware.org/git/glibc.git'
@@ -171,25 +171,6 @@ unless CREW_PRE_GLIBC_STANDALONE
     end
 
     def self.postinstall
-      glibc_libraries = %w[ld libBrokenLocale libSegFault libanl libc libcrypt
-                           libdl libm libmemusage libmvec libnsl libnss_compat libnss_db
-                           libnss_dns libnss_files libnss_hesiod libpcprofile libpthread
-                           libthread_db libresolv librlv librt libthread_db-1.0 libutil]
-      glibc_libraries.each do |lib|
-        # Reject entries which aren't libraries ending in .so, and which aren't files.
-        # Reject text files such as libc.so because they points to files like
-        # libc_nonshared.a, which are not provided by ChromeOS
-        Dir["#{CREW_GLIBC_PREFIX}/#{lib}.so*"].compact.reject { |f| File.directory?(f) }.each do |f|
-          glibc_filetype = `file #{f}`.chomp
-          puts "f: #{glibc_filetype}" if @opt_verbose
-          if ['shared object', 'symbolic link'].any? { |type| glibc_filetype.include?(type) }
-            g = File.basename(f)
-            FileUtils.ln_sf f.to_s, "#{CREW_LIB_PREFIX}/#{g}"
-          elsif @opt_verbose
-            puts "#{f} excluded because #{glibc_filetype}"
-          end
-        end
-      end
       # update search cache for ld.so
       system "#{CREW_PREFIX}/bin/ldconfig", %i[out err] => File::NULL
       puts "Please run 'crew update' immediately to finish the install.".lightblue


### PR DESCRIPTION
Reverts #12116 

Symlinking glibc-standalone libraries to `CREW_LIB_PREFIX` will make them visible to the system's glibc and thus screwing it up because of mismatched library versions.

Here is a quick demo of it:
```
# switch to system version of glibc and disable crew-preload's glibc hijacking logic
$ patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 /usr/local/bin/ruby
$ export CREW_PRELOAD_NO_CREW_GLIBC=1

# ruby is now broken
$ CREW_PRELOAD_NO_CREW_GLIBC=1 sh -c '/usr/local/bin/ruby -v'
Floating point exception   (core dumped) CREW_PRELOAD_NO_CREW_GLIBC=1 sh -c '/usr/local/bin/ruby -v'

$ CREW_PRELOAD_NO_CREW_GLIBC=1 sh -c 'LD_TRACE_LOADED_OBJECTS=1 /usr/local/bin/ruby'
        linux-vdso.so.1 (0x0000746b04b83000)
        /usr/local/lib64/crew-preload.so (0x0000746b04b72000)
        ..snip..
        libc.so.6 => /usr/local/lib64/libc.so.6 (0x0000746b040a4000)
        ..snip..
        /lib64/ld-linux-x86-64.so.2 (0x0000746b04b85000)
```