### PR TITLE
Add Kernel 6.12 headers, and set default kernel headers to 6.12 — linux_sources → 6.12,linuxheaders → 6.11

### DIFF
--- a/lib/const.rb
+++ b/lib/const.rb
@@ -4,7 +4,7 @@ require 'etc'
 require 'open3'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.66.5' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.66.6' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]
@@ -90,7 +90,7 @@ end
 # Use sane minimal defaults if in container and no override specified.
 CREW_KERNEL_VERSION ||=
   if CREW_IN_CONTAINER && ENV.fetch('CREW_KERNEL_VERSION', nil).nil?
-    ARCH.eql?('i686') ? '3.8' : '5.10'
+    ARCH.eql?('i686') ? '3.8' : '6.12'
   else
     ENV.fetch('CREW_KERNEL_VERSION', Etc.uname[:release].rpartition('.').first)
   end

--- a/manifest/armv7l/l/linuxheaders.filelist
+++ b/manifest/armv7l/l/linuxheaders.filelist
@@ -1,3 +1,4 @@
+# Total size: 6632502
 /usr/local/include/asm-generic/auxvec.h
 /usr/local/include/asm-generic/bitsperlong.h
 /usr/local/include/asm-generic/bpf_perf_event.h
@@ -78,7 +79,6 @@
 /usr/local/include/drm/drm_mode.h
 /usr/local/include/drm/drm_sarea.h
 /usr/local/include/drm/etnaviv_drm.h
-/usr/local/include/drm/evdi_drm.h
 /usr/local/include/drm/exynos_drm.h
 /usr/local/include/drm/habanalabs_accel.h
 /usr/local/include/drm/i915_drm.h
@@ -90,6 +90,8 @@
 /usr/local/include/drm/nouveau_drm.h
 /usr/local/include/drm/omap_drm.h
 /usr/local/include/drm/panfrost_drm.h
+/usr/local/include/drm/panthor_drm.h
+/usr/local/include/drm/pvr_drm.h
 /usr/local/include/drm/qaic_accel.h
 /usr/local/include/drm/qxl_drm.h
 /usr/local/include/drm/radeon_drm.h
@@ -99,6 +101,7 @@
 /usr/local/include/drm/vgem_drm.h
 /usr/local/include/drm/virtgpu_drm.h
 /usr/local/include/drm/vmwgfx_drm.h
+/usr/local/include/drm/xe_drm.h
 /usr/local/include/linux/acct.h
 /usr/local/include/linux/acrn.h
 /usr/local/include/linux/adb.h
@@ -147,13 +150,14 @@
 /usr/local/include/linux/bcm933xx_hcs.h
 /usr/local/include/linux/bfs_fs.h
 /usr/local/include/linux/binfmts.h
+/usr/local/include/linux/bits.h
+/usr/local/include/linux/blkdev.h
 /usr/local/include/linux/blkpg.h
 /usr/local/include/linux/blktrace_api.h
 /usr/local/include/linux/blkzoned.h
 /usr/local/include/linux/bpf.h
 /usr/local/include/linux/bpf_common.h
 /usr/local/include/linux/bpf_perf_event.h
-/usr/local/include/linux/bpfilter.h
 /usr/local/include/linux/bpqether.h
 /usr/local/include/linux/bsg.h
 /usr/local/include/linux/bt-bmc.h
@@ -214,6 +218,7 @@
 /usr/local/include/linux/dma-buf.h
 /usr/local/include/linux/dma-heap.h
 /usr/local/include/linux/dns_resolver.h
+/usr/local/include/linux/dpll.h
 /usr/local/include/linux/dqblk_xfs.h
 /usr/local/include/linux/dvb/audio.h
 /usr/local/include/linux/dvb/ca.h
@@ -236,6 +241,7 @@
 /usr/local/include/linux/ethtool_netlink.h
 /usr/local/include/linux/eventfd.h
 /usr/local/include/linux/eventpoll.h
+/usr/local/include/linux/exfat.h
 /usr/local/include/linux/ext4.h
 /usr/local/include/linux/f2fs.h
 /usr/local/include/linux/fadvise.h
@@ -340,7 +346,6 @@
 /usr/local/include/linux/ioam6_genl.h
 /usr/local/include/linux/ioam6_iptunnel.h
 /usr/local/include/linux/ioctl.h
