### PR TITLE
Chicken 5.4.0 => 6.0.0

### DIFF
--- a/manifest/armv7l/c/chicken.filelist
+++ b/manifest/armv7l/c/chicken.filelist
@@ -1,4 +1,4 @@
-# Total size: 11707446
+# Total size: 16571210
 /usr/local/bin/chicken
 /usr/local/bin/chicken-do
 /usr/local/bin/chicken-install
@@ -7,56 +7,61 @@
 /usr/local/bin/chicken-uninstall
 /usr/local/bin/csc
 /usr/local/bin/csi
-/usr/local/bin/feathers
 /usr/local/include/chicken/chicken-config.h
 /usr/local/include/chicken/chicken.h
-/usr/local/lib/chicken/11/chicken.base.import.so
-/usr/local/lib/chicken/11/chicken.bitwise.import.so
-/usr/local/lib/chicken/11/chicken.blob.import.so
-/usr/local/lib/chicken/11/chicken.compiler.user-pass.import.so
-/usr/local/lib/chicken/11/chicken.condition.import.so
-/usr/local/lib/chicken/11/chicken.continuation.import.so
-/usr/local/lib/chicken/11/chicken.csi.import.so
-/usr/local/lib/chicken/11/chicken.errno.import.so
-/usr/local/lib/chicken/11/chicken.eval.import.so
-/usr/local/lib/chicken/11/chicken.file.import.so
-/usr/local/lib/chicken/11/chicken.file.posix.import.so
-/usr/local/lib/chicken/11/chicken.fixnum.import.so
-/usr/local/lib/chicken/11/chicken.flonum.import.so
-/usr/local/lib/chicken/11/chicken.foreign.import.so
-/usr/local/lib/chicken/11/chicken.format.import.so
-/usr/local/lib/chicken/11/chicken.gc.import.so
-/usr/local/lib/chicken/11/chicken.internal.import.so
-/usr/local/lib/chicken/11/chicken.io.import.so
-/usr/local/lib/chicken/11/chicken.irregex.import.so
-/usr/local/lib/chicken/11/chicken.keyword.import.so
-/usr/local/lib/chicken/11/chicken.load.import.so
-/usr/local/lib/chicken/11/chicken.locative.import.so
-/usr/local/lib/chicken/11/chicken.memory.import.so
-/usr/local/lib/chicken/11/chicken.memory.representation.import.so
-/usr/local/lib/chicken/11/chicken.pathname.import.so
-/usr/local/lib/chicken/11/chicken.platform.import.so
-/usr/local/lib/chicken/11/chicken.plist.import.so
-/usr/local/lib/chicken/11/chicken.port.import.so
-/usr/local/lib/chicken/11/chicken.pretty-print.import.so
-/usr/local/lib/chicken/11/chicken.process-context.import.so
-/usr/local/lib/chicken/11/chicken.process-context.posix.import.so
-/usr/local/lib/chicken/11/chicken.process.import.so
-/usr/local/lib/chicken/11/chicken.process.signal.import.so
-/usr/local/lib/chicken/11/chicken.random.import.so
-/usr/local/lib/chicken/11/chicken.read-syntax.import.so
-/usr/local/lib/chicken/11/chicken.repl.import.so
-/usr/local/lib/chicken/11/chicken.sort.import.so
-/usr/local/lib/chicken/11/chicken.string.import.so
-/usr/local/lib/chicken/11/chicken.syntax.import.so
-/usr/local/lib/chicken/11/chicken.tcp.import.so
-/usr/local/lib/chicken/11/chicken.time.import.so
-/usr/local/lib/chicken/11/chicken.time.posix.import.so
-/usr/local/lib/chicken/11/srfi-4.import.so
-/usr/local/lib/chicken/11/types.db
-/usr/local/lib/libchicken.a
+/usr/local/lib/chicken/12/chicken.base.import.so
+/usr/local/lib/chicken/12/chicken.bitwise.import.so
+/usr/local/lib/chicken/12/chicken.bytevector.import.so
+/usr/local/lib/chicken/12/chicken.compiler.user-pass.import.so
+/usr/local/lib/chicken/12/chicken.condition.import.so
+/usr/local/lib/chicken/12/chicken.continuation.import.so
+/usr/local/lib/chicken/12/chicken.csi.import.so
+/usr/local/lib/chicken/12/chicken.errno.import.so
+/usr/local/lib/chicken/12/chicken.eval.import.so
+/usr/local/lib/chicken/12/chicken.file.import.so
+/usr/local/lib/chicken/12/chicken.file.posix.import.so
+/usr/local/lib/chicken/12/chicken.fixnum.import.so
+/usr/local/lib/chicken/12/chicken.flonum.import.so
+/usr/local/lib/chicken/12/chicken.foreign.import.so
+/usr/local/lib/chicken/12/chicken.format.import.so
+/usr/local/lib/chicken/12/chicken.gc.import.so
+/usr/local/lib/chicken/12/chicken.internal.import.so
+/usr/local/lib/chicken/12/chicken.io.import.so
+/usr/local/lib/chicken/12/chicken.irregex.import.so
+/usr/local/lib/chicken/12/chicken.keyword.import.so
+/usr/local/lib/chicken/12/chicken.load.import.so
+/usr/local/lib/chicken/12/chicken.locative.import.so
+/usr/local/lib/chicken/12/chicken.memory.import.so
+/usr/local/lib/chicken/12/chicken.memory.representation.import.so
+/usr/local/lib/chicken/12/chicken.number-vector.import.so
+/usr/local/lib/chicken/12/chicken.pathname.import.so
+/usr/local/lib/chicken/12/chicken.platform.import.so
+/usr/local/lib/chicken/12/chicken.plist.import.so
+/usr/local/lib/chicken/12/chicken.port.import.so
+/usr/local/lib/chicken/12/chicken.pretty-print.import.so
+/usr/local/lib/chicken/12/chicken.process-context.import.so
+/usr/local/lib/chicken/12/chicken.process-context.posix.import.so
+/usr/local/lib/chicken/12/chicken.process.import.so
+/usr/local/lib/chicken/12/chicken.process.signal.import.so
+/usr/local/lib/chicken/12/chicken.random.import.so
+/usr/local/lib/chicken/12/chicken.read-syntax.import.so
+/usr/local/lib/chicken/12/chicken.repl.import.so
+/usr/local/lib/chicken/12/chicken.sort.import.so
+/usr/local/lib/chicken/12/chicken.string.import.so
+/usr/local/lib/chicken/12/chicken.syntax.import.so
+/usr/local/lib/chicken/12/chicken.tcp.import.so
+/usr/local/lib/chicken/12/chicken.time.import.so
+/usr/local/lib/chicken/12/chicken.time.posix.import.so
+/usr/local/lib/chicken/12/chicken.version.import.so
+/usr/local/lib/chicken/12/scheme.file.import.so
+/usr/local/lib/chicken/12/scheme.process-context.import.so
+/usr/local/lib/chicken/12/scheme.time.import.so
+/usr/local/lib/chicken/12/scheme.write.import.so
+/usr/local/lib/chicken/12/srfi-4.import.so
+/usr/local/lib/chicken/12/types.db
+/usr/local/lib/libchicken-static.a
 /usr/local/lib/libchicken.so
