### PR TITLE
Fix distribution mapping checking in tools/version.rb

### DIFF
--- a/tools/version.rb
+++ b/tools/version.rb
@@ -116,9 +116,10 @@ def get_anitya_id(name, homepage)
     return if json2['total_items'].zero?
 
     (0..(json2['total_items'] - 1)).each do |i|
-      # Sometimes we use versions from other distributions, e.g., libdb
-      # versioning comes from Fedora.
-      # next unless json2['items'][i]['distribution'] == 'Chromebrew'
+      # If it has it under a different name, make sure that is the Chromebrew mapping, and not some other distribution,
+      # because that could lead to overmatching.
+      next unless json2['items'][i]['distribution'] == 'Chromebrew'
+
       return get_anitya_id(json2['items'][i]['project'], homepage) if json2['items'][i]['name'] == name.tr('-', '_')
     end
   else # Anitya has more than one package with this exact name.


### PR DESCRIPTION
The risk of overmatching here is much too high, hence why I originally added this check in the first place.

If we need a package to have a Chromebrew distribution mapping, we can just add it: 
<img width="657" height="401" alt="image" src="https://github.com/user-attachments/assets/99cd5b13-fd5d-463d-958b-764977051964" />

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/Zopolis4/chromebrew.git CREW_BRANCH=sigh crew update \
&& yes | crew upgrade
```
