### PR TITLE
Whois 5.5.2 => 5.6.6

### DIFF
--- a/manifest/armv7l/l/libxcrypt.filelist
+++ b/manifest/armv7l/l/libxcrypt.filelist
@@ -1,4 +1,4 @@
-# Total size: 1310501
+# Total size: 1241189
 /usr/local/include/crypt.h
 /usr/local/include/xcrypt.h
 /usr/local/lib/libcrypt.a

--- a/manifest/armv7l/w/whois.filelist
+++ b/manifest/armv7l/w/whois.filelist
@@ -1,7 +1,24 @@
-# Total size: 169894
+# Total size: 234535
 /usr/local/bin/mkpasswd
 /usr/local/bin/whois
-/usr/local/etc/whois.conf
-/usr/local/man/man1/mkpasswd.1.gz
-/usr/local/man/man1/whois.1.gz
-/usr/local/man/man5/whois.conf.5.gz
+/usr/local/share/bash-completion/completions/mkpasswd
+/usr/local/share/bash-completion/completions/whois
+/usr/local/share/locale/cs/LC_MESSAGES/whois.mo
+/usr/local/share/locale/da/LC_MESSAGES/whois.mo
+/usr/local/share/locale/de/LC_MESSAGES/whois.mo
+/usr/local/share/locale/el/LC_MESSAGES/whois.mo
+/usr/local/share/locale/es/LC_MESSAGES/whois.mo
+/usr/local/share/locale/eu/LC_MESSAGES/whois.mo
+/usr/local/share/locale/fi/LC_MESSAGES/whois.mo
+/usr/local/share/locale/fr/LC_MESSAGES/whois.mo
+/usr/local/share/locale/it/LC_MESSAGES/whois.mo
+/usr/local/share/locale/ja/LC_MESSAGES/whois.mo
+/usr/local/share/locale/ka/LC_MESSAGES/whois.mo
+/usr/local/share/locale/pl/LC_MESSAGES/whois.mo
+/usr/local/share/locale/pt_BR/LC_MESSAGES/whois.mo
+/usr/local/share/locale/ru/LC_MESSAGES/whois.mo
+/usr/local/share/locale/tr/LC_MESSAGES/whois.mo
+/usr/local/share/locale/zh_CN/LC_MESSAGES/whois.mo
+/usr/local/share/man/man1/mkpasswd.1.zst
+/usr/local/share/man/man1/whois.1.zst
+/usr/local/share/man/man5/whois.conf.5.zst

--- a/manifest/i686/l/libxcrypt.filelist
+++ b/manifest/i686/l/libxcrypt.filelist
@@ -1,4 +1,4 @@
-# Total size: 1318991
+# Total size: 1310897
 /usr/local/include/crypt.h
 /usr/local/include/xcrypt.h
 /usr/local/lib/libcrypt.a

--- a/manifest/i686/w/whois.filelist
+++ b/manifest/i686/w/whois.filelist
@@ -1,7 +1,24 @@
-# Total size: 166302
+# Total size: 240479
 /usr/local/bin/mkpasswd
 /usr/local/bin/whois
-/usr/local/etc/whois.conf
-/usr/local/man/man1/mkpasswd.1.gz
-/usr/local/man/man1/whois.1.gz
-/usr/local/man/man5/whois.conf.5.gz
+/usr/local/share/bash-completion/completions/mkpasswd
+/usr/local/share/bash-completion/completions/whois
+/usr/local/share/locale/cs/LC_MESSAGES/whois.mo
+/usr/local/share/locale/da/LC_MESSAGES/whois.mo
+/usr/local/share/locale/de/LC_MESSAGES/whois.mo
+/usr/local/share/locale/el/LC_MESSAGES/whois.mo
+/usr/local/share/locale/es/LC_MESSAGES/whois.mo
+/usr/local/share/locale/eu/LC_MESSAGES/whois.mo
+/usr/local/share/locale/fi/LC_MESSAGES/whois.mo
+/usr/local/share/locale/fr/LC_MESSAGES/whois.mo
+/usr/local/share/locale/it/LC_MESSAGES/whois.mo
+/usr/local/share/locale/ja/LC_MESSAGES/whois.mo
+/usr/local/share/locale/ka/LC_MESSAGES/whois.mo
+/usr/local/share/locale/pl/LC_MESSAGES/whois.mo
+/usr/local/share/locale/pt_BR/LC_MESSAGES/whois.mo
+/usr/local/share/locale/ru/LC_MESSAGES/whois.mo
+/usr/local/share/locale/tr/LC_MESSAGES/whois.mo
+/usr/local/share/locale/zh_CN/LC_MESSAGES/whois.mo
+/usr/local/share/man/man1/mkpasswd.1.zst
+/usr/local/share/man/man1/whois.1.zst
+/usr/local/share/man/man5/whois.conf.5.zst