-/usr/local/lib/libchicken.so.11
+/usr/local/lib/libchicken.so.12
 /usr/local/share/chicken/doc/DEPRECATED
 /usr/local/share/chicken/doc/LICENSE
 /usr/local/share/chicken/doc/README
@@ -67,7 +72,6 @@
 /usr/local/share/chicken/doc/manual/C interface.html
 /usr/local/share/chicken/doc/manual/Cross development.html
 /usr/local/share/chicken/doc/manual/Data representation.html
-/usr/local/share/chicken/doc/manual/Debugging.html
 /usr/local/share/chicken/doc/manual/Declarations.html
 /usr/local/share/chicken/doc/manual/Deployment.html
 /usr/local/share/chicken/doc/manual/Deviations from the standard.html
@@ -82,7 +86,7 @@
 /usr/local/share/chicken/doc/manual/Interface to external functions and variables.html
 /usr/local/share/chicken/doc/manual/Module (chicken base).html
 /usr/local/share/chicken/doc/manual/Module (chicken bitwise).html
-/usr/local/share/chicken/doc/manual/Module (chicken blob).html
+/usr/local/share/chicken/doc/manual/Module (chicken bytevector).html
 /usr/local/share/chicken/doc/manual/Module (chicken condition).html
 /usr/local/share/chicken/doc/manual/Module (chicken continuation).html
 /usr/local/share/chicken/doc/manual/Module (chicken csi).html
@@ -122,8 +126,24 @@
 /usr/local/share/chicken/doc/manual/Module (chicken time posix).html
 /usr/local/share/chicken/doc/manual/Module (chicken time).html
 /usr/local/share/chicken/doc/manual/Module (chicken type).html
