### PR TITLE
Fix container test workflow

### DIFF
--- a/tests/unit_test.sh
+++ b/tests/unit_test.sh
@@ -65,7 +65,7 @@ if [[ -n ${CHANGED_PACKAGES-} ]]; then
         yes | time crew remove "${pkg}" || true
       else
         echo "Testing removal of ${pkg}."
-        yes | time crew remove "${pkg}"
+        yes | time crew remove -f "${pkg}"
       fi
     else
       echo "${pkg^} is not compatible."


### PR DESCRIPTION
This should fix the following error:
```
Unpacking archive using 'tar', this may take a while...
Gcc_dev is required by the following installed packages:

  buildessential

Use `crew remove --force` if you meant to remove it.
Attempting removal since this is an upgrade or reinstall...
Command exited with non-zero status 1
8.24user 3.76system 0:12.06elapsed 99%CPU (0avgtext+0avgdata 320592maxresident)k
0inputs+2667424outputs (0major+59882minor)pagefaults 0swaps
Error: Process completed with exit code 1.
```
