### PR TITLE
Add nnn package

### DIFF
--- a/manifest/armv7l/n/nnn.filelist
+++ b/manifest/armv7l/n/nnn.filelist
@@ -1,0 +1,3 @@
+# Total size: 129489
+/usr/local/bin/nnn
+/usr/local/share/man/man1/nnn.1.zst

--- a/manifest/i686/n/nnn.filelist
+++ b/manifest/i686/n/nnn.filelist
@@ -1,0 +1,3 @@
+# Total size: 141129
+/usr/local/bin/nnn
+/usr/local/share/man/man1/nnn.1.zst

--- a/manifest/x86_64/n/nnn.filelist
+++ b/manifest/x86_64/n/nnn.filelist
@@ -1,0 +1,3 @@
+# Total size: 129461
+/usr/local/bin/nnn
+/usr/local/share/man/man1/nnn.1.zst

--- a/packages/nnn.rb
+++ b/packages/nnn.rb
@@ -1,0 +1,28 @@
+require 'package'
+
+class Nnn < Package
+  description 'Full-featured terminal file manager.'
+  homepage 'https://github.com/jarun/nnn'
+  version '5.1'
+  license 'BSD-2 Clause'
+  compatibility 'all'
+  source_url 'https://github.com/jarun/nnn.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+    aarch64: '000ba1399d70d6c9de8950cfe53b4d2f42c57d3b95262f85a8b44f8be8b28d4c',
+     armv7l: '000ba1399d70d6c9de8950cfe53b4d2f42c57d3b95262f85a8b44f8be8b28d4c',
+       i686: '17ed25fdf556d13f1665460b45175a764692864f9e67e56bff6be3a4330cfd1c',
+     x86_64: 'd1d9634870b1a13101a6832ae34d8be09c434e3550594d9cdfde5f738760103d'
+  })
+
+  depends_on 'glibc' # R
+  depends_on 'ncurses' # R
+  depends_on 'pkg_config' => :build
+  depends_on 'readline' # R
+
+  def self.install
+    system 'make', "PREFIX=#{CREW_PREFIX}", "DESTDIR=#{CREW_DEST_DIR}", 'install'
+  end
+end

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -6525,6 +6525,11 @@ url: https://sourceforge.net/projects/nmon/files/
 activity: none
 ---
 kind: url
+name: nnn
+url: https://github.com/jarun/nnn/releases
+activity: low
+---
+kind: url
 name: nocodb
 url: https://github.com/nocodb/nocodb/releases
 activity: medium


### PR DESCRIPTION
## Description
nnn (n³) is a full-featured terminal file manager. It's tiny, nearly 0-config and [incredibly fast](https://github.com/jarun/nnn/wiki/Performance).

It is designed to be unobtrusive with smart workflows to match the trains of thought.

nnn can analyze disk usage, batch rename, launch apps and pick files. The plugin repository has tons of plugins to extend the capabilities further e.g. [live previews](https://github.com/jarun/nnn/wiki/Live-previews), (un)mount disks, find & list, file/dir diff, upload files. A [patch framework](https://github.com/jarun/nnn/tree/master/patches) hosts sizable user-submitted patches which are subjective in nature.

Independent (neo)vim plugins - [nnn.vim](https://github.com/mcchrish/nnn.vim), [vim-floaterm nnn wrapper](https://github.com/voldikss/vim-floaterm#nnn) and [nnn.nvim](https://github.com/luukvbaal/nnn.nvim) (neovim exclusive).

Runs on the Pi, [Termux](https://www.youtube.com/embed/AbaauM7gUJw) (Android), Linux, macOS, BSD, Haiku, Cygwin, WSL, across DEs or a strictly CLI env.

See https://github.com/jarun/nnn.
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=add-nnn-package crew update \
&& yes | crew upgrade
```