-/usr/local/share/chicken/doc/manual/Module r4rs.html
-/usr/local/share/chicken/doc/manual/Module r5rs.html
+/usr/local/share/chicken/doc/manual/Module (chicken version).html
+/usr/local/share/chicken/doc/manual/Module (scheme base).html
+/usr/local/share/chicken/doc/manual/Module (scheme case-lambda).html
+/usr/local/share/chicken/doc/manual/Module (scheme char).html
+/usr/local/share/chicken/doc/manual/Module (scheme complex).html
+/usr/local/share/chicken/doc/manual/Module (scheme cxr).html
+/usr/local/share/chicken/doc/manual/Module (scheme eval).html
+/usr/local/share/chicken/doc/manual/Module (scheme file).html
+/usr/local/share/chicken/doc/manual/Module (scheme inexact).html
+/usr/local/share/chicken/doc/manual/Module (scheme lazy).html
+/usr/local/share/chicken/doc/manual/Module (scheme load).html
+/usr/local/share/chicken/doc/manual/Module (scheme process-context).html
+/usr/local/share/chicken/doc/manual/Module (scheme r4rs).html
+/usr/local/share/chicken/doc/manual/Module (scheme r5rs).html
+/usr/local/share/chicken/doc/manual/Module (scheme read).html
+/usr/local/share/chicken/doc/manual/Module (scheme repl).html
+/usr/local/share/chicken/doc/manual/Module (scheme time).html
+/usr/local/share/chicken/doc/manual/Module (scheme write).html
 /usr/local/share/chicken/doc/manual/Module scheme.html
 /usr/local/share/chicken/doc/manual/Module srfi-4.html
 /usr/local/share/chicken/doc/manual/Modules.html
@@ -133,7 +153,6 @@
 /usr/local/share/chicken/doc/manual/Using the compiler.html
 /usr/local/share/chicken/doc/manual/Using the interpreter.html
 /usr/local/share/chicken/doc/manual/manual.css
-/usr/local/share/chicken/feathers.tcl
 /usr/local/share/chicken/setup.defaults
 /usr/local/share/man/man1/chicken-do.1.zst
 /usr/local/share/man/man1/chicken-install.1.zst
@@ -143,4 +162,3 @@
 /usr/local/share/man/man1/chicken.1.zst
 /usr/local/share/man/man1/csc.1.zst
 /usr/local/share/man/man1/csi.1.zst
-/usr/local/share/man/man1/feathers.1.zst

--- a/manifest/i686/c/chicken.filelist
+++ b/manifest/i686/c/chicken.filelist
@@ -1,4 +1,4 @@
-# Total size: 11190360
+# Total size: 15178118
 /usr/local/bin/chicken
 /usr/local/bin/chicken-do
 /usr/local/bin/chicken-install
@@ -7,56 +7,61 @@
 /usr/local/bin/chicken-uninstall
 /usr/local/bin/csc
 /usr/local/bin/csi
-/usr/local/bin/feathers
 /usr/local/include/chicken/chicken-config.h
 /usr/local/include/chicken/chicken.h
