### PR TITLE
Google_chrome 140.0.7339.185-1 => 140.0.7339.207-1

### DIFF
--- a/manifest/x86_64/g/google_chrome.filelist
+++ b/manifest/x86_64/g/google_chrome.filelist
@@ -1,4 +1,4 @@
-# Total size: 395751783
+# Total size: 395019340
 /usr/local/bin/google-chrome
 /usr/local/share/appdata/google-chrome.appdata.xml
 /usr/local/share/applications/com.google.Chrome.desktop

--- a/packages/google_chrome.rb
+++ b/packages/google_chrome.rb
@@ -3,12 +3,12 @@ require 'package'
 class Google_chrome < Package
   description 'Google Chrome is a fast, easy to use, and secure web browser.'
   homepage 'https://www.google.com/chrome/'
-  version '140.0.7339.185-1'
+  version '140.0.7339.207-1'
   license 'google-chrome'
   compatibility 'x86_64'
 
   source_url "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_#{version}_amd64.deb"
-  source_sha256 '70f01b0d57afaffbed0702e7f9b70f9901cd7cbae1f8e830deb0ca579a700763'
+  source_sha256 'e60d2df8410925e22d8ea2a24e9a79a84fdb9062a4c6f3af2dac61e630833ecb'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m139 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-google_chrome crew update \
&& yes | crew upgrade
```