### PR TITLE
sysstat -> 12.8.0 in updater-sysstat-12.8.0 — sysstat: 12.7.9 → 12.8.0

### DIFF
--- a/manifest/armv7l/s/sysstat.filelist
+++ b/manifest/armv7l/s/sysstat.filelist
@@ -1,4 +1,4 @@
-# Total size: 1413004
+# Total size: 1419090
 /usr/local/bin/cifsiostat
 /usr/local/bin/iostat
 /usr/local/bin/mpstat
@@ -9,11 +9,11 @@
 /usr/local/lib/sa/sa1
 /usr/local/lib/sa/sa2
 /usr/local/lib/sa/sadc
-/usr/local/share/doc/sysstat-12.7.9/CHANGES
-/usr/local/share/doc/sysstat-12.7.9/COPYING
-/usr/local/share/doc/sysstat-12.7.9/CREDITS
-/usr/local/share/doc/sysstat-12.7.9/FAQ.md
-/usr/local/share/doc/sysstat-12.7.9/README.md
+/usr/local/share/doc/sysstat-12.8.0/CHANGES
+/usr/local/share/doc/sysstat-12.8.0/COPYING
+/usr/local/share/doc/sysstat-12.8.0/CREDITS
+/usr/local/share/doc/sysstat-12.8.0/FAQ.md
+/usr/local/share/doc/sysstat-12.8.0/README.md
 /usr/local/share/locale/af/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/be/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/cs/LC_MESSAGES/sysstat.mo

--- a/manifest/i686/s/sysstat.filelist
+++ b/manifest/i686/s/sysstat.filelist
@@ -1,4 +1,4 @@
-# Total size: 1675548
+# Total size: 1680910
 /usr/local/bin/cifsiostat
 /usr/local/bin/iostat
 /usr/local/bin/mpstat
@@ -9,11 +9,11 @@
 /usr/local/lib/sa/sa1
 /usr/local/lib/sa/sa2
 /usr/local/lib/sa/sadc
-/usr/local/share/doc/sysstat-12.7.9/CHANGES
-/usr/local/share/doc/sysstat-12.7.9/COPYING
-/usr/local/share/doc/sysstat-12.7.9/CREDITS
-/usr/local/share/doc/sysstat-12.7.9/FAQ.md
-/usr/local/share/doc/sysstat-12.7.9/README.md
+/usr/local/share/doc/sysstat-12.8.0/CHANGES
+/usr/local/share/doc/sysstat-12.8.0/COPYING
+/usr/local/share/doc/sysstat-12.8.0/CREDITS
+/usr/local/share/doc/sysstat-12.8.0/FAQ.md
+/usr/local/share/doc/sysstat-12.8.0/README.md
 /usr/local/share/locale/af/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/be/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/cs/LC_MESSAGES/sysstat.mo

--- a/manifest/x86_64/s/sysstat.filelist
+++ b/manifest/x86_64/s/sysstat.filelist
@@ -1,4 +1,4 @@
-# Total size: 1667915
+# Total size: 1674056
 /usr/local/bin/cifsiostat
 /usr/local/bin/iostat
 /usr/local/bin/mpstat
@@ -9,11 +9,11 @@
 /usr/local/lib64/sa/sa1
 /usr/local/lib64/sa/sa2
 /usr/local/lib64/sa/sadc
-/usr/local/share/doc/sysstat-12.7.9/CHANGES
-/usr/local/share/doc/sysstat-12.7.9/COPYING
-/usr/local/share/doc/sysstat-12.7.9/CREDITS
-/usr/local/share/doc/sysstat-12.7.9/FAQ.md
-/usr/local/share/doc/sysstat-12.7.9/README.md
+/usr/local/share/doc/sysstat-12.8.0/CHANGES
+/usr/local/share/doc/sysstat-12.8.0/COPYING
+/usr/local/share/doc/sysstat-12.8.0/CREDITS
+/usr/local/share/doc/sysstat-12.8.0/FAQ.md
+/usr/local/share/doc/sysstat-12.8.0/README.md
 /usr/local/share/locale/af/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/be/LC_MESSAGES/sysstat.mo
 /usr/local/share/locale/cs/LC_MESSAGES/sysstat.mo

--- a/packages/sysstat.rb
+++ b/packages/sysstat.rb
@@ -11,19 +11,15 @@ class Sysstat < Autotools
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '2bbc4b040c8830a9e1c29c5245aeef718ffeaa0a7a4eba240b3d357e8a4e6743',
-     armv7l: '2bbc4b040c8830a9e1c29c5245aeef718ffeaa0a7a4eba240b3d357e8a4e6743',
-       i686: '8ce65526577737faa583fa9e837bf755ed8ffa4ae07f7c2ff258f34f175d1945',
-     x86_64: '31fda4f33ffb1e7a237e70bb14685e9203b5dbc91652ab9c3afaad5fa373ba0d'
+    aarch64: 'fba6cb3a5d87032eeef03825ce89e4ec870cd5e88eb638b495004a7e79ffe282',
+     armv7l: 'fba6cb3a5d87032eeef03825ce89e4ec870cd5e88eb638b495004a7e79ffe282',
+       i686: '1c6b70023336e57001b3cfc35ac70e5b898f6528ccebb67adc230693041814aa',
+     x86_64: 'deec9065516e164d598cac67ef893d728528c8dd6e46a88bedcb096c47ca03b2'
   })
 
   depends_on 'glibc' => :library
   depends_on 'glibc_lib' => :library
 
-  def self.patch
-    system "sed -i 's/GRP=root/GRP=$(whoami)/' configure"
-    system "sed -i 's/\"root\"/\"$(whoami)\"/g' configure"
-    system "sed -i 's/root/$(whoami)/g' configure.ac"
-    system "sed -i 's/root/$(whoami)/g' sysstat-#{version}.spec"
-  end
+  autotools_pre_configure_options "man_group=#{`whoami`.chomp}"
+  autotools_configure_options '--disable-automated-sar-reporting'
 end

--- a/packages/sysstat.rb
+++ b/packages/sysstat.rb
@@ -3,7 +3,7 @@ require 'buildsystems/autotools'
 class Sysstat < Autotools
   description 'The sysstat utilities are a collection of performance monitoring tools for Linux. These include sar, sadf, mpstat, iostat, tapestat, pidstat, cifsiostat and sa tools.'
   homepage 'https://sysstat.github.io/'
-  version '12.7.9'
+  version '12.8.0'
   license 'GPL-2'
   compatibility 'all'
   source_url 'https://github.com/sysstat/sysstat.git'


### PR DESCRIPTION
## Description
#### Commits:
-  a9396a76e Refactor sysstat build.
-  e30b083f7 sysstat -> 12.8.0 in updater-sysstat-12.8.0
### Packages with Updated versions or Changed package files:
- `sysstat`: 12.7.9 &rarr; 12.8.0
##
Builds attempted for:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
##
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=updater-sysstat-12.8.0 crew update \
&& yes | crew upgrade
```
