### PR TITLE
Opera 120.0.5543.201 => 121.0.5600.38

### DIFF
--- a/manifest/x86_64/o/opera.filelist
+++ b/manifest/x86_64/o/opera.filelist
@@ -1,4 +1,4 @@
-# Total size: 351855809
+# Total size: 354649895
 /usr/local/bin/opera
 /usr/local/share/applications/opera.desktop
 /usr/local/share/doc/opera-stable/changelog.gz
@@ -137,7 +137,6 @@
 /usr/local/share/x86_64-linux-gnu/opera/resources/opera_intro_extension/427fc33b09a5b15cc69c.png
 /usr/local/share/x86_64-linux-gnu/opera/resources/opera_intro_extension/42ff001a8c225fc1a354.png
 /usr/local/share/x86_64-linux-gnu/opera/resources/opera_intro_extension/439f3447a96cad7c116c.jpg
-/usr/local/share/x86_64-linux-gnu/opera/resources/opera_intro_extension/45763c696a4442585bb4.svg
 /usr/local/share/x86_64-linux-gnu/opera/resources/opera_intro_extension/5481ba37652e144d94d4.png
 /usr/local/share/x86_64-linux-gnu/opera/resources/opera_intro_extension/587706f4d9807ac4bdf4.png
 /usr/local/share/x86_64-linux-gnu/opera/resources/opera_intro_extension/5c970459e6839141139d.png
@@ -162,6 +161,7 @@
 /usr/local/share/x86_64-linux-gnu/opera/resources/opera_intro_extension/d92eb252936a5b7d251c.jpg
 /usr/local/share/x86_64-linux-gnu/opera/resources/opera_intro_extension/dc8e6d22f2d58eab7e86.jpg
 /usr/local/share/x86_64-linux-gnu/opera/resources/opera_intro_extension/e393a69f0d2e035d1c42.svg
+/usr/local/share/x86_64-linux-gnu/opera/resources/opera_intro_extension/eed0b0cc552c8794b337.svg
 /usr/local/share/x86_64-linux-gnu/opera/resources/opera_intro_extension/fcffb6ccd23559274e62.svg
 /usr/local/share/x86_64-linux-gnu/opera/resources/opera_intro_extension/icons/logo.png
 /usr/local/share/x86_64-linux-gnu/opera/resources/opera_intro_extension/icons/logo.svg

--- a/packages/opera.rb
+++ b/packages/opera.rb
@@ -3,12 +3,12 @@ require 'package'
 class Opera < Package
   description 'Opera is a multi-platform web browser based on Chromium and developed by Opera Software.'
   homepage 'https://www.opera.com/'
-  version '120.0.5543.201'
+  version '121.0.5600.38'
   license 'OPERA-2018'
   compatibility 'x86_64'
 
   source_url "https://deb.opera.com/opera-stable/pool/non-free/o/opera-stable/opera-stable_#{version}_amd64.deb"
-  source_sha256 '04663f88326bcd981fd22fed6d67927bb77d79b7a91c10118b9a935c6d5ff6b8'
+  source_sha256 '59e87ac4fce736a0842b411a5073ad285f6c51e4b13588132e71365794a9374b'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m138 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-opera crew update \
&& yes | crew upgrade
```