### PR TITLE
Agedu 20241013.3622eda => 20260410.3622eda

### DIFF
--- a/manifest/armv7l/a/agedu.filelist
+++ b/manifest/armv7l/a/agedu.filelist
@@ -1,3 +1,3 @@
-# Total size: 81716
+# Total size: 81142
 /usr/local/bin/agedu
 /usr/local/share/man/man1/agedu.1.zst

--- a/manifest/i686/a/agedu.filelist
+++ b/manifest/i686/a/agedu.filelist
@@ -1,3 +1,3 @@
-# Total size: 106936
+# Total size: 107482
 /usr/local/bin/agedu
 /usr/local/share/man/man1/agedu.1.zst

--- a/manifest/x86_64/a/agedu.filelist
+++ b/manifest/x86_64/a/agedu.filelist
@@ -1,3 +1,3 @@
-# Total size: 105092
+# Total size: 107958
 /usr/local/bin/agedu
 /usr/local/share/man/man1/agedu.1.zst

--- a/packages/agedu.rb
+++ b/packages/agedu.rb
@@ -3,19 +3,20 @@ require 'buildsystems/cmake'
 class Agedu < CMake
   description 'Unix utility for tracking down wasted disk space'
   homepage 'https://www.chiark.greenend.org.uk/~sgtatham/agedu/'
-  version '20241013.3622eda'
+  version '20260410.3622eda'
   license 'Copyright 2008 Simon Tatham. All rights reserved.'
   compatibility 'all'
   source_url "https://www.chiark.greenend.org.uk/~sgtatham/agedu/agedu-#{version}.tar.gz"
-  source_sha256 '3f77cb2e4dd64c100f7a7b0789a6c06cc16f23e7fe78c1451f5020dd823cf2f8'
+  source_sha256 '37be3c0de116b4fa44d390cca929248fd2e12586ef22aca9474a009c568e561c'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '44559363e302ae40f141674da6d01f7262b14b2dc867ea2cf15f72323faeb1e7',
-     armv7l: '44559363e302ae40f141674da6d01f7262b14b2dc867ea2cf15f72323faeb1e7',
-       i686: '8be416e1b0168df16b13bdb005ab89ba1d4f32cf6e0c466c5123556e71e2c6d2',
-     x86_64: '4d85796caa466664eaa35b40d1fae9e546e81ab63faff3b68f648a6f622a8397'
+    aarch64: '108c293a11d76668616ad5c94e7dfa0d540ea0f7b34348d2168d0923ddb681be',
+     armv7l: '108c293a11d76668616ad5c94e7dfa0d540ea0f7b34348d2168d0923ddb681be',
+       i686: 'bc718988f578d8fb55ba7d06907810779e0d31270e6f2cb53d261bc5f62d0eef',
+     x86_64: '2746f953394dd87e80d173f6a43463cd63aafe36f1586c338ccf56c5d455488e'
   })
 
-  depends_on 'glibc' # R
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
 end

--- a/tests/package/a/agedu
+++ b/tests/package/a/agedu
@@ -1,0 +1,3 @@
+#!/bin/bash
+agedu -h | head
+agedu -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-agedu crew update \
&& yes | crew upgrade

$ crew check agedu 
Checking agedu package ...
Library test for agedu passed.
Checking agedu package ...
  usage: agedu [options] action [action...]
actions: -s, --scan directory    scan and index a directory
         -w, --web               serve HTML reports from a temporary web server
         -t, --text subdir       print a plain text report on a subdirectory
         -R, --remove            remove the index file
         -D, --dump              dump the index file on stdout
         -L, --load              load and index a dump file
         --presort               prepare a dump file for sorting
         --postsort              unprepare a dump file after sorting
         -S, --scan-dump directory scan only, generating a dump
agedu, revision 20260410.3622eda
Package tests for agedu passed.
```