### PR TITLE
Yara 4.2.3 => 4.5.8

### DIFF
--- a/manifest/armv7l/y/yara.filelist
+++ b/manifest/armv7l/y/yara.filelist
@@ -1,4 +1,4 @@
-# Total size: 3106664
+# Total size: 4001330
 /usr/local/bin/yara
 /usr/local/bin/yarac
 /usr/local/include/yara.h
@@ -26,6 +26,7 @@
 /usr/local/include/yara/rules.h
 /usr/local/include/yara/scan.h
 /usr/local/include/yara/scanner.h
+/usr/local/include/yara/simple_str.h
 /usr/local/include/yara/sizedstr.h
 /usr/local/include/yara/stack.h
 /usr/local/include/yara/stopwatch.h
@@ -33,12 +34,13 @@
 /usr/local/include/yara/strutils.h
 /usr/local/include/yara/threading.h
 /usr/local/include/yara/types.h
+/usr/local/include/yara/unaligned.h
 /usr/local/include/yara/utils.h
 /usr/local/lib/libyara.a
 /usr/local/lib/libyara.la
 /usr/local/lib/libyara.so
-/usr/local/lib/libyara.so.9
-/usr/local/lib/libyara.so.9.0.1
+/usr/local/lib/libyara.so.10
+/usr/local/lib/libyara.so.10.0.0
 /usr/local/lib/pkgconfig/yara.pc
-/usr/local/share/man/man1/yara.1.gz
-/usr/local/share/man/man1/yarac.1.gz
+/usr/local/share/man/man1/yara.1.zst
+/usr/local/share/man/man1/yarac.1.zst

--- a/manifest/i686/y/yara.filelist
+++ b/manifest/i686/y/yara.filelist
@@ -1,4 +1,4 @@
-# Total size: 3311710
+# Total size: 4652938
 /usr/local/bin/yara
 /usr/local/bin/yarac
 /usr/local/include/yara.h
@@ -26,6 +26,7 @@
 /usr/local/include/yara/rules.h
 /usr/local/include/yara/scan.h
 /usr/local/include/yara/scanner.h
+/usr/local/include/yara/simple_str.h
 /usr/local/include/yara/sizedstr.h
 /usr/local/include/yara/stack.h
 /usr/local/include/yara/stopwatch.h
@@ -33,12 +34,13 @@
 /usr/local/include/yara/strutils.h
 /usr/local/include/yara/threading.h
 /usr/local/include/yara/types.h
+/usr/local/include/yara/unaligned.h
 /usr/local/include/yara/utils.h
 /usr/local/lib/libyara.a
 /usr/local/lib/libyara.la
 /usr/local/lib/libyara.so
-/usr/local/lib/libyara.so.9
-/usr/local/lib/libyara.so.9.0.1
+/usr/local/lib/libyara.so.10
+/usr/local/lib/libyara.so.10.0.0
 /usr/local/lib/pkgconfig/yara.pc
-/usr/local/share/man/man1/yara.1.gz
-/usr/local/share/man/man1/yarac.1.gz
+/usr/local/share/man/man1/yara.1.zst
+/usr/local/share/man/man1/yarac.1.zst

--- a/manifest/x86_64/y/yara.filelist
+++ b/manifest/x86_64/y/yara.filelist
@@ -1,4 +1,4 @@
-# Total size: 3289656
+# Total size: 4714378
 /usr/local/bin/yara
 /usr/local/bin/yarac
 /usr/local/include/yara.h
@@ -26,6 +26,7 @@
 /usr/local/include/yara/rules.h
 /usr/local/include/yara/scan.h
 /usr/local/include/yara/scanner.h
+/usr/local/include/yara/simple_str.h
 /usr/local/include/yara/sizedstr.h
 /usr/local/include/yara/stack.h
 /usr/local/include/yara/stopwatch.h
@@ -33,12 +34,13 @@
 /usr/local/include/yara/strutils.h
 /usr/local/include/yara/threading.h
 /usr/local/include/yara/types.h
+/usr/local/include/yara/unaligned.h
 /usr/local/include/yara/utils.h
 /usr/local/lib64/libyara.a
 /usr/local/lib64/libyara.la
 /usr/local/lib64/libyara.so
