### PR TITLE
Brave 1.81.136 => 1.82.170

### DIFF
--- a/manifest/x86_64/b/brave.filelist
+++ b/manifest/x86_64/b/brave.filelist
@@ -1,4 +1,4 @@
-# Total size: 418934584
+# Total size: 426492321
 /usr/local/bin/brave
 /usr/local/share/brave/LICENSE
 /usr/local/share/brave/MEIPreload/manifest.json
@@ -53,9 +53,11 @@
 /usr/local/share/brave/locales/it.pak
 /usr/local/share/brave/locales/ja.pak
 /usr/local/share/brave/locales/ka.pak
+/usr/local/share/brave/locales/kk.pak
 /usr/local/share/brave/locales/km.pak
 /usr/local/share/brave/locales/kn.pak
 /usr/local/share/brave/locales/ko.pak
+/usr/local/share/brave/locales/lo.pak
 /usr/local/share/brave/locales/lt.pak
 /usr/local/share/brave/locales/lv.pak
 /usr/local/share/brave/locales/mk.pak
@@ -127,9 +129,11 @@
 /usr/local/share/brave/resources/brave_extension/_locales/it/messages.json
 /usr/local/share/brave/resources/brave_extension/_locales/ja/messages.json
 /usr/local/share/brave/resources/brave_extension/_locales/ka/messages.json
+/usr/local/share/brave/resources/brave_extension/_locales/kk/messages.json
 /usr/local/share/brave/resources/brave_extension/_locales/km/messages.json
 /usr/local/share/brave/resources/brave_extension/_locales/kn/messages.json
 /usr/local/share/brave/resources/brave_extension/_locales/ko/messages.json
+/usr/local/share/brave/resources/brave_extension/_locales/lo/messages.json
 /usr/local/share/brave/resources/brave_extension/_locales/lt/messages.json
 /usr/local/share/brave/resources/brave_extension/_locales/lv/messages.json
 /usr/local/share/brave/resources/brave_extension/_locales/mk/messages.json

--- a/packages/brave.rb
+++ b/packages/brave.rb
@@ -4,12 +4,12 @@ require 'convenience_functions'
 class Brave < Package
   description 'Next generation Brave browser for macOS, Windows, Linux, Android.'
   homepage 'https://brave.com/'
-  version '1.81.136'
+  version '1.82.170'
   license 'MPL-2'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://github.com/brave/brave-browser/releases/download/v#{version}/brave-browser-#{version}-linux-amd64.zip"
-  source_sha256 '28dcdbadbd7bfc05105df78d401be5105d20e9e23af1872fa84c4857e9f00dd0'
+  source_sha256 'f8a86484b9ca81ed559addcd6df69e80060a96f783665ab6de1c8d45a0da7747'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m139 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-brave crew update \
&& yes | crew upgrade
```