### PR TITLE
xterm -> 411 in updater-xterm-411 — xterm: 410 → 411

### DIFF
--- a/manifest/armv7l/x/xterm.filelist
+++ b/manifest/armv7l/x/xterm.filelist
@@ -1,4 +1,4 @@
-# Total size: 1516342
+# Total size: 1528731
 /usr/local/bin/koi8rxterm
 /usr/local/bin/resize
 /usr/local/bin/uxterm
@@ -31,6 +31,7 @@
 /usr/local/lib/terminfo/e/ecma+index
 /usr/local/lib/terminfo/e/ecma+italics
 /usr/local/lib/terminfo/e/ecma+strikeout
+/usr/local/lib/terminfo/i/ibm+16color
 /usr/local/lib/terminfo/r/report+da2
 /usr/local/lib/terminfo/r/report+version
 /usr/local/lib/terminfo/v/vs100
@@ -44,6 +45,7 @@
 /usr/local/lib/terminfo/x/xterm+256color
 /usr/local/lib/terminfo/x/xterm+256color2
 /usr/local/lib/terminfo/x/xterm+3keys
+/usr/local/lib/terminfo/x/xterm+88color
 /usr/local/lib/terminfo/x/xterm+acs
 /usr/local/lib/terminfo/x/xterm+alt+title
 /usr/local/lib/terminfo/x/xterm+alt1049
@@ -75,7 +77,7 @@
 /usr/local/lib/terminfo/x/xterm+pcfn
 /usr/local/lib/terminfo/x/xterm+sm+1006
 /usr/local/lib/terminfo/x/xterm+titlestack
-/usr/local/lib/terminfo/x/xterm+tmux
+/usr/local/lib/terminfo/x/xterm+tmux2
 /usr/local/lib/terminfo/x/xterm+vt+edit
 /usr/local/lib/terminfo/x/xterm+x11mouse
 /usr/local/lib/terminfo/x/xterm-16color

--- a/manifest/x86_64/x/xterm.filelist
+++ b/manifest/x86_64/x/xterm.filelist
@@ -1,4 +1,4 @@
-# Total size: 1535402
+# Total size: 1546435
 /usr/local/bin/koi8rxterm
 /usr/local/bin/resize
 /usr/local/bin/uxterm
@@ -31,6 +31,7 @@
 /usr/local/lib/terminfo/e/ecma+index
 /usr/local/lib/terminfo/e/ecma+italics
 /usr/local/lib/terminfo/e/ecma+strikeout
+/usr/local/lib/terminfo/i/ibm+16color
 /usr/local/lib/terminfo/r/report+da2
 /usr/local/lib/terminfo/r/report+version
 /usr/local/lib/terminfo/v/vs100
@@ -44,6 +45,7 @@
 /usr/local/lib/terminfo/x/xterm+256color
 /usr/local/lib/terminfo/x/xterm+256color2
 /usr/local/lib/terminfo/x/xterm+3keys
+/usr/local/lib/terminfo/x/xterm+88color
 /usr/local/lib/terminfo/x/xterm+acs
 /usr/local/lib/terminfo/x/xterm+alt+title
 /usr/local/lib/terminfo/x/xterm+alt1049
@@ -75,7 +77,7 @@
 /usr/local/lib/terminfo/x/xterm+pcfn
 /usr/local/lib/terminfo/x/xterm+sm+1006
 /usr/local/lib/terminfo/x/xterm+titlestack
-/usr/local/lib/terminfo/x/xterm+tmux
+/usr/local/lib/terminfo/x/xterm+tmux2
 /usr/local/lib/terminfo/x/xterm+vt+edit
 /usr/local/lib/terminfo/x/xterm+x11mouse
 /usr/local/lib/terminfo/x/xterm-16color

--- a/packages/xterm.rb
+++ b/packages/xterm.rb
@@ -35,6 +35,7 @@ class Xterm < Package
   depends_on 'pcre' => :executable
   depends_on 'sommelier' => :logical
 
+  conflicts_ok # conflicts with terminfo defs in ncurses
   no_env_options
 
   def self.patch

--- a/packages/xterm.rb
+++ b/packages/xterm.rb
@@ -11,14 +11,15 @@ class Xterm < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '3aade61d18517382ffaabe6326f1e8dc471bb8c4c4b64e62890f6f5a53b4b0f1',
-     armv7l: '3aade61d18517382ffaabe6326f1e8dc471bb8c4c4b64e62890f6f5a53b4b0f1',
-     x86_64: 'b9f5c469c0771fd8dde85b5990c831a2d3f56402d36959a618b4fb0938f5e944'
+    aarch64: '6e0fada45b3f5c9deeee74dbcad76833f2f9d4b519eb9c86cd0895308e960d2b',
+     armv7l: '6e0fada45b3f5c9deeee74dbcad76833f2f9d4b519eb9c86cd0895308e960d2b',
+     x86_64: 'a343f5962926a0a48406bd5bd9e948d45827bc5141f468b439fcb0647aaf761f'
   })
 
   depends_on 'fontconfig' => :executable
   depends_on 'freetype' => :executable
   depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
   depends_on 'harfbuzz' => :executable
   depends_on 'libice' => :executable
   depends_on 'libutempter' => :executable

--- a/packages/xterm.rb
+++ b/packages/xterm.rb
@@ -3,7 +3,7 @@ require 'package'
 class Xterm < Package
   description 'The xterm program is a terminal emulator for the X Window System.'
   homepage 'https://invisible-island.net/xterm/'
-  version '410'
+  version '411'
   license 'MIT'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://github.com/ThomasDickey/xterm-snapshots.git'


### PR DESCRIPTION
## Description
#### Commits:
-  f1d6fcd08 Add conflicts_ok due to terminfo definitions already in ncurses.
-  b8a6dfb10 xterm -> 411 in updater-xterm-411
### Packages with Updated versions or Changed package files:
- `xterm`: 410 &rarr; 411
##
Builds attempted for:
- [x] `x86_64`
- [x] `armv7l`
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=updater-xterm-411 crew update \
&& yes | crew upgrade
```
