### PR TITLE
Cadaver 0.24 => 0.28

### DIFF
--- a/manifest/armv7l/c/cadaver.filelist
+++ b/manifest/armv7l/c/cadaver.filelist
@@ -1,3 +1,5 @@
-# Total size: 42030
+# Total size: 123747
 /usr/local/bin/cadaver
+/usr/local/share/locale/en@quot/LC_MESSAGES/cadaver.mo
+/usr/local/share/locale/es/LC_MESSAGES/cadaver.mo
 /usr/local/share/man/man1/cadaver.1.zst

--- a/manifest/x86_64/c/cadaver.filelist
+++ b/manifest/x86_64/c/cadaver.filelist
@@ -1,3 +1,5 @@
-# Total size: 44650
+# Total size: 162179
 /usr/local/bin/cadaver
+/usr/local/share/locale/en@quot/LC_MESSAGES/cadaver.mo
+/usr/local/share/locale/es/LC_MESSAGES/cadaver.mo
 /usr/local/share/man/man1/cadaver.1.zst

--- a/packages/cadaver.rb
+++ b/packages/cadaver.rb
@@ -1,29 +1,31 @@
-require 'package'
+require 'buildsystems/autotools'
 
-class Cadaver < Package
+class Cadaver < Autotools
   description 'cadaver is a command-line WebDAV client for Unix. It supports file upload, download, on-screen display, namespace operations (move/copy), collection creation and deletion, and locking operations.'
   homepage 'https://notroj.github.io/cadaver/'
-  version '0.24'
+  version '0.28'
   license 'GPL-2'
   compatibility 'aarch64 armv7l x86_64'
-  source_url 'https://notroj.github.io/cadaver/cadaver-0.24.tar.gz'
-  source_sha256 '46cff2f3ebd32cd32836812ca47bcc75353fc2be757f093da88c0dd8f10fd5f6'
+  source_url "https://notroj.github.io/cadaver/cadaver-#{version}.tar.gz"
+  source_sha256 '33e3a54bd54b1eb325b48316a7cacc24047c533ef88e6ef98b88dfbb60e12734'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '4b9e175b449294a4d73a7cf269d57612486696aec1c5e33963b612fa1f820159',
-     armv7l: '4b9e175b449294a4d73a7cf269d57612486696aec1c5e33963b612fa1f820159',
-     x86_64: 'b2ff640177c15881965eb00793da50f184d1a636f65353cdf5079e92bb7d80e0'
+    aarch64: '7425c9c01ecb86b4727cc376aa1602c1a8e31903bbe5bad40d92c1d329a955a9',
+     armv7l: '7425c9c01ecb86b4727cc376aa1602c1a8e31903bbe5bad40d92c1d329a955a9',
+     x86_64: '01dd4554d018cc3d030f3837b4f46dab148a28d5cc07c0202b6fe62cd746d236'
   })
 
-  depends_on 'neon'
+  depends_on 'expat' => :executable
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
+  depends_on 'krb5' => :executable
+  depends_on 'libproxy' => :executable
+  depends_on 'ncurses' => :executable
+  depends_on 'neon' => :executable
+  depends_on 'openssl' => :executable
+  depends_on 'readline' => :executable
+  depends_on 'zlib' => :executable
 
-  def self.build
-    system "./configure #{CREW_CONFIGURE_OPTIONS}"
-    system 'make'
-  end
-
-  def self.install
-    system 'make', "DESTDIR=#{CREW_DEST_DIR}", 'install'
-  end
+  autotools_skip_autoreconf
 end

--- a/tests/package/c/cadaver
+++ b/tests/package/c/cadaver
@@ -1,0 +1,3 @@
+#!/bin/bash
+cadaver -h
+cadaver -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-cadaver crew update \
&& yes | crew upgrade

$ crew check cadaver 
Checking cadaver package ...
Library test for cadaver passed.
Checking cadaver package ...
Usage: cadaver [OPTIONS] URL
  URL must be an absolute URI using the http: or https: scheme.
Options:
  -t, --tolerant            Allow cd/open into non-WebDAV enabled collection.
  -r, --rcfile=FILE         Read script from FILE instead of ~/.cadaverrc.
  -p, --proxy=PROXY[:PORT]  Use proxy host PROXY and optional proxy port PORT.
  -V, --version             Display version information.
  -h, --help                Display this help message.
Please send bug reports and feature requests via <https://github.com/notroj/cadaver>
cadaver 0.28
neon 0.37.1: Library build, IPv6, Expat 2.7.4, zlib 1.3.1, OpenSSL 3.5.5 27 Jan 2026 (thread-safe), libproxy.
readline 8.3
Package tests for cadaver passed.
```