### PR TITLE
Edge 140.0.3485.54-1 => 140.0.3485.81-1

### DIFF
--- a/manifest/x86_64/e/edge.filelist
+++ b/manifest/x86_64/e/edge.filelist
@@ -1,4 +1,4 @@
-# Total size: 631959306
+# Total size: 632267608
 /usr/local/bin/edge
 /usr/local/bin/microsoft-edge
 /usr/local/bin/microsoft-edge-stable

--- a/packages/edge.rb
+++ b/packages/edge.rb
@@ -4,12 +4,12 @@ require 'convenience_functions'
 class Edge < Package
   description 'Microsoft Edge is the fast and secure browser'
   homepage 'https://www.microsoft.com/en-us/edge'
-  version '140.0.3485.54-1'
+  version '140.0.3485.81-1'
   license 'MIT'
   compatibility 'x86_64'
   min_glibc '2.29'
   source_url "https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_#{version}_amd64.deb"
-  source_sha256 '6acb1f2570b401e31ce1020585cfbcd592c9e4bb50c21498685956d427be2323'
+  source_sha256 'f065fbd1129747285a3d585f8366c1d090cb926a5cc2f64352d9722aeb014cdf'
 
   depends_on 'at_spi2_core'
   depends_on 'libcom_err'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m139 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-edge crew update \
&& yes | crew upgrade
```