-/usr/local/include/linux/iommu.h
 /usr/local/include/linux/iommufd.h
 /usr/local/include/linux/ioprio.h
 /usr/local/include/linux/ip.h
@@ -352,7 +357,6 @@
 /usr/local/include/linux/ipmi_msgdefs.h
 /usr/local/include/linux/ipmi_ssif_bmc.h
 /usr/local/include/linux/ipsec.h
-/usr/local/include/linux/ipu-isys.h
 /usr/local/include/linux/ipu-psys.h
 /usr/local/include/linux/ipv6.h
 /usr/local/include/linux/ipv6_route.h
@@ -387,6 +391,7 @@
 /usr/local/include/linux/loadpin.h
 /usr/local/include/linux/loop.h
 /usr/local/include/linux/lp.h
+/usr/local/include/linux/lsm.h
 /usr/local/include/linux/lwtunnel.h
 /usr/local/include/linux/magic.h
 /usr/local/include/linux/major.h
@@ -398,6 +403,8 @@
 /usr/local/include/linux/mdio.h
 /usr/local/include/linux/media-bus-format.h
 /usr/local/include/linux/media.h
+/usr/local/include/linux/media/raspberrypi/pisp_be_config.h
+/usr/local/include/linux/media/raspberrypi/pisp_common.h
 /usr/local/include/linux/mei.h
 /usr/local/include/linux/mei_uuid.h
 /usr/local/include/linux/membarrier.h
@@ -414,6 +421,7 @@
 /usr/local/include/linux/mpls.h
 /usr/local/include/linux/mpls_iptunnel.h
 /usr/local/include/linux/mptcp.h
+/usr/local/include/linux/mptcp_pm.h
 /usr/local/include/linux/mqueue.h
 /usr/local/include/linux/mroute.h
 /usr/local/include/linux/mroute6.h
@@ -421,6 +429,7 @@
 /usr/local/include/linux/msdos_fs.h
 /usr/local/include/linux/msg.h
 /usr/local/include/linux/mtio.h
+/usr/local/include/linux/mtk-fd-v4l2-controls.h
 /usr/local/include/linux/nbd-netlink.h
 /usr/local/include/linux/nbd.h
 /usr/local/include/linux/ncsi.h
@@ -591,12 +600,16 @@
 /usr/local/include/linux/nfsd/debug.h
 /usr/local/include/linux/nfsd/export.h
 /usr/local/include/linux/nfsd/stats.h
+/usr/local/include/linux/nfsd_netlink.h
 /usr/local/include/linux/nilfs2_api.h
 /usr/local/include/linux/nilfs2_ondisk.h
 /usr/local/include/linux/nitro_enclaves.h
 /usr/local/include/linux/nl80211-vnd-intel.h
 /usr/local/include/linux/nl80211.h
+/usr/local/include/linux/npcm-video.h
 /usr/local/include/linux/nsfs.h
+/usr/local/include/linux/nsm.h
+/usr/local/include/linux/ntsync.h
 /usr/local/include/linux/nubus.h
 /usr/local/include/linux/nvme_ioctl.h
 /usr/local/include/linux/nvram.h
@@ -606,6 +619,7 @@
 /usr/local/include/linux/openat2.h
 /usr/local/include/linux/openvswitch.h
 /usr/local/include/linux/packet_diag.h
+/usr/local/include/linux/papr_pdsm.h
 /usr/local/include/linux/param.h
 /usr/local/include/linux/parport.h
 /usr/local/include/linux/patchkey.h
@@ -733,7 +747,6 @@
 /usr/local/include/linux/tc_act/tc_gact.h
 /usr/local/include/linux/tc_act/tc_gate.h
 /usr/local/include/linux/tc_act/tc_ife.h
-/usr/local/include/linux/tc_act/tc_ipt.h
 /usr/local/include/linux/tc_act/tc_mirred.h
 /usr/local/include/linux/tc_act/tc_mpls.h
 /usr/local/include/linux/tc_act/tc_nat.h
@@ -754,6 +767,7 @@
 /usr/local/include/linux/tee.h
 /usr/local/include/linux/termios.h
 /usr/local/include/linux/thermal.h
