### PR TITLE
Atop 2.12.1 => 2.13.0

### DIFF
--- a/manifest/armv7l/a/atop.filelist
+++ b/manifest/armv7l/a/atop.filelist
@@ -1,11 +1,11 @@
-# Total size: 910299
+# Total size: 956935
 /usr/local/bin/atop
-/usr/local/bin/atop-2.12.1
+/usr/local/bin/atop-2.13.0
 /usr/local/bin/atopcat
 /usr/local/bin/atopconvert
 /usr/local/bin/atophide
 /usr/local/bin/atopsar
-/usr/local/bin/atopsar-2.12.1
+/usr/local/bin/atopsar-2.13.0
 /usr/local/etc/cron.d/atop
 /usr/local/etc/default/atop
 /usr/local/etc/init.d/atop

--- a/manifest/x86_64/a/atop.filelist
+++ b/manifest/x86_64/a/atop.filelist
@@ -1,11 +1,11 @@
-# Total size: 975263
+# Total size: 1036487
 /usr/local/bin/atop
-/usr/local/bin/atop-2.12.1
+/usr/local/bin/atop-2.13.0
 /usr/local/bin/atopcat
 /usr/local/bin/atopconvert
 /usr/local/bin/atophide
 /usr/local/bin/atopsar
-/usr/local/bin/atopsar-2.12.1
+/usr/local/bin/atopsar-2.13.0
 /usr/local/etc/cron.d/atop
 /usr/local/etc/default/atop
 /usr/local/etc/init.d/atop

--- a/packages/atop.rb
+++ b/packages/atop.rb
@@ -3,23 +3,24 @@ require 'package'
 class Atop < Package
   description 'ASCII full-screen performance monitor'
   homepage 'https://www.atoptool.nl/'
-  version '2.12.1'
+  version '2.13.0'
   license 'GPL-2'
   compatibility 'aarch64 armv7l x86_64'
   source_url "https://www.atoptool.nl/download/atop-#{version}.tar.gz"
-  source_sha256 '4fdbe67c5dfaf89405639e18599f4eae77978073ffa54f3c78c368ab54bd12f6'
+  source_sha256 'ea182f84c9f52ca922e5af4f17dff97ff424400a4f2f92393317a6af66e6a874'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '11fb48eec0f39c66d957604479d720fdf26cc6fd76864bc70808469c8832cb8c',
-     armv7l: '11fb48eec0f39c66d957604479d720fdf26cc6fd76864bc70808469c8832cb8c',
-     x86_64: '0d8ae8ca232411497c9fefe7bb3f855a2e4f651b85c12053f226301ff7fdef7d'
+    aarch64: 'ab5216f3406ddf446a57d450fc37b46b0b1e64377eb99dc3320eef30a4737313',
+     armv7l: 'ab5216f3406ddf446a57d450fc37b46b0b1e64377eb99dc3320eef30a4737313',
+     x86_64: '2675b53c5086f028cb3e41c184f54cfac24c06752e0b7616f44a2939c93fba79'
   })
 
-  depends_on 'glib' # R
-  depends_on 'glibc' # R
-  depends_on 'ncurses' # R
-  depends_on 'zlib' # R
+  depends_on 'glib' => :executable
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'ncurses' => :executable
+  depends_on 'zlib' => :executable
 
   def self.patch
     system "sed -i 's,/usr/bin,#{CREW_PREFIX}/bin,g' Makefile"

--- a/tests/package/a/atop
+++ b/tests/package/a/atop
@@ -1,0 +1,3 @@
+#!/bin/bash
+atop -h | head
+atop -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-atop crew update \
&& yes | crew upgrade

$ crew check atop
Checking atop package ...
Library test for atop passed.
Checking atop package ...
Usage: atop [-t [absdir]] [-flags] [interval [samples]]
		or
Usage: atop -w  file  [-S] [-a] [interval [samples]]
       atop -r [file] [-b [YYYYMMDD]hhmm[ss]] [-e [YYYYMMDD]hhmm[ss]] [-flags]

	generic flags:
	  -t  twin mode: live measurement with possibility to review earlier samples
	                 (raw file created in /tmp or in specific directory path)
	  -B  show bar graphs for system statistics
	  -H  show bar graphs without categories
Version: 2.13.0 - 2026/07/18 19:38:52     <gerlof.langeveld@atoptool.nl>
Package tests for atop passed.
```