### PR TITLE
Appstream_glib 0.8.3 => 0.8.4

### DIFF
--- a/manifest/armv7l/a/appstream_glib.filelist
+++ b/manifest/armv7l/a/appstream_glib.filelist
@@ -1,4 +1,4 @@
-# Total size: 2164664
+# Total size: 2236510
 /usr/local/bin/appstream-builder
 /usr/local/bin/appstream-compose
 /usr/local/bin/appstream-util

--- a/manifest/x86_64/a/appstream_glib.filelist
+++ b/manifest/x86_64/a/appstream_glib.filelist
@@ -1,4 +1,4 @@
-# Total size: 2378862
+# Total size: 2465040
 /usr/local/bin/appstream-builder
 /usr/local/bin/appstream-compose
 /usr/local/bin/appstream-util

--- a/packages/appstream_glib.rb
+++ b/packages/appstream_glib.rb
@@ -3,7 +3,7 @@ require 'buildsystems/meson'
 class Appstream_glib < Meson
   description 'Objects and methods for reading and writing AppStream metadata'
   homepage 'https://people.freedesktop.org/~hughsient/appstream-glib/'
-  version '0.8.3'
+  version '0.8.4'
   license 'LGPL-2.1+'
   compatibility 'aarch64 armv7l x86_64'
   source_url 'https://github.com/hughsie/appstream-glib.git'
@@ -11,34 +11,35 @@ class Appstream_glib < Meson
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'ef6e1cb2540ec553015b679cc0784e598bd55f462ed4a984eba94b43fe9cd24a',
-     armv7l: 'ef6e1cb2540ec553015b679cc0784e598bd55f462ed4a984eba94b43fe9cd24a',
-     x86_64: 'cc23b59bb3432eb68886c03f9109967d8975dc71a3170734032d846ea332341c'
+    aarch64: '7347e65dcaff9ebc286c9803329659f72b3989a034ee66f1ddebbdd788fa1a15',
+     armv7l: '7347e65dcaff9ebc286c9803329659f72b3989a034ee66f1ddebbdd788fa1a15',
+     x86_64: 'be19d39cde627ae56f7bcffdfe037bbf3d54e0440289774786f986d3c05033ec'
   })
 
-  depends_on 'cairo' # R
-  depends_on 'curl' # R
+  depends_on 'cairo' => :library
+  depends_on 'curl' => :library
   depends_on 'docbook' => :build
-  depends_on 'fontconfig' # R
-  depends_on 'freetype' # R
+  depends_on 'fontconfig' => :library
+  depends_on 'freetype' => :library
   depends_on 'gcab' => :build
-  depends_on 'gdk_pixbuf' # R
-  depends_on 'glibc' # R
-  depends_on 'glib' # R
+  depends_on 'gdk_pixbuf' => :library
+  depends_on 'glib' => :library
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
   depends_on 'gobject_introspection' => :build
   depends_on 'gperf' => :build
-  depends_on 'gtk3' # R
+  depends_on 'gtk3' => :library
   depends_on 'gtk_doc' => :build
-  depends_on 'harfbuzz' # R
-  depends_on 'json_glib' # R
-  depends_on 'libarchive' # R
+  depends_on 'harfbuzz' => :library
+  depends_on 'json_glib' => :library
+  depends_on 'libarchive' => :library
   depends_on 'libjpeg_turbo' => :build
-  depends_on 'libsoup2' => :build
   depends_on 'libsoup' => :build
+  depends_on 'libsoup2' => :build
   depends_on 'libstemmer' => :build
-  depends_on 'libyaml' # R
-  depends_on 'pango' # R
-  depends_on 'util_linux' # R
+  depends_on 'libyaml' => :library
+  depends_on 'pango' => :library
+  depends_on 'util_linux' => :library
 
   meson_options '-Dintrospection=true -Dman=false -Drpm=false'
 end

--- a/tests/package/a/appstream_glib
+++ b/tests/package/a/appstream_glib
@@ -1,0 +1,5 @@
+#!/bin/bash
+appstream-builder -h | head
+appstream-compose -h | head
+appstream-util -h | head
+appstream-util --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-appstream_glib crew update \
&& yes | crew upgrade

$ crew check appstream_glib 
Checking appstream_glib package ...
Library test for appstream_glib passed.
Checking appstream_glib package ...
Usage:
  appstream-builder [OPTION…]

Help Options:
  -h, --help                     Show help options

Application Options:
  -v, --verbose                  Show extra debugging information
  --add-cache-id                 Add a cache ID to each component
  --include-failed               Include failed results in the output
Usage:
  appstream-compose [OPTION…]  - APP-IDS

Help Options:
  -h, --help                    Show help options

Application Options:
  -v, --verbose                 Show extra debugging information
  --prefix=DIR                  Set the prefix
  --output-dir=DIR              Set the output directory
Usage:
  appstream-util [OPTION…]

  add-language                      Add a language to a source file
  add-provide                       Add a provide to a source file
  agreement-export                  Exports the agreement to text
  appdata-from-desktop              Creates an example AppData file from a .desktop file
  appdata-to-news                   Convert an AppData file to NEWS format
  check-component                   check an installed application
  check-root                        Check installed application data
Version:	0.8.4
Package tests for appstream_glib passed.
```