### PR TITLE
Add cert_cli package

### DIFF
--- a/manifest/armv7l/c/cert_cli.filelist
+++ b/manifest/armv7l/c/cert_cli.filelist
@@ -1,0 +1,2 @@
+# Total size: 6159816
+/usr/local/bin/cert-cli

--- a/manifest/i686/c/cert_cli.filelist
+++ b/manifest/i686/c/cert_cli.filelist
@@ -1,0 +1,2 @@
+# Total size: 6148112
+/usr/local/bin/cert-cli

--- a/manifest/x86_64/c/cert_cli.filelist
+++ b/manifest/x86_64/c/cert_cli.filelist
@@ -1,0 +1,2 @@
+# Total size: 6327976
+/usr/local/bin/cert-cli

--- a/packages/cert_cli.rb
+++ b/packages/cert_cli.rb
@@ -1,0 +1,30 @@
+require 'package'
+
+class Cert_cli < Package
+  description 'An OSINT tool for discovering domains, organizations, and addresses from SSL/TLS certificates using crt.sh.'
+  homepage 'https://github.com/mihneamanolache/cert-cli'
+  version '1.0.0'
+  license 'MIT'
+  compatibility 'all'
+  source_url 'https://github.com/mihneamanolache/cert-cli.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+    aarch64: '0ca2c114a0565d0bce0f02f1f69e2ea7984eeff1a490b06f4aaa0d9d62cfcee0',
+     armv7l: '0ca2c114a0565d0bce0f02f1f69e2ea7984eeff1a490b06f4aaa0d9d62cfcee0',
+       i686: 'a04d2b39dc4fea76eb2eaa2807bc9f241f3a5f136114bf7e49c10936cb08cb05',
+     x86_64: '67dabe47e3fccabf7a8a057efb6dd0c5e0b4315dd413b6ac8f9d6fb3ef4dd839'
+  })
+
+  depends_on 'glibc' # R
+  depends_on 'go' => :build
+
+  def self.install
+    system "go build -o #{CREW_DEST_PREFIX}/bin/cert-cli cmd/main.go"
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nType 'cert-cli -h' to get started.\n"
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -875,6 +875,11 @@ url: https://sourceforge.net/projects/wodim/files/cdrkit/
 activity: none
 ---
 kind: url
+name: cert_cli
+url: https://github.com/mihneamanolache/cert-cli/releases
+activity: low
+---
+kind: url
 name: cf
 url: https://github.com/cloudfoundry/cli/releases
 activity: medium


### PR DESCRIPTION
## Description
An OSINT tool for discovering domains, organizations, and addresses from SSL/TLS certificates using crt.sh. Supports proxy configurations, JSON output, and robust error handling for large-scale certificate analysis.  See https://github.com/mihneamanolache/cert-cli.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-cert_cli-package crew update \
&& yes | crew upgrade
```