### PR TITLE
Use deb_version gem in lieu of ruby-libversion, avoiding external library. 

### DIFF
--- a/.github/workflows/Container-Package-Updater.yml
+++ b/.github/workflows/Container-Package-Updater.yml
@@ -2,7 +2,7 @@
 name: Generate Updates for Core and Buildessential Packages.
 on:
   schedule:
-    - cron: '0 12 * * *'  # Daily
+    - cron: '0 8 * * *'  # Daily
   workflow_dispatch:
 env:
   GH_TOKEN: ${{ secrets.CREW_PR_TOKEN }}  # setting GH_TOKEN for the entire workflow
@@ -19,28 +19,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: true
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.4.5'
-      - name: Install ruby-libversion  # Hopefully this will get added as an Ubuntu/Debian package. https://github.com/repology/libversion/issues/35
-        working-directory: ${{ runner.temp }}
-        run: |
-          git clone --depth 1 -b 3.0.3 https://github.com/repology/libversion
-          cd libversion
-          mkdir build
-          cd build
-          cmake ..
-          make -j "$(nproc)"
-          sudo make install
-          sudo gem install --no-update-sources -N ruby-libversion --conservative
       - name: Check for updates in core and buildessential packages.
-        id: pip-update-checks
+        id: trigger-update-checks
         run: |
-          set -x
-          # Make crew do automatic gem installs before looking for deps.
-          ruby bin/crew version
-          # Force creation of temporary device.json.
-          ruby bin/crew deps zstd_static
-          export PACKAGES="$(ruby bin/crew deps core buildessential | sort -u)"
           # shellcheck disable=SC2116
-          gh workflow -R chromebrew/chromebrew run Updater-on-Demand.yml -f version_cmd_input="$(echo ${PACKAGES})"
+          gh workflow -R chromebrew/chromebrew run Package-Dependencies-Updater.yml -f version_cmd_input="core buildessential"

--- a/.github/workflows/Generate-PR.yml
+++ b/.github/workflows/Generate-PR.yml
@@ -339,17 +339,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
           ref: ${{ inputs.branch || github.ref_name }}
-      - name: Install ruby-libversion  # Hopefully this will get added as an Ubuntu/Debian package. https://github.com/repology/libversion/issues/35
-        working-directory: ${{ runner.temp }}
-        run: |
-          git clone --depth 1 -b 3.0.3 https://github.com/repology/libversion
-          cd libversion
-          mkdir build
-          cd build
-          cmake ..
-          make -j "$(nproc)"
-          sudo make install
-          sudo gem install ruby-libversion
       - name: Save git log
         id: save-git-log
         env:
@@ -389,6 +378,18 @@ jobs:
               - '!manifest/**'
               - '!packages/*.rb'
               - '!.github/**'
+      - name: Get Changed Packages
+        id: changed-packages
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.packages }}
+        run: |
+            if [[ -n "${CHANGED_FILES}" ]]; then
+              # Convert "packages/foo.rb packages/bar.rb" (from steps.changed-files.outputs.packages_all_changed_files) into "foo bar"
+              echo "CHANGED_PACKAGES=$(echo "${CHANGED_FILES}" | xargs basename -s .rb | xargs)" >> "$GITHUB_ENV"
+              echo "CHANGED_PACKAGES=$(echo "${CHANGED_FILES}" | xargs basename -s .rb | xargs)" >> "$GITHUB_OUTPUT"
+            else
+              echo "No Changed Files."
+            fi
       - name: Get GH Token
         id: get_workflow_token
         uses: peter-murray/workflow-application-token-action@v4
@@ -402,7 +403,7 @@ jobs:
           CHANGED_GITHUB_CONFIG_FILES: ${{ steps.changed-files.outputs.github_all_changed_files }}
           CHANGED_MANIFEST_FILES: ${{ steps.changed-files.outputs.manifest_all_changed_files }}
           CHANGED_OTHER_FILES: ${{ steps.changed-files.outputs.other_all_changed_files }}
-          CHANGED_PACKAGES: ${{ needs.setup.outputs.changed_packages }}
+          # CHANGED_PACKAGES: ${{ needs.setup.outputs.changed_packages }}
           CREW_BRANCH: ${{ inputs.branch || github.ref_name }}
           DRAFT_PR: ${{ inputs.draft_pr }}
           GH_TOKEN: ${{ steps.get_workflow_token.outputs.token }}

