### PR TITLE
Add postremove section to cabal.rb

### DIFF
--- a/packages/cabal.rb
+++ b/packages/cabal.rb
@@ -22,4 +22,8 @@ class Cabal < Package
   def self.install
     FileUtils.install 'cabal', "#{CREW_DEST_PREFIX}/bin/cabal", mode: 0o755
   end
+
+  def self.postremove
+    Package.agree_to_remove("#{CREW_PREFIX}/.config/cabal")
+  end
 end


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-cabal crew update \
&& yes | crew upgrade
```