### PR TITLE
gcc_build: add COBOL to GCC languages

### DIFF
--- a/packages/gcc_build.rb
+++ b/packages/gcc_build.rb
@@ -2,7 +2,7 @@ require 'English'
 require 'package'
 
 class Gcc_build < Package
-  description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, and Go.'
+  description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, Go, and COBOL.'
   homepage 'https://www.gnu.org/software/gcc/'
   version '16.2.0'
   license 'GPL-3, LGPL-3, libgcc, FDL-1.2'
@@ -37,7 +37,7 @@ class Gcc_build < Package
 
   @glibc_flags = "-L#{CREW_LIB_PREFIX}"
   @cflags = @cxxflags = "-fPIC -pipe #{@glibc_flags} -B#{CREW_LIB_PREFIX}"
-  @languages = 'c,c++,jit,objc,fortran,go,rust'
+  @languages = 'c,c++,jit,objc,fortran,go,rust,cobol'
   case ARCH
   when 'armv7l', 'aarch64'
     @archflags = '--with-arch=armv7-a+fp --with-float=hard --with-tune=cortex-a15 --with-fpu=vfpv3-d16'
@@ -45,6 +45,7 @@ class Gcc_build < Package
     @archflags = '--with-arch-64=x86-64'
   when 'i686'
     @archflags = '--with-arch-32=i686'
+    @languages = @languages.gsub(',cobol', '')  # COBOL in GCC needs 64bits
   end
   @ldflags = @glibc_flags
   @path = "#{CREW_PREFIX}/share/cargo/bin:" + ENV.fetch('PATH', nil)

--- a/packages/gcc_build.rb
+++ b/packages/gcc_build.rb
@@ -39,13 +39,16 @@ class Gcc_build < Package
   @cflags = @cxxflags = "-fPIC -pipe #{@glibc_flags} -B#{CREW_LIB_PREFIX}"
   @languages = 'c,c++,jit,objc,fortran,go,rust,cobol'
   case ARCH
-  when 'armv7l', 'aarch64'
+  when 'armv7l'
     @archflags = '--with-arch=armv7-a+fp --with-float=hard --with-tune=cortex-a15 --with-fpu=vfpv3-d16'
-  when 'x86_64'
-    @archflags = '--with-arch-64=x86-64'
+    @languages = @languages.gsub(',cobol', '')  # COBOL in GCC needs 64bits
   when 'i686'
     @archflags = '--with-arch-32=i686'
     @languages = @languages.gsub(',cobol', '')  # COBOL in GCC needs 64bits
+  when 'aarch64'
+    @archflags = '--with-arch=armv7-a+fp --with-float=hard --with-tune=cortex-a15 --with-fpu=vfpv3-d16'
+  when 'x86_64'
+    @archflags = '--with-arch-64=x86-64'
   end
   @ldflags = @glibc_flags
   @path = "#{CREW_PREFIX}/share/cargo/bin:" + ENV.fetch('PATH', nil)

--- a/packages/gcc_build.rb
+++ b/packages/gcc_build.rb
@@ -2,7 +2,7 @@ require 'English'
 require 'package'
 
 class Gcc_build < Package
-  description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, Go, and COBOL.'
+  description 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, Go, and for 64bit: COBOL.'
   homepage 'https://www.gnu.org/software/gcc/'
   version '16.2.0'
   license 'GPL-3, LGPL-3, libgcc, FDL-1.2'
@@ -37,18 +37,15 @@ class Gcc_build < Package
 
   @glibc_flags = "-L#{CREW_LIB_PREFIX}"
   @cflags = @cxxflags = "-fPIC -pipe #{@glibc_flags} -B#{CREW_LIB_PREFIX}"
-  @languages = 'c,c++,jit,objc,fortran,go,rust,cobol'
+  @languages = 'c,c++,jit,objc,fortran,go,rust'
   case ARCH
-  when 'armv7l'
-    @archflags = '--with-arch=armv7-a+fp --with-float=hard --with-tune=cortex-a15 --with-fpu=vfpv3-d16'
-    @languages = @languages.gsub(',cobol', '')  # COBOL in GCC needs 64bits
-  when 'i686'
-    @archflags = '--with-arch-32=i686'
-    @languages = @languages.gsub(',cobol', '')  # COBOL in GCC needs 64bits
-  when 'aarch64'
+  when 'armv7l', 'aarch64'
     @archflags = '--with-arch=armv7-a+fp --with-float=hard --with-tune=cortex-a15 --with-fpu=vfpv3-d16'
   when 'x86_64'
     @archflags = '--with-arch-64=x86-64'
+    @languages = "#{@languages},cobol"  # COBOL in GCC needs 64bits, so only added here
+  when 'i686'
+    @archflags = '--with-arch-32=i686'
   end
   @ldflags = @glibc_flags
   @path = "#{CREW_PREFIX}/share/cargo/bin:" + ENV.fetch('PATH', nil)


### PR DESCRIPTION
## Description
GCC15 included a COBOL backend which is considered "overall working" in GCC 16 for 64bit environments.
This PR is a check if "just adding it" will work on any of those.

## Additional information
As the languages are not identical for all envs, the file list will be different for each one.
The test was not run locally yet, this PR is intended to do that.

<!--
##
Builds:
- [ ] `x86_64`
- [ ] `i686`
- [ ] `armv7l`
##
Tested & Working properly:
- [ ] `x86_64`
- [ ] `i686`
- [ ] `armv7l` <!-- (reasons why it doesn't) - ->
##
- [ ] This PR has no manifest .filelist changes. _(Package changes have neither added nor removed files.)_
##
-->

### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/GitMensch/chromebrew.git CREW_BRANCH=patch-1 crew update \
&& yes | crew upgrade
```

