### PR TITLE
Dash 0.5.12-f47009f => 0.5.13.5

### DIFF
--- a/manifest/armv7l/d/dash.filelist
+++ b/manifest/armv7l/d/dash.filelist
@@ -1,3 +1,3 @@
-# Total size: 133593
+# Total size: 139179
 /usr/local/bin/dash
 /usr/local/share/man/man1/dash.1.zst

--- a/manifest/i686/d/dash.filelist
+++ b/manifest/i686/d/dash.filelist
@@ -1,3 +1,3 @@
-# Total size: 175761
+# Total size: 187107
 /usr/local/bin/dash
 /usr/local/share/man/man1/dash.1.zst

--- a/manifest/x86_64/d/dash.filelist
+++ b/manifest/x86_64/d/dash.filelist
@@ -1,3 +1,3 @@
-# Total size: 176409
+# Total size: 188743
 /usr/local/bin/dash
 /usr/local/share/man/man1/dash.1.zst

--- a/packages/dash.rb
+++ b/packages/dash.rb
@@ -3,21 +3,22 @@ require 'buildsystems/autotools'
 class Dash < Autotools
   description 'The Debian Almquist Shell (dash) is a POSIX-compliant shell derived from ash that executes scripts faster than bash and has fewer library dependencies.'
   homepage 'https://salsa.debian.org/debian/dash/'
-  version '0.5.12-f47009f'
+  version '0.5.13.5'
   license 'BSD'
   compatibility 'all'
-  source_url 'https://salsa.debian.org/debian/dash.git'
-  git_hashtag 'upstream/0.5.12+git20240518+f47009f9a76e'
+  source_url 'https://git.kernel.org/pub/scm/utils/dash/dash.git'
+  git_hashtag "v#{version}"
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: 'c11486d7feb0581f5828bfd258433d0adfb08ee45c8dc7cbe4752586df18f4a8',
-     armv7l: 'c11486d7feb0581f5828bfd258433d0adfb08ee45c8dc7cbe4752586df18f4a8',
-       i686: 'fde5c4a4a255e7270ba026a795f93aecc4076b1327de3951598800b5a96e91d0',
-     x86_64: '57a73df2cff50a4cc86245ce85e9c2fdf5f372884af3ccda7341c0d940f3b5a8'
+    aarch64: '9a9afd1b141790a308f022e80f8aef0cbe0c96d0303f0c689d33bebc1513bc39',
+     armv7l: '9a9afd1b141790a308f022e80f8aef0cbe0c96d0303f0c689d33bebc1513bc39',
+       i686: '199c06d51f19292315a790c0470d3f493bd4159f30d9341fe0a919c3d8b0e138',
+     x86_64: 'e2d601df37cc360fe4f4b324f636780424f9c9a4e17624f8900de7368a4ec4d9'
   })
 
   depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
   depends_on 'libedit' => :executable
 
   autotools_configure_options '--with-libedit'


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-dash crew update \
&& yes | crew upgrade

$ crew check dash 
Checking dash package ...
Library test for dash passed.
Checking dash package ...
DASH(1)                                                                                      General Commands Manual                                                                                    DASH(1)

NAME
     dash —— command interpreter (shell)

SYNOPSIS
     dash [-aCefnuvxIimqVEb] [+aCefnuvxIimqVEb] [-o option_name] [+o option_name] [command_file [argument ...]]
     dash -c [-aCefnuvxIimqVEb] [+aCefnuvxIimqVEb] [-o option_name] [+o option_name] command_string [command_name [argument ...]]
     dash -s [-aCefnuvxIimqVEb] [+aCefnuvxIimqVEb] [-o option_name] [+o option_name] [argument ...]

Package tests for dash passed.
```