### PR TITLE
Codex 0.125.0 => 0.153.4

### DIFF
--- a/manifest/x86_64/c/codex.filelist
+++ b/manifest/x86_64/c/codex.filelist
@@ -1,2 +1,2 @@
-# Total size: 201696696
+# Total size: 258659424
 /usr/local/bin/codex

--- a/packages/codex.rb
+++ b/packages/codex.rb
@@ -3,20 +3,20 @@ require 'package'
 class Codex < Package
   description 'Lightweight coding agent that runs in your terminal'
   homepage 'https://github.com/openai/codex'
-  version '0.125.0'
+  version '0.153.4'
   license 'Apache-2.0'
   compatibility 'x86_64'
   min_glibc '2.28'
-  source_url "https://github.com/openai/codex/releases/download/rust-v#{version}/codex-x86_64-unknown-linux-gnu.zst"
-  source_sha256 '65c7e86cb98c8093241818da12181bd0bf9b1dd2366edb892c14ea4f4d448004'
+  source_url "https://github.com/openai/codex/releases/download/rust-v#{version}/codex-x86_64-unknown-linux-musl.zst"
+  source_sha256 'c485e889611b73ff5c3cc11fb5cea7551ef504465ad8675163766b9b1a9ec84a'
 
   depends_on 'zstd'
 
   no_compile_needed
 
   def self.install
-    system 'zstd -dv codex-x86_64-unknown-linux-gnu.zst'
-    FileUtils.install 'codex-x86_64-unknown-linux-gnu', "#{CREW_DEST_PREFIX}/bin/codex", mode: 0o755
+    system 'zstd -dv codex-x86_64-unknown-linux-musl.zst'
+    FileUtils.install 'codex-x86_64-unknown-linux-musl', "#{CREW_DEST_PREFIX}/bin/codex", mode: 0o755
   end
 
   def self.postinstall

--- a/tests/package/c/codex
+++ b/tests/package/c/codex
@@ -1,3 +1,3 @@
 #!/bin/bash
-codex -h
+codex -h | head
 codex --version


### PR DESCRIPTION
The gnu releases are no longer available.
#
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-codex crew update \
&& yes | crew upgrade

$ crew check codex 
Checking codex package ...
Library test for codex passed.
Checking codex package ...
Codex CLI

Usage: codex [OPTIONS] [PROMPT]
       codex [OPTIONS] <COMMAND> [ARGS]

Commands:
  agents            Browse all agent sessions on the shared local app-server daemon
  exec              Run Codex non-interactively [aliases: e]
  review            Run a code review non-interactively
  login             Manage login
codex-cli 0.153.4
Package tests for codex passed.
```