-/usr/local/lib64/libyara.so.9
-/usr/local/lib64/libyara.so.9.0.1
+/usr/local/lib64/libyara.so.10
+/usr/local/lib64/libyara.so.10.0.0
 /usr/local/lib64/pkgconfig/yara.pc
-/usr/local/share/man/man1/yara.1.gz
-/usr/local/share/man/man1/yarac.1.gz
+/usr/local/share/man/man1/yara.1.zst
+/usr/local/share/man/man1/yarac.1.zst

--- a/packages/yara.rb
+++ b/packages/yara.rb
@@ -1,33 +1,27 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Yara < Package
+class Yara < Autotools
   description 'The pattern matching swiss knife for malware researchers (and everyone else).'
   homepage 'https://virustotal.github.io/yara/'
-  version '4.2.3'
+  version '4.5.8'
   license 'BSD-3 Clause'
   compatibility 'all'
-  source_url 'https://github.com/VirusTotal/yara/archive/v4.2.3.tar.gz'
-  source_sha256 '1cd84fc2db606e83084a648152eb35103c3e30350825cb7553448d5ccde02a0d'
+  source_url 'https://github.com/VirusTotal/yara.git'
+  git_hashtag "v#{version}"
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'ddbebdd46dbe4d0da19fde9596b1e4c0c33a6a2a25abe88c07e4f7d41d1d05fb',
-     armv7l: 'ddbebdd46dbe4d0da19fde9596b1e4c0c33a6a2a25abe88c07e4f7d41d1d05fb',
-       i686: '0bdee5b010c9765aa14c0fea82866914c087814e0ca540e460e17176020cf404',
-     x86_64: 'd63b0bcb7feb4eef29d8271dd008d9c4cf9825eecc9e12cddde8b875d2457e8a'
+    aarch64: 'a4be8fac6c81b03ad01bc006e702b9e9c0ae1cd0b499b8cfdeee43eb0d77cb37',
+     armv7l: 'a4be8fac6c81b03ad01bc006e702b9e9c0ae1cd0b499b8cfdeee43eb0d77cb37',
+       i686: '6361816f374607d92d8420ed38f85a654ec8351dcdabaf7e94dd3666bc083ea3',
+     x86_64: 'e7a67ae29395bbb788c3ee55831517cd116bb60964d22753a694e601310ee772'
   })
 
-  def self.build
-    system './bootstrap.sh'
-    system "YACC=bison ./configure #{CREW_CONFIGURE_OPTIONS}"
-    system 'make'
-  end
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
+  depends_on 'openssl' => :library
 
-  def self.check
-    system 'make', 'check'
-  end
+  autotools_pre_configure_options 'YACC=bison'
 
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  run_tests
 end

--- a/tests/package/y/yara
+++ b/tests/package/y/yara
@@ -1,0 +1,5 @@
+#!/bin/bash
+yara -h | head
+yara -v
+yarac -h | head
+yarac -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-yara crew update \
&& yes | crew upgrade

$ crew check yara
Checking yara package ...
Library test for yara passed.
Checking yara package ...
YARA 4.5.8, the pattern matching swiss army knife.
Usage: yara [OPTION]... [NAMESPACE:]RULES_FILE... FILE | DIR | PID

Mandatory arguments to long options are mandatory for short options too.

       --atom-quality-table=FILE           path to a file with the atom quality table
  -C,  --compiled-rules                    load compiled rules
  -c,  --count                             print only number of matches
  -E,  --strict-escape                     warn on unknown escape sequences
  -d,  --define=VAR=VALUE                  define external variable
4.5.8
Usage: yarac [OPTION]... [NAMESPACE:]SOURCE_FILE... OUTPUT_FILE

       --atom-quality-table=FILE        path to a file with the atom quality table
  -d,  --define=VAR=VALUE               define external variable
       --fail-on-warnings               fail on warnings
  -h,  --help                           show this help and exit
  -E,  --strict-escape                  warn on unknown escape sequences
       --max-strings-per-rule=NUMBER    set maximum number of strings per rule (default=10000)
  -w,  --no-warnings                    disable warnings
  -v,  --version                        show version information
4.5.8
Package tests for yara passed.
```