### PR TITLE
Add pip_search package

### DIFF
--- a/manifest/armv7l/p/pip_search.filelist
+++ b/manifest/armv7l/p/pip_search.filelist
@@ -1,0 +1,3 @@
+# Total size: 315
+/usr/local/bin/pip_search
+/usr/local/etc/env.d/10-pip_search

--- a/manifest/i686/p/pip_search.filelist
+++ b/manifest/i686/p/pip_search.filelist
@@ -1,0 +1,3 @@
+# Total size: 315
+/usr/local/bin/pip_search
+/usr/local/etc/env.d/10-pip_search

--- a/manifest/x86_64/p/pip_search.filelist
+++ b/manifest/x86_64/p/pip_search.filelist
@@ -1,0 +1,3 @@
+# Total size: 315
+/usr/local/bin/pip_search
+/usr/local/etc/env.d/10-pip_search

--- a/packages/pip_search.rb
+++ b/packages/pip_search.rb
@@ -1,0 +1,52 @@
+require 'package'
+
+class Pip_search < Package
+  description "Replacement for the deprecated 'pip search' command."
+  homepage 'https://github.com/chromebrew'
+  version '1.0'
+  license 'GPL-3'
+  compatibility 'all'
+  source_url 'SKIP'
+
+  depends_on 'xdg_utils' # R
+
+  print_source_bashrc
+
+  def self.preflight
+    Dir.chdir("#{CREW_PREFIX}/bin") do
+      abort "\nNo default browser is available.  Install your preferred browser, make it the default and then try again.\n".lightred unless File.exist?('x-www-browser') && File.symlink?('x-www-browser') && File.realpath('x-www-browser')
+    end
+  end
+
+  def self.build
+    File.write '10-pip_search', <<~EOF
+      alias pip='function _pip(){
+        if [ "$1" == "search" ]; then
+          if ! test $2; then
+            echo "Usage: pip search <keyword>"
+          else
+            pip_search "$2"
+          fi;
+        else pip "$@";
+        fi;
+      };_pip'
+    EOF
+    File.write 'pip_search.sh', <<~EOF
+      #!/bin/bash
+      if ! test $1; then
+        echo "Usage: pip_search <keyword>"
+        exit 1
+      fi
+      xdg-open "https://pypi.org/search/?q=$1"
+    EOF
+  end
+
+  def self.install
+    FileUtils.install 'pip_search.sh', "#{CREW_DEST_PREFIX}/bin/pip_search", mode: 0o755
+    FileUtils.install '10-pip_search', "#{CREW_DEST_PREFIX}/etc/env.d/10-pip_search", mode: 0o644
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nType 'pip search <keyword>' to find python packages.\n"
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -7350,6 +7350,11 @@ url: https://gnupg.org/ftp/gcrypt/pinentry
 activity: low
 ---
 kind: url
+name: pip_search
+url: https://github.com/chromebrew
+activity: none
+---
+kind: url
 name: pipes_sh
 url: https://github.com/pipeseroni/pipes.sh/releases
 activity: none


### PR DESCRIPTION
## Description
This package was inspired by the lack of a working way to find python packages from the command line.  The pypi.org project decided to deprecate the 'pip search' command due to ["unidentified" traffic](https://warehouse.pypa.io/api-reference/xml-rpc.html#search-spec-operator).  Needless to say, this has bothered me especially since other attempts to get a working solution have been squashed such as https://github.com/victorgarric/pip_search.  The solution here is not ideal but it was the best way I could think of to make something more convenient available.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-pip_search-package crew update \
&& yes | crew upgrade
```