### PR TITLE
Move multiple package update check into single workflow. 

### DIFF
--- a/.github/workflows/Container-Package-Updater.yml
+++ b/.github/workflows/Container-Package-Updater.yml
@@ -2,7 +2,7 @@
 name: Generate Updates for Core and Buildessential Packages.
 on:
   schedule:
-    - cron: '0 12 * * *'  # Daily
+    - cron: '0 8 * * *'  # Daily
   workflow_dispatch:
 env:
   GH_TOKEN: ${{ secrets.CREW_PR_TOKEN }}  # setting GH_TOKEN for the entire workflow
@@ -19,28 +19,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: true
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.4.5'
-      - name: Install ruby-libversion  # Hopefully this will get added as an Ubuntu/Debian package. https://github.com/repology/libversion/issues/35
-        working-directory: ${{ runner.temp }}
-        run: |
-          git clone --depth 1 -b 3.0.3 https://github.com/repology/libversion
-          cd libversion
-          mkdir build
-          cd build
-          cmake ..
-          make -j "$(nproc)"
-          sudo make install
-          sudo gem install --no-update-sources -N ruby-libversion --conservative
       - name: Check for updates in core and buildessential packages.
-        id: pip-update-checks
+        id: trigger-update-checks
         run: |
-          set -x
-          # Make crew do automatic gem installs before looking for deps.
-          ruby bin/crew version
-          # Force creation of temporary device.json.
-          ruby bin/crew deps zstd_static
-          export PACKAGES="$(ruby bin/crew deps core buildessential | sort -u)"
           # shellcheck disable=SC2116
-          gh workflow -R chromebrew/chromebrew run Updater-on-Demand.yml -f version_cmd_input="$(echo ${PACKAGES})"
+          gh workflow -R chromebrew/chromebrew run Package-Dependencies-Updater.yml -f version_cmd_input="core buildessential"

--- a/.github/workflows/Generate-PR.yml
+++ b/.github/workflows/Generate-PR.yml
@@ -349,7 +349,7 @@ jobs:
           cmake ..
           make -j "$(nproc)"
           sudo make install
-          sudo gem install ruby-libversion
+          sudo gem install --no-update-sources -N ruby-libversion --conservative
       - name: Save git log
         id: save-git-log
         env:
@@ -389,6 +389,18 @@ jobs:
               - '!manifest/**'
               - '!packages/*.rb'
               - '!.github/**'
+      - name: Get Changed Packages
+        id: changed-packages
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.packages }}
+        run: |
+            if [[ -n "${CHANGED_FILES}" ]]; then
+              # Convert "packages/foo.rb packages/bar.rb" (from steps.changed-files.outputs.packages_all_changed_files) into "foo bar"
+              echo "CHANGED_PACKAGES=$(echo "${CHANGED_FILES}" | xargs basename -s .rb | xargs)" >> "$GITHUB_ENV"
+              echo "CHANGED_PACKAGES=$(echo "${CHANGED_FILES}" | xargs basename -s .rb | xargs)" >> "$GITHUB_OUTPUT"
+            else
+              echo "No Changed Files."
+            fi
       - name: Get GH Token
         id: get_workflow_token
         uses: peter-murray/workflow-application-token-action@v4
@@ -402,7 +414,7 @@ jobs:
           CHANGED_GITHUB_CONFIG_FILES: ${{ steps.changed-files.outputs.github_all_changed_files }}
           CHANGED_MANIFEST_FILES: ${{ steps.changed-files.outputs.manifest_all_changed_files }}
           CHANGED_OTHER_FILES: ${{ steps.changed-files.outputs.other_all_changed_files }}
-          CHANGED_PACKAGES: ${{ needs.setup.outputs.changed_packages }}
+          # CHANGED_PACKAGES: ${{ needs.setup.outputs.changed_packages }}
           CREW_BRANCH: ${{ inputs.branch || github.ref_name }}
           DRAFT_PR: ${{ inputs.draft_pr }}
           GH_TOKEN: ${{ steps.get_workflow_token.outputs.token }}

--- a/.github/workflows/Package-Dependencies-Updater.yml
+++ b/.github/workflows/Package-Dependencies-Updater.yml
@@ -1,0 +1,47 @@
+---
+name: Generate Updates for Packages and Their Dependencies.
+on:
+  workflow_dispatch:
+    inputs:
+      version_cmd_input:
+        description: "Packages to check for dependency tree updates."
+        required: true
+env:
+  GH_TOKEN: ${{ secrets.CREW_PR_TOKEN }}  # setting GH_TOKEN for the entire workflow
+permissions:                    # Global permissions configuration starts here
+  actions: write
+  contents: write
+  packages: write
+  pull-requests: write          # 'write' access to pull requests
+jobs:
+  update-check:
+    if: ${{ github.repository_owner == 'chromebrew' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4.5'
+      - name: Check for updates in core and buildessential packages.
+        id: trigger-update-checks
+        run: |
+          set -x
+          # Make crew do automatic gem installs before looking for deps.
+          ruby bin/crew version
+          # Force creation of temporary device.json.
+          ruby bin/crew deps zstd_static
+          # Make sure input matches packages in existing packages list.
+          export INPUT="${{ inputs.version_cmd_input }}"
+          # shellcheck disable=SC2046,SC2155
+          export INPUT_PACKAGES="$(comm -12  <(ruby bin/crew list available| sort -u) <(echo $INPUT | tr ' ' '\n'| sort -u))"
+          if [[ -n "${INPUT_PACKAGES}" ]]; then
+            # shellcheck disable=SC2086,SC2155
+            export PACKAGES="$(ruby bin/crew deps $INPUT_PACKAGES | sort -u)"
+          else
+            echo "No valid input packages found."
+            exit 1
+          fi
+          # shellcheck disable=SC2086,SC2116
+          gh workflow -R chromebrew/chromebrew run Updater-on-Demand.yml -f version_cmd_input="$(echo ${PACKAGES})"


### PR DESCRIPTION
## Description
- New workflow to pick up all dependencies of a package during update checks.
- Now the core/buildessential update checks are just a subset of the former.
#### Commits:
-  ff75d91f2 Move multiple package update check into single workflow.
### Updated GitHub configuration files:
- .github/workflows/Package-Dependencies-Updater.yml
- .github/workflows/Container-Package-Updater.yml
- .github/workflows/Generate-PR.yml
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=workflows crew update \
&& yes | crew upgrade
```
