### PR TITLE
Add ignore_updater to older llvm releases. — llvm16_build: 16.0.6 → 16.0.6,llvm17_build: 17.0.6 → 17.0.6,llvm18_build: 18.1.8 → 18.1.8,llvm19_build: 19.1.7 → 19.1.7,llvm20_build: 20.1.8 → 20.1.8,llvm21_build: 21.1.8 → 21.1.8,llvm22_buil...

### DIFF
--- a/packages/llvm16_build.rb
+++ b/packages/llvm16_build.rb
@@ -32,8 +32,9 @@ class Llvm16_build < Package
   depends_on 'zlib' # R
   depends_on 'zstd' # R
 
-  no_env_options
   conflicts_ok
+  ignore_updater
+  no_env_options
 
   case ARCH
   when 'aarch64', 'armv7l'

--- a/packages/llvm17_build.rb
+++ b/packages/llvm17_build.rb
@@ -33,8 +33,9 @@ class Llvm17_build < Package
   depends_on 'zlib' # R
   depends_on 'zstd' # R
 
-  no_env_options
   conflicts_ok
+  ignore_updater
+  no_env_options
 
   case ARCH
   when 'aarch64', 'armv7l'

--- a/packages/llvm18_build.rb
+++ b/packages/llvm18_build.rb
@@ -34,8 +34,9 @@ class Llvm18_build < Package
   depends_on 'zlib' # R
   depends_on 'zstd' # R
 
-  no_env_options
   conflicts_ok
+  ignore_updater
+  no_env_options
 
   case ARCH
   when 'aarch64', 'armv7l'

--- a/packages/llvm19_build.rb
+++ b/packages/llvm19_build.rb
@@ -33,8 +33,9 @@ class Llvm19_build < Package
   depends_on 'zlib' # R
   depends_on 'zstd' # R
 
-  no_env_options
   conflicts_ok
+  ignore_updater
+  no_env_options
 
   case ARCH
   when 'aarch64', 'armv7l'

--- a/packages/llvm20_build.rb
+++ b/packages/llvm20_build.rb
@@ -33,6 +33,7 @@ class Llvm20_build < Package
   depends_on 'zstd' # R
 
   conflicts_ok
+  ignore_updater
   no_env_options
 
   case ARCH

--- a/packages/llvm21_build.rb
+++ b/packages/llvm21_build.rb
@@ -33,6 +33,7 @@ class Llvm21_build < Package
   depends_on 'zstd' # R
 
   conflicts_ok
+  ignore_updater
   no_env_options
 
   case ARCH

--- a/packages/llvm22_build.rb
+++ b/packages/llvm22_build.rb
@@ -37,6 +37,7 @@ class Llvm22_build < Package
   depends_on 'zstd' => :library
 
   conflicts_ok
+  ignore_updater
   no_env_options
 
   def self.patch


### PR DESCRIPTION
## Description
- This should keep the automatic updater from trying to update the older LLVM release packages to the current version.
#### Commits:
-  114f67c95 Add ignore_updater to older llvm releases.
### Packages with Updated versions or Changed package files:
- `llvm16_build`: 16.0.6 &rarr; 16.0.6 (current version is 23.1.0)
- `llvm17_build`: 17.0.6 &rarr; 17.0.6 (current version is 23.1.0)
- `llvm18_build`: 18.1.8 &rarr; 18.1.8 (current version is 23.1.0)
- `llvm19_build`: 19.1.7 &rarr; 19.1.7 (current version is 23.1.0)
- `llvm20_build`: 20.1.8 &rarr; 20.1.8 (current version is 23.1.0)
- `llvm21_build`: 21.1.8 &rarr; 21.1.8 (current version is 23.1.0)
- `llvm22_build`: 22.1.8 &rarr; 22.1.8 (current version is 23.1.0)
##
Builds attempted for:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
- [x] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=llvm_updater crew update \
&& yes | crew upgrade
```
