### PR TITLE
Bottom 0.12.3 => 0.14.9

### DIFF
--- a/manifest/armv7l/b/bottom.filelist
+++ b/manifest/armv7l/b/bottom.filelist
@@ -1,3 +1,3 @@
-# Total size: 4072791
+# Total size: 4240860
 /usr/local/bin/btm
 /usr/local/etc/bash.d/btm.bash

--- a/manifest/i686/b/bottom.filelist
+++ b/manifest/i686/b/bottom.filelist
@@ -1,3 +1,0 @@
-# Total size: 4719759
-/usr/local/bin/btm
-/usr/local/etc/bash.d/btm.bash

--- a/manifest/x86_64/b/bottom.filelist
+++ b/manifest/x86_64/b/bottom.filelist
@@ -1,3 +1,3 @@
-# Total size: 4990427
+# Total size: 5112532
 /usr/local/bin/btm
 /usr/local/etc/bash.d/btm.bash

--- a/packages/bottom.rb
+++ b/packages/bottom.rb
@@ -3,21 +3,19 @@ require 'package'
 class Bottom < Package
   description 'Yet another cross-platform graphical process/system monitor.'
   homepage 'https://github.com/ClementTsang/bottom'
-  version '0.12.3'
+  version '0.14.9'
   license 'MIT'
-  compatibility 'all'
-  min_glibc '2.28' if ARCH.eql?('x86_64')
+  compatibility 'aarch64 armv7l x86_64'
+  min_glibc '2.28'
   source_url({
     aarch64: "https://github.com/ClementTsang/bottom/releases/download/#{version}/bottom_armv7-unknown-linux-gnueabihf.tar.gz",
      armv7l: "https://github.com/ClementTsang/bottom/releases/download/#{version}/bottom_armv7-unknown-linux-gnueabihf.tar.gz",
-       i686: "https://github.com/ClementTsang/bottom/releases/download/#{version}/bottom_i686-unknown-linux-gnu.tar.gz",
      x86_64: "https://github.com/ClementTsang/bottom/releases/download/#{version}/bottom_x86_64-unknown-linux-gnu.tar.gz"
   })
   source_sha256({
-    aarch64: '42554905f61056d760206a466e3732b348f9fa78221f2dfdb0700d6707661938',
-     armv7l: '42554905f61056d760206a466e3732b348f9fa78221f2dfdb0700d6707661938',
-       i686: 'e479e7f6e4cfeb96bc6c9045e266e6f5fa1bcdf937fd53d9561171221fc95e24',
-     x86_64: '468131d586dee6f4cce23fae597646cfd032103ecf749a478acb9d236adab6d6'
+    aarch64: 'a9c1aa0a12d6f6fcbd7948c4dc50504504c916ad1ef4ed0219483e64fbe03038',
+     armv7l: 'a9c1aa0a12d6f6fcbd7948c4dc50504504c916ad1ef4ed0219483e64fbe03038',
+     x86_64: 'e0c325829e8bdcea25a8a7651da05dbb6f1fc109ac5d2f0187867d3d5d9c0df8'
   })
 
   no_compile_needed

--- a/tests/package/b/bottom
+++ b/tests/package/b/bottom
@@ -1,0 +1,3 @@
+#!/bin/bash
+btm -h | head
+btm -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-bottom crew update \
&& yes | crew upgrade

$ crew check bottom
Checking bottom package ...
Library test for bottom passed.
Checking bottom package ...
bottom 0.14.9
Clement Tsang <cjhtsang@uwaterloo.ca>

A customizable cross-platform graphical process/system monitor for the terminal. Supports Linux, macOS, and Windows.

Usage: btm [OPTIONS]

General Options:
      --autohide_time                 Temporarily shows the time scale in graphs.
  -b, --basic                         Hides graphs and uses a more basic look.
bottom 0.14.9
Package tests for bottom passed.
```