### PR TITLE
Add lazygit package

### DIFF
--- a/manifest/armv7l/l/lazygit.filelist
+++ b/manifest/armv7l/l/lazygit.filelist
@@ -1,0 +1,2 @@
+# Total size: 20512952
+/usr/local/bin/lazygit

--- a/manifest/i686/l/lazygit.filelist
+++ b/manifest/i686/l/lazygit.filelist
@@ -1,0 +1,2 @@
+# Total size: 20357304
+/usr/local/bin/lazygit

--- a/manifest/x86_64/l/lazygit.filelist
+++ b/manifest/x86_64/l/lazygit.filelist
@@ -1,0 +1,2 @@
+# Total size: 21999800
+/usr/local/bin/lazygit

--- a/packages/lazygit.rb
+++ b/packages/lazygit.rb
@@ -1,0 +1,36 @@
+require 'package'
+
+class Lazygit < Package
+  description 'A simple terminal UI for git commands'
+  homepage 'https://github.com/jesseduffield/lazygit'
+  version '0.55.0'
+  license 'MIT'
+  compatibility 'all'
+  source_url({
+    aarch64: "https://github.com/jesseduffield/lazygit/releases/download/v#{version}/lazygit_#{version}_linux_armv6.tar.gz",
+     armv7l: "https://github.com/jesseduffield/lazygit/releases/download/v#{version}/lazygit_#{version}_linux_armv6.tar.gz",
+       i686: "https://github.com/jesseduffield/lazygit/releases/download/v#{version}/lazygit_#{version}_linux_32-bit.tar.gz",
+     x86_64: "https://github.com/jesseduffield/lazygit/releases/download/v#{version}/lazygit_#{version}_linux_x86_64.tar.gz"
+  })
+  source_sha256({
+    aarch64: '063948635231925b3877eaa19eda0d31fa51ad143e53feef653487030c6f2ed8',
+     armv7l: '063948635231925b3877eaa19eda0d31fa51ad143e53feef653487030c6f2ed8',
+       i686: '5c1383a58683df66ea8a5521893d0bf9a0f5f9f4593a13d2a4738d3af987b4be',
+     x86_64: 'e7c1c2d127ebdb241398f3daf05907a71a0c977ff12beba6b8ebdb069f9dba6a'
+  })
+
+  no_compile_needed
+  no_shrink
+
+  def self.install
+    FileUtils.install 'lazygit', "#{CREW_DEST_PREFIX}/bin/lazygit", mode: 0o755
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nType 'lazygit' to get started.\n"
+  end
+
+  def self.postremove
+    Package.agree_to_remove("#{HOME}/.local/state/lazygit")
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -3875,6 +3875,11 @@ url: https://www.netlib.org/lapack/
 activity: none
 ---
 kind: url
+name: lazygit
+url: https://github.com/jesseduffield/lazygit/releases
+activity: high
+---
+kind: url
 name: lcms
 url: https://sourceforge.net/projects/lcms/files/lcms/
 activity: low


### PR DESCRIPTION
## Description
A simple terminal UI for git commands.  See https://github.com/jesseduffield/lazygit.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-lazygit-package crew update \
&& yes | crew upgrade
```