### PR TITLE
zotero => 7.0.24 — zotero → 7.0.24

### DIFF
--- a/manifest/x86_64/z/zotero.filelist
+++ b/manifest/x86_64/z/zotero.filelist
@@ -1,3 +1,4 @@
+# Total size: 223767930
 /usr/local/bin/zotero
 /usr/local/share/applications/zotero.desktop
 /usr/local/share/fonts/TwemojiMozilla.ttf

--- a/packages/zotero.rb
+++ b/packages/zotero.rb
@@ -3,11 +3,11 @@ require 'package'
 class Zotero < Package
   description 'Zotero is a free, easy-to-use tool to help you collect, organize, annotate, cite, and share research.'
   homepage 'https://www.zotero.org/'
-  version '7.0.25'
+  version '7.0.24'
   license 'GPL-3'
   compatibility 'x86_64'
   source_url "https://download.zotero.org/client/release/#{version}/Zotero-#{version}_linux-x86_64.tar.bz2"
-  source_sha256 '3f98aebf6ed9aa637e8ec15c1417358f60e6164943a3ce2452ddf9354b8ca891'
+  source_sha256 'a9b78cb2ba163d29036ee7ec8b7c88ebae4370a3fbf5255d74949069ddb5d6a0'
 
   depends_on 'dbus_glib'
   depends_on 'gtk3'


### PR DESCRIPTION
## Description
#### Commits:
-  45fd5a208 Update version.rb to check if new source_url exists.
-  d9ef575a6 zotero => 7.0.24
### Packages with Updated versions or Changed package files:
- `zotero` &rarr; 7.0.24 (current version is 7.0.25)
##
Builds attempted for:
- [x] `x86_64`
### Other changed files:
- tools/version.rb
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=zotero_7.0.24 crew update \
&& yes | crew upgrade
```