-/usr/local/lib/chicken/11/chicken.base.import.so
-/usr/local/lib/chicken/11/chicken.bitwise.import.so
-/usr/local/lib/chicken/11/chicken.blob.import.so
-/usr/local/lib/chicken/11/chicken.compiler.user-pass.import.so
-/usr/local/lib/chicken/11/chicken.condition.import.so
-/usr/local/lib/chicken/11/chicken.continuation.import.so
-/usr/local/lib/chicken/11/chicken.csi.import.so
-/usr/local/lib/chicken/11/chicken.errno.import.so
-/usr/local/lib/chicken/11/chicken.eval.import.so
-/usr/local/lib/chicken/11/chicken.file.import.so
-/usr/local/lib/chicken/11/chicken.file.posix.import.so
-/usr/local/lib/chicken/11/chicken.fixnum.import.so
-/usr/local/lib/chicken/11/chicken.flonum.import.so
-/usr/local/lib/chicken/11/chicken.foreign.import.so
-/usr/local/lib/chicken/11/chicken.format.import.so
-/usr/local/lib/chicken/11/chicken.gc.import.so
-/usr/local/lib/chicken/11/chicken.internal.import.so
-/usr/local/lib/chicken/11/chicken.io.import.so
-/usr/local/lib/chicken/11/chicken.irregex.import.so
-/usr/local/lib/chicken/11/chicken.keyword.import.so
-/usr/local/lib/chicken/11/chicken.load.import.so
-/usr/local/lib/chicken/11/chicken.locative.import.so
-/usr/local/lib/chicken/11/chicken.memory.import.so
-/usr/local/lib/chicken/11/chicken.memory.representation.import.so
-/usr/local/lib/chicken/11/chicken.pathname.import.so
-/usr/local/lib/chicken/11/chicken.platform.import.so
-/usr/local/lib/chicken/11/chicken.plist.import.so
-/usr/local/lib/chicken/11/chicken.port.import.so
-/usr/local/lib/chicken/11/chicken.pretty-print.import.so
-/usr/local/lib/chicken/11/chicken.process-context.import.so
-/usr/local/lib/chicken/11/chicken.process-context.posix.import.so
-/usr/local/lib/chicken/11/chicken.process.import.so
-/usr/local/lib/chicken/11/chicken.process.signal.import.so
-/usr/local/lib/chicken/11/chicken.random.import.so
-/usr/local/lib/chicken/11/chicken.read-syntax.import.so
-/usr/local/lib/chicken/11/chicken.repl.import.so
-/usr/local/lib/chicken/11/chicken.sort.import.so
-/usr/local/lib/chicken/11/chicken.string.import.so
-/usr/local/lib/chicken/11/chicken.syntax.import.so
-/usr/local/lib/chicken/11/chicken.tcp.import.so
-/usr/local/lib/chicken/11/chicken.time.import.so
-/usr/local/lib/chicken/11/chicken.time.posix.import.so
-/usr/local/lib/chicken/11/srfi-4.import.so
-/usr/local/lib/chicken/11/types.db
-/usr/local/lib/libchicken.a
+/usr/local/lib/chicken/12/chicken.base.import.so
+/usr/local/lib/chicken/12/chicken.bitwise.import.so
+/usr/local/lib/chicken/12/chicken.bytevector.import.so
+/usr/local/lib/chicken/12/chicken.compiler.user-pass.import.so
+/usr/local/lib/chicken/12/chicken.condition.import.so
+/usr/local/lib/chicken/12/chicken.continuation.import.so
+/usr/local/lib/chicken/12/chicken.csi.import.so
+/usr/local/lib/chicken/12/chicken.errno.import.so
+/usr/local/lib/chicken/12/chicken.eval.import.so
+/usr/local/lib/chicken/12/chicken.file.import.so
+/usr/local/lib/chicken/12/chicken.file.posix.import.so
+/usr/local/lib/chicken/12/chicken.fixnum.import.so
+/usr/local/lib/chicken/12/chicken.flonum.import.so
+/usr/local/lib/chicken/12/chicken.foreign.import.so
+/usr/local/lib/chicken/12/chicken.format.import.so
+/usr/local/lib/chicken/12/chicken.gc.import.so
+/usr/local/lib/chicken/12/chicken.internal.import.so
+/usr/local/lib/chicken/12/chicken.io.import.so
+/usr/local/lib/chicken/12/chicken.irregex.import.so
+/usr/local/lib/chicken/12/chicken.keyword.import.so
+/usr/local/lib/chicken/12/chicken.load.import.so
+/usr/local/lib/chicken/12/chicken.locative.import.so
+/usr/local/lib/chicken/12/chicken.memory.import.so
+/usr/local/lib/chicken/12/chicken.memory.representation.import.so
+/usr/local/lib/chicken/12/chicken.number-vector.import.so
+/usr/local/lib/chicken/12/chicken.pathname.import.so
+/usr/local/lib/chicken/12/chicken.platform.import.so
+/usr/local/lib/chicken/12/chicken.plist.import.so
+/usr/local/lib/chicken/12/chicken.port.import.so
+/usr/local/lib/chicken/12/chicken.pretty-print.import.so
+/usr/local/lib/chicken/12/chicken.process-context.import.so
+/usr/local/lib/chicken/12/chicken.process-context.posix.import.so
+/usr/local/lib/chicken/12/chicken.process.import.so
+/usr/local/lib/chicken/12/chicken.process.signal.import.so
+/usr/local/lib/chicken/12/chicken.random.import.so
+/usr/local/lib/chicken/12/chicken.read-syntax.import.so
+/usr/local/lib/chicken/12/chicken.repl.import.so
+/usr/local/lib/chicken/12/chicken.sort.import.so
+/usr/local/lib/chicken/12/chicken.string.import.so
+/usr/local/lib/chicken/12/chicken.syntax.import.so
+/usr/local/lib/chicken/12/chicken.tcp.import.so
+/usr/local/lib/chicken/12/chicken.time.import.so
+/usr/local/lib/chicken/12/chicken.time.posix.import.so
+/usr/local/lib/chicken/12/chicken.version.import.so
+/usr/local/lib/chicken/12/scheme.file.import.so
+/usr/local/lib/chicken/12/scheme.process-context.import.so
+/usr/local/lib/chicken/12/scheme.time.import.so
+/usr/local/lib/chicken/12/scheme.write.import.so
+/usr/local/lib/chicken/12/srfi-4.import.so
+/usr/local/lib/chicken/12/types.db
+/usr/local/lib/libchicken-static.a
 /usr/local/lib/libchicken.so
-/usr/local/lib/libchicken.so.11
+/usr/local/lib/libchicken.so.12
 /usr/local/share/chicken/doc/DEPRECATED
 /usr/local/share/chicken/doc/LICENSE
 /usr/local/share/chicken/doc/README
