### PR TITLE
Xrandr 1.5.3 => 1.5.4

### DIFF
--- a/manifest/armv7l/x/xrandr.filelist
+++ b/manifest/armv7l/x/xrandr.filelist
@@ -1,4 +1,4 @@
-# Total size: 56831
+# Total size: 76442
 /usr/local/bin/xkeystone
 /usr/local/bin/xrandr
 /usr/local/share/man/man1/xrandr.1.zst

--- a/manifest/x86_64/x/xrandr.filelist
+++ b/manifest/x86_64/x/xrandr.filelist
@@ -1,4 +1,4 @@
-# Total size: 55863
+# Total size: 92070
 /usr/local/bin/xkeystone
 /usr/local/bin/xrandr
 /usr/local/share/man/man1/xrandr.1.zst

--- a/packages/xrandr.rb
+++ b/packages/xrandr.rb
@@ -3,7 +3,7 @@ require 'buildsystems/autotools'
 class Xrandr < Autotools
   description 'Command line interface to X11 Resize, Rotate, and Reflect (RandR) extension'
   homepage 'https://gitlab.freedesktop.org/xorg/app/xrandr'
-  version '1.5.3'
+  version '1.5.4'
   license 'MIT'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://gitlab.freedesktop.org/xorg/app/xrandr.git'
@@ -11,15 +11,16 @@ class Xrandr < Autotools
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '244014996409b4778ed756e3bdbb313f47bb9514f19945ece8c0cc0df2c45eae',
-     armv7l: '244014996409b4778ed756e3bdbb313f47bb9514f19945ece8c0cc0df2c45eae',
-     x86_64: '9e69504d88e1c4598a1936483d80fb05cefeea697511f0716c46bc44c11f6054'
+    aarch64: 'd04bea69eb13ed9e46d59c34e879eec0c4d1ce433affda981d4aebc319d3ef9e',
+     armv7l: 'd04bea69eb13ed9e46d59c34e879eec0c4d1ce433affda981d4aebc319d3ef9e',
+     x86_64: '8547c100ec66efd87de966dc0107a5ecc1469969ff9c7762bca3c988b4eb97d4'
   })
 
-  depends_on 'glibc' # R
-  depends_on 'libx11' # R
-  depends_on 'libxrandr' # R
-  depends_on 'libxrender' # R
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'libx11' => :executable
+  depends_on 'libxrandr' => :executable
+  depends_on 'libxrender' => :executable
 
   run_tests
 end

--- a/tests/package/x/xrandr
+++ b/tests/package/x/xrandr
@@ -1,0 +1,3 @@
+#!/bin/bash
+xrandr --help | head
+xrandr --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-xrandr crew update \
&& yes | crew upgrade

$ crew check xrandr
Checking xrandr package ...
Library test for xrandr passed.
Checking xrandr package ...
usage: xrandr [options]
  where options are:
  --display <display> or -d <display>
  --help
  -o <normal,inverted,left,right,0,1,2,3>
            or --orientation <normal,inverted,left,right,0,1,2,3>
  -q        or --query
  -s <size>/<width>x<height> or --size <size>/<width>x<height>
  -r <rate> or --rate <rate> or --refresh <rate>
  -v        or --version
xrandr program version       1.5.4
Server reports RandR version 1.6
Package tests for xrandr passed.
```