### PR TITLE
Cbindgen 0.29.2 => 0.29.4

### DIFF
--- a/manifest/armv7l/c/cbindgen.filelist
+++ b/manifest/armv7l/c/cbindgen.filelist
@@ -1,2 +1,2 @@
-# Total size: 4329428
+# Total size: 4248316
 /usr/local/bin/cbindgen

--- a/manifest/i686/c/cbindgen.filelist
+++ b/manifest/i686/c/cbindgen.filelist
@@ -1,2 +1,2 @@
-# Total size: 6296128
+# Total size: 6154288
 /usr/local/bin/cbindgen

--- a/manifest/x86_64/c/cbindgen.filelist
+++ b/manifest/x86_64/c/cbindgen.filelist
@@ -1,2 +1,2 @@
-# Total size: 5646576
+# Total size: 5280424
 /usr/local/bin/cbindgen

--- a/packages/cbindgen.rb
+++ b/packages/cbindgen.rb
@@ -6,7 +6,7 @@ require 'buildsystems/rust'
 class Cbindgen < RUST
   description 'A tool for generating C bindings to Rust code'
   homepage 'https://github.com/eqrion/cbindgen'
-  version '0.29.2'
+  version '0.29.4'
   license 'MPL2'
   compatibility 'all'
   source_url 'https://github.com/eqrion/cbindgen.git'
@@ -14,12 +14,13 @@ class Cbindgen < RUST
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '8af4b7ea672d356f40a932d46fd1d90cd76654e26680d5c2d9d025d72b540eea',
-     armv7l: '8af4b7ea672d356f40a932d46fd1d90cd76654e26680d5c2d9d025d72b540eea',
-       i686: 'd48fd6f06e25120ffe9eca3705b1c60432ed0f1a16eb385268df1fb9d74753fc',
-     x86_64: '33e2838b0e6d5730c71f3ab8a7a77008e5557cf03e1c7083d2169dc8177a9d1b'
+    aarch64: '3e9e69afdfb577e376a7964e04b1a40f27f4843cdcf6a707ebfd3dee6dde0ac2',
+     armv7l: '3e9e69afdfb577e376a7964e04b1a40f27f4843cdcf6a707ebfd3dee6dde0ac2',
+       i686: 'ce984d9b467bcecc2305c032a9be1c6a2df9805a566dd9cf8f00e610014d33a5',
+     x86_64: '4851cb46c1e5d4102559f45dc56fcc65448551bcc1c2a3a006eae382dcfffbd8'
   })
 
-  depends_on 'gcc_lib' # R
-  depends_on 'glibc' # R
+  depends_on 'gcc_lib' => :executable
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
 end

--- a/tests/package/c/cbindgen
+++ b/tests/package/c/cbindgen
@@ -1,0 +1,3 @@
+#!/bin/bash
+cbindgen -h | head
+cbindgen -V


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-cbindgen crew update \
&& yes | crew upgrade

$ crew check cbindgen 
Checking cbindgen package ...
Library test for cbindgen passed.
Checking cbindgen package ...
Generate C bindings for a Rust library

Usage: cbindgen [OPTIONS] [INPUT]

Arguments:
  [INPUT]  A crate directory or source file to generate bindings for. In general this is the folder where the Cargo.toml file of source Rust library resides.

Options:
  -v...                           Enable verbose logging
      --verify                    Generate bindings and compare it to the existing bindings file and error if they are different
cbindgen 0.29.4
Package tests for cbindgen passed.
```