+/usr/local/include/linux/thp7312.h
 /usr/local/include/linux/time.h
 /usr/local/include/linux/time_types.h
 /usr/local/include/linux/timerfd.h
@@ -767,6 +781,7 @@
 /usr/local/include/linux/tls.h
 /usr/local/include/linux/toshiba.h
 /usr/local/include/linux/tps6594_pfsm.h
+/usr/local/include/linux/trace_mmap.h
 /usr/local/include/linux/tty.h
 /usr/local/include/linux/tty_flags.h
 /usr/local/include/linux/types.h
@@ -789,8 +804,8 @@
 /usr/local/include/linux/usb/ch11.h
 /usr/local/include/linux/usb/ch9.h
 /usr/local/include/linux/usb/charger.h
-/usr/local/include/linux/usb/f_accessory.h
 /usr/local/include/linux/usb/functionfs.h
+/usr/local/include/linux/usb/g_hid.h
 /usr/local/include/linux/usb/g_printer.h
 /usr/local/include/linux/usb/g_uvc.h
 /usr/local/include/linux/usb/gadgetfs.h
@@ -818,6 +833,7 @@
 /usr/local/include/linux/vdpa.h
 /usr/local/include/linux/vduse.h
 /usr/local/include/linux/version.h
+/usr/local/include/linux/vesa.h
 /usr/local/include/linux/veth.h
 /usr/local/include/linux/vfio.h
 /usr/local/include/linux/vfio_ccw.h
@@ -851,7 +867,6 @@
 /usr/local/include/linux/virtio_scsi.h
 /usr/local/include/linux/virtio_snd.h
 /usr/local/include/linux/virtio_types.h
-/usr/local/include/linux/virtio_video.h
 /usr/local/include/linux/virtio_vsock.h
 /usr/local/include/linux/virtio_wl.h
 /usr/local/include/linux/virtwl.h
@@ -877,6 +892,7 @@
 /usr/local/include/linux/zorro_ids.h
 /usr/local/include/misc/cxl.h
 /usr/local/include/misc/fastrpc.h
+/usr/local/include/misc/mrvl_cn10k_dpi.h
 /usr/local/include/misc/ocxl.h
 /usr/local/include/misc/pvpanic.h
 /usr/local/include/misc/uacce/hisi_qm.h
@@ -916,6 +932,7 @@
 /usr/local/include/rdma/rvt-abi.h
 /usr/local/include/rdma/siw-abi.h
 /usr/local/include/rdma/vmw_pvrdma-abi.h
+/usr/local/include/regulator/regulator.h
 /usr/local/include/scsi/cxlflash_ioctl.h
 /usr/local/include/scsi/fc/fc_els.h
 /usr/local/include/scsi/fc/fc_fs.h
@@ -938,6 +955,7 @@
 /usr/local/include/sound/hdspm.h
 /usr/local/include/sound/intel/avs/tokens.h
 /usr/local/include/sound/sb16_csp.h
+/usr/local/include/sound/scarlett2.h
 /usr/local/include/sound/sfnt_info.h
 /usr/local/include/sound/skl-tplg-interface.h
 /usr/local/include/sound/snd_ar_tokens.h

--- a/manifest/x86_64/l/linuxheaders.filelist
+++ b/manifest/x86_64/l/linuxheaders.filelist
@@ -1,3 +1,4 @@
+# Total size: 6797300
 /usr/local/include/asm-generic/auxvec.h
 /usr/local/include/asm-generic/bitsperlong.h
 /usr/local/include/asm-generic/bpf_perf_event.h
@@ -45,6 +46,7 @@
 /usr/local/include/asm/byteorder.h
 /usr/local/include/asm/debugreg.h
 /usr/local/include/asm/e820.h
+/usr/local/include/asm/elf.h
 /usr/local/include/asm/errno.h
 /usr/local/include/asm/fcntl.h
 /usr/local/include/asm/hw_breakpoint.h
@@ -76,6 +78,7 @@
 /usr/local/include/asm/resource.h
 /usr/local/include/asm/sembuf.h
 /usr/local/include/asm/setup.h
+/usr/local/include/asm/setup_data.h
 /usr/local/include/asm/sgx.h
 /usr/local/include/asm/shmbuf.h
 /usr/local/include/asm/sigcontext.h
