### PR TITLE
Google_chrome 140.0.7339.207-1 => 141.0.7390.54-1

### DIFF
--- a/manifest/x86_64/g/google_chrome.filelist
+++ b/manifest/x86_64/g/google_chrome.filelist
@@ -1,4 +1,4 @@
-# Total size: 395019340
+# Total size: 396749046
 /usr/local/bin/google-chrome
 /usr/local/share/appdata/google-chrome.appdata.xml
 /usr/local/share/applications/com.google.Chrome.desktop
@@ -254,7 +254,6 @@
 /usr/local/share/chrome/product_logo_24.png
 /usr/local/share/chrome/product_logo_256.png
 /usr/local/share/chrome/product_logo_32.png
-/usr/local/share/chrome/product_logo_32.xpm
 /usr/local/share/chrome/product_logo_48.png
 /usr/local/share/chrome/product_logo_64.png
 /usr/local/share/chrome/resources.pak
@@ -266,4 +265,3 @@
 /usr/local/share/gnome-control-center/default-apps/google-chrome.xml
 /usr/local/share/man/man1/google-chrome-stable.1.zst
 /usr/local/share/man/man1/google-chrome.1.zst
-/usr/local/share/menu/google-chrome.menu

--- a/packages/google_chrome.rb
+++ b/packages/google_chrome.rb
@@ -3,12 +3,12 @@ require 'package'
 class Google_chrome < Package
   description 'Google Chrome is a fast, easy to use, and secure web browser.'
   homepage 'https://www.google.com/chrome/'
-  version '140.0.7339.207-1'
+  version '141.0.7390.54-1'
   license 'google-chrome'
   compatibility 'x86_64'
 
   source_url "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_#{version}_amd64.deb"
-  source_sha256 'e60d2df8410925e22d8ea2a24e9a79a84fdb9062a4c6f3af2dac61e630833ecb'
+  source_sha256 'bc93077f020f7fe68cdee8f7525606a3f6314deacd2eb568b8a34d140a46978f'
 
   no_compile_needed
   no_shrink


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64` Unable to launch in hatch m140 container
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/uberhacker/chromebrew.git CREW_BRANCH=update-google_chrome crew update \
&& yes | crew upgrade
```