--- a/.github/workflows/Package-Dependencies-Updater.yml
+++ b/.github/workflows/Package-Dependencies-Updater.yml
@@ -1,0 +1,47 @@
+---
+name: Generate Updates for Packages and Their Dependencies.
+on:
+  workflow_dispatch:
+    inputs:
+      version_cmd_input:
+        description: "Packages to check for dependency tree updates."
+        required: true
+env:
+  GH_TOKEN: ${{ secrets.CREW_PR_TOKEN }}  # setting GH_TOKEN for the entire workflow
+permissions:                    # Global permissions configuration starts here
+  actions: write
+  contents: write
+  packages: write
+  pull-requests: write          # 'write' access to pull requests
+jobs:
+  update-check:
+    if: ${{ github.repository_owner == 'chromebrew' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4.5'
+      - name: Check for updates in core and buildessential packages.
+        id: trigger-update-checks
+        run: |
+          set -x
+          # Make crew do automatic gem installs before looking for deps.
+          ruby bin/crew version
+          # Force creation of temporary device.json.
+          ruby bin/crew deps zstd_static
+          # Make sure input matches packages in existing packages list.
+          export INPUT="${{ inputs.version_cmd_input }}"
+          # shellcheck disable=SC2046,SC2155
+          export INPUT_PACKAGES="$(comm -12  <(ruby bin/crew list available| sort -u) <(echo $INPUT | tr ' ' '\n'| sort -u))"
+          if [[ -n "${INPUT_PACKAGES}" ]]; then
+            # shellcheck disable=SC2086,SC2155
+            export PACKAGES="$(ruby bin/crew deps $INPUT_PACKAGES | sort -u)"
+          else
+            echo "No valid input packages found."
+            exit 1
+          fi
+          # shellcheck disable=SC2086,SC2116
+          gh workflow -R chromebrew/chromebrew run Updater-on-Demand.yml -f version_cmd_input="$(echo ${PACKAGES})"

--- a/.github/workflows/Updater-on-Demand.yml
+++ b/.github/workflows/Updater-on-Demand.yml
@@ -33,17 +33,6 @@ jobs:
           git config --global push.autoSetupRemote true
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
-      - name: Install ruby-libversion  # Hopefully this will get added as an Ubuntu/Debian package. https://github.com/repology/libversion/issues/35
-        working-directory: ${{ runner.temp }}
-        run: |
-          git clone --depth 1 -b 3.0.3 https://github.com/repology/libversion
-          cd libversion
-          mkdir build
-          cd build
-          cmake ..
-          make -j "$(nproc)"
-          sudo make install
-          sudo gem install --no-update-sources -N ruby-libversion --conservative
       - name: Check for updates.
         id: update-checks
         run: |

--- a/tools/version.rb
+++ b/tools/version.rb
@@ -32,7 +32,7 @@ require File.join(crew_local_repo_root, 'lib/package')
 require File.join(crew_local_repo_root, 'lib/package_utils')
 require File.join(crew_local_repo_root, 'lib/require_gem')
 require_gem('cgi')
-require_gem 'ruby-libversion', 'ruby_libversion'
+require_gem('deb_version')
 require_gem('ptools')
 
 # Add >LOCAL< lib to LOAD_PATH
@@ -287,8 +287,8 @@ if filelist.length.positive?
     versions_updated[@pkg.name.to_sym] = 'Not Found.' if upstream_version.nil? || upstream_version.to_s.chomp == 'null'
 
     unless upstream_version.nil?
-      versions_updated[@pkg.name.to_sym] = 'Up to date.' if (Libversion.version_compare2(PackageUtils.get_clean_version(@pkg.version), upstream_version) >= 0) && versions_updated[@pkg.name.to_sym] != 'Not Found.'
-      if Libversion.version_compare2(PackageUtils.get_clean_version(@pkg.version), upstream_version) == -1
+      versions_updated[@pkg.name.to_sym] = 'Up to date.' if (DebVersion.new(PackageUtils.get_clean_version(@pkg.version)) >= DebVersion.new(upstream_version)) && versions_updated[@pkg.name.to_sym] != 'Not Found.'
+      if DebVersion.new(PackageUtils.get_clean_version(@pkg.version)) < DebVersion.new(upstream_version)
         if UPDATE_PACKAGE_FILES && !@pkg.name[/#{CREW_AUTOMATIC_VERSION_UPDATE_EXCLUSION_REGEX}/] && updatable_pkg[@pkg.name.to_sym] == 'Yes'
           file = File.read(filename)
           FileUtils.cp filename, "#{filename}.bak"


### PR DESCRIPTION
## Description
- This avoids the use of the external `libversion` library, which needs to be compiled and installed external to crew for `tools/version.rb` to work.
#### Commits:
-  26bfec551 Adjust workflows to remove libversion build requirement.
-  e08a64b05 Use deb_version gem in lieu of ruby-libversion, avoiding external library.
### Updated GitHub configuration files:
- .github/workflows/Generate-PR.yml
- .github/workflows/Updater-on-Demand.yml
### Other changed files:
- tools/version.rb
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=use_deb_version crew update \
&& yes | crew upgrade
```
