### PR TITLE
Add so package

### DIFF
--- a/manifest/armv7l/s/so.filelist
+++ b/manifest/armv7l/s/so.filelist
@@ -1,0 +1,2 @@
+# Total size: 9630292
+/usr/local/bin/so

--- a/manifest/x86_64/s/so.filelist
+++ b/manifest/x86_64/s/so.filelist
@@ -1,0 +1,2 @@
+# Total size: 14150000
+/usr/local/bin/so

--- a/packages/so.rb
+++ b/packages/so.rb
@@ -1,0 +1,24 @@
+require 'package'
+
+class So < Package
+  description 'A terminal interface for Stack Overflow.'
+  homepage 'https://github.com/samtay/so'
+  version '0.4.10'
+  license 'MIT'
+  compatibility 'aarch64 armv7l x86_64'
+  min_glibc '2.28'
+  source_url({
+    aarch64: "https://github.com/samtay/so/releases/download/v#{version}/so-armv7-unknown-linux-gnueabihf.tar.gz",
+     armv7l: "https://github.com/samtay/so/releases/download/v#{version}/so-armv7-unknown-linux-gnueabihf.tar.gz",
+     x86_64: "https://github.com/samtay/so/releases/download/v#{version}/so-x86_64-unknown-linux-gnu.tar.gz"
+  })
+  source_sha256({
+    aarch64: 'f2836ef57869425d487a3d788a70ccb740c920550bdef197b5e7d0f56773d88c',
+     armv7l: 'f2836ef57869425d487a3d788a70ccb740c920550bdef197b5e7d0f56773d88c',
+     x86_64: 'b94ca89f01758dce4d763d78f5ec1b400c4e2aa64975b6d267bd635a519bcb37'
+  })
+
+  def self.install
+    FileUtils.install 'so', "#{CREW_DEST_PREFIX}/bin/so", mode: 0o755
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -8810,6 +8810,11 @@ url: https://github.com/subhra74/snowflake/releases
 activity: none
 ---
 kind: url
+name: so
+url: https://github.com/samtay/so/releases
+activity: low
+---
+kind: url
 name: socat
 url: http://www.dest-unreach.org/socat/download
 activity: none


### PR DESCRIPTION
## Description
A terminal interface for Stack Overflow.  See https://github.com/samtay/so.
```
$ so how to reverse array in ruby
<!-- language: lang-ruby --> 

a = [12,16,5,9,11,5,4]       
# => [12, 16, 5, 9, 11, 5, 4]
a.reverse                    
# => [4, 5, 11, 9, 5, 16, 12]

I'm not seeing what you're seeing.  

Edit: Expanding on what Ben noticed, you may be reversing a string.  

<!-- language: lang-ruby --> 

"12,16,5,9,11,5,4".reverse
# => "4,5,11,9,5,61,21"   

If you have to reverse a string in that manner, you should do something like the following:

<!-- language: lang-ruby --> 

"12,16,5,9,11,5,4".split(",").reverse.join(",")
# => "4,5,11,9,5,16,12"                        

Press [SPACE] to see more results, [o] to open in the browser, or any other key to exit
```
<img width="1889" height="1080" alt="image" src="https://github.com/user-attachments/assets/6bb82af0-6979-4ba7-8020-1e4c4fcf0f37" />

##
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-so-package crew update \
&& yes | crew upgrade
```