--- a/manifest/x86_64/l/libxcrypt.filelist
+++ b/manifest/x86_64/l/libxcrypt.filelist
@@ -1,4 +1,4 @@
-# Total size: 1317953
+# Total size: 1332553
 /usr/local/include/crypt.h
 /usr/local/include/xcrypt.h
 /usr/local/lib64/libcrypt.a

--- a/manifest/x86_64/w/whois.filelist
+++ b/manifest/x86_64/w/whois.filelist
@@ -1,7 +1,24 @@
-# Total size: 212854
+# Total size: 302443
 /usr/local/bin/mkpasswd
 /usr/local/bin/whois
-/usr/local/etc/whois.conf
-/usr/local/man/man1/mkpasswd.1.gz
-/usr/local/man/man1/whois.1.gz
-/usr/local/man/man5/whois.conf.5.gz
+/usr/local/share/bash-completion/completions/mkpasswd
+/usr/local/share/bash-completion/completions/whois
+/usr/local/share/locale/cs/LC_MESSAGES/whois.mo
+/usr/local/share/locale/da/LC_MESSAGES/whois.mo
+/usr/local/share/locale/de/LC_MESSAGES/whois.mo
+/usr/local/share/locale/el/LC_MESSAGES/whois.mo
+/usr/local/share/locale/es/LC_MESSAGES/whois.mo
+/usr/local/share/locale/eu/LC_MESSAGES/whois.mo
+/usr/local/share/locale/fi/LC_MESSAGES/whois.mo
+/usr/local/share/locale/fr/LC_MESSAGES/whois.mo
+/usr/local/share/locale/it/LC_MESSAGES/whois.mo
+/usr/local/share/locale/ja/LC_MESSAGES/whois.mo
+/usr/local/share/locale/ka/LC_MESSAGES/whois.mo
+/usr/local/share/locale/pl/LC_MESSAGES/whois.mo
+/usr/local/share/locale/pt_BR/LC_MESSAGES/whois.mo
+/usr/local/share/locale/ru/LC_MESSAGES/whois.mo
+/usr/local/share/locale/tr/LC_MESSAGES/whois.mo
+/usr/local/share/locale/zh_CN/LC_MESSAGES/whois.mo
+/usr/local/share/man/man1/mkpasswd.1.zst
+/usr/local/share/man/man1/whois.1.zst
+/usr/local/share/man/man5/whois.conf.5.zst

--- a/packages/libxcrypt.rb
+++ b/packages/libxcrypt.rb
@@ -11,13 +11,14 @@ class Libxcrypt < Autotools
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '71a07dc54be7bbd21105ee89243e5b9e4687ac9f2f47fba61449005e00eca2c4',
-     armv7l: '71a07dc54be7bbd21105ee89243e5b9e4687ac9f2f47fba61449005e00eca2c4',
-       i686: '5bf079bf54015f8727cbdc44a2d73f5de914a6b94e3e1237030b355630d0d4ce',
-     x86_64: '1553a96a54eb3480a4906eec597178d9cce561f2417d78315fead429a45c5fd8'
+    aarch64: '8ee04ec38fba081b7fed26007a922e45033313022406eda41edb3aa95bca435a',
+     armv7l: '8ee04ec38fba081b7fed26007a922e45033313022406eda41edb3aa95bca435a',
+       i686: 'b366ff7a08295510aa900738c384a208508bf4c44fda541475df899f22545412',
+     x86_64: 'ebcef904c8434c450cdf5c9f9104f1f0003dc6d00f77e850472c0e389d0281a1'
   })
 
   depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
   depends_on 'llvm_dev' => :build
 
   conflicts_ok

