### PR TITLE
Opera 120.0.5543.161 => 120.0.5543.201

### DIFF
--- a/manifest/x86_64/o/opera.filelist
+++ b/manifest/x86_64/o/opera.filelist
@@ -1,3 +1,4 @@
+# Total size: 351855809
 /usr/local/bin/opera
 /usr/local/share/applications/opera.desktop
 /usr/local/share/doc/opera-stable/changelog.gz

--- a/packages/opera.rb
+++ b/packages/opera.rb
@@ -3,12 +3,12 @@ require 'package'
 class Opera < Package
   description 'Opera is a multi-platform web browser based on Chromium and developed by Opera Software.'
   homepage 'https://www.opera.com/'
-  version '120.0.5543.161'
+  version '120.0.5543.201'
   license 'OPERA-2018'
   compatibility 'x86_64'
 
-  source_url 'https://deb.opera.com/opera-stable/pool/non-free/o/opera-stable/opera-stable_120.0.5543.161_amd64.deb'
-  source_sha256 '37b910edaf3580e5a30efc62d85303909e1fdaf73aaf78574b10e43b04d98060'
+  source_url "https://deb.opera.com/opera-stable/pool/non-free/o/opera-stable/opera-stable_#{version}_amd64.deb"
+  source_sha256 '04663f88326bcd981fd22fed6d67927bb77d79b7a91c10118b9a935c6d5ff6b8'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m138 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-opera crew update \
&& yes | crew upgrade
```