### PR TITLE
Add crew version <name> command to get versions of packages. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Where available commands are:
 | upgrade             | update all or specific package(s) |
 | upload              | upload binaries for all or specific package(s) |
 | upstream            | check if an upstream version is available for package(s) |
+| version             | check for the Chromebrew version, or if a package is specified, the package version |
 | whatprovides        | regex search for package(s) that contains file(s) |
 
 Available packages are listed in the [packages directory](https://github.com/chromebrew/chromebrew/tree/master/packages).

--- a/bin/crew
+++ b/bin/crew
@@ -46,7 +46,7 @@ begin
 rescue Docopt::Exit => e
   if ARGV[0]
     case ARGV[0]
-    when '-V', '--version', 'version'
+    when '-V', '--version'
       puts CREW_VERSION
       exit 0
     when '-L', '--license', 'license'
@@ -2041,6 +2041,18 @@ def upstream_command(args)
   args = { '<name>' => args.split } if args.is_a? String
   Dir.chdir CREW_PACKAGES_PATH do
     system "../tools/version.rb #{args['<name>'].join(' ').gsub('.rb', '')} #{@json} #{@update} #{@short_verbose}"
+  end
+end
+
+def version_command(args)
+  args = { '<name>' => args.split } if args.is_a? String
+  if args['<name>'].empty?
+    puts CREW_VERSION
+  else
+    args['<name>'].each do |name|
+      search name
+      puts @pkg.version
+    end
   end
 end
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -4,7 +4,7 @@ require 'etc'
 require 'open3'
 
 OLD_CREW_VERSION ||= defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION ||= '1.67.3' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION ||= '1.67.4' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH ||= Etc.uname[:machine]

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -465,6 +465,7 @@ CREW_DOCOPT ||= <<~DOCOPT
     crew upgrade [options] [-f|--force] [-k|--keep] [-s|--source] [-v|--verbose] [<name> ...]
     crew upload [options] [-f|--force] [-v|--verbose] [<name> ...]
     crew upstream [options] [-j|--json|-u|--update-package-files|-v|--verbose] <name> ...
+    crew version [options] [<name>]
     crew whatprovides [options] <pattern> ...
 
     -b --include-build-deps    Include build dependencies in output.


### PR DESCRIPTION
## Description
#### Commits:
-  bd691b073 Add crew version <name> command to get versions of packages.
### Other changed files:
- bin/crew
- lib/const.rb
- tools/version.rb
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=crew_version crew update \
&& yes | crew upgrade
```