--- a/packages/whois.rb
+++ b/packages/whois.rb
@@ -1,41 +1,32 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Whois < Package
+class Whois < Autotools
   description 'Intelligent WHOIS client'
   homepage 'https://github.com/rfc1036/whois'
-  version '5.5.2'
+  version '5.6.6'
   license 'GPL-2'
   compatibility 'all'
-  source_url 'https://github.com/rfc1036/whois/archive/v5.5.2.tar.gz'
-  source_sha256 '9e007306bc0a5e0da4fe9abd52bc79aa8202af5ee6e852fb4f130cf362340b40'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/rfc1036/whois.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'e1fb23bf6dc47d2504f8452f33668599ab039b32bbe6b70c3b4cf0f9c529a424',
-     armv7l: 'e1fb23bf6dc47d2504f8452f33668599ab039b32bbe6b70c3b4cf0f9c529a424',
-       i686: '737063cadba182cd240e01a64b5380c781472877b7f2dfec91c33e9049dde4a2',
-     x86_64: 'b788ba9c31a33dcc7b3dafcb4984117527e1dd802994f05519631f75a14d4378'
+    aarch64: '943ee1aa0e5450732694343accddf1a14c71fdcce060baaba84266bb861aa1a6',
+     armv7l: '943ee1aa0e5450732694343accddf1a14c71fdcce060baaba84266bb861aa1a6',
+       i686: '7e722134682492bdecd300d517ebdcfcb53e6a2665339857329ede1ca8dacf89',
+     x86_64: 'ad3c41464a1ede24a1304261d66b79f46670a235086d766a20decdcd218e41d5'
   })
 
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'libidn2' => :executable
+  depends_on 'libxcrypt' => :executable
+
+  autotools_skip_configure
+  autotools_skip_autoreconf
+
   def self.patch
-    system "sed -i 's,prefix = /usr,prefix = #{CREW_PREFIX},' Makefile"
-    system "sed -i 's,prefix = /usr,prefix = #{CREW_PREFIX},' po/Makefile"
-    system "sed -i 's,/share/,/,g' Makefile"
-    system "sed -i 's,/share/,/,g' po/Makefile"
-    system "sed -i 's,/share/,/,g' config.h"
-  end
-
-  def self.build
-    system 'make'
-  end
-
-  def self.install
-    system 'gzip -9 mkpasswd.1 whois.1 whois.conf.5'
-    system "install -Dm755 mkpasswd #{CREW_DEST_PREFIX}/bin/mkpasswd"
-    system "install -Dm755 whois #{CREW_DEST_PREFIX}/bin/whois"
-    system "install -Dm644 whois.conf #{CREW_DEST_PREFIX}/etc/whois.conf"
-    system "install -Dm644 mkpasswd.1.gz #{CREW_DEST_PREFIX}/man/man1/mkpasswd.1.gz"
-    system "install -Dm644 whois.1.gz #{CREW_DEST_PREFIX}/man/man1/whois.1.gz"
-    system "install -Dm644 whois.conf.5.gz #{CREW_DEST_PREFIX}/man/man5/whois.conf.5.gz"
+    system "sed -i 's,\$(BASEDIR)\$(prefix),#{CREW_DEST_PREFIX},g' Makefile"
+    system "sed -i 's,\$(BASEDIR)\$(prefix),#{CREW_DEST_PREFIX},g' po/Makefile"
   end
 end

--- a/tests/package/w/whois
+++ b/tests/package/w/whois
@@ -1,0 +1,3 @@
+#!/bin/bash
+whois --help | head
+whois --version


### PR DESCRIPTION
Rebuild libxcrypt to fix mold error
##
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-whois crew update \
&& yes | crew upgrade

$ crew check whois
Checking whois package ...
Library test for whois passed.
Checking whois package ...
Usage: whois [OPTION]... OBJECT...

-h HOST, --host HOST   connect to server HOST
-p PORT, --port PORT   connect to PORT
-I                     query whois.iana.org and follow its referral
-H                     hide legal disclaimers
      --verbose        explain what is being done
      --no-recursion   disable recursion from registry to registrar servers
      --help           display this help and exit
      --version        output version information and exit
Version 5.6.6.

Report bugs to <md+whois@linux.it>.
Package tests for whois passed.
```