@@ -106,7 +109,6 @@
 /usr/local/include/drm/drm_mode.h
 /usr/local/include/drm/drm_sarea.h
 /usr/local/include/drm/etnaviv_drm.h
-/usr/local/include/drm/evdi_drm.h
 /usr/local/include/drm/exynos_drm.h
 /usr/local/include/drm/habanalabs_accel.h
 /usr/local/include/drm/i915_drm.h
@@ -118,6 +120,8 @@
 /usr/local/include/drm/nouveau_drm.h
 /usr/local/include/drm/omap_drm.h
 /usr/local/include/drm/panfrost_drm.h
+/usr/local/include/drm/panthor_drm.h
+/usr/local/include/drm/pvr_drm.h
 /usr/local/include/drm/qaic_accel.h
 /usr/local/include/drm/qxl_drm.h
 /usr/local/include/drm/radeon_drm.h
@@ -127,6 +131,7 @@
 /usr/local/include/drm/vgem_drm.h
 /usr/local/include/drm/virtgpu_drm.h
 /usr/local/include/drm/vmwgfx_drm.h
+/usr/local/include/drm/xe_drm.h
 /usr/local/include/linux/a.out.h
 /usr/local/include/linux/acct.h
 /usr/local/include/linux/acrn.h
@@ -176,13 +181,14 @@
 /usr/local/include/linux/bcm933xx_hcs.h
 /usr/local/include/linux/bfs_fs.h
 /usr/local/include/linux/binfmts.h
+/usr/local/include/linux/bits.h
+/usr/local/include/linux/blkdev.h
 /usr/local/include/linux/blkpg.h
 /usr/local/include/linux/blktrace_api.h
 /usr/local/include/linux/blkzoned.h
 /usr/local/include/linux/bpf.h
 /usr/local/include/linux/bpf_common.h
 /usr/local/include/linux/bpf_perf_event.h
-/usr/local/include/linux/bpfilter.h
 /usr/local/include/linux/bpqether.h
 /usr/local/include/linux/bsg.h
 /usr/local/include/linux/bt-bmc.h
@@ -243,6 +249,7 @@
 /usr/local/include/linux/dma-buf.h
 /usr/local/include/linux/dma-heap.h
 /usr/local/include/linux/dns_resolver.h
+/usr/local/include/linux/dpll.h
 /usr/local/include/linux/dqblk_xfs.h
 /usr/local/include/linux/dvb/audio.h
 /usr/local/include/linux/dvb/ca.h
@@ -265,6 +272,7 @@
 /usr/local/include/linux/ethtool_netlink.h
 /usr/local/include/linux/eventfd.h
 /usr/local/include/linux/eventpoll.h
+/usr/local/include/linux/exfat.h
 /usr/local/include/linux/ext4.h
 /usr/local/include/linux/f2fs.h
 /usr/local/include/linux/fadvise.h
@@ -369,7 +377,6 @@
 /usr/local/include/linux/ioam6_genl.h
 /usr/local/include/linux/ioam6_iptunnel.h
 /usr/local/include/linux/ioctl.h
-/usr/local/include/linux/iommu.h
 /usr/local/include/linux/iommufd.h
 /usr/local/include/linux/ioprio.h
 /usr/local/include/linux/ip.h
@@ -381,7 +388,6 @@
 /usr/local/include/linux/ipmi_msgdefs.h
 /usr/local/include/linux/ipmi_ssif_bmc.h
 /usr/local/include/linux/ipsec.h
-/usr/local/include/linux/ipu-isys.h
 /usr/local/include/linux/ipu-psys.h
 /usr/local/include/linux/ipv6.h
 /usr/local/include/linux/ipv6_route.h
@@ -417,6 +423,7 @@
 /usr/local/include/linux/loadpin.h
 /usr/local/include/linux/loop.h
 /usr/local/include/linux/lp.h
+/usr/local/include/linux/lsm.h
 /usr/local/include/linux/lwtunnel.h
 /usr/local/include/linux/magic.h
 /usr/local/include/linux/major.h
@@ -428,6 +435,8 @@
 /usr/local/include/linux/mdio.h
 /usr/local/include/linux/media-bus-format.h
 /usr/local/include/linux/media.h
