### PR TITLE
Add typst package

### DIFF
--- a/manifest/armv7l/t/typst.filelist
+++ b/manifest/armv7l/t/typst.filelist
@@ -1,0 +1,2 @@
+# Total size: 49033400
+/usr/local/bin/typst

--- a/manifest/x86_64/t/typst.filelist
+++ b/manifest/x86_64/t/typst.filelist
@@ -1,0 +1,2 @@
+# Total size: 55739488
+/usr/local/bin/typst

--- a/packages/typst.rb
+++ b/packages/typst.rb
@@ -1,0 +1,30 @@
+require 'package'
+
+class Typst < Package
+  description 'A markup-based typesetting system that is powerful and easy to learn.'
+  homepage 'https://typst.app/'
+  version '0.15.1'
+  license 'Apache-2.0'
+  compatibility 'aarch64 armv7l x86_64'
+  source_url({
+    aarch64: "https://github.com/typst/typst/releases/download/v#{version}/typst-armv7-unknown-linux-musleabi.tar.xz",
+     armv7l: "https://github.com/typst/typst/releases/download/v#{version}/typst-armv7-unknown-linux-musleabi.tar.xz",
+     x86_64: "https://github.com/typst/typst/releases/download/v#{version}/typst-x86_64-unknown-linux-musl.tar.xz"
+  })
+  source_sha256({
+    aarch64: '44986312e557b9ac0f2c71d5d5156c0ad93b2da374d54c859d6c0c7c0b73709f',
+     armv7l: '44986312e557b9ac0f2c71d5d5156c0ad93b2da374d54c859d6c0c7c0b73709f',
+     x86_64: 'a6d077d0a95eed5a2eba715b2dae06be954f624ccbf85758a03f389ded33118c'
+  })
+
+  no_compile_needed
+  no_shrink
+
+  def self.install
+    FileUtils.install 'typst', "#{CREW_DEST_PREFIX}/bin/typst", mode: 0o755
+  end
+
+  def self.postinstall
+    ExitMessage.add "\nType 'typst' to get started.\n"
+  end
+end

--- a/tests/package/t/typst
+++ b/tests/package/t/typst
@@ -1,0 +1,3 @@
+#!/bin/bash
+typst -h | head
+typst -V

--- a/tools/packages.yaml
+++ b/tools/packages.yaml
@@ -10025,6 +10025,11 @@ url: https://github.com/microsoft/TypeScript/releases
 activity: high
 ---
 kind: url
+name: typst
+url: https://github.com/typst/typst/releases
+activity: medium
+---
+kind: url
 name: uasm
 url: https://github.com/Terraspace/UASM/releases
 activity: low


### PR DESCRIPTION
## Description
A markup-based typesetting system that is powerful and easy to learn.  See https://typst.app/.
#
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=add-typst-package crew update \
&& yes | crew upgrade

$ crew check typst 
Checking typst package ...
Library test for typst passed.
Checking typst package ...
Typst 0.15.1 (9dfd3a08)

Usage: typst [OPTIONS] <COMMAND>

Commands:
  compile      Compiles an input file into a supported output format [aliases:
               c]
  watch        Watches an input file and recompiles on changes [aliases: w]
  init         Initializes a new project from a template
  eval         Evaluates a piece of Typst code, optionally in the context of a
typst 0.15.1 (9dfd3a08)
Package tests for typst passed.
```