### PR TITLE
Zsync 0.6.3 => 0.8.0

### DIFF
--- a/manifest/armv7l/z/zsync.filelist
+++ b/manifest/armv7l/z/zsync.filelist
@@ -1,7 +1,5 @@
-# Total size: 173599
+# Total size: 8127451
 /usr/local/bin/zsync
 /usr/local/bin/zsyncmake
-/usr/local/share/doc/zsync/COPYING
-/usr/local/share/doc/zsync/README
 /usr/local/share/man/man1/zsync.1.zst
 /usr/local/share/man/man1/zsyncmake.1.zst

--- a/manifest/i686/z/zsync.filelist
+++ b/manifest/i686/z/zsync.filelist
@@ -1,7 +1,5 @@
-# Total size: 188003
+# Total size: 7890795
 /usr/local/bin/zsync
 /usr/local/bin/zsyncmake
-/usr/local/share/doc/zsync/COPYING
-/usr/local/share/doc/zsync/README
 /usr/local/share/man/man1/zsync.1.zst
 /usr/local/share/man/man1/zsyncmake.1.zst

--- a/manifest/x86_64/z/zsync.filelist
+++ b/manifest/x86_64/z/zsync.filelist
@@ -1,7 +1,5 @@
-# Total size: 207711
+# Total size: 8151715
 /usr/local/bin/zsync
 /usr/local/bin/zsyncmake
-/usr/local/share/doc/zsync/COPYING
-/usr/local/share/doc/zsync/README
 /usr/local/share/man/man1/zsync.1.zst
 /usr/local/share/man/man1/zsyncmake.1.zst

--- a/packages/zsync.rb
+++ b/packages/zsync.rb
@@ -1,26 +1,32 @@
-require 'buildsystems/autotools'
+require 'package'
 
-class Zsync < Autotools
+class Zsync < Package
   description 'zsync is a client-side file transfer program similar to rsync.'
   homepage 'http://zsync.moria.org.uk/'
-  version '0.6.3'
+  version '0.8.0'
   license 'Artistic-2'
   compatibility 'all'
-  source_url "https://zsync.moria.org.uk/download/zsync-#{version}.tar.bz2"
-  source_sha256 '0b9d53433387aa4f04634a6c63a5efa8203070f2298af72a705f9be3dda65af2'
+  source_url "https://zsync.moria.org.uk/download/zsync-#{version}.tar.gz"
+  source_sha256 '58b02f27e14326b62b7fdd6ed431a3e243b1c5a3ea9e3c1678e136dbf00c238d'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'f7e83459da35ae6c1ae2522f5303da8eb7d8efb54d95dfefc13eb997efdbb593',
-     armv7l: 'f7e83459da35ae6c1ae2522f5303da8eb7d8efb54d95dfefc13eb997efdbb593',
-       i686: 'dd72efc81d19983e828cedb61a0313d50b67e51a90a8fabbf019768c9ba2b856',
-     x86_64: 'c2fec91043612cbf99514003f273f2334596cfc7c41f8746e415cc88ae0f0099'
+    aarch64: '962ac9cfb9254758c9cfea7e9c3f4887b7e5ea3b9349722c9040714b550d609f',
+     armv7l: '962ac9cfb9254758c9cfea7e9c3f4887b7e5ea3b9349722c9040714b550d609f',
+       i686: 'e0cf3eb430b914ba711e7aa81c421a7073b60e3952bd02d4efc537dd1dae20b9',
+     x86_64: 'bab028f04261c378eebbbc369176a3ff99d877eade56e1aceb62778b11600572'
   })
 
-  depends_on 'glibc' # R
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'go' => :build
 
-  def self.patch
-    downloader 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD', 'asasasa', 'autotools/config.guess'
-    downloader 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD', 'asascdcd', 'autotools/config.sub'
+  no_shrink
+
+  def self.install
+    FileUtils.mkdir_p "#{CREW_DEST_PREFIX}/bin"
+    system "go build -o #{CREW_DEST_PREFIX}/bin/zsync ./cmd/zsync"
+    system "go build -o #{CREW_DEST_PREFIX}/bin/zsyncmake ./cmd/zsyncmake"
+    FileUtils.install Dir['man/zsync*.1'], "#{CREW_DEST_MAN_PREFIX}/man1", mode: 0o644
   end
 end

--- a/tests/package/z/zsync
+++ b/tests/package/z/zsync
@@ -1,0 +1,5 @@
+#!/bin/bash
+zsync -h 2>&1
+zsync -V
+zsyncmake -h 2>&1
+zsyncmake -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-zsync crew update \
&& yes | crew upgrade

$ crew check zsync
Checking zsync package ...
Library test for zsync passed.
Checking zsync package ...
Usage of zsync:
  -A value
    	hostname=username:password
  -V	show version
  -i value
    	seed file to supply as local source data
  -k string
    	save a copy of the .zsync file to this path. If the download is interrupted, the download can be resumed using this local copy instead of redownloading.
  -no-check-certificate
    	Disable verifying the SSL certificate of any target server. NOTE: this makes the file transfer vulnerable to man-in-the-middle attacks.
  -o string
    	output filename or directory. A filename is required if the remote .zsync file does not set a filename.
  -q	suppress progress output
  -u string
    	If a local zsync file is supplied, this supplies the URL from which the .zsync file is or could be downloaded - this is used for resolving relative URLs in the .zsync file, as if the .zsync was downloaded from this URL.
  -v	verbose mode - reports some debugging stats
zsync v0.8.0
Usage of zsyncmake:
  -V	show version
  -Z	no-op (for compatibility)
  -b int
    	block size (must be power of 2)
  -e	no-op (for compatibility)
  -f string
    	recommended filename clients should use for the target file
  -o string
    	filename for the created .zsync file
  -s string
    	strong hash algorithm used. Options are MD4 (default), MD5 or SHA-224. Note that older versions of the zsync client only support .zsync files using MD4. (default "MD4")
  -u value
    	URL to include in .zsync
  -v	verbose output
  -z	no-op (for compatibility)
zsyncmake v0.8.0
By Colin Phipps <cph@moria.org.uk>
Published under the Artistic License 2.0, see the LICENSE file for details.
Package tests for zsync passed.
```