### PR TITLE
Auto-generated update for signal_desktop (7.66.0)

### DIFF
--- a/packages/signal_desktop.rb
+++ b/packages/signal_desktop.rb
@@ -46,4 +46,3 @@ class Signal_desktop < Package
     ExitMessage.add "\nType 'signal-desktop' to get started.\n"
   end
 end
-

--- a/packages/signal_desktop.rb
+++ b/packages/signal_desktop.rb
@@ -3,12 +3,17 @@ require 'package'
 class Signal_desktop < Package
   description 'Private Messenger for Windows, Mac, and Linux'
   homepage 'https://signal.org/'
-  version '7.64.0'
+  version '7.66.0'
   license 'AGPL-3.0'
   compatibility 'x86_64'
-  min_glibc '2.29'
-  source_url "https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_#{version}_amd64.deb"
-  source_sha256 '02ef930e19f4b5d11c3e83cb17aef85b4ed895539e4fd8c9b817c45c07adc06e'
+
+  source_url({
+    x86_64: 'https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.66.0_amd64.deb'
+  })
+
+  source_sha256({
+    x86_64: '8bae7c7e8c45036b4ad76767cf5e02a1d5813afe8e04052ed230b3525980af39'
+  })
 
   no_compile_needed
   no_shrink

--- a/packages/signal_desktop.rb
+++ b/packages/signal_desktop.rb
@@ -47,8 +47,3 @@ class Signal_desktop < Package
   end
 end
 
-
-  def self.postinstall
-    ExitMessage.add "\nType 'signal-desktop' to get started.\n"
-  end
-end

--- a/packages/signal_desktop.rb
+++ b/packages/signal_desktop.rb
@@ -7,13 +7,8 @@ class Signal_desktop < Package
   license 'AGPL-3.0'
   compatibility 'x86_64'
 
-  source_url({
-    x86_64: 'https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.66.0_amd64.deb'
-  })
-
-  source_sha256({
-    x86_64: '8bae7c7e8c45036b4ad76767cf5e02a1d5813afe8e04052ed230b3525980af39'
-  })
+  source_url 'https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.66.0_amd64.deb'
+  source_sha256 '8bae7c7e8c45036b4ad76767cf5e02a1d5813afe8e04052ed230b3525980af39'
 
   no_compile_needed
   no_shrink
@@ -46,6 +41,12 @@ class Signal_desktop < Package
     FileUtils.install 'signal.sh', "#{CREW_DEST_PREFIX}/bin/signal-desktop", mode: 0o755
     # FileUtils.ln_s "#{CREW_PREFIX}/share/Signal/signal-desktop", "#{CREW_DEST_PREFIX}/bin/signal-desktop"
   end
+
+  def self.postinstall
+    ExitMessage.add "\nType 'signal-desktop' to get started.\n"
+  end
+end
+
 
   def self.postinstall
     ExitMessage.add "\nType 'signal-desktop' to get started.\n"


### PR DESCRIPTION
### Package information
- Package name: signal_desktop
- Old version: 7.64.0
- New version: 7.66.0

This PR is generated by [crew-update-checker](https://github.com/supechicken/crew-update-checker)
