### PR TITLE
Add gmic package

### DIFF
--- a/manifest/x86_64/g/gmic.filelist
+++ b/manifest/x86_64/g/gmic.filelist
@@ -1,0 +1,10 @@
+# Total size: 41055109
+/usr/local/bin/gmic
+/usr/local/include/CImg.h
+/usr/local/include/gmic.h
+/usr/local/lib64/cmake/gmic/GmicConfig.cmake
+/usr/local/lib64/cmake/gmic/GmicTargets-release.cmake
+/usr/local/lib64/cmake/gmic/GmicTargets.cmake
+/usr/local/lib64/libgmic.a
+/usr/local/lib64/libgmic.so
+/usr/local/lib64/libgmic.so.1

--- a/packages/gmic.rb
+++ b/packages/gmic.rb
@@ -1,0 +1,33 @@
+require 'buildsystems/cmake'
+
+class Gmic < CMake
+  description "GREYC's Magic for Image Computing: A Full-Featured Open-Source Framework for Image Processing"
+  homepage 'https://gmic.eu/'
+  version '4.0.4'
+  license 'CeCILL and CeCILL-C'
+  compatibility 'x86_64'
+  source_url 'https://github.com/GreycLab/gmic.git'
+  git_hashtag "v.#{version}"
+  binary_compression 'tar.zst'
+
+  binary_sha256({
+    x86_64: '64e3659c392430ce58552e66489208aefb92112dd10982b482d120d002a9dfd4'
+  })
+
+  depends_on 'curl' => :library
+  depends_on 'fftw' => :library
+  depends_on 'gcc_lib' => :library
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
+  depends_on 'graphicsmagick' => :library
+  depends_on 'libjpeg_turbo' => :library
+  depends_on 'libpng' => :library
+  depends_on 'libtiff' => :library
+  depends_on 'libx11' => :library
+  depends_on 'openexr' => :library
+  depends_on 'zlib' => :library
+
+  # For whatever reason, the man page build fails with
+  # error while loading shared libraries: libfftw3.so.3
+  cmake_options '-DBUILD_BASH_COMPLETION=OFF -DBUILD_LIB=ON -DBUILD_MAN=OFF'
+end

--- a/tests/package/g/gmic
+++ b/tests/package/g/gmic
@@ -1,0 +1,2 @@
+#!/bin/bash
+gmic help 2>&1 | head


### PR DESCRIPTION
Depends on #18494.

## Description
GREYC's Magic for Image Computing: A Full-Featured Open-Source Framework for Image Processing.  See https://gmic.eu/.
##
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=add-gmic-package crew update \
&& yes | crew upgrade

$ crew check gmic 
Checking gmic package ...
Library test for gmic passed.
Checking gmic package ...
gmic: /usr/local/lib64/libuuid.so.1: no version information available (required by /usr/local/lib64/libSM.so.6)


  gmic: GREYC's Magic for Image Computing: Command-Line Interface
        Version 4.0.4
        (https://gmic.eu)

        Copyright (c) 2008-2026, David Tschumperlé / GREYC / CNRS.
        (https://www.greyc.fr)

Package tests for gmic passed.
```