### PR TITLE
Update Updater workflows, have version.rb deduplicate update list. 

### DIFF
--- a/.github/workflows/Container-Package-Updater.yml
+++ b/.github/workflows/Container-Package-Updater.yml
@@ -35,4 +35,5 @@ jobs:
         run: |
           export CORE_PACKAGES=$(ruby bin/crew deps core)
           export BUILDESSENTIAL_PACKAGES=$(ruby bin/crew deps buildessential)
+          # shellcheck disable=SC2116
           gh workflow -R chromebrew/chromebrew run Updater-on-Demand.yml -f version_cmd_input="$(echo ${CORE_PACKAGES} ${BUILDESSENTIAL_PACKAGES})"

--- a/.github/workflows/Container-Package-Updater.yml
+++ b/.github/workflows/Container-Package-Updater.yml
@@ -1,0 +1,38 @@
+---
+name: Generate Updates for Core and Buildessential Packages.
+on:
+  schedule:
+    - cron: '0 12 * * *'  # Daily
+  workflow_dispatch:
+env:
+  GH_TOKEN: ${{ secrets.CREW_PR_TOKEN }}  # setting GH_TOKEN for the entire workflow
+permissions:                    # Global permissions configuration starts here
+  actions: write
+  contents: write
+  packages: write
+  pull-requests: write          # 'write' access to pull requests
+jobs:
+  update-check:
+    if: ${{ github.repository_owner == 'chromebrew' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4.5'
+      - name: Install ruby-libversion  # Hopefully this will get added as an Ubuntu/Debian package. https://github.com/repology/libversion/issues/35
+        working-directory: ${{ runner.temp }}
+        run: |
+          git clone --depth 1 -b 3.0.3 https://github.com/repology/libversion
+          cd libversion
+          mkdir build
+          cd build
+          cmake ..
+          make -j "$(nproc)"
+          sudo make install
+          sudo gem install --no-update-sources -N ruby-libversion --conservative
+      - name: Check for updates in core and buildessential packages.
+        id: pip-update-checks
+        run: |
+          export CORE_PACKAGES=$(ruby bin/crew deps core)
+          export BUILDESSENTIAL_PACKAGES=$(ruby bin/crew deps buildessential)
+          gh workflow -R chromebrew/chromebrew run Updater-on-Demand.yml -f version_cmd_input="$(echo ${CORE_PACKAGES} ${BUILDESSENTIAL_PACKAGES})"

--- a/.github/workflows/Updater-on-Demand.yml
+++ b/.github/workflows/Updater-on-Demand.yml
@@ -51,7 +51,7 @@ jobs:
           git pull
           git stash drop || true
           echo "pwd is $(pwd)"
-          LD_LIBRARY_PATH=/usr/local/lib ruby tools/version.rb -u "${{ inputs.version_cmd_input }}"
+          LD_LIBRARY_PATH=/usr/local/lib ruby tools/version.rb -u -v "${{ inputs.version_cmd_input }}"
           for i in $(git status --porcelain | awk '{print $2}' | grep ^packages/)
           do
             git stash pop || true
@@ -71,7 +71,8 @@ jobs:
               git config advice.detachedHead false
               git checkout remotes/origin/"${updater_branch}"
               git pull origin "${updater_branch}"
-              git pull --rebase origin master; git push origin "HEAD:${updater_branch}" -f ; git pull origin "${updater_branch}"
+              # Let build workflow handle rebasing.
+              # git pull --rebase origin master; git push origin "HEAD:${updater_branch}" -f ; git pull origin "${updater_branch}"
               git stash pop || true
             else
               git checkout -b "${updater_branch}"
@@ -81,7 +82,7 @@ jobs:
             # If there are no changes, the next step will fail, but that
             # is ok.
             git commit -m "Add unbuilt ${pkg} to ${updater_branch}" || true
-            git push || true
+            git push origin "HEAD:${updater_branch}" -f || true
             gh workflow -R chromebrew/chromebrew run Build.yml -f branch="${updater_branch}"
             git stash || true
             git checkout master

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -181,6 +181,8 @@ end
 # Some packges need manual adjustments of URLS for different versions.
 unless defined?(CREW_UPDATER_EXCLUDED_PKGS)
   CREW_UPDATER_EXCLUDED_PKGS = Set[
+    { pkg_name: 'e2fsprogs', comments: 'Upstream issue: https://github.com/tytso/e2fsprogs/issues/240' },
+    { pkg_name: 'glibc', comments: 'Requires manual update' },
     { pkg_name: 'py3_ldapdomaindump', comments: 'Build is broken.' }
   ].to_h { |h| [h[:pkg_name], h[:comments]] }
 end

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -184,7 +184,8 @@ unless defined?(CREW_UPDATER_EXCLUDED_PKGS)
     { pkg_name: 'e2fsprogs', comments: 'Upstream issue: https://github.com/tytso/e2fsprogs/issues/240' },
     { pkg_name: 'glibc', comments: 'Requires manual update' },
     { pkg_name: 'py3_ldapdomaindump', comments: 'Build is broken.' },
-    { pkg_name: 'ruby', comments: 'Upstream issue: https://bugs.ruby-lang.org/issues/21607' }
+    { pkg_name: 'ruby', comments: 'Upstream issue: https://bugs.ruby-lang.org/issues/21607' },
+    { pkg_name: 'tika', comments: 'Versioning issue: https://github.com/fedora-infra/anitya/issues/1944' }
   ].to_h { |h| [h[:pkg_name], h[:comments]] }
 end
 CREW_AUTOMATIC_VERSION_UPDATE_EXCLUSION_REGEX = "(#{CREW_UPDATER_EXCLUDED_PKGS.keys.map { |p| "^#{p}$" }.join('|')})" unless defined?(CREW_AUTOMATIC_VERSION_UPDATE_EXCLUSION_REGEX)

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -183,7 +183,8 @@ unless defined?(CREW_UPDATER_EXCLUDED_PKGS)
   CREW_UPDATER_EXCLUDED_PKGS = Set[
     { pkg_name: 'e2fsprogs', comments: 'Upstream issue: https://github.com/tytso/e2fsprogs/issues/240' },
     { pkg_name: 'glibc', comments: 'Requires manual update' },
-    { pkg_name: 'py3_ldapdomaindump', comments: 'Build is broken.' }
+    { pkg_name: 'py3_ldapdomaindump', comments: 'Build is broken.' },
+    { pkg_name: 'ruby', comments: 'Upstream issue: https://bugs.ruby-lang.org/issues/21607' }
   ].to_h { |h| [h[:pkg_name], h[:comments]] }
 end
 CREW_AUTOMATIC_VERSION_UPDATE_EXCLUSION_REGEX = "(#{CREW_UPDATER_EXCLUDED_PKGS.keys.map { |p| "^#{p}$" }.join('|')})" unless defined?(CREW_AUTOMATIC_VERSION_UPDATE_EXCLUSION_REGEX)

--- a/tools/version.rb
+++ b/tools/version.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# version.rb version 2.6 (for Chromebrew)
+# version.rb version 2.7 (for Chromebrew)
 
 OPTIONS = %w[-h --help -j --json -u --update-package-files -v --verbose]
 
@@ -177,6 +177,9 @@ else
     filelist.push filename
   end
 end
+
+# Remove duplicates.
+filelist.uniq!
 
 if filelist.length.positive?
   max_pkg_name_length = File.basename(filelist.max_by(&:length)).length - 3


### PR DESCRIPTION
## Description
#### Commits:
-  97a457e54 Add tika versioning exclusion.
-  700e9c591 Add ruby to updater exclusion.
-  dadc226e7 Add updater exclusions.
-  8a1075595 Ignore shellcheck complaint.
-  c15791e93 Update Updater workflows, have version.rb deduplicate update list.
### Updated GitHub configuration files:
- .github/workflows/Container-Package-Updater.yml
- .github/workflows/Updater-on-Demand.yml
### Other changed files:
- lib/const.rb
- tools/version.rb
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=core_buildessential_automatic_updater crew update \
&& yes | crew upgrade
```