@@ -67,7 +72,6 @@
 /usr/local/share/chicken/doc/manual/C interface.html
 /usr/local/share/chicken/doc/manual/Cross development.html
 /usr/local/share/chicken/doc/manual/Data representation.html
-/usr/local/share/chicken/doc/manual/Debugging.html
 /usr/local/share/chicken/doc/manual/Declarations.html
 /usr/local/share/chicken/doc/manual/Deployment.html
 /usr/local/share/chicken/doc/manual/Deviations from the standard.html
@@ -82,7 +86,7 @@
 /usr/local/share/chicken/doc/manual/Interface to external functions and variables.html
 /usr/local/share/chicken/doc/manual/Module (chicken base).html
 /usr/local/share/chicken/doc/manual/Module (chicken bitwise).html
-/usr/local/share/chicken/doc/manual/Module (chicken blob).html
+/usr/local/share/chicken/doc/manual/Module (chicken bytevector).html
 /usr/local/share/chicken/doc/manual/Module (chicken condition).html
 /usr/local/share/chicken/doc/manual/Module (chicken continuation).html
 /usr/local/share/chicken/doc/manual/Module (chicken csi).html
@@ -122,8 +126,24 @@
 /usr/local/share/chicken/doc/manual/Module (chicken time posix).html
 /usr/local/share/chicken/doc/manual/Module (chicken time).html
 /usr/local/share/chicken/doc/manual/Module (chicken type).html
-/usr/local/share/chicken/doc/manual/Module r4rs.html
-/usr/local/share/chicken/doc/manual/Module r5rs.html
+/usr/local/share/chicken/doc/manual/Module (chicken version).html
+/usr/local/share/chicken/doc/manual/Module (scheme base).html
+/usr/local/share/chicken/doc/manual/Module (scheme case-lambda).html
+/usr/local/share/chicken/doc/manual/Module (scheme char).html
+/usr/local/share/chicken/doc/manual/Module (scheme complex).html
+/usr/local/share/chicken/doc/manual/Module (scheme cxr).html
+/usr/local/share/chicken/doc/manual/Module (scheme eval).html
+/usr/local/share/chicken/doc/manual/Module (scheme file).html
+/usr/local/share/chicken/doc/manual/Module (scheme inexact).html
+/usr/local/share/chicken/doc/manual/Module (scheme lazy).html
+/usr/local/share/chicken/doc/manual/Module (scheme load).html
+/usr/local/share/chicken/doc/manual/Module (scheme process-context).html
+/usr/local/share/chicken/doc/manual/Module (scheme r4rs).html
+/usr/local/share/chicken/doc/manual/Module (scheme r5rs).html
+/usr/local/share/chicken/doc/manual/Module (scheme read).html
+/usr/local/share/chicken/doc/manual/Module (scheme repl).html
+/usr/local/share/chicken/doc/manual/Module (scheme time).html
+/usr/local/share/chicken/doc/manual/Module (scheme write).html
 /usr/local/share/chicken/doc/manual/Module scheme.html
 /usr/local/share/chicken/doc/manual/Module srfi-4.html
 /usr/local/share/chicken/doc/manual/Modules.html
@@ -133,7 +153,6 @@
 /usr/local/share/chicken/doc/manual/Using the compiler.html
 /usr/local/share/chicken/doc/manual/Using the interpreter.html
 /usr/local/share/chicken/doc/manual/manual.css
-/usr/local/share/chicken/feathers.tcl
 /usr/local/share/chicken/setup.defaults
 /usr/local/share/man/man1/chicken-do.1.zst
 /usr/local/share/man/man1/chicken-install.1.zst
@@ -143,4 +162,3 @@
 /usr/local/share/man/man1/chicken.1.zst
 /usr/local/share/man/man1/csc.1.zst
 /usr/local/share/man/man1/csi.1.zst
-/usr/local/share/man/man1/feathers.1.zst

--- a/manifest/x86_64/c/chicken.filelist
+++ b/manifest/x86_64/c/chicken.filelist
@@ -1,4 +1,4 @@
-# Total size: 13907828
+# Total size: 18902244
 /usr/local/bin/chicken
 /usr/local/bin/chicken-do
 /usr/local/bin/chicken-install
@@ -7,56 +7,61 @@
 /usr/local/bin/chicken-uninstall
 /usr/local/bin/csc
 /usr/local/bin/csi
-/usr/local/bin/feathers
 /usr/local/include/chicken/chicken-config.h
 /usr/local/include/chicken/chicken.h
