### PR TITLE
Xdotool 3.20160805.1 => 4.20260303.1

### DIFF
--- a/manifest/armv7l/x/xdotool.filelist
+++ b/manifest/armv7l/x/xdotool.filelist
@@ -1,6 +1,7 @@
-# Total size: 385193
+# Total size: 152549
 /usr/local/bin/xdotool
 /usr/local/include/xdo.h
 /usr/local/lib/libxdo.so
-/usr/local/lib/libxdo.so.3
-/usr/local/man/man1/xdotool.1.gz
+/usr/local/lib/libxdo.so.4
+/usr/local/lib/pkgconfig/libxdo.pc
+/usr/local/share/man/man1/xdotool.1.zst

--- a/manifest/x86_64/x/xdotool.filelist
+++ b/manifest/x86_64/x/xdotool.filelist
@@ -1,6 +1,7 @@
-# Total size: 406873
+# Total size: 196307
 /usr/local/bin/xdotool
 /usr/local/include/xdo.h
 /usr/local/lib64/libxdo.so
-/usr/local/lib64/libxdo.so.3
-/usr/local/man/man1/xdotool.1.gz
+/usr/local/lib64/libxdo.so.4
+/usr/local/lib64/pkgconfig/libxdo.pc
+/usr/local/share/man/man1/xdotool.1.zst

--- a/packages/xdotool.rb
+++ b/packages/xdotool.rb
@@ -6,22 +6,25 @@ require 'package'
 class Xdotool < Package
   description 'Command-line X11 automation tool'
   homepage 'https://www.semicomplete.com/projects/xdotool/'
-  version '3.20160805.1'
+  version '4.20260303.1'
   license 'BSD'
   compatibility 'aarch64 armv7l x86_64'
-  source_url 'https://github.com/jordansissel/xdotool/releases/download/v3.20160805.1/xdotool-3.20160805.1.tar.gz'
-  source_sha256 '35be5ff6edf0c620a0e16f09ea5e101d5173280161772fca18657d83f20fcca8'
-  binary_compression 'tar.xz'
+  source_url 'https://github.com/jordansissel/xdotool.git'
+  git_hashtag "v#{version}"
+  binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '37b9d630ca048ed377c184d44cbbc261022fabe6bec143abc0c066563f913bc4',
-     armv7l: '37b9d630ca048ed377c184d44cbbc261022fabe6bec143abc0c066563f913bc4',
-     x86_64: '4ed5c2e4c5b4dfde83c94c017ef7f37e601dc0252ad67341252b38b1a7b47cc2'
+    aarch64: '82de36e4590faf639a102bca1fd4b7faf5af3bb5f0cf5c99c4b707f42d701a64',
+     armv7l: '82de36e4590faf639a102bca1fd4b7faf5af3bb5f0cf5c99c4b707f42d701a64',
+     x86_64: 'b7816c01d71594b82753d3bcbcb092b8a08de8dfedc9bc5b46dfc9db8489c48d'
   })
 
-  depends_on 'libxtst'
-  depends_on 'libxinerama'
-  depends_on 'libxkbcommon'
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
+  depends_on 'libx11' => :library
+  depends_on 'libxinerama' => :library
+  depends_on 'libxkbcommon' => :library
+  depends_on 'libxtst' => :library
 
   def self.build
     system "PREFIX=#{CREW_PREFIX} INSTALLLIB=#{CREW_LIB_PREFIX} make WITHOUT_RPATH_FIX=1"

--- a/tests/package/x/xdotool
+++ b/tests/package/x/xdotool
@@ -1,0 +1,3 @@
+#!/bin/bash
+xdotool help | head
+xdotool version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-xdotool crew update \
&& yes | crew upgrade

$ crew check xdotool 
Checking xdotool package ...
Library test for xdotool passed.
Checking xdotool package ...
Available commands:
  getactivewindow
  getwindowfocus
  getwindowname
  getwindowclassname
  getwindowpid
  getwindowgeometry
  getdisplaygeometry
  search
  selectwindow
xdotool version 4.20260303.1
Package tests for xdotool passed.
```