### PR TITLE
Apr_util 1.6.3 => 1.6.5

### DIFF
--- a/manifest/armv7l/a/apr_util.filelist
+++ b/manifest/armv7l/a/apr_util.filelist
@@ -1,4 +1,4 @@
-# Total size: 1652244
+# Total size: 1923055
 /usr/local/bin/apu-1-config
 /usr/local/include/apr-1/apr_anylock.h
 /usr/local/include/apr-1/apr_base64.h
@@ -35,6 +35,10 @@
 /usr/local/include/apr-1/apu_errno.h
 /usr/local/include/apr-1/apu_version.h
 /usr/local/include/apr-1/apu_want.h
+/usr/local/lib/apr-util-1/apr_dbd_odbc-1.so
+/usr/local/lib/apr-util-1/apr_dbd_odbc.a
+/usr/local/lib/apr-util-1/apr_dbd_odbc.la
+/usr/local/lib/apr-util-1/apr_dbd_odbc.so
 /usr/local/lib/apr-util-1/apr_dbd_sqlite3-1.so
 /usr/local/lib/apr-util-1/apr_dbd_sqlite3.a
 /usr/local/lib/apr-util-1/apr_dbd_sqlite3.la
@@ -44,5 +48,5 @@
 /usr/local/lib/libaprutil-1.la
 /usr/local/lib/libaprutil-1.so
 /usr/local/lib/libaprutil-1.so.0
-/usr/local/lib/libaprutil-1.so.0.6.3
+/usr/local/lib/libaprutil-1.so.0.6.5
 /usr/local/lib/pkgconfig/apr-util-1.pc

--- a/manifest/i686/a/apr_util.filelist
+++ b/manifest/i686/a/apr_util.filelist
@@ -1,4 +1,4 @@
-# Total size: 1765534
+# Total size: 1988867
 /usr/local/bin/apu-1-config
 /usr/local/include/apr-1/apr_anylock.h
 /usr/local/include/apr-1/apr_base64.h
@@ -35,6 +35,10 @@
 /usr/local/include/apr-1/apu_errno.h
 /usr/local/include/apr-1/apu_version.h
 /usr/local/include/apr-1/apu_want.h
+/usr/local/lib/apr-util-1/apr_dbd_odbc-1.so
+/usr/local/lib/apr-util-1/apr_dbd_odbc.a
+/usr/local/lib/apr-util-1/apr_dbd_odbc.la
+/usr/local/lib/apr-util-1/apr_dbd_odbc.so
 /usr/local/lib/apr-util-1/apr_dbd_sqlite3-1.so
 /usr/local/lib/apr-util-1/apr_dbd_sqlite3.a
 /usr/local/lib/apr-util-1/apr_dbd_sqlite3.la
@@ -44,5 +48,5 @@
 /usr/local/lib/libaprutil-1.la
 /usr/local/lib/libaprutil-1.so
 /usr/local/lib/libaprutil-1.so.0
-/usr/local/lib/libaprutil-1.so.0.6.3
+/usr/local/lib/libaprutil-1.so.0.6.5
 /usr/local/lib/pkgconfig/apr-util-1.pc

--- a/manifest/x86_64/a/apr_util.filelist
+++ b/manifest/x86_64/a/apr_util.filelist
@@ -1,4 +1,4 @@
-# Total size: 1814020
+# Total size: 2062219
 /usr/local/bin/apu-1-config
 /usr/local/include/apr-1/apr_anylock.h
 /usr/local/include/apr-1/apr_base64.h
@@ -35,6 +35,10 @@
 /usr/local/include/apr-1/apu_errno.h
 /usr/local/include/apr-1/apu_version.h
 /usr/local/include/apr-1/apu_want.h
