### PR TITLE
Auto-generated update for brave (1.81.135)

### DIFF
--- a/packages/brave.rb
+++ b/packages/brave.rb
@@ -7,13 +7,8 @@ class Brave < Package
   license 'MPL-2'
   compatibility 'x86_64'
 
-  source_url({
-    x86_64: 'https://brave-browser-apt-release.s3.brave.com/pool/main/b/brave-browser/brave-browser_1.81.135_amd64.deb'
-  })
-
-  source_sha256({
-    x86_64: '33df4b1743dcef8c6c4269c7f7b013094c6b03215f890d11c3c29822f909a0f7'
-  })
+  source_url 'https://brave-browser-apt-release.s3.brave.com/pool/main/b/brave-browser/brave-browser_1.81.135_amd64.deb'
+  source_sha256 '33df4b1743dcef8c6c4269c7f7b013094c6b03215f890d11c3c29822f909a0f7'
 
   no_compile_needed
   no_shrink
@@ -34,6 +29,11 @@ class Brave < Package
   def self.postinstall
     ConvenienceFunctions.set_default_browser('Brave', 'brave')
   end
+
+  def self.preremove
+    ConvenienceFunctions.unset_default_browser('Brave', 'brave')
+  end
+end
 
   def self.preremove
     ConvenienceFunctions.unset_default_browser('Brave', 'brave')

--- a/packages/brave.rb
+++ b/packages/brave.rb
@@ -1,15 +1,19 @@
 require 'package'
-require 'convenience_functions'
 
 class Brave < Package
   description 'Next generation Brave browser for macOS, Windows, Linux, Android.'
   homepage 'https://brave.com/'
-  version '1.81.131'
+  version '1.81.135'
   license 'MPL-2'
   compatibility 'x86_64'
-  min_glibc '2.29'
-  source_url "https://github.com/brave/brave-browser/releases/download/v#{version}/brave-browser-#{version}-linux-amd64.zip"
-  source_sha256 '3a73bd94be8573d5a327a764634ae087984d2530679081cb25a0327d4b6aba91'
+
+  source_url({
+    x86_64: 'https://brave-browser-apt-release.s3.brave.com/pool/main/b/brave-browser/brave-browser_1.81.135_amd64.deb'
+  })
+
+  source_sha256({
+    x86_64: '33df4b1743dcef8c6c4269c7f7b013094c6b03215f890d11c3c29822f909a0f7'
+  })
 
   no_compile_needed
   no_shrink

--- a/packages/brave.rb
+++ b/packages/brave.rb
@@ -34,8 +34,3 @@ class Brave < Package
     ConvenienceFunctions.unset_default_browser('Brave', 'brave')
   end
 end
-
-  def self.preremove
-    ConvenienceFunctions.unset_default_browser('Brave', 'brave')
-  end
-end


### PR DESCRIPTION
### Package information
- Package name: brave
- Old version: 1.81.131
- New version: 1.81.135

This PR is generated by [crew-update-checker](https://github.com/supechicken/crew-update-checker)
