### PR TITLE
Fix package hashes getting updated during force lib/downloader usage from commands/download.

### DIFF
--- a/commands/download.rb
+++ b/commands/download.rb
@@ -56,7 +56,7 @@ class Command
         puts "Cached build artifact from #{gitlab_build_artifact_date} exists! with sha256 #{gitlab_build_artifact_sha256}".lightgreen
         puts "Downloading most recent cached build artifact for #{pkg.name}-#{pkg.version}...".orange
         # Download the package build artifact.
-        downloader(build_cache_url, gitlab_build_artifact_sha256, build_cachefile, no_update_hash: true)
+        downloader(build_cache_url, gitlab_build_artifact_sha256, build_cachefile, pkg, no_update_hash: true)
         File.write "#{build_cachefile}.sha256", <<~BUILD_CACHEFILE_SHA256_EOF
           #{gitlab_build_artifact_sha256} #{build_cachefile}
         BUILD_CACHEFILE_SHA256_EOF
@@ -87,7 +87,7 @@ class Command
           end
         end
         # Download file if not cached.
-        downloader url, sha256sum, filename, verbose: verbose
+        downloader url, sha256sum, filename, pkg, verbose: verbose
 
         puts "#{pkg.name.capitalize} archive downloaded.".lightgreen
         # Stow file in cache if requested, if cachefile does not exist, and cache is writable.
@@ -104,7 +104,7 @@ class Command
       else
         unless git # We don't want to download a git repository as a file.
           FileUtils.mkdir_p extract_dir
-          downloader url, sha256sum, filename, verbose: verbose
+          downloader url, sha256sum, filename, pkg, verbose: verbose
 
           puts "#{filename}: File downloaded.".lightgreen
 

--- a/lib/const.rb
+++ b/lib/const.rb
@@ -4,7 +4,7 @@ require 'etc'
 require 'open3'
 
 OLD_CREW_VERSION = defined?(CREW_VERSION) ? CREW_VERSION : '1.0'
-CREW_VERSION = '1.75.7' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
+CREW_VERSION = '1.75.8' unless defined?(CREW_VERSION) && CREW_VERSION == OLD_CREW_VERSION
 
 # Kernel architecture.
 KERN_ARCH = Etc.uname[:machine]

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -26,7 +26,7 @@ rescue RuntimeError => e
   end
 end
 
-def downloader(url, sha256sum, filename = File.basename(url).gsub(/\s+/, ''), no_update_hash: false, verbose: false)
+def downloader(url, sha256sum, filename = File.basename(url).gsub(/\s+/, ''), pkg = nil, no_update_hash: false, verbose: false)
   # downloader: wrapper for all Chromebrew downloaders (`net/http`,`curl`...)
   # Usage: downloader <url>, <sha256sum>, <filename::optional>, <verbose::optional>
   #
@@ -35,7 +35,7 @@ def downloader(url, sha256sum, filename = File.basename(url).gsub(/\s+/, ''), no
   #      <filename>: (Optional) Output path/filename
   #       <verbose>: (Optional) Verbose output
   #
-  puts "downloader(#{url}, #{sha256sum}, #{filename}, #{verbose})" if verbose
+  puts "downloader(#{url}, #{sha256sum}, #{filename},#{" #{pkg}," unless pkg.nil?} #{verbose})" if verbose
   uri = URI(url)
 
   # Make sure the destination dir for the filename exists.
@@ -77,7 +77,12 @@ def downloader(url, sha256sum, filename = File.basename(url).gsub(/\s+/, ''), no
       # When called from Convenience_functions, name ends up as
       # Convenience_functions, so we do not want to use it as a backstop
       # for a missing @pkg_name.
-      pkg_name = @pkg_name.blank? ? caller.select { it.include?('Package::') }.to_s.split('::').last.split('.').first.downcase : @pkg_name
+      # When called from commands/download.rb pass pkg so we get a name.
+      pkg_name = if pkg.nil?
+                   @pkg_name.to_s.blank? ? caller.select { it.include?('Package::') }.to_s.split('::').last.split('.').first.downcase : @pkg_name
+                 else
+                   pkg.name
+                 end
       puts "Updating checksum for #{filename}".lightblue
       puts "from #{sha256sum} to #{calc_sha256sum}".lightblue
       puts "in #{CREW_LOCAL_REPO_ROOT}/packages/#{pkg_name}.rb .".lightblue


### PR DESCRIPTION
## Description
- Noticed that the source package hash for llvm23 wasn't getting updated during the build as it should, so this fixes that.
#### Commits:
-  14765a898 Fix package hashes getting updated during force lib/downloader usage from commands/download.
### Other changed files:
- commands/download.rb
- lib/const.rb
- lib/downloader.rb
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=downloader_package_hash crew update \
&& yes | crew upgrade
```
