### PR TITLE
Rebuild fftw with threads enabled

### DIFF
--- a/manifest/armv7l/f/fftw.filelist
+++ b/manifest/armv7l/f/fftw.filelist
@@ -1,4 +1,4 @@
-# Total size: 8208030
+# Total size: 8432135
 /usr/local/bin/fftw-wisdom
 /usr/local/bin/fftw-wisdom-to-conf
 /usr/local/include/fftw3.f
@@ -13,6 +13,11 @@
 /usr/local/lib/libfftw3.so
 /usr/local/lib/libfftw3.so.3
 /usr/local/lib/libfftw3.so.3.7.11
+/usr/local/lib/libfftw3_threads.a
+/usr/local/lib/libfftw3_threads.la
+/usr/local/lib/libfftw3_threads.so
+/usr/local/lib/libfftw3_threads.so.3
+/usr/local/lib/libfftw3_threads.so.3.7.11
 /usr/local/lib/pkgconfig/fftw3.pc
 /usr/local/share/info/fftw3.info-1.zst
 /usr/local/share/info/fftw3.info-2.zst

--- a/manifest/i686/f/fftw.filelist
+++ b/manifest/i686/f/fftw.filelist
@@ -1,4 +1,4 @@
-# Total size: 8691642
+# Total size: 8931133
 /usr/local/bin/fftw-wisdom
 /usr/local/bin/fftw-wisdom-to-conf
 /usr/local/include/fftw3.f
@@ -13,6 +13,11 @@
 /usr/local/lib/libfftw3.so
 /usr/local/lib/libfftw3.so.3
 /usr/local/lib/libfftw3.so.3.7.11
+/usr/local/lib/libfftw3_threads.a
+/usr/local/lib/libfftw3_threads.la
+/usr/local/lib/libfftw3_threads.so
+/usr/local/lib/libfftw3_threads.so.3
+/usr/local/lib/libfftw3_threads.so.3.7.11
 /usr/local/lib/pkgconfig/fftw3.pc
 /usr/local/share/info/fftw3.info-1.zst
 /usr/local/share/info/fftw3.info-2.zst

--- a/manifest/x86_64/f/fftw.filelist
+++ b/manifest/x86_64/f/fftw.filelist
@@ -1,4 +1,4 @@
-# Total size: 9653310
+# Total size: 9907203
 /usr/local/bin/fftw-wisdom
 /usr/local/bin/fftw-wisdom-to-conf
 /usr/local/include/fftw3.f
@@ -13,6 +13,11 @@
 /usr/local/lib64/libfftw3.so
 /usr/local/lib64/libfftw3.so.3
 /usr/local/lib64/libfftw3.so.3.7.11
+/usr/local/lib64/libfftw3_threads.a
+/usr/local/lib64/libfftw3_threads.la
+/usr/local/lib64/libfftw3_threads.so
+/usr/local/lib64/libfftw3_threads.so.3
+/usr/local/lib64/libfftw3_threads.so.3.7.11
 /usr/local/lib64/pkgconfig/fftw3.pc
 /usr/local/share/info/fftw3.info-1.zst
 /usr/local/share/info/fftw3.info-2.zst

--- a/packages/fftw.rb
+++ b/packages/fftw.rb
@@ -11,10 +11,10 @@ class Fftw < Autotools
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '967ee876b47a3f0a8354fa5587a9cd6103cd6629a908ded148b69634cef47839',
-     armv7l: '967ee876b47a3f0a8354fa5587a9cd6103cd6629a908ded148b69634cef47839',
-       i686: '8ef033f81a7398024a7a757187bb5e259562d472752e7680746afd1cbb692ebc',
-     x86_64: '27e304bd4022d580dbc181e5f08f250179c80cd2c109639dd7e2ab619fc4e136'
+    aarch64: '7c12af0ee15819d3c4cd87e09c86f33587250bd1ba791e10ab1dfd6ec2ecb76d',
+     armv7l: '7c12af0ee15819d3c4cd87e09c86f33587250bd1ba791e10ab1dfd6ec2ecb76d',
+       i686: 'a2e3de9475c9b8e91088b80a4f8c65cd89c24530dfd94a46f2514a76c51a850f',
+     x86_64: '6530ec2a959bb3de0f15ebf96c3b2cf9d93853d2bd4a01769d78e559ce7c7887'
   })
 
   depends_on 'glibc' => :library
@@ -23,6 +23,6 @@ class Fftw < Autotools
   # We'd need to build fftw three times with each precision option in order to support things properly.
   # https://www.linuxfromscratch.org/blfs/view/cvs/general/fftw.html
   # https://github.com/FFTW/fftw3/pull/276
-  autotools_configure_options '--enable-shared'
+  autotools_configure_options '--enable-shared --enable-threads'
   run_tests
 end


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-fftw crew update \
&& yes | crew upgrade

$ crew check fftw 
Checking fftw package ...
Library test for fftw passed.
Checking fftw package ...
Usage: fftw-wisdom [options] [sizes]
    Create wisdom (pre-planned/optimized transforms) for specified sizes,
    writing wisdom to stdout (or to a file, using -o).

Options:
fftw-wisdom tool for FFTW version 3.3.11.

Copyright (c) 2003, 2007-14 Matteo Frigo
Copyright (c) 2003, 2007-14 Massachusetts Institute of Technology

This program is free software; you can redistribute it and/or modify
it under the terms of the GNU General Public License as published by
the Free Software Foundation; either version 2 of the License, or
(at your option) any later version.

This program is distributed in the hope that it will be useful,
but WITHOUT ANY WARRANTY; without even the implied warranty of
MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
GNU General Public License for more details.

You should have received a copy of the GNU General Public License
along with this program; if not, write to the Free Software
Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
Usage: fftw-wisdom-to-conf [OPTIONS] [< INPUT] [> OUTPUT]
Convert wisdom (stdin) to C configuration routine (stdout).

Options:
        -h, --help: print this help
fftw-wisdom-to-conf from FFTW version 3.3.11

Copyright (c) 2003, 2007-14 Matteo Frigo
Copyright (c) 2003, 2007-14 Massachusetts Institute of Technology

This program is free software; you can redistribute it and/or modify
it under the terms of the GNU General Public License as published by
the Free Software Foundation; either version 2 of the License, or
(at your option) any later version.

This program is distributed in the hope that it will be useful,
but WITHOUT ANY WARRANTY; without even the implied warranty of
MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
GNU General Public License for more details.

You should have received a copy of the GNU General Public License
along with this program; if not, write to the Free Software
Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA    
Package tests for fftw passed.
```