### PR TITLE
Dehtml 2.0 => 2.1

### DIFF
--- a/manifest/armv7l/d/dehtml.filelist
+++ b/manifest/armv7l/d/dehtml.filelist
@@ -1,4 +1,4 @@
-# Total size: 26250
+# Total size: 23914
 /usr/local/bin/dehtml
 /usr/local/share/locale/de/LC_MESSAGES/dehtml.mo
 /usr/local/share/locale/nl/LC_MESSAGES/dehtml.mo

--- a/manifest/i686/d/dehtml.filelist
+++ b/manifest/i686/d/dehtml.filelist
@@ -1,4 +1,4 @@
-# Total size: 26626
+# Total size: 26470
 /usr/local/bin/dehtml
 /usr/local/share/locale/de/LC_MESSAGES/dehtml.mo
 /usr/local/share/locale/nl/LC_MESSAGES/dehtml.mo

--- a/manifest/x86_64/d/dehtml.filelist
+++ b/manifest/x86_64/d/dehtml.filelist
@@ -1,4 +1,4 @@
-# Total size: 28598
+# Total size: 29246
 /usr/local/bin/dehtml
 /usr/local/share/locale/de/LC_MESSAGES/dehtml.mo
 /usr/local/share/locale/nl/LC_MESSAGES/dehtml.mo

--- a/packages/dehtml.rb
+++ b/packages/dehtml.rb
@@ -3,30 +3,24 @@ require 'buildsystems/autotools'
 class Dehtml < Autotools
   description 'Dehtml removes HTML constructs from documents for indexing, spell checking and so on.'
   homepage 'http://www.moria.de/~michael/dehtml/'
-  version '2.0'
+  version '2.1'
   license 'GPL-2+'
   compatibility 'all'
   source_url "http://www.moria.de/~michael/dehtml/dehtml-#{version}.tar.gz"
-  source_sha256 '838d2a3c892eab8f26a29c94732b8eff2ce5594014ea1da09e3a532d5149b2db'
+  source_sha256 '3dd66197f2438a17ed16abc572207a25eb1d74776a228e1f294c42d56639f9c3'
   binary_compression 'tar.zst'
 
   binary_sha256({
-    aarch64: '649cb05f43386af89a6717b45e40cca2d83bfbdd804688dd7d9ae82519de3139',
-     armv7l: '649cb05f43386af89a6717b45e40cca2d83bfbdd804688dd7d9ae82519de3139',
-       i686: '3dd3356aca416e5cbcbb4d351bc045ab3e8bf7180103aa1667f2b148a3c9c0de',
-     x86_64: '67800096fda44e8685c9a74d785c35b070be22b5ca1de16f7d1cbda33e9b8a59'
+    aarch64: '384ee28a3f36a84c25637f5679b153228ac63da210af39d54434491e694451cf',
+     armv7l: '384ee28a3f36a84c25637f5679b153228ac63da210af39d54434491e694451cf',
+       i686: 'c2beceecd2db8db317e942da8109570a2441b70ed2e9dfe73cb702dfb5756555',
+     x86_64: '5734580522004fd5b727a3cfc0500d78a2c6a0e9eeadab6b2b117dcfbe0dd26b'
   })
 
-  depends_on 'glibc' # R
+  depends_on 'glibc' => :executable
+  depends_on 'glibc_lib' => :executable
 
   autotools_build_relative_dir '.'
-
-  def self.patch
-    # Fix config.status: error: cannot find input file: `test/run.in'.
-    system "sed -i 's, test/run,,' configure"
-    # Fix chmod: missing operand after '755'.
-    system "sed -i 's,chmod 755,,' configure"
-  end
 
   # The Makefile.in does not respect DESTDIR, so we override the buildsystem and append the explicit paths here.
   def self.build


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
- [x] `i686`
- [x] `armv7l`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-dehtml crew update \
&& yes | crew upgrade

$ crew check dehtml 
Checking dehtml package ...
Library test for dehtml passed.
Checking dehtml package ...
Usage: dehtml [-w] [-s] [-l] [-p] [-u] [file ...]

Remove HTML constructs from documents.

-w, --word-list     output a word list
-s, --skip-headers  do not output headers
-l, --skip-lists    do not output lists
-p, --pretty-print  pretty printed output
-u, --skip-urls     Do not include indexed URLs
-h, --help          display this help and exit
    --version       display version and exit

Report bugs to <michael@moria.de>.
dehtml 2.0
Package tests for dehtml passed.
```