-/usr/local/lib64/chicken/11/chicken.base.import.so
-/usr/local/lib64/chicken/11/chicken.bitwise.import.so
-/usr/local/lib64/chicken/11/chicken.blob.import.so
-/usr/local/lib64/chicken/11/chicken.compiler.user-pass.import.so
-/usr/local/lib64/chicken/11/chicken.condition.import.so
-/usr/local/lib64/chicken/11/chicken.continuation.import.so
-/usr/local/lib64/chicken/11/chicken.csi.import.so
-/usr/local/lib64/chicken/11/chicken.errno.import.so
-/usr/local/lib64/chicken/11/chicken.eval.import.so
-/usr/local/lib64/chicken/11/chicken.file.import.so
-/usr/local/lib64/chicken/11/chicken.file.posix.import.so
-/usr/local/lib64/chicken/11/chicken.fixnum.import.so
-/usr/local/lib64/chicken/11/chicken.flonum.import.so
-/usr/local/lib64/chicken/11/chicken.foreign.import.so
-/usr/local/lib64/chicken/11/chicken.format.import.so
-/usr/local/lib64/chicken/11/chicken.gc.import.so
-/usr/local/lib64/chicken/11/chicken.internal.import.so
-/usr/local/lib64/chicken/11/chicken.io.import.so
-/usr/local/lib64/chicken/11/chicken.irregex.import.so
-/usr/local/lib64/chicken/11/chicken.keyword.import.so
-/usr/local/lib64/chicken/11/chicken.load.import.so
-/usr/local/lib64/chicken/11/chicken.locative.import.so
-/usr/local/lib64/chicken/11/chicken.memory.import.so
-/usr/local/lib64/chicken/11/chicken.memory.representation.import.so
-/usr/local/lib64/chicken/11/chicken.pathname.import.so
-/usr/local/lib64/chicken/11/chicken.platform.import.so
-/usr/local/lib64/chicken/11/chicken.plist.import.so
-/usr/local/lib64/chicken/11/chicken.port.import.so
-/usr/local/lib64/chicken/11/chicken.pretty-print.import.so
-/usr/local/lib64/chicken/11/chicken.process-context.import.so
-/usr/local/lib64/chicken/11/chicken.process-context.posix.import.so
-/usr/local/lib64/chicken/11/chicken.process.import.so
-/usr/local/lib64/chicken/11/chicken.process.signal.import.so
-/usr/local/lib64/chicken/11/chicken.random.import.so
-/usr/local/lib64/chicken/11/chicken.read-syntax.import.so
-/usr/local/lib64/chicken/11/chicken.repl.import.so
-/usr/local/lib64/chicken/11/chicken.sort.import.so
-/usr/local/lib64/chicken/11/chicken.string.import.so
-/usr/local/lib64/chicken/11/chicken.syntax.import.so
-/usr/local/lib64/chicken/11/chicken.tcp.import.so
-/usr/local/lib64/chicken/11/chicken.time.import.so
-/usr/local/lib64/chicken/11/chicken.time.posix.import.so
-/usr/local/lib64/chicken/11/srfi-4.import.so
-/usr/local/lib64/chicken/11/types.db
-/usr/local/lib64/libchicken.a
+/usr/local/lib64/chicken/12/chicken.base.import.so
+/usr/local/lib64/chicken/12/chicken.bitwise.import.so
+/usr/local/lib64/chicken/12/chicken.bytevector.import.so
+/usr/local/lib64/chicken/12/chicken.compiler.user-pass.import.so
+/usr/local/lib64/chicken/12/chicken.condition.import.so
+/usr/local/lib64/chicken/12/chicken.continuation.import.so
+/usr/local/lib64/chicken/12/chicken.csi.import.so
+/usr/local/lib64/chicken/12/chicken.errno.import.so
+/usr/local/lib64/chicken/12/chicken.eval.import.so
+/usr/local/lib64/chicken/12/chicken.file.import.so
+/usr/local/lib64/chicken/12/chicken.file.posix.import.so
+/usr/local/lib64/chicken/12/chicken.fixnum.import.so
+/usr/local/lib64/chicken/12/chicken.flonum.import.so
+/usr/local/lib64/chicken/12/chicken.foreign.import.so
+/usr/local/lib64/chicken/12/chicken.format.import.so
+/usr/local/lib64/chicken/12/chicken.gc.import.so
+/usr/local/lib64/chicken/12/chicken.internal.import.so
+/usr/local/lib64/chicken/12/chicken.io.import.so
+/usr/local/lib64/chicken/12/chicken.irregex.import.so
+/usr/local/lib64/chicken/12/chicken.keyword.import.so
+/usr/local/lib64/chicken/12/chicken.load.import.so
+/usr/local/lib64/chicken/12/chicken.locative.import.so
+/usr/local/lib64/chicken/12/chicken.memory.import.so
+/usr/local/lib64/chicken/12/chicken.memory.representation.import.so
+/usr/local/lib64/chicken/12/chicken.number-vector.import.so
+/usr/local/lib64/chicken/12/chicken.pathname.import.so
+/usr/local/lib64/chicken/12/chicken.platform.import.so
+/usr/local/lib64/chicken/12/chicken.plist.import.so
+/usr/local/lib64/chicken/12/chicken.port.import.so
+/usr/local/lib64/chicken/12/chicken.pretty-print.import.so
+/usr/local/lib64/chicken/12/chicken.process-context.import.so
+/usr/local/lib64/chicken/12/chicken.process-context.posix.import.so
+/usr/local/lib64/chicken/12/chicken.process.import.so
+/usr/local/lib64/chicken/12/chicken.process.signal.import.so
+/usr/local/lib64/chicken/12/chicken.random.import.so
+/usr/local/lib64/chicken/12/chicken.read-syntax.import.so
+/usr/local/lib64/chicken/12/chicken.repl.import.so
+/usr/local/lib64/chicken/12/chicken.sort.import.so
+/usr/local/lib64/chicken/12/chicken.string.import.so
+/usr/local/lib64/chicken/12/chicken.syntax.import.so
+/usr/local/lib64/chicken/12/chicken.tcp.import.so
+/usr/local/lib64/chicken/12/chicken.time.import.so
+/usr/local/lib64/chicken/12/chicken.time.posix.import.so
+/usr/local/lib64/chicken/12/chicken.version.import.so
+/usr/local/lib64/chicken/12/scheme.file.import.so
+/usr/local/lib64/chicken/12/scheme.process-context.import.so
+/usr/local/lib64/chicken/12/scheme.time.import.so
+/usr/local/lib64/chicken/12/scheme.write.import.so
+/usr/local/lib64/chicken/12/srfi-4.import.so
+/usr/local/lib64/chicken/12/types.db
+/usr/local/lib64/libchicken-static.a
 /usr/local/lib64/libchicken.so
