### PR TITLE
Bats 1.13.0 => 1.14.0

### DIFF
--- a/manifest/armv7l/b/bats.filelist
+++ b/manifest/armv7l/b/bats.filelist
@@ -1,4 +1,4 @@
-# Total size: 147046
+# Total size: 151717
 /usr/local/bin/bats
 /usr/local/lib/bats-core/common.bash
 /usr/local/lib/bats-core/formatter.bash

--- a/manifest/i686/b/bats.filelist
+++ b/manifest/i686/b/bats.filelist
@@ -1,4 +1,4 @@
-# Total size: 147046
+# Total size: 151717
 /usr/local/bin/bats
 /usr/local/lib/bats-core/common.bash
 /usr/local/lib/bats-core/formatter.bash

--- a/manifest/x86_64/b/bats.filelist
+++ b/manifest/x86_64/b/bats.filelist
@@ -1,4 +1,4 @@
-# Total size: 147048
+# Total size: 151719
 /usr/local/bin/bats
 /usr/local/lib64/bats-core/common.bash
 /usr/local/lib64/bats-core/formatter.bash

--- a/packages/bats.rb
+++ b/packages/bats.rb
@@ -3,7 +3,7 @@ require 'package'
 class Bats < Package
   description 'Bash Automated Testing System'
   homepage 'https://github.com/bats-core/bats-core'
-  version '1.13.0'
+  version '1.14.0'
   license 'MIT'
   compatibility 'all'
   source_url 'https://github.com/bats-core/bats-core.git'
@@ -11,10 +11,10 @@ class Bats < Package
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '3d4611b3b3edb932d5ab561ba026530a442790ae0a49f3250360d5a808a5c5e4',
-     armv7l: '3d4611b3b3edb932d5ab561ba026530a442790ae0a49f3250360d5a808a5c5e4',
-       i686: '9ed3dbf1660222836086d6a6bee6325bbc83945792f789ad89f533bf4bd24993',
-     x86_64: 'dd3909855f57b21b3dcb0ed284f516f5292225843d8fed79f45da32ee85f9aea'
+    aarch64: '547f34298cf4b94e799e02f05ce42a49d82dd5131e5939eca7d4d79082262bb6',
+     armv7l: '547f34298cf4b94e799e02f05ce42a49d82dd5131e5939eca7d4d79082262bb6',
+       i686: '7d924a856b66296fb3e134990e61579399ecc3d6c55d57bba06ac5397747a700',
+     x86_64: '597df5d0be67f5f1d6c6630b0029c2a55f35d22dc743308700892a3f99bd1921'
   })
 
   def self.install

--- a/tests/package/b/bats
+++ b/tests/package/b/bats
@@ -1,0 +1,3 @@
+#!/bin/bash
+bats -h | head
+bats -v


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-bats crew update \
&& yes | crew upgrade

$ crew check bats 
Checking bats package ...
Library test for bats passed.
Checking bats package ...
Bats 1.14.0
Usage: bats [OPTIONS] <tests>
       bats [-h | -v]

  <tests> is the path to a Bats test file, or the path to a directory
  containing Bats test files (ending with ".bats")

  --abort                   Stop execution of suite on first failed test
  --allow-empty-suite       Exit with code 0 (instead of the default code 1) when no tests are found.
  -c, --count               Count test cases without running any tests
Bats 1.14.0
Package tests for bats passed.
```