### PR TITLE
Update mediainfo packages

### DIFF
--- a/packages/libmediainfo.rb
+++ b/packages/libmediainfo.rb
@@ -3,18 +3,18 @@ require 'package'
 class Libmediainfo < Package
   description 'MediaInfo is a convenient unified display of the most relevant technical and tag data for video and audio files.'
   homepage 'https://mediaarea.net/en/MediaInfo'
-  version '25.04'
+  version '25.07'
   license 'BSD-2'
   compatibility 'all'
   source_url "https://mediaarea.net/download/binary/libmediainfo0/#{version}/MediaInfo_DLL_#{version}_GNU_FromSource.tar.xz"
-  source_sha256 '958530caacf1a897d48587d59177dc7d4d54cfd0cc4ccb922432d907c94af1d4'
+  source_sha256 'cbcc46a661d03904795b5f55a7eeb98c0210e8887e89e3efc0c6c415d236f276'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '028a158e4ec285018b9e7e285ef4f4e67273890edb3455fa9c8f06b0c82a284b',
-     armv7l: '028a158e4ec285018b9e7e285ef4f4e67273890edb3455fa9c8f06b0c82a284b',
-       i686: '42dfcbdba287f36429d57fe344bf0c9bb5f2b71bc14a097b9d8a8723f2992229',
-     x86_64: '20b41b5118591f29f0567b1d9bdacfc7cd87f5c634e243fcd73183dd7e09ee51'
+    aarch64: 'fd19130288ee2e5d159e05aefdb49d39d81cf489d50775ff7b4145158dad9913',
+     armv7l: 'fd19130288ee2e5d159e05aefdb49d39d81cf489d50775ff7b4145158dad9913',
+       i686: '6ec2f166519f77cce83c44696ddac51a823538fd94393a0bdd2622fa50105d5a',
+     x86_64: 'b5514a30eef8332a533ed1dc3ff918f05b76a5c4dec02ad4145b51fb30d7e62a'
   })
 
   depends_on 'gcc_lib' # R

--- a/packages/mediainfo.rb
+++ b/packages/mediainfo.rb
@@ -3,18 +3,18 @@ require 'package'
 class Mediainfo < Package
   description 'MediaInfo is a convenient unified display of the most relevant technical and tag data for video and audio files.'
   homepage 'https://mediaarea.net/en/MediaInfo'
-  version '25.04'
+  version '25.07'
   license 'BSD-2'
   compatibility 'all'
   source_url "https://mediaarea.net/download/binary/mediainfo/#{version}/MediaInfo_CLI_#{version}_GNU_FromSource.tar.xz"
-  source_sha256 'ecd286de77cb13ea4b6ce0ebdbbff3f3da89c67ec2d5c330d47f385a4329c5d2'
+  source_sha256 'd810a56b84a8f6c009958312459e1d7353b3722db8f18c2bc87da512ebd51482'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'de0646614be731fa8011661ac2a7277136c4c57508220ba2ebd76d4bad2920e2',
-     armv7l: 'de0646614be731fa8011661ac2a7277136c4c57508220ba2ebd76d4bad2920e2',
-       i686: '2ed96d3e74442d3445a8c46d0223cdb5bac87fe55f54be5be65fef0157345df4',
-     x86_64: '43fd82dc685e1a5955f1302029be5af6eaf5060f1b4ba3caa3d6f276629bedbd'
+    aarch64: 'daaea81c433718d4760a8ea6b0dcd6745b380addd374ef2ddd4ec4257ea1df98',
+     armv7l: 'daaea81c433718d4760a8ea6b0dcd6745b380addd374ef2ddd4ec4257ea1df98',
+       i686: '99647e32da8e872ba14b00fda6caf1cc1db7aa918f83d3cd4bf56b3d66925349',
+     x86_64: '9e07a9c7cc8ca950cb01198c6c049c1db1c5d9c66634bc07270618f09daef4f0'
   })
 
   depends_on 'gcc_lib' # R

--- a/packages/mediainfo_gui.rb
+++ b/packages/mediainfo_gui.rb
@@ -3,17 +3,17 @@ require 'package'
 class Mediainfo_gui < Package
   description 'MediaInfo is a convenient unified display of the most relevant technical and tag data for video and audio files.'
   homepage 'https://mediaarea.net/en/MediaInfo'
-  version '25.04'
+  version '25.07'
   license 'BSD-2'
   compatibility 'aarch64 armv7l x86_64'
   source_url "https://mediaarea.net/download/binary/mediainfo-gui/#{version}/MediaInfo_GUI_#{version}_GNU_FromSource.tar.xz"
-  source_sha256 '6a24f6529ab802e594ce89cc2e7816a2b0ffe06130545c3593ab334f2ceb9cd1'
+  source_sha256 'eff17dc966290f3ee0f8be0abd279e98eb0d34e1799fbb8b1ec7b210ed624d88'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '22dc67babe776a8e731bbd3c9d8203506935f8b475f9c4f175e647be99be147f',
-     armv7l: '22dc67babe776a8e731bbd3c9d8203506935f8b475f9c4f175e647be99be147f',
-     x86_64: 'cadcc0059ce6d49c71e155bcc0965447c3c0bb143296d8379928d117f160fcaf'
+    aarch64: 'bd18e0f5b105d2c2e1ca0ec134dc4fd7b73dacbe7c95b703cdf913a50274957b',
+     armv7l: 'bd18e0f5b105d2c2e1ca0ec134dc4fd7b73dacbe7c95b703cdf913a50274957b',
+     x86_64: 'cb8fb802283962a91e2880d6cd79e5c7085a8f12df79832a8208242a24ddc4db'
   })
 
   depends_on 'at_spi2_core' # R
@@ -25,7 +25,6 @@ class Mediainfo_gui < Package
   depends_on 'gtk3' # R
   depends_on 'harfbuzz' # R
   depends_on 'libjpeg_turbo' # R
-  depends_on 'libmediainfo' # R
   depends_on 'libsm' # R
   depends_on 'libtiff' # R
   depends_on 'libx11' # R


### PR DESCRIPTION
- Libmediainfo 25.04 => 25.07
- Mediainfo 25.04 => 25.07
- Mediainfo_gui 25.04 => 25.07
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686` Libmediainfo only
- [x] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-mediainfo-packages crew update \
&& yes | crew upgrade
```