### PR TITLE
generate_prs_flip_draft_to_ready — 

### DIFF
--- a/.github/workflows/Generate-PR.yml
+++ b/.github/workflows/Generate-PR.yml
@@ -404,13 +404,13 @@ jobs:
           if [[ -z ${PR_NUMBER} ]]; then
             PR_NUMBER=$(gh pr create ${PR_DRAFT_FLAG} --reviewer chromebrew/active --title "$(echo "${{ inputs.pr_title || inputs.branch || github.ref_name }}" | sed -e "s/^'//" -e "s/'$//") — ${CHANGED_PACKAGES}" -F /tmp/pr.txt | rev | cut -d"/" -f1  | rev)
           else
-            gh pr edit --title "$(echo "${{ inputs.pr_title || inputs.branch || github.ref_name }}" | sed -e "s/^'//" -e "s/'$//") — ${CHANGED_PACKAGES}" -F /tmp/pr.txt
-            gh pr edit --add-reviewer chromebrew/active
+            gh pr edit --add-reviewer chromebrew/active --title "$(echo "${{ inputs.pr_title || inputs.branch || github.ref_name }}" | sed -e "s/^'//" -e "s/'$//") — ${CHANGED_PACKAGES}" -F /tmp/pr.txt
           fi
           # Draft PRs can not be set to automerge.
           if [[ $DRAFT_PR == 'true' ]]; then
             gh pr ready --undo || true
           else
+            gh pr ready || true
             gh pr merge --auto || true
           fi
           echo "PR_NUMBER is ${PR_NUMBER}"

--- a/.github/workflows/Linter-Handoff.yml
+++ b/.github/workflows/Linter-Handoff.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Update branch
-        if: ${{ github.event.action != 'synchronize' || !contains(github.ref_name, '/merge') }}
+        if: ${{ !contains(github.ref_name, '/merge') }}
         run: |
           git fetch origin
           git checkout "${{ github.ref_name }}"


### PR DESCRIPTION
## Description
#### Commits:
-  a433d41a8 Adjust Linter Handoff workflow git update logic.
-  a89bd2079 Flip draft PRs to ready from the Generate PRs workflow if there is an existing PR in draft and the workflow was not started with PR in Draft Mode selected.
### Updated GitHub configuration files:
- .github/workflows/Generate-PR.yml
- .github/workflows/Linter-Handoff.yml
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=generate_prs_flip_draft_to_ready crew update \
&& yes | crew upgrade
```
