### PR TITLE
pkgconf — pkgconf → 2.5.1-1

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -71,8 +71,9 @@ jobs:
             git config user.name "${{ github.actor }}"
             git config user.email "${{ github.actor }}@users.noreply.github.com"
             # git pull --rebase origin master
+            git fetch origin
             git pull
-            git rebase -X master ${{ inputs.branch || github.ref_name }}
+            git rebase -X theirs origin/master
             git push --force-with-lease
       - name: Set Timestamp
         id: set-timestamp

--- a/.github/workflows/Generate-PR.yml
+++ b/.github/workflows/Generate-PR.yml
@@ -73,8 +73,9 @@ jobs:
             git config user.email "${{ github.actor }}@users.noreply.github.com"
             # git pull --rebase origin master
             # git push -f
+            git fetch origin
             git pull
-            git rebase -X master ${{ inputs.branch || github.ref_name }}
+            git rebase -X theirs origin/master
             git push --force-with-lease
       - name: Get changed files
         id: changed-files
@@ -342,7 +343,7 @@ jobs:
             if [[ ${REBASE} == 'true' ]]; then
               git reset --hard "origin/${{ inputs.branch || github.ref_name }}"
               git pull
-              git rebase -X master ${{ inputs.branch || github.ref_name }}
+              git rebase -X theirs origin/master
               git push --force-with-lease
               #  git pull --rebase origin master && git push -f
             fi

--- a/manifest/armv7l/p/pkgconf.filelist
+++ b/manifest/armv7l/p/pkgconf.filelist
@@ -1,6 +1,7 @@
-# Total size: 173938
+# Total size: 172003
 /usr/local/bin/bomtool
 /usr/local/bin/pkgconf
+/usr/local/etc/env.d/pkgconf
 /usr/local/include/pkgconf/libpkgconf/bsdstubs.h
 /usr/local/include/pkgconf/libpkgconf/iter.h
 /usr/local/include/pkgconf/libpkgconf/libpkgconf-api.h

--- a/manifest/i686/p/pkgconf.filelist
+++ b/manifest/i686/p/pkgconf.filelist
@@ -1,6 +1,7 @@
-# Total size: 235218
+# Total size: 219639
 /usr/local/bin/bomtool
 /usr/local/bin/pkgconf
+/usr/local/etc/env.d/pkgconf
 /usr/local/include/pkgconf/libpkgconf/bsdstubs.h
 /usr/local/include/pkgconf/libpkgconf/iter.h
 /usr/local/include/pkgconf/libpkgconf/libpkgconf-api.h

--- a/manifest/x86_64/c/codon.filelist
+++ b/manifest/x86_64/c/codon.filelist
@@ -1,4 +1,4 @@
-# Total size: 224524121
+# Total size: 199976806
 /usr/local/bin/codon
 /usr/local/include/codon/cir/analyze/analysis.h
 /usr/local/include/codon/cir/analyze/dataflow/capture.h

--- a/manifest/x86_64/c/codon.filelist
+++ b/manifest/x86_64/c/codon.filelist
@@ -1,4 +1,4 @@
-# Total size: 199976806
+# Total size: 224524121
 /usr/local/bin/codon
 /usr/local/include/codon/cir/analyze/analysis.h
 /usr/local/include/codon/cir/analyze/dataflow/capture.h

--- a/manifest/x86_64/p/pkgconf.filelist
+++ b/manifest/x86_64/p/pkgconf.filelist
@@ -1,6 +1,7 @@
-# Total size: 226964
+# Total size: 211757
 /usr/local/bin/bomtool
 /usr/local/bin/pkgconf
+/usr/local/etc/env.d/pkgconf
 /usr/local/include/pkgconf/libpkgconf/bsdstubs.h
 /usr/local/include/pkgconf/libpkgconf/iter.h
 /usr/local/include/pkgconf/libpkgconf/libpkgconf-api.h

--- a/packages/pkgconf.rb
+++ b/packages/pkgconf.rb
@@ -12,10 +12,10 @@ class Pkgconf < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '8717887d196af6b2970b542d59196625997af8d0c13732ca3a5dbb6ed2684f42',
-     armv7l: '8717887d196af6b2970b542d59196625997af8d0c13732ca3a5dbb6ed2684f42',
-       i686: 'dabeea4374873f88ec064d40375584d7d311039ed167dc1b221b7e0c53e44a54',
-     x86_64: 'ae962bd24c03bdebde15e8a2fefb185ab6e0b0e5ab5f76c59d092e6d1beee721'
+    aarch64: 'a7ca43d7d547b706cf03994e13bf2f8a10148ba5ee5f6d485222a9da7abe4b57',
+     armv7l: 'a7ca43d7d547b706cf03994e13bf2f8a10148ba5ee5f6d485222a9da7abe4b57',
+       i686: 'beefb30f039587728478b065e675ea6e13156d452a26cba49ab8ce91ec77ccb5',
+     x86_64: '7fab7668f18dde6e0eaadf5261e392002ca8ccec61f9223e3d7fd22c1060d750'
   })
 
   depends_on 'gcc_lib' # R

--- a/packages/pkgconf.rb
+++ b/packages/pkgconf.rb
@@ -3,11 +3,11 @@ require 'buildsystems/meson'
 class Pkgconf < Meson
   description 'Package compiler and linker metadata toolkit'
   homepage 'https://github.com/pkgconf/pkgconf'
-  version '2.5.1'
+  version '2.5.1-1'
   license 'ISC'
   compatibility 'all'
   source_url 'https://github.com/pkgconf/pkgconf.git'
-  git_hashtag "pkgconf-#{version}"
+  git_hashtag "pkgconf-#{version.split('-').first}"
   source_sha256 '6a181e0bf1195e95b7cd535a1854827aedb383b26b1fc24ca13586cb5e8e55af'
   binary_compression 'tar.zst'
 
@@ -29,4 +29,11 @@ class Pkgconf < Meson
   meson_options "-Dtests=disabled \
     -Dwith-system-libdir=#{CREW_LIB_PREFIX} \
     -Dwith-system-includedir=#{CREW_PREFIX}/include"
+
+  meson_install_extras do
+    File.write 'pkgconf_envd', <<~PKGCONFEOF
+      export PKG_CONFIG=#{CREW_PREFIX}/bin/pkgconf
+    PKGCONFEOF
+    FileUtils.install 'pkgconf_envd', "#{CREW_DEST_PREFIX}/etc/env.d/pkgconf", mode: 0o644
+  end
 end


### PR DESCRIPTION
## Description
#### Commits:
-  2dc87a53a Fix rebase commands in workflows.
-  9524a46ea pkgconf: rebuild with env.d file
### Updated GitHub configuration files:
- .github/workflows/Build.yml
- .github/workflows/Generate-PR.yml
### Packages with Updated versions or Changed package files:
- `pkgconf` &rarr; 2.5.1-1 (current version is 2.5.1)
##
Builds attempted for:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=pkgconf crew update \
&& yes | crew upgrade
```
