### PR TITLE
Audacity 3.7.4 => 3.7.5

### DIFF
--- a/manifest/x86_64/a/audacity.filelist
+++ b/manifest/x86_64/a/audacity.filelist
@@ -1,3 +1,4 @@
+# Total size: 384845654
 /usr/local/bin/audacity
 /usr/local/share/applications/audacity-url-handler.desktop
 /usr/local/share/applications/audacity.desktop
@@ -8,6 +9,7 @@
 /usr/local/share/audacity/apprun-hooks/install-url-handler.sh
 /usr/local/share/audacity/apprun-hooks/linuxdeploy-plugin-gtk.sh
 /usr/local/share/audacity/apprun-hooks/setup-gtk2-theme.sh
+/usr/local/share/audacity/audacity-url-handler.desktop
 /usr/local/share/audacity/audacity.desktop
 /usr/local/share/audacity/audacity.png
 /usr/local/share/audacity/audacity.sh

--- a/packages/audacity.rb
+++ b/packages/audacity.rb
@@ -3,12 +3,12 @@ require 'package'
 class Audacity < Package
   description "Audacity is the world's most popular audio editing and recording app"
   homepage 'https://www.audacityteam.org/'
-  version '3.7.4'
+  version '3.7.5'
   license 'GPL-3'
   compatibility 'x86_64'
   min_glibc '2.30'
   source_url "https://github.com/audacity/audacity/releases/download/Audacity-#{version}/audacity-linux-#{version}-x64-22.04.AppImage"
-  source_sha256 '378b25113a243e3c1e4207989444174796fbbd9c2e6fa673ed59213a2882a386'
+  source_sha256 'aa092571e6447b3e82d8cf6b9e31ee4907581e4925b791f49c8563e1cfa93716'
 
   depends_on 'gtk3'
   depends_on 'libthai'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m139 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-audacity crew update \
&& yes | crew upgrade
```