-/usr/local/lib64/libchicken.so.11
+/usr/local/lib64/libchicken.so.12
 /usr/local/share/chicken/doc/DEPRECATED
 /usr/local/share/chicken/doc/LICENSE
 /usr/local/share/chicken/doc/README
@@ -67,7 +72,6 @@
 /usr/local/share/chicken/doc/manual/C interface.html
 /usr/local/share/chicken/doc/manual/Cross development.html
 /usr/local/share/chicken/doc/manual/Data representation.html
-/usr/local/share/chicken/doc/manual/Debugging.html
 /usr/local/share/chicken/doc/manual/Declarations.html
 /usr/local/share/chicken/doc/manual/Deployment.html
 /usr/local/share/chicken/doc/manual/Deviations from the standard.html
@@ -82,7 +86,7 @@
 /usr/local/share/chicken/doc/manual/Interface to external functions and variables.html
 /usr/local/share/chicken/doc/manual/Module (chicken base).html
 /usr/local/share/chicken/doc/manual/Module (chicken bitwise).html
-/usr/local/share/chicken/doc/manual/Module (chicken blob).html
+/usr/local/share/chicken/doc/manual/Module (chicken bytevector).html
 /usr/local/share/chicken/doc/manual/Module (chicken condition).html
 /usr/local/share/chicken/doc/manual/Module (chicken continuation).html
 /usr/local/share/chicken/doc/manual/Module (chicken csi).html
@@ -122,8 +126,24 @@
 /usr/local/share/chicken/doc/manual/Module (chicken time posix).html
 /usr/local/share/chicken/doc/manual/Module (chicken time).html
 /usr/local/share/chicken/doc/manual/Module (chicken type).html
-/usr/local/share/chicken/doc/manual/Module r4rs.html
-/usr/local/share/chicken/doc/manual/Module r5rs.html
+/usr/local/share/chicken/doc/manual/Module (chicken version).html
+/usr/local/share/chicken/doc/manual/Module (scheme base).html
+/usr/local/share/chicken/doc/manual/Module (scheme case-lambda).html
+/usr/local/share/chicken/doc/manual/Module (scheme char).html
+/usr/local/share/chicken/doc/manual/Module (scheme complex).html
+/usr/local/share/chicken/doc/manual/Module (scheme cxr).html
+/usr/local/share/chicken/doc/manual/Module (scheme eval).html
+/usr/local/share/chicken/doc/manual/Module (scheme file).html
+/usr/local/share/chicken/doc/manual/Module (scheme inexact).html
+/usr/local/share/chicken/doc/manual/Module (scheme lazy).html
+/usr/local/share/chicken/doc/manual/Module (scheme load).html
+/usr/local/share/chicken/doc/manual/Module (scheme process-context).html
+/usr/local/share/chicken/doc/manual/Module (scheme r4rs).html
+/usr/local/share/chicken/doc/manual/Module (scheme r5rs).html
+/usr/local/share/chicken/doc/manual/Module (scheme read).html
+/usr/local/share/chicken/doc/manual/Module (scheme repl).html
+/usr/local/share/chicken/doc/manual/Module (scheme time).html
+/usr/local/share/chicken/doc/manual/Module (scheme write).html
 /usr/local/share/chicken/doc/manual/Module scheme.html
 /usr/local/share/chicken/doc/manual/Module srfi-4.html
 /usr/local/share/chicken/doc/manual/Modules.html