+/usr/local/lib64/apr-util-1/apr_dbd_odbc-1.so
+/usr/local/lib64/apr-util-1/apr_dbd_odbc.a
+/usr/local/lib64/apr-util-1/apr_dbd_odbc.la
+/usr/local/lib64/apr-util-1/apr_dbd_odbc.so
 /usr/local/lib64/apr-util-1/apr_dbd_sqlite3-1.so
 /usr/local/lib64/apr-util-1/apr_dbd_sqlite3.a
 /usr/local/lib64/apr-util-1/apr_dbd_sqlite3.la
@@ -44,5 +48,5 @@
 /usr/local/lib64/libaprutil-1.la
 /usr/local/lib64/libaprutil-1.so
 /usr/local/lib64/libaprutil-1.so.0
-/usr/local/lib64/libaprutil-1.so.0.6.3
+/usr/local/lib64/libaprutil-1.so.0.6.5
 /usr/local/lib64/pkgconfig/apr-util-1.pc

--- a/packages/apr_util.rb
+++ b/packages/apr_util.rb
@@ -3,22 +3,33 @@ require 'buildsystems/autotools'
 class Apr_util < Autotools
   description 'APR-util provides a number of helpful abstractions on top of APR.'
   homepage 'https://apache.org/dist/apr'
-  version '1.6.3'
+  version '1.6.5'
   license 'Apache-2.0'
   compatibility 'all'
-  source_url 'https://dlcdn.apache.org/apr/apr-util-1.6.3.tar.bz2'
-  source_sha256 'a41076e3710746326c3945042994ad9a4fcac0ce0277dd8fea076fec3c9772b5'
+  source_url "https://dlcdn.apache.org/apr/apr-util-#{version}.tar.bz2"
+  source_sha256 '96de1dd6f6a0476d2d2e7964926d8c1ddc3bb0e210e1b1812d3ba5a454a392e2'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '51950f0c56c7f9c8e8e86dd2783a6f2ca4f3f3867a043f0e267218c9d4f42915',
-     armv7l: '51950f0c56c7f9c8e8e86dd2783a6f2ca4f3f3867a043f0e267218c9d4f42915',
-       i686: '377343921064393e2f63b891df8dc1e485c2b4ff87611e91aeb17096fac12dc7',
-     x86_64: '501d3d799eda2eb77a76994ca0ef00ccf56b231acd59de3a915e598b3555e5db'
+    aarch64: '2603f0186cc0310495f73a949c78812a2ebc0934b0fa40530c15cafa10949d8f',
+     armv7l: '2603f0186cc0310495f73a949c78812a2ebc0934b0fa40530c15cafa10949d8f',
+       i686: '40fbfd6d7e9a46f640e51a1970cf1877d9490c4e17d0477ae7d7740c648dbf4e',
+     x86_64: 'ddf0c7fd9578d3db9fc645ef587c8d138ecc5afeed01b5335ddda89ed78e7078'
   })
 
-  depends_on 'apr'
-  depends_on 'expat'
+  depends_on 'apr' => :library
+  depends_on 'expat' => :library
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
+  depends_on 'libtool' => :library
+  depends_on 'libxcrypt' => :library
+  depends_on 'sqlite' => :library
+  depends_on 'unixodbc' => :library
+  depends_on 'util_linux' => :library
 
   autotools_configure_options "--with-apr=#{CREW_PREFIX}"
+
+  def self.prebuild
+    ConvenienceFunctions.libtoolize('libuuid', 'util_linux')
+  end
 end

--- a/tests/package/a/apr_util
+++ b/tests/package/a/apr_util
@@ -1,0 +1,3 @@
+#!/bin/bash
+apu-1-config --help | head
+apu-1-config --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-apr_util crew update \
&& yes | crew upgrade

$ crew check apr_util 
Checking apr_util package ...
Library test for apr_util passed.
Checking apr_util package ...
Usage: apu-1-config [OPTION]

Known values for OPTION are:
  --prefix[=DIR]    change prefix to DIR
  --bindir          print location where binaries are installed
  --includes        print include information
  --includedir      print location where headers are installed
  --ldflags         print linker flags
  --libs            print library information
  --avoid-ldap      do not include ldap library information with --libs
1.6.5
Package tests for apr_util passed.
```