### PR TITLE
Revert llvm23 package logic. — llvm23_dev: 23.1.0 → 23.1.0,llvm23_lib: 23.1.0 → 23.1.0

### DIFF
--- a/packages/llvm23_dev.rb
+++ b/packages/llvm23_dev.rb
@@ -1,14 +1,13 @@
 require 'package'
 
 class Llvm23_dev < Package
-  @llvm_build_obj = Package.load_package("#{__dir__}/#{ancestors[0].to_s.split('::')[1].downcase.split('_').first}_build.rb")
-  @default_llvm_build_obj = Package.load_package("#{__dir__}/#{CREW_LLVM_VER}_build.rb")
+  llvm_build_obj = Package.load_package("#{__dir__}/llvm23_build.rb")
   description 'LLVM: Everything except libLLVM & llvm-strip'
-  homepage @llvm_build_obj.homepage
-  version @llvm_build_obj.version
+  homepage llvm_build_obj.homepage
+  version llvm_build_obj.version
   # When upgrading llvm*_build, be sure to upgrade llvm_lib*, llvm_dev*, libclc, and openmp in tandem.
-  puts "#{self} version differs from llvm version #{@default_llvm_build_obj.version}".orange if version != @default_llvm_build_obj.version && !ENV['NESTED_CI']
-  license @llvm_build_obj.license
+  puts "#{self} version differs from llvm version #{llvm_build_obj.version}".orange if version != llvm_build_obj.version && !ENV['NESTED_CI']
+  license llvm_build_obj.license
   compatibility 'all'
   source_url 'SKIP'
   binary_compression 'tar.zst'
@@ -39,8 +38,9 @@ class Llvm23_dev < Package
   no_strip
 
   def self.preflight
-    abort "Update #{ancestors[0].to_s.split('::')[1].downcase.split('_').first}_build first.".lightred if Gem::Version.new(version) < Gem::Version.new(@default_llvm_build_obj.version.split('-').first)
-    llvm_lib_obj = Package.load_package("#{__dir__}/#{ancestors[0].to_s.split('::')[1].downcase.split('_').first}_lib.rb")
+    llvm_build_obj = Package.load_package("#{__dir__}/#{CREW_LLVM_VER}_build.rb")
+    abort "Update #{CREW_LLVM_VER}_build first.".lightred if Gem::Version.new(version) < Gem::Version.new(llvm_build_obj.version.split('-').first)
+    llvm_lib_obj = Package.load_package("#{__dir__}/#{CREW_LLVM_VER}_dev.rb")
     abort "Update  #{CREW_LLVM_VER}_lib first.".lightred if Gem::Version.new(version) > Gem::Version.new(llvm_lib_obj.version.split('-').first)
   end
 

--- a/packages/llvm23_lib.rb
+++ b/packages/llvm23_lib.rb
@@ -1,14 +1,13 @@
 require 'package'
 
 class Llvm23_lib < Package
-  @llvm_build_obj = Package.load_package("#{__dir__}/#{ancestors[0].to_s.split('::')[1].downcase.split('_').first}_build.rb")
-  @default_llvm_build_obj = Package.load_package("#{__dir__}/#{CREW_LLVM_VER}_build.rb")
+  llvm_build_obj = Package.load_package("#{__dir__}/llvm23_build.rb")
   description 'LibLLVM and llvm-strip'
-  homepage @llvm_build_obj.homepage
-  version @llvm_build_obj.version
+  homepage llvm_build_obj.homepage
+  version llvm_build_obj.version
   # When upgrading llvm*_build, be sure to upgrade llvm_lib*, llvm_dev*, libclc, and openmp in tandem.
-  puts "#{self} version differs from llvm version #{@default_llvm_build_obj.version}".orange if version != @default_llvm_build_obj.version && !ENV['NESTED_CI']
-  license @llvm_build_obj.license
+  puts "#{self} version differs from llvm version #{llvm_build_obj.version}".orange if version != llvm_build_obj.version && !ENV['NESTED_CI']
+  license llvm_build_obj.license
   compatibility 'all'
   source_url 'SKIP'
   binary_compression 'tar.zst'
@@ -36,7 +35,8 @@ class Llvm23_lib < Package
   no_strip
 
   def self.preflight
-    abort "Update #{ancestors[0].to_s.split('::')[1].downcase.split('_').first}_build first.".lightred if Gem::Version.new(version) < Gem::Version.new(@default_llvm_build_obj.version.split('-').first)
+    llvm_build_obj = Package.load_package("#{__dir__}/#{CREW_LLVM_VER}_build.rb")
+    abort "Update #{CREW_LLVM_VER} first.".lightred if Gem::Version.new(version) < Gem::Version.new(llvm_build_obj.version.split('-').first)
   end
 
   def self.install


### PR DESCRIPTION
## Description
#### Commits:
-  f2e9d37ff Revert llvm23 package logic.
### Packages with Updated versions or Changed package files:
- `llvm23_dev`: 23.1.0 &rarr; 23.1.0
- `llvm23_lib`: 23.1.0 &rarr; 23.1.0
##
Builds attempted for:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=llvm23_package_logic crew update \
&& yes | crew upgrade
```
