### PR TITLE
Add ruby_rubocop_chromebrew to buildessential — buildessential

### DIFF
--- a/.github/workflows/Container-Package-Updater.yml
+++ b/.github/workflows/Container-Package-Updater.yml
@@ -39,6 +39,8 @@ jobs:
           set -x
           # Make crew do automatic gem installs before looking for deps.
           ruby bin/crew version
+          # Force creation of temporary device.json.
+          ruby bin/crew deps zstd_static
           export PACKAGES="$(ruby bin/crew deps core buildessential | sort -u)"
           # shellcheck disable=SC2116
           gh workflow -R chromebrew/chromebrew run Updater-on-Demand.yml -f version_cmd_input="$(echo ${PACKAGES})"

--- a/.github/workflows/Generate-PR.yml
+++ b/.github/workflows/Generate-PR.yml
@@ -447,7 +447,7 @@ jobs:
           PR_NUMBER=$(gh pr list -L 1 -s open -H ${{ inputs.branch || github.ref_name }} | cut -f1)
           PR_TITLE_INPUT="${{ inputs.pr_title }}"
           if [[ -z ${PR_TITLE_INPUT} ]]; then
-            PR_TITLE="$(git log --oneline master..${{ inputs.branch || github.ref_name }} | grep -v "Build Run on\|Package File Update Run on" | tail -n 1 | cut -c 11-)"
+            PR_TITLE="$(git log --oneline master..${{ inputs.branch || github.ref_name }} | grep -v "Merge branch 'master'\|Build Run on\|Package File Update Run on" | tail -n 1 | cut -c 11-)"
           else
             PR_TITLE="${{ inputs.pr_title }}"
           fi

--- a/packages/buildessential.rb
+++ b/packages/buildessential.rb
@@ -3,7 +3,7 @@ require 'package'
 class Buildessential < Package
   description 'A collection of tools essential to compile and build software.'
   homepage 'SKIP'
-  version '1.47'
+  version '1.48'
   license 'GPL-3+'
   compatibility 'all'
 
@@ -188,6 +188,7 @@ class Buildessential < Package
   # Add rubocop for linting packages. (This also installs the
   # rubocop config file.)
   depends_on 'ruby_rubocop'
+  depends_on 'ruby_rubocop_chromebrew'
 
   # Code quality
   depends_on 'py3_pre_commit'


### PR DESCRIPTION
## Description
#### Commits:
-  9986f63f1 Update Gen PR workflow.
-  30501eb29 Merge branch 'master' into rubocop_chromebrew_deps
-  1da1bd029 Adjust Container Package Updater workflow.
-  8ce4b8061 Add ruby_rubocop_chromebrew to buildessential
### Updated GitHub configuration files:
- .github/workflows/Container-Package-Updater.yml
- .github/workflows/Generate-PR.yml
### Packages with Updated versions or Changed package files:
- buildessential
##
Builds attempted for:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=rubocop_chromebrew_deps crew update \
&& yes | crew upgrade
```
