### PR TITLE
crew: Check for dependency before removal

### DIFF
--- a/commands/remove.rb
+++ b/commands/remove.rb
@@ -37,7 +37,7 @@ class Command
         pkg_file      = File.join(CREW_PACKAGES_PATH, "#{installed_pkg_info['name']}.rb")
         installed_pkg = Package.load_package(pkg_file)
 
-        pkgs_that_need_it << installed_pkg.name if installed_pkg.dependencies.keys.any?(pkg.name)
+        pkgs_that_need_it << installed_pkg.name if installed_pkg.dependencies.key?(pkg.name)
       end
 
       if pkgs_that_need_it.any?

--- a/commands/remove.rb
+++ b/commands/remove.rb
@@ -21,14 +21,34 @@ class Command
     if CREW_ESSENTIAL_PACKAGES.include?(pkg.name) && !force
       return if pkg.in_upgrade
 
-      puts <<~ESSENTIAL_PACKAGE_WARNING_EOF.gsub(/^(?=\w)/, '  ').lightred
+      # Exit with failure if attempt to remove an essential package
+      # is made.
+      abort <<~ESSENTIAL_PACKAGE_WARNING_EOF.gsub(/^(?=\w)/, '  ').lightred
         #{pkg.name.capitalize} is considered an essential package needed for
         Chromebrew to function and thus cannot be removed.
       ESSENTIAL_PACKAGE_WARNING_EOF
+    end
 
-      # Exit with failure if attempt to remove an essential package
-      # is made.
-      exit 1
+    # Check whether the removal breaks dependency of other installed packages
+    unless force
+      pkgs_that_need_it = []
+
+      device_json['installed_packages'].each do |installed_pkg_info|
+        pkg_file      = File.join(CREW_PACKAGES_PATH, "#{installed_pkg_info['name']}.rb")
+        installed_pkg = Package.load_package(pkg_file)
+
+        pkgs_that_need_it << installed_pkg.name if installed_pkg.dependencies.keys.any?(pkg.name)
+      end
+
+      if pkgs_that_need_it.any?
+        abort <<~EOT.lightred
+          #{pkg.name.capitalize} is required by the following installed packages:
+
+            #{pkgs_that_need_it.join("\n  ")}
+
+          Use `crew remove --force` if you meant to remove it.
+        EOT
+      end
     end
 
     # Perform any operations required prior to package removal.

--- a/commands/remove.rb
+++ b/commands/remove.rb
@@ -23,7 +23,7 @@ class Command
 
       # Exit with failure if attempt to remove an essential package
       # is made.
-      abort <<~ESSENTIAL_PACKAGE_WARNING_EOF.gsub(/^(?=\w)/, '  ').lightred
+      abort <<~ESSENTIAL_PACKAGE_WARNING_EOF.gsub(/^(?=\w)/, '  ').chomp.lightred
         #{pkg.name.capitalize} is considered an essential package needed for
         Chromebrew to function and thus cannot be removed.
       ESSENTIAL_PACKAGE_WARNING_EOF
@@ -41,7 +41,7 @@ class Command
       end
 
       if pkgs_that_need_it.any?
-        abort <<~EOT.lightred
+        abort <<~EOT.chomp.lightred
           #{pkg.name.capitalize} is required by the following installed packages:
 
             #{pkgs_that_need_it.join("\n  ")}

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -4,7 +4,7 @@ require 'etc'
 require 'open3'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.64.7' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.64.8' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]


### PR DESCRIPTION
Fixes #858

Here is a quick demo of it:
```
chronos@localhost / $ crew remove libx11
Libx11 is required by the following installed packages:

  dbus
  libxkbfile
  gtk3

...snip...

Use `crew remove --force` if you meant to remove it.

chronos@localhost / $ crew remove libx11 -f
libx11 removed!
```

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/supechicken/chromebrew.git CREW_BRANCH=check_dependency_before_remove crew update \
&& yes | crew upgrade
```
