### PR TITLE
Zvbi 0.2.42-be5efeb => 0.2.45

### DIFF
--- a/manifest/armv7l/z/zvbi.filelist
+++ b/manifest/armv7l/z/zvbi.filelist
@@ -1,4 +1,4 @@
-# Total size: 4029328
+# Total size: 4243497
 /usr/local/bin/zvbi-atsc-cc
 /usr/local/bin/zvbi-chains
 /usr/local/bin/zvbi-ntsc-cc

--- a/manifest/x86_64/z/zvbi.filelist
+++ b/manifest/x86_64/z/zvbi.filelist
@@ -1,4 +1,4 @@
-# Total size: 4649922
+# Total size: 5053489
 /usr/local/bin/zvbi-atsc-cc
 /usr/local/bin/zvbi-chains
 /usr/local/bin/zvbi-ntsc-cc

--- a/packages/zvbi.rb
+++ b/packages/zvbi.rb
@@ -3,26 +3,27 @@ require 'buildsystems/autotools'
 class Zvbi < Autotools
   description 'VBI capture and decoding library.'
   homepage 'https://github.com/zapping-vbi/zvbi'
-  version '0.2.42-be5efeb'
+  version '0.2.45'
   license 'GPL-2+'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://github.com/zapping-vbi/zvbi.git'
-  git_hashtag 'be5efebaadeb95be57d5435468bd3ec0f3007683'
+  git_hashtag "v#{version}"
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'd2f582b4ee393dc0eca53805098b354efc68a766a32b2277fad26033a4bc1258',
-     armv7l: 'd2f582b4ee393dc0eca53805098b354efc68a766a32b2277fad26033a4bc1258',
-     x86_64: '622a92ff1bb9711422ba33d37a7635245adc0c1ba5f60cfb7a3aa7b150956682'
+    aarch64: 'fbf3013bca7f19416d6bd897bb2160ff7800aa55942f3dcda716dd9b3130359a',
+     armv7l: 'fbf3013bca7f19416d6bd897bb2160ff7800aa55942f3dcda716dd9b3130359a',
+     x86_64: '89c7a3244515259b3ccc016bd568054e43b1d35b6a7c7a8cfa644772faae0f7d'
   })
 
-  depends_on 'glibc' # R
-  depends_on 'libbsd' # R
-  depends_on 'libmd' # R
-  depends_on 'libpng' # R
-  depends_on 'libx11' # R
-  depends_on 'libxau' # R
-  depends_on 'libxcb' # R
-  depends_on 'libxdmcp' # R
-  depends_on 'zlib' # R
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
+  depends_on 'libbsd' => :executable
+  depends_on 'libmd' => :library
+  depends_on 'libpng' => :library
+  depends_on 'libx11' => :executable
+  depends_on 'libxau' => :executable
+  depends_on 'libxcb' => :executable
+  depends_on 'libxdmcp' => :executable
+  depends_on 'zlib' => :library
 end

--- a/tests/package/z/zvbi
+++ b/tests/package/z/zvbi
@@ -1,0 +1,3 @@
+#!/bin/bash
+zvbi-atsc-cc -h | head
+zvbi-ntsc-cc -h | head


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-zvbi crew update \
&& yes | crew upgrade

$ crew check zvbi 
Checking zvbi package ...
Library test for zvbi passed.
Checking zvbi package ...
ATSC-CC 0.5 -- ATSC Closed Caption and XDS decoder
Copyright (C) 2008 Michael H. Schimek <mschimek@users.sf.net>
Based on code by Mike Baker, Mark K. Kim and timecop@japan.co.jp.
This program is licensed under GPL 2 or later. NO WARRANTIES.

Usage: zvbi-atsc-cc [options] [-n] station name
Options:
-? | -h | --help | --usage     Print this message, then terminate
-1 ... -4 | --cc1-file ... --cc4-file file name
                               Append CC1 ... CC4 to this file
CCDecoder 0.13 -- Closed Caption and XDS decoder
Copyright (C) 2003-2007 Mike Baker, Mark K. Kim, Michael H. Schimek
<mschimek@users.sf.net>; Based on code by timecop@japan.co.jp.
This program is licensed under GPL 2 or later. NO WARRANTIES.

Usage: zvbi-ntsc-cc [options]
Options:
-? | -h | --help | --usage  Print this message and exit
-1 ... -4 | --cc1-file ... --cc4-file filename
                            Append caption channel CC1 ... CC4 to this file
Package tests for zvbi passed.
```