### PR TITLE
Terraform 1.12.2 => 1.13.1

### DIFF
--- a/packages/terraform.rb
+++ b/packages/terraform.rb
@@ -3,7 +3,7 @@ require 'package'
 class Terraform < Package
   description 'Terraform is a tool for building, changing, and combining infrastructure safely and efficiently.'
   homepage 'https://www.terraform.io/'
-  version '1.12.2'
+  version '1.13.1'
   license 'Apache-2.0, BSD-2, BSD-4, ECL-2.0, imagemagick, ISC, JSON, MIT, MIT-with-advertising, MPL-2.0 and unicode'
   compatibility 'all'
   source_url({
@@ -13,10 +13,10 @@ class Terraform < Package
      x86_64: "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_amd64.zip"
   })
   source_sha256({
-    aarch64: '4d5d39d57755a45b7bb6c6ad7301ac3c301eba44b647e2d0ca79c117cb817259',
-     armv7l: '4d5d39d57755a45b7bb6c6ad7301ac3c301eba44b647e2d0ca79c117cb817259',
-       i686: '73b380f262324985e911323ecc446066343ffe78add6570a122b7444b04b120b',
-     x86_64: '1eaed12ca41fcfe094da3d76a7e9aa0639ad3409c43be0103ee9f5a1ff4b7437'
+    aarch64: 'dc983c8178c8cbe174a8265c0073092deb3704f767571a1a3254927284de982f',
+     armv7l: 'dc983c8178c8cbe174a8265c0073092deb3704f767571a1a3254927284de982f',
+       i686: 'c5b006ffea002ff5080e3038c670be472a76db2626dc36dd5aca72955103ef2d',
+     x86_64: '4449e2ddc0dee283f0909dd603eaf98edeebaa950f4635cea94f2caf0ffacc5a'
   })
 
   def self.install


### PR DESCRIPTION
## Description

This commit updates the Terraform CLI from version 1.12.2 to version 1.13.1.

## Additional information
Tested & Working properly:
- [X] `x86_64`
- [X] `i686`
- [X] `armv7l` <!-- (reasons why it doesn't) -->
##
- [X] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##