+/usr/local/include/linux/media/raspberrypi/pisp_be_config.h
+/usr/local/include/linux/media/raspberrypi/pisp_common.h
 /usr/local/include/linux/mei.h
 /usr/local/include/linux/mei_uuid.h
 /usr/local/include/linux/membarrier.h
@@ -444,6 +453,7 @@
 /usr/local/include/linux/mpls.h
 /usr/local/include/linux/mpls_iptunnel.h
 /usr/local/include/linux/mptcp.h
+/usr/local/include/linux/mptcp_pm.h
 /usr/local/include/linux/mqueue.h
 /usr/local/include/linux/mroute.h
 /usr/local/include/linux/mroute6.h
@@ -451,6 +461,7 @@
 /usr/local/include/linux/msdos_fs.h
 /usr/local/include/linux/msg.h
 /usr/local/include/linux/mtio.h
+/usr/local/include/linux/mtk-fd-v4l2-controls.h
 /usr/local/include/linux/nbd-netlink.h
 /usr/local/include/linux/nbd.h
 /usr/local/include/linux/ncsi.h
@@ -621,12 +632,16 @@
 /usr/local/include/linux/nfsd/debug.h
 /usr/local/include/linux/nfsd/export.h
 /usr/local/include/linux/nfsd/stats.h
+/usr/local/include/linux/nfsd_netlink.h
 /usr/local/include/linux/nilfs2_api.h
 /usr/local/include/linux/nilfs2_ondisk.h
 /usr/local/include/linux/nitro_enclaves.h
 /usr/local/include/linux/nl80211-vnd-intel.h
 /usr/local/include/linux/nl80211.h
+/usr/local/include/linux/npcm-video.h
 /usr/local/include/linux/nsfs.h
+/usr/local/include/linux/nsm.h
+/usr/local/include/linux/ntsync.h
 /usr/local/include/linux/nubus.h
 /usr/local/include/linux/nvme_ioctl.h
 /usr/local/include/linux/nvram.h
@@ -636,6 +651,7 @@
 /usr/local/include/linux/openat2.h
 /usr/local/include/linux/openvswitch.h
 /usr/local/include/linux/packet_diag.h
+/usr/local/include/linux/papr_pdsm.h
 /usr/local/include/linux/param.h
 /usr/local/include/linux/parport.h
 /usr/local/include/linux/patchkey.h
@@ -763,7 +779,6 @@
 /usr/local/include/linux/tc_act/tc_gact.h
 /usr/local/include/linux/tc_act/tc_gate.h
 /usr/local/include/linux/tc_act/tc_ife.h
-/usr/local/include/linux/tc_act/tc_ipt.h
 /usr/local/include/linux/tc_act/tc_mirred.h
 /usr/local/include/linux/tc_act/tc_mpls.h
 /usr/local/include/linux/tc_act/tc_nat.h
@@ -784,6 +799,7 @@
 /usr/local/include/linux/tee.h
 /usr/local/include/linux/termios.h
 /usr/local/include/linux/thermal.h
+/usr/local/include/linux/thp7312.h
 /usr/local/include/linux/time.h
 /usr/local/include/linux/time_types.h
 /usr/local/include/linux/timerfd.h
@@ -797,6 +813,7 @@
 /usr/local/include/linux/tls.h
 /usr/local/include/linux/toshiba.h
 /usr/local/include/linux/tps6594_pfsm.h
+/usr/local/include/linux/trace_mmap.h
 /usr/local/include/linux/tty.h
 /usr/local/include/linux/tty_flags.h
 /usr/local/include/linux/types.h
@@ -819,8 +836,8 @@
 /usr/local/include/linux/usb/ch11.h
 /usr/local/include/linux/usb/ch9.h
 /usr/local/include/linux/usb/charger.h
-/usr/local/include/linux/usb/f_accessory.h
 /usr/local/include/linux/usb/functionfs.h
+/usr/local/include/linux/usb/g_hid.h
 /usr/local/include/linux/usb/g_printer.h
 /usr/local/include/linux/usb/g_uvc.h
 /usr/local/include/linux/usb/gadgetfs.h
@@ -848,6 +865,7 @@
 /usr/local/include/linux/vdpa.h
 /usr/local/include/linux/vduse.h
 /usr/local/include/linux/version.h
