### PR TITLE
Baobab 45.0 => 48.0

### DIFF
--- a/manifest/armv7l/b/baobab.filelist
+++ b/manifest/armv7l/b/baobab.filelist
@@ -1,4 +1,4 @@
-# Total size: 1541610
+# Total size: 1474286
 /usr/local/bin/baobab
 /usr/local/share/applications/org.gnome.baobab.desktop
 /usr/local/share/dbus-1/services/org.gnome.baobab.service
@@ -396,6 +396,7 @@
 /usr/local/share/locale/it/LC_MESSAGES/baobab.mo
 /usr/local/share/locale/ja/LC_MESSAGES/baobab.mo
 /usr/local/share/locale/ka/LC_MESSAGES/baobab.mo
+/usr/local/share/locale/kab/LC_MESSAGES/baobab.mo
 /usr/local/share/locale/kk/LC_MESSAGES/baobab.mo
 /usr/local/share/locale/km/LC_MESSAGES/baobab.mo
 /usr/local/share/locale/kn/LC_MESSAGES/baobab.mo
@@ -447,4 +448,4 @@
 /usr/local/share/locale/zh_HK/LC_MESSAGES/baobab.mo
 /usr/local/share/locale/zh_TW/LC_MESSAGES/baobab.mo
 /usr/local/share/man/man1/baobab.1.zst
-/usr/local/share/metainfo/org.gnome.baobab.appdata.xml
+/usr/local/share/metainfo/org.gnome.baobab.metainfo.xml

--- a/manifest/x86_64/b/baobab.filelist
+++ b/manifest/x86_64/b/baobab.filelist
@@ -1,4 +1,4 @@
-# Total size: 1455930
+# Total size: 1555482
 /usr/local/bin/baobab
 /usr/local/share/applications/org.gnome.baobab.desktop
 /usr/local/share/dbus-1/services/org.gnome.baobab.service
@@ -396,6 +396,7 @@
 /usr/local/share/locale/it/LC_MESSAGES/baobab.mo
 /usr/local/share/locale/ja/LC_MESSAGES/baobab.mo
 /usr/local/share/locale/ka/LC_MESSAGES/baobab.mo
+/usr/local/share/locale/kab/LC_MESSAGES/baobab.mo
 /usr/local/share/locale/kk/LC_MESSAGES/baobab.mo
 /usr/local/share/locale/km/LC_MESSAGES/baobab.mo
 /usr/local/share/locale/kn/LC_MESSAGES/baobab.mo
@@ -447,4 +448,4 @@
 /usr/local/share/locale/zh_HK/LC_MESSAGES/baobab.mo
 /usr/local/share/locale/zh_TW/LC_MESSAGES/baobab.mo
 /usr/local/share/man/man1/baobab.1.zst
-/usr/local/share/metainfo/org.gnome.baobab.appdata.xml
+/usr/local/share/metainfo/org.gnome.baobab.metainfo.xml

--- a/packages/baobab.rb
+++ b/packages/baobab.rb
@@ -3,29 +3,31 @@ require 'buildsystems/meson'
 class Baobab < Meson
   description 'Disk Usage Analyzer (also known as baobab) scans folders, devices or remote locations and and reports on the disk space consumed by each element.'
   homepage 'https://wiki.gnome.org/Apps/DiskUsageAnalyzer'
-  version '45.0'
+  version '48.0'
   license 'GPL-2+ and FDL-1.1+'
   compatibility 'aarch64 armv7l x86_64'
+  min_glibc '2.29'
   source_url 'https://gitlab.gnome.org/GNOME/baobab.git'
   git_hashtag version
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '7405ce4a84ca2ffeab17643a9efa11ced62a1687ee3c8433215bda8f177b541f',
-     armv7l: '7405ce4a84ca2ffeab17643a9efa11ced62a1687ee3c8433215bda8f177b541f',
-     x86_64: '0e1c62920726909f86756309f9a1a2efc7a520eaa78c63d88678bdbd4ea11e67'
+    aarch64: '8ec019f195cf97b40c0aa76b98439873b94b3efbd0cbf42faa0429113d599828',
+     armv7l: '8ec019f195cf97b40c0aa76b98439873b94b3efbd0cbf42faa0429113d599828',
+     x86_64: '36a249ef46164f7a3455d424f1b4ba037aa1b060d4b1499c58d69de54a4cbb50'
   })
 
   depends_on 'cairo' # R
   depends_on 'desktop_file_utils' => :build
-  depends_on 'glibc' # R
   depends_on 'glib' # R
+  depends_on 'glibc' # R
+  depends_on 'graphene' # R
   depends_on 'gsettings_desktop_schemas' => :build
   depends_on 'gtk4' # R
   depends_on 'harfbuzz' # R
-  depends_on 'py3_itstool' => :build
   depends_on 'libadwaita' # R
   depends_on 'pango' # R
+  depends_on 'py3_itstool' => :build
   depends_on 'vala' => :build
   depends_on 'vulkan_headers' => :build
   depends_on 'vulkan_icd_loader' => :build


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m138 container
- [x] `armv7l` Unable to launch in strongbad m138 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-baobab crew update \
&& yes | crew upgrade
```