### PR TITLE
Attr 2.5.2-4d4a562 => 2.6.0

### DIFF
--- a/manifest/armv7l/a/attr.filelist
+++ b/manifest/armv7l/a/attr.filelist
@@ -1,4 +1,4 @@
-# Total size: 302899
+# Total size: 295647
 /usr/local/bin/attr
 /usr/local/bin/getfattr
 /usr/local/bin/setfattr
@@ -10,7 +10,7 @@
 /usr/local/lib/libattr.la
 /usr/local/lib/libattr.so
 /usr/local/lib/libattr.so.1
-/usr/local/lib/libattr.so.1.1.2502
+/usr/local/lib/libattr.so.1.1.2600
 /usr/local/lib/pkgconfig/libattr.pc
 /usr/local/share/doc/attr/CHANGES
 /usr/local/share/doc/attr/COPYING

--- a/manifest/i686/a/attr.filelist
+++ b/manifest/i686/a/attr.filelist
@@ -1,4 +1,4 @@
-# Total size: 323067
+# Total size: 315535
 /usr/local/bin/attr
 /usr/local/bin/getfattr
 /usr/local/bin/setfattr
@@ -10,7 +10,7 @@
 /usr/local/lib/libattr.la
 /usr/local/lib/libattr.so
 /usr/local/lib/libattr.so.1
-/usr/local/lib/libattr.so.1.1.2502
+/usr/local/lib/libattr.so.1.1.2600
 /usr/local/lib/pkgconfig/libattr.pc
 /usr/local/share/doc/attr/CHANGES
 /usr/local/share/doc/attr/COPYING

--- a/manifest/x86_64/a/attr.filelist
+++ b/manifest/x86_64/a/attr.filelist
@@ -1,4 +1,4 @@
-# Total size: 334451
+# Total size: 327135
 /usr/local/bin/attr
 /usr/local/bin/getfattr
 /usr/local/bin/setfattr
@@ -10,7 +10,7 @@
 /usr/local/lib64/libattr.la
 /usr/local/lib64/libattr.so
 /usr/local/lib64/libattr.so.1
-/usr/local/lib64/libattr.so.1.1.2502
+/usr/local/lib64/libattr.so.1.1.2600
 /usr/local/lib64/pkgconfig/libattr.pc
 /usr/local/share/doc/attr/CHANGES
 /usr/local/share/doc/attr/COPYING

--- a/packages/attr.rb
+++ b/packages/attr.rb
@@ -3,22 +3,22 @@ require 'buildsystems/autotools'
 class Attr < Autotools
   description 'Commands for Manipulating Filesystem Extended Attributes.'
   homepage 'https://savannah.nongnu.org/projects/attr'
-  version '2.5.2-4d4a562'
+  version '2.6.0'
   license 'LGPL-2.1'
   compatibility 'all'
   source_url 'https://git.savannah.gnu.org/git/attr.git'
-  git_hashtag '4d4a562d7b73dcea8bd4b2d40b8c030d5065111b'
-  # git_hashtag "v#{version.split('-').first}"
+  git_hashtag "v#{version}"
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'ad03b735e0a60ab60b0c68cb5590b0f93206f31d50c27516b89c39814dcec6f1',
-     armv7l: 'ad03b735e0a60ab60b0c68cb5590b0f93206f31d50c27516b89c39814dcec6f1',
-       i686: '9ef95add0044d6d1681132eeb371c3214768af5caf9b25aaa8aa1fe7fa483ec4',
-     x86_64: 'eab11fd7c7b070b0bdaaa130ef733168481a25c05ec7b4c285a3dd893f33e947'
+    aarch64: '1446a5efca5a65e2dda6db0bbb3b64f820dc762d6d9abba3244c3afd6b92a7d5',
+     armv7l: '1446a5efca5a65e2dda6db0bbb3b64f820dc762d6d9abba3244c3afd6b92a7d5',
+       i686: 'd8abeca24be3aa0c70d3ef2e35ea254e7db773d0c64dc32a9fca99f023f8c1da',
+     x86_64: 'ac19a0cb4e2175a81f63fdb32bd4d70da57c9968601ffb40db1509e3b71d7593'
   })
 
   depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
   depends_on 'libcap' => :build
 
   no_filefix

--- a/tests/package/a/attr
+++ b/tests/package/a/attr
@@ -1,0 +1,5 @@
+#!/bin/bash
+getfattr --help
+getfattr --version
+setfattr --help
+setfattr --version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-attr crew update \
&& yes | crew upgrade

$ crew check attr 
Checking attr package ...
Library test for attr passed.
Checking attr package ...
getfattr 2.6.0 -- get extended attributes
Usage: getfattr [-hRLP] [-n name|-d] [-e en] [-m pattern] path...
  -n, --name=name         get the named extended attribute value
  -d, --dump              get all extended attribute values
  -e, --encoding=...      encode values (as 'text', 'hex' or 'base64')
  -m, --match=pattern     only get attributes with names matching pattern
      --only-values       print the bare values only
  -h, --no-dereference    do not dereference symbolic links
      --one-file-system   skip files on different filesystems
      --absolute-names    don't strip leading '/' in pathnames
  -R, --recursive         recurse into subdirectories
  -L, --logical           logical walk, follow symbolic links
  -P  --physical          physical walk, do not follow symbolic links
      --version           print version and exit
      --help              this help text
getfattr 2.6.0
setfattr 2.6.0 -- set extended attributes
Usage: setfattr {-n name} [-v value] [-h] file...
       setfattr {-x name} [-h] file...
       setfattr [-hP] --restore=file
  -n, --name=name         set the value of the named extended attribute
  -x, --remove=name       remove the named extended attribute
  -v, --value=value       use value as the attribute value
  -h, --no-dereference    do not dereference symbolic links
  -P, --physical          do not traverse symbolic links during a restore
      --restore=file      restore extended attributes
      --raw               attribute value is not encoded
      --version           print version and exit
      --help              this help text
setfattr 2.6.0
Package tests for attr passed.
```