### PR TITLE
Cabal 3.16.1.0 => 3.18.1.0

### DIFF
--- a/manifest/i686/c/cabal.filelist
+++ b/manifest/i686/c/cabal.filelist
@@ -1,2 +1,2 @@
-# Total size: 52267512
+# Total size: 35674780
 /usr/local/bin/cabal

--- a/manifest/x86_64/c/cabal.filelist
+++ b/manifest/x86_64/c/cabal.filelist
@@ -1,2 +1,2 @@
-# Total size: 61323816
+# Total size: 62752752
 /usr/local/bin/cabal

--- a/packages/cabal.rb
+++ b/packages/cabal.rb
@@ -3,17 +3,17 @@ require 'package'
 class Cabal < Package
   description 'Common Architecture for Building Applications and Libraries'
   homepage 'https://www.haskell.org/cabal/'
-  version '3.16.1.0'
+  version '3.18.1.0'
   license 'BSD'
   compatibility 'i686 x86_64'
 
   source_url({
-    x86_64: "https://downloads.haskell.org/~cabal/cabal-install-#{version}/cabal-install-#{version}-x86_64-linux-alpine3_12.tar.xz",
-      i686: "https://downloads.haskell.org/~cabal/cabal-install-#{version}/cabal-install-#{version}-i386-linux-alpine3_22.tar.xz"
+    x86_64: "https://downloads.haskell.org/~cabal/cabal-install-#{version}/cabal-install-#{version}-x86_64-linux-unknown.tar.xz",
+      i686: "https://downloads.haskell.org/~cabal/cabal-install-#{version}/cabal-install-#{version}-i386-linux-unknown.tar.xz"
   })
   source_sha256({
-    x86_64: '5ebe58932e7856dd08e5617414597c5d07799d72796faf24d23f2355ca37b3df',
-      i686: 'ee40adbb1407b61e01624d09326783d12f7d67755511ae18b5df8e1dbb91d11b'
+    x86_64: 'c6385c155ff61f792dfed0e8c101004db63f8d8b556dd6c9838f81a012bf28a6',
+      i686: '8cf20d0d9b258c9add7efd0471da97b0c719c06422219e9211f5b16ca509c39e'
   })
 
   no_compile_needed


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-cabal crew update \
&& yes | crew upgrade

$ crew check cabal 
Checking cabal package ...
Library test for cabal passed.
Checking cabal package ...
Command line interface to the Haskell Cabal infrastructure.

See http://www.haskell.org/cabal/ for more information.

Usage: cabal [GLOBAL FLAGS] [COMMAND [FLAGS]]

Commands:
 [global]
  user-config            Display and update the user's global cabal configuration.
  help                   Help about commands.
cabal-install version 3.18.1.0
compiled using version 3.18.1.0 of the Cabal library 
Package tests for cabal passed.
```