### PR TITLE
Veracrypt 1.25.9 => 1.26.29

### DIFF
--- a/manifest/armv7l/v/veracrypt.filelist
+++ b/manifest/armv7l/v/veracrypt.filelist
@@ -1,2 +1,2 @@
-# Total size: 4166592
+# Total size: 4951768
 /usr/local/bin/veracrypt

--- a/manifest/x86_64/v/veracrypt.filelist
+++ b/manifest/x86_64/v/veracrypt.filelist
@@ -1,2 +1,2 @@
-# Total size: 1240488
+# Total size: 5979704
 /usr/local/bin/veracrypt

--- a/packages/veracrypt.rb
+++ b/packages/veracrypt.rb
@@ -1,33 +1,33 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Veracrypt < Package
+class Veracrypt < Autotools
   description 'VeraCrypt is a free open source disk encryption software for Windows, Mac OSX and Linux.'
   homepage 'https://www.veracrypt.fr/en/Home.html'
-  version '1.25.9'
+  version '1.26.29'
   license 'Apache 2.0 and TrueCrypt 3.0'
   compatibility 'aarch64 armv7l x86_64'
-  source_url 'https://www.veracrypt.fr/code/VeraCrypt/snapshot/VeraCrypt_1.25.9.tar.gz'
-  source_sha256 '66f2195f126df53f1037cc4b81ea4b9eaa5cd6aaa351f5cfe324760fdefab0d0'
+  source_url 'https://github.com/veracrypt/VeraCrypt.git'
+  git_hashtag "VeraCrypt_#{version}"
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '110caf9f2d53edb107d94ab8a45d08014f6fd93f54e3f4f8f5fef6bebb809229',
-     armv7l: '110caf9f2d53edb107d94ab8a45d08014f6fd93f54e3f4f8f5fef6bebb809229',
-     x86_64: '6ffd9a70f7161d662a2db6427ed52753836e780386f3171bd8b308ba2b7f72f1'
+    aarch64: '7f94d896fca02834f3cba32e13a62d28aed2dd1abc67a28edf1ce155c110527a',
+     armv7l: '7f94d896fca02834f3cba32e13a62d28aed2dd1abc67a28edf1ce155c110527a',
+     x86_64: '504ff9ceff8514b7e88a3373a241f1d649485e6488e675c209d9a4d42cee697a'
   })
 
+  depends_on 'fuse2' => :executable
+  depends_on 'gcc_lib' => :executable
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'pcsc_lite' => :executable
+  depends_on 'wxwidgets31' => :executable
   depends_on 'yasm' => :build
-  depends_on 'fuse2'
-  depends_on 'wxwidgets31'
 
-  def self.build
-    Dir.chdir 'src' do
-      system 'make'
-    end
-  end
+  autotools_skip_configure
+  autotools_build_relative_dir 'src'
 
   def self.install
-    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
     FileUtils.install 'src/Main/veracrypt', "#{CREW_DEST_PREFIX}/bin/veracrypt", mode: 0o755
   end
 end

--- a/tests/package/v/veracrypt
+++ b/tests/package/v/veracrypt
@@ -1,0 +1,3 @@
+#!/bin/bash
+veracrypt -t -h 2>&1 | head
+veracrypt -t --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-veracrypt crew update \
&& yes | crew upgrade

$ crew check veracrypt 
Checking veracrypt package ...
Library test for veracrypt passed.
Checking veracrypt package ...
veracrypt: /usr/local/lib64/libuuid.so.1: no version information available (required by /usr/local/lib64/libSM.so.6)
Usage: veracrypt [--auto-mount <str>] [--backup-headers] [--background-task] [-C] [-c] [--create-keyfile] [--delete-token-keyfiles] [-d] [-u] [--emergency-unmount] [--display-password] [--encryption <str>] [--explore] [--export-token-keyfile] [--filesystem <str>] [-f] [--fs-options <str>] [--hash <str>] [-h] [--import-token-keyfiles] [-k <str>] [-l] [--list-token-keyfiles] [--list-securitytoken-keyfiles] [--list-emvtoken-keyfiles] [--load-preferences] [--mount] [-m <str>] [--new-hash <str>] [--new-keyfiles <str>] [--new-password <str>] [--new-pim <str>] [--non-interactive] [--stdin] [-p <str>] [--pim <str>] [--protect-hidden <str>] [--protection-hash <str>] [--protection-keyfiles <str>] [--protection-password <str>] [--protection-pim <str>] [--random-source <str>] [--restore-headers] [--save-preferences] [--quick] [--size <str>] [--slot <str>] [--test] [-t] [--token-lib <str>] [--token-pin <str>] [-v] [--version] [--volume-properties] [--volume-type <str>] [--no-size-check] [--legacy-password-maxlength] [--use-dummy-sudo-password] [--allow-insecure-mount] [Volume path] [Mount point]
  --auto-mount=<str>           	Auto mount device-hosted/favorite volumes
  --backup-headers             	Backup volume headers
  --background-task            	Start Background Task
  -C, --change                 	Change password or keyfiles
  -c, --create                 	Create new volume
  --create-keyfile             	Create new keyfile
  --delete-token-keyfiles      	Delete security token keyfiles
  -d, --dismount               	Unmount volume (deprecated: use 'unmount')
VeraCrypt 1.26.29
Package tests for veracrypt passed.
```