### PR TITLE
Add py3_pydf package

### DIFF
--- a/manifest/armv7l/p/py3_pydf.filelist
+++ b/manifest/armv7l/p/py3_pydf.filelist
@@ -1,0 +1,9 @@
+# Total size: 23317
+/usr/local/bin/pydf
+/usr/local/lib/python3.13/site-packages/pydf-12.dist-info/INSTALLER
+/usr/local/lib/python3.13/site-packages/pydf-12.dist-info/METADATA
+/usr/local/lib/python3.13/site-packages/pydf-12.dist-info/RECORD
+/usr/local/lib/python3.13/site-packages/pydf-12.dist-info/REQUESTED
+/usr/local/lib/python3.13/site-packages/pydf-12.dist-info/WHEEL
+/usr/local/lib/python3.13/site-packages/pydf-12.dist-info/licenses/COPYING
+/usr/local/lib/python3.13/site-packages/pydf-12.dist-info/top_level.txt

--- a/manifest/i686/p/py3_pydf.filelist
+++ b/manifest/i686/p/py3_pydf.filelist
@@ -1,0 +1,9 @@
+# Total size: 23317
+/usr/local/bin/pydf
+/usr/local/lib/python3.13/site-packages/pydf-12.dist-info/INSTALLER
+/usr/local/lib/python3.13/site-packages/pydf-12.dist-info/METADATA
+/usr/local/lib/python3.13/site-packages/pydf-12.dist-info/RECORD
+/usr/local/lib/python3.13/site-packages/pydf-12.dist-info/REQUESTED
+/usr/local/lib/python3.13/site-packages/pydf-12.dist-info/WHEEL
+/usr/local/lib/python3.13/site-packages/pydf-12.dist-info/licenses/COPYING
+/usr/local/lib/python3.13/site-packages/pydf-12.dist-info/top_level.txt

--- a/manifest/x86_64/p/py3_pydf.filelist
+++ b/manifest/x86_64/p/py3_pydf.filelist
@@ -1,0 +1,9 @@
+# Total size: 23317
+/usr/local/bin/pydf
+/usr/local/lib/python3.13/site-packages/pydf-12.dist-info/INSTALLER
+/usr/local/lib/python3.13/site-packages/pydf-12.dist-info/METADATA
+/usr/local/lib/python3.13/site-packages/pydf-12.dist-info/RECORD
+/usr/local/lib/python3.13/site-packages/pydf-12.dist-info/REQUESTED
+/usr/local/lib/python3.13/site-packages/pydf-12.dist-info/WHEEL
+/usr/local/lib/python3.13/site-packages/pydf-12.dist-info/licenses/COPYING
+/usr/local/lib/python3.13/site-packages/pydf-12.dist-info/top_level.txt

--- a/packages/py3_pydf.rb
+++ b/packages/py3_pydf.rb
@@ -1,0 +1,22 @@
+require 'buildsystems/pip'
+
+class Py3_pydf < Pip
+  description 'Displays the amount of disk space available on the mounted filesystems, using different colours for different types of filesystems.'
+  homepage 'https://github.com/garabik/pydf'
+  version "12-#{CREW_PY_VER}"
+  license 'BSD-2'
+  compatibility 'all'
+  source_url 'SKIP'
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+    aarch64: '98dacc9c63ac7748a590a85f9fd262443480459ad105a0594b5658470f70056d',
+     armv7l: '98dacc9c63ac7748a590a85f9fd262443480459ad105a0594b5658470f70056d',
+       i686: '668ac069f4b08722a586116c1b09ab9fbbb2e96dae53d7c7e78864348d34c150',
+     x86_64: '736cfd6c5b6fcd8cfeca6053c09bffee0391a0b86bca63a0c27c4b4236752030'
+  })
+
+  depends_on 'python3' => :build
+
+  no_source_build
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -7730,6 +7730,11 @@ url: https://github.com/pre-commit/pre-commit/releases
 activity: medium
 ---
 kind: url
+name: py3_pydf
+url: https://github.com/garabik/pydf
+activity: none
+---
+kind: url
 name: py3_pygobject
 url: https://gitlab.gnome.org/GNOME/pygobject/-/tags
 activity: high


### PR DESCRIPTION
## Description
pydf is all-singing, all-dancing, fully colourised df(1)-clone
written in python.  See https://github.com/garabik/pydf.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-py3_pydf-package crew update \
&& yes | crew upgrade
```