### PR TITLE
Xvfb 21.1.23 => 21.1.24

### DIFF
--- a/manifest/armv7l/x/xvfb.filelist
+++ b/manifest/armv7l/x/xvfb.filelist
@@ -1,4 +1,4 @@
-# Total size: 1510970
+# Total size: 1510953
 /usr/local/bin/Xvfb
 /usr/local/bin/xvfb-run
 /usr/local/share/man/man1/Xvfb.1.zst

--- a/manifest/x86_64/x/xvfb.filelist
+++ b/manifest/x86_64/x/xvfb.filelist
@@ -1,4 +1,4 @@
-# Total size: 2501482
+# Total size: 2501321
 /usr/local/bin/Xvfb
 /usr/local/bin/xvfb-run
 /usr/local/share/man/man1/Xvfb.1.zst

--- a/packages/xvfb.rb
+++ b/packages/xvfb.rb
@@ -4,16 +4,16 @@ Package.load_package("#{__dir__}/xorg_server.rb")
 class Xvfb < Package
   description 'XVfb from Xorg Server.'
   homepage 'https://gitlab.freedesktop.org/xorg/xserver'
-  version '21.1.23'
+  version '21.1.24'
   license 'BSD-3, MIT, BSD-4, MIT-with-advertising, ISC and custom'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'SKIP'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '873e8fb0a937644fed1bb284a02462c303fd969746b6c23c15ab279abbafef2a',
-     armv7l: '873e8fb0a937644fed1bb284a02462c303fd969746b6c23c15ab279abbafef2a',
-     x86_64: 'f8936fcf50e6177a80bc285a82f7bf8b1bb52ac1c70089cc1e9487b8d1b58c14'
+    aarch64: '9f2ac117cdcfed6f01304fff428f72bcb8cb2f591a8a981992a26001b6899b64',
+     armv7l: '9f2ac117cdcfed6f01304fff428f72bcb8cb2f591a8a981992a26001b6899b64',
+     x86_64: '1ab3f67daa3335355c9963b179126948f2938b4577cf577ee411a213c8c13d89'
   })
 
   depends_on 'glibc' => :executable

--- a/tests/package/x/xvfb
+++ b/tests/package/x/xvfb
@@ -1,0 +1,3 @@
+#!/bin/bash
+Xvfb -help 2>&1 | head
+xvfb-run -help 2>&1 | head


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-xvfb crew update \
&& yes | crew upgrade

$ crew check xvfb 
Checking xvfb package ...
Library test for xvfb passed.
Checking xvfb package ...
use: X [:<display>] [option]
-a #                   default pointer acceleration (factor)
-ac                    disable access control restrictions
-audit int             set audit trail level
-auth file             select authorization file
-br                    create root window with black background
+bs                    enable any backing store support
-bs                    disable any backing store support
+byteswappedclients    Allow clients with endianess different to that of the server
-byteswappedclients    Prohibit clients with endianess different to that of the server
pgrep: invalid option -- 'A'

Usage:
 pgrep [options] <pattern>

Options:
 -d, --delimiter <string>  specify output delimiter
 -l, --list-name           list PID and process name
 -a, --list-full           list PID and full command line
 -v, --inverse             negates the matching
Package tests for xvfb passed.
```