### PR TITLE
Dmd 2.112.1 => 2.113.0

### DIFF
--- a/manifest/x86_64/d/dmd.filelist
+++ b/manifest/x86_64/d/dmd.filelist
@@ -1,4 +1,4 @@
-# Total size: 104847372
+# Total size: 106646450
 /usr/local/bin/ddemangle
 /usr/local/bin/dmd
 /usr/local/bin/dub
@@ -7,8 +7,8 @@
 /usr/local/etc/dmd.conf
 /usr/local/lib64/libphobos2.a
 /usr/local/lib64/libphobos2.so
-/usr/local/lib64/libphobos2.so.0.112
-/usr/local/lib64/libphobos2.so.0.112.0
+/usr/local/lib64/libphobos2.so.0.113
+/usr/local/lib64/libphobos2.so.0.113.0
 /usr/local/share/man/man1/dmd.1.zst
 /usr/local/share/man/man1/dumpobj.1.zst
 /usr/local/share/man/man1/obj2asm.1.zst

--- a/packages/dmd.rb
+++ b/packages/dmd.rb
@@ -3,12 +3,12 @@ require 'package'
 class Dmd < Package
   description 'D Programming Language compiler'
   homepage 'https://dlang.org/'
-  version '2.112.1'
+  version '2.113.0'
   license 'BSL-1.0'
   compatibility 'x86_64'
   min_glibc '2.32'
-  source_url "https://github.com/dlang/dmd/releases/download/v#{version}/dmd.stable.linux.tar.xz"
-  source_sha256 '556ec06dc5f27e04c4fd4aad6274873cc7a404a3f85cd48f592f16c76d6361b4'
+  source_url "https://github.com/dlang/dmd/releases/download/v#{version}/dmd.#{version}.linux.tar.xz"
+  source_sha256 'b342ab8bd40cc0c46407692b31d7cd69661ff01da686234f426949e881727294'
 
   conflicts_with 'ldc'
   depends_on 'gcc_lib' # R


### PR DESCRIPTION
Tested & Working properly:
- [x] `x86_64`
### Run the following to get this pull request's changes locally for testing.
```bash
CREW_REPO=https://github.com/chromebrew/chromebrew.git CREW_BRANCH=update-dmd crew update \
&& yes | crew upgrade

$ crew check dmd 
Checking dmd package ...
Library test for dmd passed.
Checking dmd package ...
DMD64 D Compiler v2.113.0
Copyright (C) 1999-2026 by The D Language Foundation, All Rights Reserved written by Walter Bright

Documentation: https://dlang.org/
Config file: /etc/dmd.conf
Usage:
  dmd [<option>...] <file>...
  dmd [<option>...] -run <file> [<arg>...]

Where:
DMD64 D Compiler v2.113.0
Copyright (C) 1999-2026 by The D Language Foundation, All Rights Reserved written by Walter Bright
Package tests for dmd passed.
```