@@ -133,7 +153,6 @@
 /usr/local/share/chicken/doc/manual/Using the compiler.html
 /usr/local/share/chicken/doc/manual/Using the interpreter.html
 /usr/local/share/chicken/doc/manual/manual.css
-/usr/local/share/chicken/feathers.tcl
 /usr/local/share/chicken/setup.defaults
 /usr/local/share/man/man1/chicken-do.1.zst
 /usr/local/share/man/man1/chicken-install.1.zst
@@ -143,4 +162,3 @@
 /usr/local/share/man/man1/chicken.1.zst
 /usr/local/share/man/man1/csc.1.zst
 /usr/local/share/man/man1/csi.1.zst
-/usr/local/share/man/man1/feathers.1.zst

--- a/packages/chicken.rb
+++ b/packages/chicken.rb
@@ -3,27 +3,28 @@ require 'package'
 class Chicken < Package
   description 'CHICKEN is a practical and portable scheme system.'
   homepage 'https://code.call-cc.org/'
-  version '5.4.0'
+  version '6.0.0'
   license 'BSD'
   compatibility 'all'
   source_url "https://code.call-cc.org/releases/#{version}/chicken-#{version}.tar.gz"
-  source_sha256 '3c5d4aa61c1167bf6d9bf9eaf891da7630ba9f5f3c15bf09515a7039bfcdec5f'
+  source_sha256 '92835552b1b687ad26737e429b5aba36510bf429f8816ec0f6d336c8cb41f443'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'f9821dfba5cd2e2be8653792fe29a3524e2851a99320702b304fe946963012fe',
-     armv7l: 'f9821dfba5cd2e2be8653792fe29a3524e2851a99320702b304fe946963012fe',
-       i686: 'f5b00b3ac5b6e06fbc17ba765cc1ad44de159178117ecf361fa1741413acc5a8',
-     x86_64: '82e81bf7b319bd2b879407968928fa3adac20d0ee8ea74e3dd62058aafdc8b99'
+    aarch64: '497ad8e35946e23e39e4fea42dd14bad382e7a902ae59987c5cdf60520c4336d',
+     armv7l: '497ad8e35946e23e39e4fea42dd14bad382e7a902ae59987c5cdf60520c4336d',
+       i686: '469dc02022c66f9b3b328c2a7a1627d48099af3b5aa352f5bb9e7d3e9f2ca3cf',
+     x86_64: 'f48a8b54e92b10c600961573c29aa05a4ac4d309c958cfaa37cfe5c5af9a25b3'
   })
 
-  depends_on 'filecmd' => :build
+  depends_on 'glibc' => :library
+  depends_on 'glibc_lib' => :library
 
   def self.build
-    system 'make', "PREFIX=#{CREW_PREFIX}", "LIBDIR=#{CREW_LIB_PREFIX}"
+    system 'make', "PREFIX=#{CREW_PREFIX}", "LIBDIR=#{CREW_LIB_PREFIX}", 'PLATFORM=linux'
   end
 
   def self.install
-    system 'make', "PREFIX=#{CREW_PREFIX}", "LIBDIR=#{CREW_LIB_PREFIX}", "DESTDIR=#{CREW_DEST_DIR}", 'install'
+    system 'make', "PREFIX=#{CREW_PREFIX}", "LIBDIR=#{CREW_LIB_PREFIX}", "DESTDIR=#{CREW_DEST_DIR}", 'PLATFORM=linux', 'install'
   end
 end

--- a/tests/package/c/chicken
+++ b/tests/package/c/chicken
@@ -1,0 +1,3 @@
+#!/bin/bash
+chicken -help | head
+chicken -version


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-chicken crew update \
&& yes | crew upgrade

$ crew check chicken 
Checking chicken package ...
Library test for chicken passed.
Checking chicken package ...
Version 6.0.0 (rev 2e30c07e)
linux-unix-gnu-x86-64 [ 64bit dload ptables ]

Usage: chicken FILENAME [OPTION ...]

  `chicken' is the CHICKEN compiler.

  FILENAME should be a complete source file name with extension, or "-" for
  standard input. OPTION may be one of the following:

CHICKEN
(c)2000-2007 Felix L. Winkelmann, (c)2008 The CHICKEN Team
Version 6.0.0 (rev 2e30c07e)
linux-unix-gnu-x86-64 [ 64bit dload ptables ]

Package tests for chicken passed.
```