+/usr/local/include/linux/vesa.h
 /usr/local/include/linux/veth.h
 /usr/local/include/linux/vfio.h
 /usr/local/include/linux/vfio_ccw.h
@@ -881,7 +899,6 @@
 /usr/local/include/linux/virtio_scsi.h
 /usr/local/include/linux/virtio_snd.h
 /usr/local/include/linux/virtio_types.h
-/usr/local/include/linux/virtio_video.h
 /usr/local/include/linux/virtio_vsock.h
 /usr/local/include/linux/virtio_wl.h
 /usr/local/include/linux/virtwl.h
@@ -907,6 +924,7 @@
 /usr/local/include/linux/zorro_ids.h
 /usr/local/include/misc/cxl.h
 /usr/local/include/misc/fastrpc.h
+/usr/local/include/misc/mrvl_cn10k_dpi.h
 /usr/local/include/misc/ocxl.h
 /usr/local/include/misc/pvpanic.h
 /usr/local/include/misc/uacce/hisi_qm.h
@@ -946,6 +964,7 @@
 /usr/local/include/rdma/rvt-abi.h
 /usr/local/include/rdma/siw-abi.h
 /usr/local/include/rdma/vmw_pvrdma-abi.h
+/usr/local/include/regulator/regulator.h
 /usr/local/include/scsi/cxlflash_ioctl.h
 /usr/local/include/scsi/fc/fc_els.h
 /usr/local/include/scsi/fc/fc_fs.h
@@ -968,6 +987,7 @@
 /usr/local/include/sound/hdspm.h
 /usr/local/include/sound/intel/avs/tokens.h
 /usr/local/include/sound/sb16_csp.h
+/usr/local/include/sound/scarlett2.h
 /usr/local/include/sound/sfnt_info.h
 /usr/local/include/sound/skl-tplg-interface.h
 /usr/local/include/sound/snd_ar_tokens.h

--- a/packages/linux_sources.rb
+++ b/packages/linux_sources.rb
@@ -3,19 +3,24 @@ require 'package'
 class Linux_sources < Package
   description 'Sources for the Linux kernel'
   homepage 'https://kernel.org/'
-  version ARCH == 'i686' ? '3.8' : '4.14-1'
+  version ARCH == 'i686' ? '3.8' : '6.12'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://chromium.googlesource.com/chromiumos/third_party/kernel.git'
   git_hashtag "chromeos-#{CREW_KERNEL_VERSION}"
-  binary_compression 'tpxz'
+  binary_compression 'tar.zst'
 
   binary_sha256({
     aarch64: 'c9b3116f83033215bf7f925a433bcea906067006d8c4c3f9747a279d729d4db0',
      armv7l: 'c9b3116f83033215bf7f925a433bcea906067006d8c4c3f9747a279d729d4db0',
-       i686: '2e8cf6b96bfb2f1f65809123696799244ac20b3a7a6b516d00d9f09a0b682266',
-     x86_64: '5dc236576f40cbf6926b4b5f9241ed7e9e3e7db8f2b26643316a2ce1f08a4a02'
+       i686: '373f8d251a78c8e8ceba8a1a9d85b0fbfe106f75a5127cfb7e3274363dc211f7',
+     x86_64: '4915d7e6b21e7467fc4bb7211f89ab216d86b3403127ab3af684f8d561aeeea9'
   })
+
+  depends_on 'binutils' # R
+  depends_on 'glibc' # R
+  depends_on 'zlib' # R
+  depends_on 'zstd' # R
 
   no_env_options
   no_fhs

