### PR TITLE
Bacon 5.0.3 => 5.0.4

### DIFF
--- a/manifest/armv7l/b/bacon.filelist
+++ b/manifest/armv7l/b/bacon.filelist
@@ -1,4 +1,4 @@
-# Total size: 2865368
+# Total size: 2656232
 /usr/local/bin/bacon
 /usr/local/bin/bacon.sh
 /usr/local/share/BaCon/LICENSE.txt

--- a/manifest/i686/b/bacon.filelist
+++ b/manifest/i686/b/bacon.filelist
@@ -1,4 +1,4 @@
-# Total size: 2886124
+# Total size: 2866072
 /usr/local/bin/bacon
 /usr/local/bin/bacon.sh
 /usr/local/share/BaCon/LICENSE.txt

--- a/manifest/x86_64/b/bacon.filelist
+++ b/manifest/x86_64/b/bacon.filelist
@@ -1,4 +1,4 @@
-# Total size: 2790932
+# Total size: 2763948
 /usr/local/bin/bacon
 /usr/local/bin/bacon.sh
 /usr/local/share/BaCon/LICENSE.txt

--- a/packages/bacon.rb
+++ b/packages/bacon.rb
@@ -3,21 +3,22 @@ require 'buildsystems/autotools'
 class Bacon < Autotools
   description 'BaCon is a free BASIC to C translator for Unix-based systems.'
   homepage 'https://chiselapp.com/user/bacon/repository/bacon/home'
-  version '5.0.3'
+  version '5.0.4'
   license 'MIT'
   compatibility 'all'
   source_url "https://www.basic-converter.org/stable/bacon-#{version}.tar.gz"
-  source_sha256 '17b7ca78cd9ac019b42db517df47038b9036c269fe76bb6ff07ea1c0c8038918'
+  source_sha256 'bc771cb23efa589dd13abbc599564b9667392e0060db3cc4bda205eebaf72ab0'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'e4060f1682208b403f2e9a2da4f31d3df8b16b8035c21fa437786167dac94715',
-     armv7l: 'e4060f1682208b403f2e9a2da4f31d3df8b16b8035c21fa437786167dac94715',
-       i686: '783e565c4f5068bf9e71bab02e55439d95572f45612a98ee818ade6975ea642b',
-     x86_64: 'd483716bd64c47cd54e3fff09b78308db0736125c9b1d031a7d969cc026a6f9b'
+    aarch64: '9419f1eac5f375c0848e7079f6ccff92ba43cc318a5893b31331f61744864bc2',
+     armv7l: '9419f1eac5f375c0848e7079f6ccff92ba43cc318a5893b31331f61744864bc2',
+       i686: '302224d70289867631e116cced2681a0da1f3a320c2b91a38debd7085d6c0d29',
+     x86_64: '307bae5ab40b2d5072888554f0bdfc469ec16ef5f688efa4c92ba687d960946e'
   })
 
-  depends_on 'glibc' # R
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
 
   def self.patch
     system 'sed -i "s,/usr/share,\$\(DATADIR\)," Makefile.in'

--- a/tests/package/b/bacon
+++ b/tests/package/b/bacon
@@ -1,0 +1,3 @@
+#!/bin/bash
+bacon -h | head
+bacon -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-bacon crew update \
&& yes | crew upgrade

$ crew check bacon
Checking bacon package ...
Library test for bacon passed.
Checking bacon package ...

USAGE: bacon [options] program[.bac]

OPTIONS:

 -c <compiler>	Compiler to use (default: cc)
 -l <ldflags>	Pass libraries to linker
 -o <options>	Pass compiler options
 -i <include>	Add include file to C code
 -d <tmpdir>	Temporary directory (default: .)

BaCon version 5.0.4 on Linux x86_64 - (c) Peter van Eerten - MIT License.

Package tests for bacon passed.
``