### PR TITLE
Refactor and rubify write_deps in tools/getrealdeps.rb

### DIFF
--- a/tests/tools/getrealdeps.rb
+++ b/tests/tools/getrealdeps.rb
@@ -76,7 +76,6 @@ class GetRealDepsTest < Minitest::Test
     test_wrapper(input_file, expected_pkg_file, deps)
   end
 
-  # TODO: The expected output in this case could be improved.
   def test_add_multiple_dependencies_in_order
     deps = %w[libcanberra banner]
     input_file = <<~EOF
@@ -94,7 +93,8 @@ class GetRealDepsTest < Minitest::Test
 
         depends_on 'a2png'
         depends_on 'banner' # R
-        depends_on 'libcanberra' # R  depends_on 'libmaxminddb'
+        depends_on 'libcanberra' # R
+        depends_on 'libmaxminddb'
         depends_on 'lzlib'
       end
     EOF


### PR DESCRIPTION
## Description
The big refactor I've been working on.

I didn't end up using the package dependencies directly, there wasn't a ton of advantages to doing so compared to the existing method. Might swap in the future.

Drops all the exising sed/gawk logic in favor of a different sorting and placement method using ruby methods, fixes two dependencies being added on one line.

I could simplify things further if we didn't want to print as much information, but I figured I'd just stick to the current behavior for now.

Tested and working locally.
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=duper crew update \
&& yes | crew upgrade
```