### PR TITLE
Cfitsio 4.6.3 => 4.7.0

### DIFF
--- a/manifest/armv7l/c/cfitsio.filelist
+++ b/manifest/armv7l/c/cfitsio.filelist
@@ -1,4 +1,4 @@
-# Total size: 1709850
+# Total size: 1702971
 /usr/local/bin/cookbook
 /usr/local/bin/fitscopy
 /usr/local/bin/fitsverify
@@ -17,5 +17,5 @@
 /usr/local/lib/cmake/cfitsio/cfitsioTargets.cmake
 /usr/local/lib/libcfitsio.so
 /usr/local/lib/libcfitsio.so.10
-/usr/local/lib/libcfitsio.so.4.6.3
+/usr/local/lib/libcfitsio.so.4.7.0
 /usr/local/lib/pkgconfig/cfitsio.pc

--- a/manifest/i686/c/cfitsio.filelist
+++ b/manifest/i686/c/cfitsio.filelist
@@ -1,4 +1,4 @@
-# Total size: 2700982
+# Total size: 2742279
 /usr/local/bin/cookbook
 /usr/local/bin/fitscopy
 /usr/local/bin/fitsverify
@@ -17,5 +17,5 @@
 /usr/local/lib/cmake/cfitsio/cfitsioTargets.cmake
 /usr/local/lib/libcfitsio.so
 /usr/local/lib/libcfitsio.so.10
-/usr/local/lib/libcfitsio.so.4.6.3
+/usr/local/lib/libcfitsio.so.4.7.0
 /usr/local/lib/pkgconfig/cfitsio.pc

--- a/manifest/x86_64/c/cfitsio.filelist
+++ b/manifest/x86_64/c/cfitsio.filelist
@@ -1,4 +1,4 @@
-# Total size: 2495078
+# Total size: 2585647
 /usr/local/bin/cookbook
 /usr/local/bin/fitscopy
 /usr/local/bin/fitsverify
@@ -17,5 +17,5 @@
 /usr/local/lib64/cmake/cfitsio/cfitsioTargets.cmake
 /usr/local/lib64/libcfitsio.so
 /usr/local/lib64/libcfitsio.so.10
-/usr/local/lib64/libcfitsio.so.4.6.3
+/usr/local/lib64/libcfitsio.so.4.7.0
 /usr/local/lib64/pkgconfig/cfitsio.pc

--- a/packages/cfitsio.rb
+++ b/packages/cfitsio.rb
@@ -3,21 +3,22 @@ require 'buildsystems/cmake'
 class Cfitsio < CMake
   description 'A library of C and Fortran subroutines for reading and writing data files in FITS Flexible Image Transport System data format'
   homepage 'https://heasarc.gsfc.nasa.gov/fitsio/'
-  version '4.6.3'
+  version '4.7.0'
   license 'ISC'
   compatibility 'all'
   source_url "https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-#{version}.tar.gz"
-  source_sha256 'fad44fff274fdda5ffcc0c0fff3bc3c596362722b9292fc8944db91187813600'
+  source_sha256 'ce573bbea8e75b429f8c3d3e86498741ba3dc9628a1530d2f65268397ad059e8'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '893c4305e83b2257ccae7a7695a7816a4b6b66960eb6f43136e230002d3713cf',
-     armv7l: '893c4305e83b2257ccae7a7695a7816a4b6b66960eb6f43136e230002d3713cf',
-       i686: '60c458e9588a54b77128f2021d246415bfe6c72484bd45733f01bb492f9ca29f',
-     x86_64: '2bf2f306ed51f38e1a544da2dc6bdae4b79538bec181bdc13e70e0cca8619bbe'
+    aarch64: 'e051753c055e2001d5aeae352112733baefaec34f061fb23824de7d48a99ac15',
+     armv7l: 'e051753c055e2001d5aeae352112733baefaec34f061fb23824de7d48a99ac15',
+       i686: '59bc10402139767648483cfbd56f03d665c1975cb2ef9025eb93e5a8c5b4e250',
+     x86_64: 'ebc0566727ae013cecb4d1ef2aa24982b4c815a23d4b8c3d4b8309276d428100'
   })
 
   depends_on 'curl' => :library
   depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
   depends_on 'zlib' => :library
 end


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-cfitsio crew update \
&& yes | crew upgrade

$ crew check cfitsio 
Checking cfitsio package ...
Library test for cfitsio passed.
Checking cfitsio package ...
fitsverify -- Verify that the input files conform to the FITS Standard.

USAGE:   fitsverify filename ...  - verify one or more FITS files
                                    (may use wildcard characters)
   or    fitsverify @filelist.txt - verify a list of FITS files
      
   Optional flags:
          -H  test ESO HIERARCH keywords
          -l  list all header keywords
          -q  quiet; print one-line pass/fail summary per file
fpack, a FITS image compression program.  Version 1.7.0 (Dec 2013) CFITSIO version 4.070
usage: fpack [-r|-h|-g|-p] [-w|-t <axes>] [-q <level>] [-s <scale>] [-n <noise>] -v <FITS>
more:   [-T] [-R] [-F] [-D] [-Y] [-O <file>] [-S] [-L] [-C] [-H] [-V] [-i2f]

NOTE: the compression parameters specified on the fpack command line may
be over-ridden by compression directive keywords in the header of each HDU
of the input file(s). See the fpack User's Guide for more details

Flags must be separate and appear before filenames:
 -r          Rice compression [default], or
1.7.0 (Dec 2013) CFITSIO version 4.070
funpack, decompress fpacked files.  Version 1.7.0 (Dec 2013) CFITSIO version 4.070
usage: funpack [-E <HDUlist>] [-P <pre>] [-O <name>] [-Z] -v <FITS>
more:   [-F] [-D] [-S] [-L] [-C] [-H] [-V] 

Flags must be separate and appear before filenames:
 -E <HDUlist> Unpack only the list of HDU names or numbers in the file.
 -P <pre>    Prepend <pre> to create new output filenames.
 -O <name>   Specify full output file name.
 -Z          Recompress the output file with host GZIP program.
 -F          Overwrite input file by output file with same name.
1.7.0 (Dec 2013) CFITSIO version 4.070
Package tests for cfitsio passed.
```