--- a/packages/linux_sources.rb
+++ b/packages/linux_sources.rb
@@ -14,7 +14,14 @@ class Linux_sources < Package
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://chromium.googlesource.com/chromiumos/third_party/kernel.git'
-  git_hashtag "chromeos-#{CREW_KERNEL_VERSION}"
+  git_hashtag case ARCH
+              when 'i686'
+                'chromeos-3.8'
+              when 'armv7l'
+                'chromeos-4.14'
+              else
+                "chromeos-#{CREW_KERNEL_VERSION}"
+              end
   binary_compression 'tar.zst'
 
   binary_sha256({

--- a/packages/linux_sources.rb
+++ b/packages/linux_sources.rb
@@ -3,7 +3,14 @@ require 'package'
 class Linux_sources < Package
   description 'Sources for the Linux kernel'
   homepage 'https://kernel.org/'
-  version ARCH == 'i686' ? '3.8' : '6.12'
+  version case ARCH
+          when 'i686'
+            '3.8'
+          when 'armv7l'
+            '4.14-1'
+          else
+            '6.12'
+          end
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://chromium.googlesource.com/chromiumos/third_party/kernel.git'

--- a/packages/linuxheaders.rb
+++ b/packages/linuxheaders.rb
@@ -12,9 +12,10 @@ class Linuxheaders < Package
 
   case CREW_KERNEL_VERSION
   when '3.8'
-    binary_sha256({
-         i686: '362ab05c4f6903793560fffd33abf79e5194fb72d3d38ec1648a93c56ebf91e8'
-    })
+
+  binary_sha256({
+       i686: '362ab05c4f6903793560fffd33abf79e5194fb72d3d38ec1648a93c56ebf91e8'
+  })
   when '3.10'
     binary_sha256({
       aarch64: 'c72bd617ad3b828daffb6715461e8fd9d40770c381a3acab1a9028d5efefb141',
@@ -68,6 +69,13 @@ class Linuxheaders < Package
        armv7l: '57da5af2e1ce96222fcf0f574d5a3093c851754cccd2a7d06aa0d7cecd25a7f6',
        x86_64: '4c2271b3415bf20c3f3de7ca2687ec06749d8586bd792b7b931ce49bf1451ce4'
     })
+  when '6.12'
+
+  binary_sha256({
+    aarch64: '5c98953b23222a11d9a1a70624a95251053f24830a66fc68e7bcbdf115c1ca2f',
+     armv7l: '5c98953b23222a11d9a1a70624a95251053f24830a66fc68e7bcbdf115c1ca2f',
+     x86_64: '619f3c0156cca2f38cf8b999158f2619f1ed659908f0b0005b902f93ba2b6e6a'
+  })
   end
 
   depends_on 'rsync' => :build

--- a/packages/linuxheaders.rb
+++ b/packages/linuxheaders.rb
@@ -13,9 +13,9 @@ class Linuxheaders < Package
   case CREW_KERNEL_VERSION
   when '3.8'
 
-  binary_sha256({
-       i686: '362ab05c4f6903793560fffd33abf79e5194fb72d3d38ec1648a93c56ebf91e8'
-  })
+    binary_sha256({
+         i686: '362ab05c4f6903793560fffd33abf79e5194fb72d3d38ec1648a93c56ebf91e8'
+    })
   when '3.10'
     binary_sha256({
       aarch64: 'c72bd617ad3b828daffb6715461e8fd9d40770c381a3acab1a9028d5efefb141',
@@ -71,11 +71,11 @@ class Linuxheaders < Package
     })
   when '6.12'
 
-  binary_sha256({
-    aarch64: '5c98953b23222a11d9a1a70624a95251053f24830a66fc68e7bcbdf115c1ca2f',
-     armv7l: '5c98953b23222a11d9a1a70624a95251053f24830a66fc68e7bcbdf115c1ca2f',
-     x86_64: '619f3c0156cca2f38cf8b999158f2619f1ed659908f0b0005b902f93ba2b6e6a'
-  })
+    binary_sha256({
+      aarch64: '5c98953b23222a11d9a1a70624a95251053f24830a66fc68e7bcbdf115c1ca2f',
+       armv7l: '5c98953b23222a11d9a1a70624a95251053f24830a66fc68e7bcbdf115c1ca2f',
+       x86_64: '619f3c0156cca2f38cf8b999158f2619f1ed659908f0b0005b902f93ba2b6e6a'
+    })
   end
 
   depends_on 'rsync' => :build


### PR DESCRIPTION
## Description
- Using more recent kernel headers should help compiles not fail...
#### Commits:
-  38a49fd43 fixup hashtag logic
-  eb2b763eb Update linux_sources
-  921cc3b02 Add Kernel 6.12 headers, and set default kernel headers to 6.12
### Packages with Updated versions or Changed package files:
- `linux_sources` &rarr; 6.12
- `linuxheaders` &rarr; 6.11
##
Builds attempted for:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Other changed files:
- lib/const.rb
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=kernel_61 crew update \
&& yes | crew upgrade
```
